### PR TITLE
Make macOS control panel auto-height reliable (Safari) + min-height + avatar nudge

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/AccountProfileHeader.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AccountProfileHeader.tsx
@@ -59,6 +59,9 @@ export function AccountProfileHeader({
                 name={ACCOUNT_PROFILE_AVATAR_ICON}
                 alt={accountAvatarLabel}
                 className="size-full object-contain"
+                // Nudge the head/shoulders silhouette down so it sits lower in
+                // the circle (shoulders crop naturally at the bottom edge).
+                style={{ transform: "translateY(8%)" }}
               />
             )}
           </div>

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
@@ -51,12 +51,17 @@ export function ControlPanelsMacAnimatedBody({
 
     // The measure subtree is NEVER height-constrained: when content exceeds the
     // window cap, the body (motion.div) itself scrolls, not any inner element.
-    // So the measure node's border box always reflects the true natural content
+    // So the measure node's layout box always reflects the true natural content
     // height on every engine — no scroll-overflow / flex / collapsed-inner-scroller
     // hacks. Crucially, toggling the body's overflow (data-scrollable) cannot
     // change a child's height, so there is no measure↔layout feedback loop — the
     // root cause of the Safari auto-size jank, worst for panes with inner scrollers.
-    const next = Math.ceil(root.getBoundingClientRect().height);
+    //
+    // Use offsetHeight (the layout border-box height). A visual rect would also
+    // include ancestor transforms, so the window's open/scale animation would
+    // corrupt the first measurement (locking in a too-short Show All on initial
+    // load, since a transform end fires no ResizeObserver to correct it).
+    const next = root.offsetHeight;
     if (next <= 0) return;
 
     const prev = naturalHeightRef.current;

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
@@ -1,12 +1,10 @@
 import {
   useCallback,
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
 } from "react";
-import { createPortal } from "react-dom";
 import { motion } from "motion/react";
 import { useResizeObserverWithRef } from "@/hooks/useResizeObserver";
 import { useAppStore } from "@/stores/useAppStore";
@@ -20,23 +18,6 @@ import {
 
 const CONTENT_MEASURE_SELECTOR =
   ".control-panels-category-grid, .control-panels-mac-pane";
-
-// TEMP DEBUG: on-screen auto-height diagnostics for the macOS Control Panels.
-// Enable with `?cp-debug=1` in the URL (easy to set + screenshot on iOS Safari)
-// or `localStorage["ryos:debug:cp-autoheight"]="1"`. Remove once the Safari
-// bottom-padding/clipping issue is resolved.
-function readCpAutoHeightDebug(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    const sp = new URLSearchParams(window.location.search);
-    if (sp.has("cp-debug")) return sp.get("cp-debug") !== "0";
-    return localStorage.getItem("ryos:debug:cp-autoheight") === "1";
-  } catch {
-    return false;
-  }
-}
-
-type CpAutoHeightDiag = Record<string, number | string | boolean | null>;
 
 export type ControlPanelsMacAnimatedBodyProps = {
   instanceId?: string;
@@ -59,11 +40,6 @@ export function ControlPanelsMacAnimatedBody({
   const [naturalHeight, setNaturalHeight] = useState<number | null>(null);
   const [isMeasuring, setIsMeasuring] = useState(true);
   const lastWindowHeightRef = useRef<number | null>(null);
-
-  // TEMP DEBUG
-  const debugEnabled = useRef(readCpAutoHeightDebug()).current;
-  const [diag, setDiag] = useState<CpAutoHeightDiag | null>(null);
-  const diagKeyRef = useRef("");
 
   const maxBodyHeight = Math.max(
     0,
@@ -93,26 +69,18 @@ export function ControlPanelsMacAnimatedBody({
     // padding on every engine; scrollHeight of the flex pane still wins in the
     // height-capped/scrollable state where `root` is itself flex-constrained. On
     // Chrome these are all equal, so this is a no-op there.
-    const contentSH = content.scrollHeight;
-    const contentRH = content.getBoundingClientRect().height;
-    const rootSH = root.scrollHeight;
-    const rootRH = root.getBoundingClientRect().height;
-    let measured = Math.max(contentSH, contentRH, rootSH, rootRH);
+    let measured = Math.max(
+      content.scrollHeight,
+      content.getBoundingClientRect().height,
+      root.scrollHeight,
+      root.getBoundingClientRect().height
+    );
 
     // Only in auto-height mode (below the cap): add back any content a collapsed
     // inner scroller is hiding. In the capped/scrollable state scrollHeight already
     // reports the full natural height, so skipping avoids double-counting.
-    let collapsedOverflow = 0;
-    let panelSH = 0;
-    let panelCH = 0;
-    const panel = content.querySelector<HTMLElement>(
-      ".control-panels-pref-tab-panel:not([hidden])"
-    );
-    if (panel) {
-      panelSH = panel.scrollHeight;
-      panelCH = panel.clientHeight;
-    }
     if (measured < maxBodyHeight) {
+      let collapsedOverflow = 0;
       content
         .querySelectorAll<HTMLElement>(
           ".control-panels-pref-tab-panel:not([hidden])"
@@ -129,32 +97,6 @@ export function ControlPanelsMacAnimatedBody({
     const next = Math.ceil(measured);
     if (next <= 0) return;
 
-    // TEMP DEBUG: capture every height signal so the on-screen overlay can show
-    // exactly which one is short on real iOS Safari.
-    if (debugEnabled) {
-      const bodyEl = root.parentElement as HTMLElement | null;
-      const snapshot: CpAutoHeightDiag = {
-        ua: typeof navigator !== "undefined" ? navigator.userAgent : "",
-        navKey,
-        toolbarH: toolbarHeight,
-        maxBodyH: maxBodyHeight,
-        contentSH,
-        contentRH: Math.round(contentRH),
-        rootSH,
-        rootRH: Math.round(rootRH),
-        tabPanel: panel ? `${panelSH}/${panelCH}` : "—",
-        collapsedOverflow,
-        measuredNext: next,
-        bodyRectH: bodyEl ? Math.round(bodyEl.getBoundingClientRect().height) : null,
-        dpr: typeof window !== "undefined" ? window.devicePixelRatio : null,
-      };
-      const key = JSON.stringify(snapshot);
-      if (key !== diagKeyRef.current) {
-        diagKeyRef.current = key;
-        setDiag(snapshot);
-      }
-    }
-
     const prev = naturalHeightRef.current;
     if (prev !== null && next < prev - 1 && next <= maxBodyHeight) {
       return;
@@ -163,7 +105,7 @@ export function ControlPanelsMacAnimatedBody({
     if (prev === next) return;
     naturalHeightRef.current = next;
     setNaturalHeight(next);
-  }, [maxBodyHeight, debugEnabled, navKey, toolbarHeight]);
+  }, [maxBodyHeight]);
 
   const updateHeight = useCallback(
     (_entry: ResizeObserverEntry) => {
@@ -193,51 +135,6 @@ export function ControlPanelsMacAnimatedBody({
     !isMeasuring &&
     naturalHeight !== null &&
     naturalHeight > maxBodyHeight;
-
-  // TEMP DEBUG: poll the post-layout/animated state — bodyRectH is the final
-  // clipped height; clippedPad > 0 means the pane bottom padding is being cut.
-  const [live, setLive] = useState<CpAutoHeightDiag | null>(null);
-  useEffect(() => {
-    if (!debugEnabled) return;
-    const id = window.setInterval(() => {
-      const root = measureRef.current;
-      const bodyEl = root?.parentElement as HTMLElement | null;
-      const inner = root?.querySelector<HTMLElement>(
-        ".control-panels-mac-pane-inner"
-      );
-      const winSize = instanceId
-        ? useAppStore.getState().instances[instanceId]?.size
-        : undefined;
-      const bodyBottom = bodyEl
-        ? bodyEl.getBoundingClientRect().bottom
-        : null;
-      const innerBottom = inner ? inner.getBoundingClientRect().bottom : null;
-      // Visible gap between the card (well) and the body bottom — this is the
-      // rendered bottom padding the user sees. Should be ~18 when correct.
-      const card = root?.querySelector<HTMLElement>(
-        ".control-panels-pref-tabbed > .control-panels-pref-well, .control-panels-pref-well, .control-panels-pref-form"
-      );
-      const cardBottom = card ? card.getBoundingClientRect().bottom : null;
-      setLive({
-        bodyRectH: bodyEl
-          ? Math.round(bodyEl.getBoundingClientRect().height)
-          : null,
-        clippedPad:
-          innerBottom != null && bodyBottom != null
-            ? Math.max(0, Math.round(innerBottom - bodyBottom))
-            : null,
-        wellGap:
-          cardBottom != null && bodyBottom != null
-            ? Math.round(bodyBottom - cardBottom)
-            : null,
-        winH: winSize?.height ?? null,
-        naturalH: naturalHeightRef.current,
-        animatedH: animatedHeight ?? null,
-        scroll: needsScroll,
-      });
-    }, 400);
-    return () => window.clearInterval(id);
-  }, [debugEnabled, instanceId, animatedHeight, needsScroll]);
 
   useLayoutEffect(() => {
     if (!instanceId || animatedHeight === undefined) return;
@@ -282,101 +179,6 @@ export function ControlPanelsMacAnimatedBody({
       <div ref={measureRef} className="control-panels-mac-body-measure">
         <div className="control-panels-mac-body-layout">{children}</div>
       </div>
-      {debugEnabled ? (
-        <CpAutoHeightDebugOverlay diag={diag} live={live} />
-      ) : null}
     </motion.div>
-  );
-}
-
-// TEMP DEBUG: portal overlay rendered to <body> so overflow:hidden ancestors
-// cannot clip it. Tap it to copy the full signal set to the clipboard (low-res
-// screenshots are unreadable, so copy + paste the numbers instead).
-function CpAutoHeightDebugOverlay({
-  diag,
-  live,
-}: {
-  diag: CpAutoHeightDiag | null;
-  live: CpAutoHeightDiag | null;
-}) {
-  const [copied, setCopied] = useState(false);
-  if (typeof document === "undefined") return null;
-  const rows: Array<[string, CpAutoHeightDiag | null]> = [
-    ["measure", diag],
-    ["live", live],
-  ];
-  const asText = rows
-    .map(
-      ([label, data]) =>
-        `${label}: ${
-          data
-            ? Object.entries(data)
-                .map(([k, v]) => `${k}=${v}`)
-                .join(" ")
-            : "—"
-        }`
-    )
-    .join("\n");
-  const copy = () => {
-    const done = () => {
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
-    };
-    try {
-      if (navigator.clipboard?.writeText) {
-        navigator.clipboard.writeText(asText).then(done, done);
-        return;
-      }
-    } catch {
-      /* fall through to textarea */
-    }
-    try {
-      const ta = document.createElement("textarea");
-      ta.value = asText;
-      document.body.appendChild(ta);
-      ta.select();
-      document.execCommand("copy");
-      document.body.removeChild(ta);
-    } catch {
-      /* ignore */
-    }
-    done();
-  };
-  return createPortal(
-    <div
-      onClick={copy}
-      role="button"
-      style={{
-        position: "fixed",
-        left: 6,
-        bottom: 6,
-        zIndex: 2147483647,
-        maxWidth: "min(94vw, 420px)",
-        padding: "8px 10px",
-        background: "rgba(0,0,0,0.88)",
-        color: "#0f0",
-        font: "12px/1.4 ui-monospace, Menlo, monospace",
-        borderRadius: 8,
-        pointerEvents: "auto",
-        whiteSpace: "pre-wrap",
-        wordBreak: "break-all",
-      }}
-    >
-      <div style={{ color: "#ff0", fontWeight: 700 }}>
-        CP auto-height debug — {copied ? "COPIED ✓" : "tap to copy"}
-      </div>
-      {rows.map(([label, data]) => (
-        <div key={label} style={{ marginTop: 4 }}>
-          <span style={{ color: "#0ff" }}>{label}:</span>{" "}
-          {data
-            ? Object.entries(data)
-                .filter(([k]) => k !== "ua")
-                .map(([k, v]) => `${k}=${v}`)
-                .join("  ")
-            : "—"}
-        </div>
-      ))}
-    </div>,
-    document.body
   );
 }

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
@@ -49,13 +49,18 @@ export function ControlPanelsMacAnimatedBody({
     const root = measureRef.current;
     if (!root) return;
 
-    // The measure subtree is NEVER height-constrained: when content exceeds the
-    // window cap, the body (motion.div) itself scrolls, not any inner element.
-    // So the measure node's layout box always reflects the true natural content
-    // height on every engine — no scroll-overflow / flex / collapsed-inner-scroller
-    // hacks. Crucially, toggling the body's overflow (data-scrollable) cannot
-    // change a child's height, so there is no measure↔layout feedback loop — the
-    // root cause of the Safari auto-size jank, worst for panes with inner scrollers.
+    // The FIRST measure always runs unconstrained: data-scrollable is only set
+    // once naturalHeight is known (and isMeasuring is false), so the initial
+    // layout-effect measure (and the per-pane re-measure on navKey) reads the
+    // true natural content height — the well auto-sizes to the tallest tab.
+    //
+    // Tabbed panes then scroll INSIDE the active tab panel (pinned tab bar) once
+    // capped, which constrains this measure subtree. That can't reopen the old
+    // Safari auto-size feedback loop: the high-water guard below freezes the
+    // captured natural height, and we never try to recover it from the collapsed
+    // inner scroller (the recovery math was what bounced on Safari). Simple panes
+    // stay unconstrained — the body itself scrolls — so they measure naturally
+    // on every pass.
     //
     // Use offsetHeight (the layout border-box height). A visual rect would also
     // include ancestor transforms, so the window's open/scale animation would

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
@@ -55,7 +55,15 @@ export function ControlPanelsMacAnimatedBody({
     // collapse scrollHeight and toggle data-scrollable (height flicker).
     const content =
       root.querySelector<HTMLElement>(CONTENT_MEASURE_SELECTOR) ?? root;
-    const next = Math.ceil(content.scrollHeight);
+    // WebKit/Safari underreports scrollHeight for flex content by the bottom
+    // padding amount; the height-capped body then clips that padding so it looks
+    // missing. getBoundingClientRect reflects the true rendered box for the
+    // unconstrained auto-height panes, while scrollHeight still wins for the
+    // height-capped scrollable panes (where the box is flex-constrained). Take
+    // whichever is larger so both browsers keep the bottom padding.
+    const next = Math.ceil(
+      Math.max(content.scrollHeight, content.getBoundingClientRect().height)
+    );
     if (next <= 0) return;
 
     const prev = naturalHeightRef.current;

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
@@ -55,15 +55,40 @@ export function ControlPanelsMacAnimatedBody({
     // collapse scrollHeight and toggle data-scrollable (height flicker).
     const content =
       root.querySelector<HTMLElement>(CONTENT_MEASURE_SELECTOR) ?? root;
-    // WebKit/Safari underreports scrollHeight for flex content by the bottom
-    // padding amount; the height-capped body then clips that padding so it looks
-    // missing. getBoundingClientRect reflects the true rendered box for the
-    // unconstrained auto-height panes, while scrollHeight still wins for the
-    // height-capped scrollable panes (where the box is flex-constrained). Take
-    // whichever is larger so both browsers keep the bottom padding.
-    const next = Math.ceil(
-      Math.max(content.scrollHeight, content.getBoundingClientRect().height)
+    // WebKit/Safari underreports the natural height of flex content in two ways
+    // that the height-capped body then clips (so padding/rows look missing on
+    // Safari but fine on Chrome):
+    //  1. scrollHeight omits the flex pane's bottom padding — getBoundingClientRect
+    //     reflects the true rendered box for the unconstrained auto-height panes.
+    //  2. flex-constrained inner scrollers (tabbed pref panels with overflow-y:auto)
+    //     collapse below their content in auto-height mode, hiding overflow that
+    //     Chrome would expand to fit.
+    // Recover both so the window grows tall enough on Safari. On Chrome these are
+    // no-ops: boundingRect === scrollHeight and the inner panels never overflow here.
+    let measured = Math.max(
+      content.scrollHeight,
+      content.getBoundingClientRect().height
     );
+
+    // Only in auto-height mode (below the cap): add back any content a collapsed
+    // inner scroller is hiding. In the capped/scrollable state scrollHeight already
+    // reports the full natural height, so skipping avoids double-counting.
+    if (measured < maxBodyHeight) {
+      let collapsedOverflow = 0;
+      content
+        .querySelectorAll<HTMLElement>(
+          ".control-panels-pref-tab-panel:not([hidden])"
+        )
+        .forEach((panel) => {
+          collapsedOverflow = Math.max(
+            collapsedOverflow,
+            panel.scrollHeight - panel.clientHeight
+          );
+        });
+      measured += collapsedOverflow;
+    }
+
+    const next = Math.ceil(measured);
     if (next <= 0) return;
 
     const prev = naturalHeightRef.current;

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
@@ -16,9 +16,6 @@ import {
   CONTROL_PANELS_MAC_SIZE_TRANSITION,
 } from "./controlPanelsMacMotion";
 
-const CONTENT_MEASURE_SELECTOR =
-  ".control-panels-category-grid, .control-panels-mac-pane";
-
 export type ControlPanelsMacAnimatedBodyProps = {
   instanceId?: string;
   toolbarHeight: number;
@@ -52,56 +49,24 @@ export function ControlPanelsMacAnimatedBody({
     const root = measureRef.current;
     if (!root) return;
 
-    // Measure unconstrained content roots so scroll-constrained flex layout cannot
-    // collapse scrollHeight and toggle data-scrollable (height flicker).
-    const content =
-      root.querySelector<HTMLElement>(CONTENT_MEASURE_SELECTOR) ?? root;
-    // WebKit/Safari underreports the natural height of flex content in ways the
-    // height-capped body then clips (so padding/rows look missing on Safari but
-    // fine on Chrome):
-    //  1. scrollHeight omits the flex pane's bottom padding.
-    //  2. flex-constrained inner scrollers (tabbed pref panels with overflow-y:auto)
-    //     collapse below their content in auto-height mode, hiding overflow that
-    //     Chrome would expand to fit.
-    // Defenses: take the largest of several height signals. getBoundingClientRect
-    // reflects the true rendered box, and `root` (the measure wrapper) is a plain
-    // block in auto-height mode whose scrollHeight reliably includes descendant
-    // padding on every engine; scrollHeight of the flex pane still wins in the
-    // height-capped/scrollable state where `root` is itself flex-constrained. On
-    // Chrome these are all equal, so this is a no-op there.
-    let measured = Math.max(
-      content.scrollHeight,
-      content.getBoundingClientRect().height,
-      root.scrollHeight,
-      root.getBoundingClientRect().height
-    );
-
-    // Only in auto-height mode (below the cap): add back any content a collapsed
-    // inner scroller is hiding. In the capped/scrollable state scrollHeight already
-    // reports the full natural height, so skipping avoids double-counting.
-    if (measured < maxBodyHeight) {
-      let collapsedOverflow = 0;
-      content
-        .querySelectorAll<HTMLElement>(
-          ".control-panels-pref-tab-panel:not([hidden])"
-        )
-        .forEach((p) => {
-          collapsedOverflow = Math.max(
-            collapsedOverflow,
-            p.scrollHeight - p.clientHeight
-          );
-        });
-      measured += collapsedOverflow;
-    }
-
-    const next = Math.ceil(measured);
+    // The measure subtree is NEVER height-constrained: when content exceeds the
+    // window cap, the body (motion.div) itself scrolls, not any inner element.
+    // So the measure node's border box always reflects the true natural content
+    // height on every engine — no scroll-overflow / flex / collapsed-inner-scroller
+    // hacks. Crucially, toggling the body's overflow (data-scrollable) cannot
+    // change a child's height, so there is no measure↔layout feedback loop — the
+    // root cause of the Safari auto-size jank, worst for panes with inner scrollers.
+    const next = Math.ceil(root.getBoundingClientRect().height);
     if (next <= 0) return;
 
     const prev = naturalHeightRef.current;
-    if (prev !== null && next < prev - 1 && next <= maxBodyHeight) {
-      return;
-    }
-
+    // Within a single pane (same navKey) grow to fit, but don't shrink on content
+    // swaps like switching tabs — the inactive tab panel is display:none, so the
+    // stacked well reports only the active tab's height. Holding the high-water
+    // mark keeps the window sized to the tallest tab so swaps don't jitter. The
+    // navKey reset (below) re-baselines when navigating to a different pane.
+    // Shrinks above the cap are allowed (the window is already maxed there).
+    if (prev !== null && next < prev - 1 && next <= maxBodyHeight) return;
     if (prev === next) return;
     naturalHeightRef.current = next;
     setNaturalHeight(next);

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
@@ -13,6 +13,7 @@ import { useAppStore } from "@/stores/useAppStore";
 import { cn } from "@/lib/utils";
 import {
   CONTROL_PANELS_MAC_MAX_WINDOW_HEIGHT,
+  CONTROL_PANELS_MAC_MIN_WINDOW_HEIGHT,
   CONTROL_PANELS_MACOSX_TITLEBAR_HEIGHT,
   CONTROL_PANELS_MAC_SIZE_TRANSITION,
 } from "./controlPanelsMacMotion";
@@ -241,9 +242,14 @@ export function ControlPanelsMacAnimatedBody({
   useLayoutEffect(() => {
     if (!instanceId || animatedHeight === undefined) return;
 
-    const totalWindowHeight = Math.min(
-      CONTROL_PANELS_MAC_MAX_WINDOW_HEIGHT,
-      CONTROL_PANELS_MACOSX_TITLEBAR_HEIGHT + toolbarHeight + animatedHeight
+    // Respect the window's min/max height: never auto-shrink below the configured
+    // minimum (matches windowConstraints.minHeight) even when content is short.
+    const totalWindowHeight = Math.max(
+      CONTROL_PANELS_MAC_MIN_WINDOW_HEIGHT,
+      Math.min(
+        CONTROL_PANELS_MAC_MAX_WINDOW_HEIGHT,
+        CONTROL_PANELS_MACOSX_TITLEBAR_HEIGHT + toolbarHeight + animatedHeight
+      )
     );
 
     if (lastWindowHeightRef.current === totalWindowHeight) return;

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
@@ -211,6 +211,12 @@ export function ControlPanelsMacAnimatedBody({
         ? bodyEl.getBoundingClientRect().bottom
         : null;
       const innerBottom = inner ? inner.getBoundingClientRect().bottom : null;
+      // Visible gap between the card (well) and the body bottom — this is the
+      // rendered bottom padding the user sees. Should be ~18 when correct.
+      const card = root?.querySelector<HTMLElement>(
+        ".control-panels-pref-tabbed > .control-panels-pref-well, .control-panels-pref-well, .control-panels-pref-form"
+      );
+      const cardBottom = card ? card.getBoundingClientRect().bottom : null;
       setLive({
         bodyRectH: bodyEl
           ? Math.round(bodyEl.getBoundingClientRect().height)
@@ -218,6 +224,10 @@ export function ControlPanelsMacAnimatedBody({
         clippedPad:
           innerBottom != null && bodyBottom != null
             ? Math.max(0, Math.round(innerBottom - bodyBottom))
+            : null,
+        wellGap:
+          cardBottom != null && bodyBottom != null
+            ? Math.round(bodyBottom - cardBottom)
             : null,
         winH: winSize?.height ?? null,
         naturalH: naturalHeightRef.current,
@@ -274,7 +284,8 @@ export function ControlPanelsMacAnimatedBody({
 }
 
 // TEMP DEBUG: portal overlay rendered to <body> so overflow:hidden ancestors
-// cannot clip it. Shows the raw measurement signals + the post-layout state.
+// cannot clip it. Tap it to copy the full signal set to the clipboard (low-res
+// screenshots are unreadable, so copy + paste the numbers instead).
 function CpAutoHeightDebugOverlay({
   diag,
   live,
@@ -282,32 +293,74 @@ function CpAutoHeightDebugOverlay({
   diag: CpAutoHeightDiag | null;
   live: CpAutoHeightDiag | null;
 }) {
+  const [copied, setCopied] = useState(false);
   if (typeof document === "undefined") return null;
   const rows: Array<[string, CpAutoHeightDiag | null]> = [
     ["measure", diag],
     ["live", live],
   ];
+  const asText = rows
+    .map(
+      ([label, data]) =>
+        `${label}: ${
+          data
+            ? Object.entries(data)
+                .map(([k, v]) => `${k}=${v}`)
+                .join(" ")
+            : "—"
+        }`
+    )
+    .join("\n");
+  const copy = () => {
+    const done = () => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    };
+    try {
+      if (navigator.clipboard?.writeText) {
+        navigator.clipboard.writeText(asText).then(done, done);
+        return;
+      }
+    } catch {
+      /* fall through to textarea */
+    }
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = asText;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+    } catch {
+      /* ignore */
+    }
+    done();
+  };
   return createPortal(
     <div
+      onClick={copy}
+      role="button"
       style={{
         position: "fixed",
         left: 6,
         bottom: 6,
         zIndex: 2147483647,
-        maxWidth: "min(92vw, 360px)",
-        padding: "6px 8px",
-        background: "rgba(0,0,0,0.82)",
+        maxWidth: "min(94vw, 420px)",
+        padding: "8px 10px",
+        background: "rgba(0,0,0,0.88)",
         color: "#0f0",
-        font: "10px/1.35 ui-monospace, Menlo, monospace",
-        borderRadius: 6,
-        pointerEvents: "none",
+        font: "12px/1.4 ui-monospace, Menlo, monospace",
+        borderRadius: 8,
+        pointerEvents: "auto",
         whiteSpace: "pre-wrap",
         wordBreak: "break-all",
       }}
     >
-      <div style={{ color: "#ff0", fontWeight: 700 }}>CP auto-height debug</div>
+      <div style={{ color: "#ff0", fontWeight: 700 }}>
+        CP auto-height debug — {copied ? "COPIED ✓" : "tap to copy"}
+      </div>
       {rows.map(([label, data]) => (
-        <div key={label} style={{ marginTop: 3 }}>
+        <div key={label} style={{ marginTop: 4 }}>
           <span style={{ color: "#0ff" }}>{label}:</span>{" "}
           {data
             ? Object.entries(data)

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
@@ -55,19 +55,24 @@ export function ControlPanelsMacAnimatedBody({
     // collapse scrollHeight and toggle data-scrollable (height flicker).
     const content =
       root.querySelector<HTMLElement>(CONTENT_MEASURE_SELECTOR) ?? root;
-    // WebKit/Safari underreports the natural height of flex content in two ways
-    // that the height-capped body then clips (so padding/rows look missing on
-    // Safari but fine on Chrome):
-    //  1. scrollHeight omits the flex pane's bottom padding — getBoundingClientRect
-    //     reflects the true rendered box for the unconstrained auto-height panes.
+    // WebKit/Safari underreports the natural height of flex content in ways the
+    // height-capped body then clips (so padding/rows look missing on Safari but
+    // fine on Chrome):
+    //  1. scrollHeight omits the flex pane's bottom padding.
     //  2. flex-constrained inner scrollers (tabbed pref panels with overflow-y:auto)
     //     collapse below their content in auto-height mode, hiding overflow that
     //     Chrome would expand to fit.
-    // Recover both so the window grows tall enough on Safari. On Chrome these are
-    // no-ops: boundingRect === scrollHeight and the inner panels never overflow here.
+    // Defenses: take the largest of several height signals. getBoundingClientRect
+    // reflects the true rendered box, and `root` (the measure wrapper) is a plain
+    // block in auto-height mode whose scrollHeight reliably includes descendant
+    // padding on every engine; scrollHeight of the flex pane still wins in the
+    // height-capped/scrollable state where `root` is itself flex-constrained. On
+    // Chrome these are all equal, so this is a no-op there.
     let measured = Math.max(
       content.scrollHeight,
-      content.getBoundingClientRect().height
+      content.getBoundingClientRect().height,
+      root.scrollHeight,
+      root.getBoundingClientRect().height
     );
 
     // Only in auto-height mode (below the cap): add back any content a collapsed

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
@@ -1,10 +1,12 @@
 import {
   useCallback,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import { motion } from "motion/react";
 import { useResizeObserverWithRef } from "@/hooks/useResizeObserver";
 import { useAppStore } from "@/stores/useAppStore";
@@ -17,6 +19,23 @@ import {
 
 const CONTENT_MEASURE_SELECTOR =
   ".control-panels-category-grid, .control-panels-mac-pane";
+
+// TEMP DEBUG: on-screen auto-height diagnostics for the macOS Control Panels.
+// Enable with `?cp-debug=1` in the URL (easy to set + screenshot on iOS Safari)
+// or `localStorage["ryos:debug:cp-autoheight"]="1"`. Remove once the Safari
+// bottom-padding/clipping issue is resolved.
+function readCpAutoHeightDebug(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const sp = new URLSearchParams(window.location.search);
+    if (sp.has("cp-debug")) return sp.get("cp-debug") !== "0";
+    return localStorage.getItem("ryos:debug:cp-autoheight") === "1";
+  } catch {
+    return false;
+  }
+}
+
+type CpAutoHeightDiag = Record<string, number | string | boolean | null>;
 
 export type ControlPanelsMacAnimatedBodyProps = {
   instanceId?: string;
@@ -39,6 +58,11 @@ export function ControlPanelsMacAnimatedBody({
   const [naturalHeight, setNaturalHeight] = useState<number | null>(null);
   const [isMeasuring, setIsMeasuring] = useState(true);
   const lastWindowHeightRef = useRef<number | null>(null);
+
+  // TEMP DEBUG
+  const debugEnabled = useRef(readCpAutoHeightDebug()).current;
+  const [diag, setDiag] = useState<CpAutoHeightDiag | null>(null);
+  const diagKeyRef = useRef("");
 
   const maxBodyHeight = Math.max(
     0,
@@ -68,26 +92,34 @@ export function ControlPanelsMacAnimatedBody({
     // padding on every engine; scrollHeight of the flex pane still wins in the
     // height-capped/scrollable state where `root` is itself flex-constrained. On
     // Chrome these are all equal, so this is a no-op there.
-    let measured = Math.max(
-      content.scrollHeight,
-      content.getBoundingClientRect().height,
-      root.scrollHeight,
-      root.getBoundingClientRect().height
-    );
+    const contentSH = content.scrollHeight;
+    const contentRH = content.getBoundingClientRect().height;
+    const rootSH = root.scrollHeight;
+    const rootRH = root.getBoundingClientRect().height;
+    let measured = Math.max(contentSH, contentRH, rootSH, rootRH);
 
     // Only in auto-height mode (below the cap): add back any content a collapsed
     // inner scroller is hiding. In the capped/scrollable state scrollHeight already
     // reports the full natural height, so skipping avoids double-counting.
+    let collapsedOverflow = 0;
+    let panelSH = 0;
+    let panelCH = 0;
+    const panel = content.querySelector<HTMLElement>(
+      ".control-panels-pref-tab-panel:not([hidden])"
+    );
+    if (panel) {
+      panelSH = panel.scrollHeight;
+      panelCH = panel.clientHeight;
+    }
     if (measured < maxBodyHeight) {
-      let collapsedOverflow = 0;
       content
         .querySelectorAll<HTMLElement>(
           ".control-panels-pref-tab-panel:not([hidden])"
         )
-        .forEach((panel) => {
+        .forEach((p) => {
           collapsedOverflow = Math.max(
             collapsedOverflow,
-            panel.scrollHeight - panel.clientHeight
+            p.scrollHeight - p.clientHeight
           );
         });
       measured += collapsedOverflow;
@@ -95,6 +127,32 @@ export function ControlPanelsMacAnimatedBody({
 
     const next = Math.ceil(measured);
     if (next <= 0) return;
+
+    // TEMP DEBUG: capture every height signal so the on-screen overlay can show
+    // exactly which one is short on real iOS Safari.
+    if (debugEnabled) {
+      const bodyEl = root.parentElement as HTMLElement | null;
+      const snapshot: CpAutoHeightDiag = {
+        ua: typeof navigator !== "undefined" ? navigator.userAgent : "",
+        navKey,
+        toolbarH: toolbarHeight,
+        maxBodyH: maxBodyHeight,
+        contentSH,
+        contentRH: Math.round(contentRH),
+        rootSH,
+        rootRH: Math.round(rootRH),
+        tabPanel: panel ? `${panelSH}/${panelCH}` : "—",
+        collapsedOverflow,
+        measuredNext: next,
+        bodyRectH: bodyEl ? Math.round(bodyEl.getBoundingClientRect().height) : null,
+        dpr: typeof window !== "undefined" ? window.devicePixelRatio : null,
+      };
+      const key = JSON.stringify(snapshot);
+      if (key !== diagKeyRef.current) {
+        diagKeyRef.current = key;
+        setDiag(snapshot);
+      }
+    }
 
     const prev = naturalHeightRef.current;
     if (prev !== null && next < prev - 1 && next <= maxBodyHeight) {
@@ -104,7 +162,7 @@ export function ControlPanelsMacAnimatedBody({
     if (prev === next) return;
     naturalHeightRef.current = next;
     setNaturalHeight(next);
-  }, [maxBodyHeight]);
+  }, [maxBodyHeight, debugEnabled, navKey, toolbarHeight]);
 
   const updateHeight = useCallback(
     (_entry: ResizeObserverEntry) => {
@@ -134,6 +192,41 @@ export function ControlPanelsMacAnimatedBody({
     !isMeasuring &&
     naturalHeight !== null &&
     naturalHeight > maxBodyHeight;
+
+  // TEMP DEBUG: poll the post-layout/animated state — bodyRectH is the final
+  // clipped height; clippedPad > 0 means the pane bottom padding is being cut.
+  const [live, setLive] = useState<CpAutoHeightDiag | null>(null);
+  useEffect(() => {
+    if (!debugEnabled) return;
+    const id = window.setInterval(() => {
+      const root = measureRef.current;
+      const bodyEl = root?.parentElement as HTMLElement | null;
+      const inner = root?.querySelector<HTMLElement>(
+        ".control-panels-mac-pane-inner"
+      );
+      const winSize = instanceId
+        ? useAppStore.getState().instances[instanceId]?.size
+        : undefined;
+      const bodyBottom = bodyEl
+        ? bodyEl.getBoundingClientRect().bottom
+        : null;
+      const innerBottom = inner ? inner.getBoundingClientRect().bottom : null;
+      setLive({
+        bodyRectH: bodyEl
+          ? Math.round(bodyEl.getBoundingClientRect().height)
+          : null,
+        clippedPad:
+          innerBottom != null && bodyBottom != null
+            ? Math.max(0, Math.round(innerBottom - bodyBottom))
+            : null,
+        winH: winSize?.height ?? null,
+        naturalH: naturalHeightRef.current,
+        animatedH: animatedHeight ?? null,
+        scroll: needsScroll,
+      });
+    }, 400);
+    return () => window.clearInterval(id);
+  }, [debugEnabled, instanceId, animatedHeight, needsScroll]);
 
   useLayoutEffect(() => {
     if (!instanceId || animatedHeight === undefined) return;
@@ -173,6 +266,58 @@ export function ControlPanelsMacAnimatedBody({
       <div ref={measureRef} className="control-panels-mac-body-measure">
         <div className="control-panels-mac-body-layout">{children}</div>
       </div>
+      {debugEnabled ? (
+        <CpAutoHeightDebugOverlay diag={diag} live={live} />
+      ) : null}
     </motion.div>
+  );
+}
+
+// TEMP DEBUG: portal overlay rendered to <body> so overflow:hidden ancestors
+// cannot clip it. Shows the raw measurement signals + the post-layout state.
+function CpAutoHeightDebugOverlay({
+  diag,
+  live,
+}: {
+  diag: CpAutoHeightDiag | null;
+  live: CpAutoHeightDiag | null;
+}) {
+  if (typeof document === "undefined") return null;
+  const rows: Array<[string, CpAutoHeightDiag | null]> = [
+    ["measure", diag],
+    ["live", live],
+  ];
+  return createPortal(
+    <div
+      style={{
+        position: "fixed",
+        left: 6,
+        bottom: 6,
+        zIndex: 2147483647,
+        maxWidth: "min(92vw, 360px)",
+        padding: "6px 8px",
+        background: "rgba(0,0,0,0.82)",
+        color: "#0f0",
+        font: "10px/1.35 ui-monospace, Menlo, monospace",
+        borderRadius: 6,
+        pointerEvents: "none",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-all",
+      }}
+    >
+      <div style={{ color: "#ff0", fontWeight: 700 }}>CP auto-height debug</div>
+      {rows.map(([label, data]) => (
+        <div key={label} style={{ marginTop: 3 }}>
+          <span style={{ color: "#0ff" }}>{label}:</span>{" "}
+          {data
+            ? Object.entries(data)
+                .filter(([k]) => k !== "ua")
+                .map(([k, v]) => `${k}=${v}`)
+                .join("  ")
+            : "—"}
+        </div>
+      ))}
+    </div>,
+    document.body
   );
 }

--- a/src/apps/control-panels/components/control-panels-app/SystemTabContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/SystemTabContent.tsx
@@ -171,6 +171,8 @@ export function SystemTabContent({
                         name={ACCOUNT_PROFILE_AVATAR_ICON}
                         alt={accountAvatarLabel}
                         className="size-full object-contain"
+                        // Nudge the silhouette down so it sits lower in the circle.
+                        style={{ transform: "translateY(8%)" }}
                       />
                     )}
                   </div>

--- a/src/apps/control-panels/components/control-panels-app/controlPanelsMacMotion.ts
+++ b/src/apps/control-panels/components/control-panels-app/controlPanelsMacMotion.ts
@@ -14,3 +14,6 @@ export const CONTROL_PANELS_MACOSX_TITLEBAR_HEIGHT = 24;
 
 /** control-panels appRegistry windowConfig.maxSize.height */
 export const CONTROL_PANELS_MAC_MAX_WINDOW_HEIGHT = 600;
+
+/** Minimum macosx window height — keep in sync with windowConstraints.minHeight. */
+export const CONTROL_PANELS_MAC_MIN_WINDOW_HEIGHT = 200;

--- a/src/styles/themes/control-panels-mac.css
+++ b/src/styles/themes/control-panels-mac.css
@@ -294,9 +294,11 @@
 }
 
 :root[data-os-theme="macosx"] .control-panels-mac-pane-inner {
-  /* Simple form panes (Appearance, International, etc.): more air below toolbar. */
+  /* Simple form panes (Appearance, International, etc.): more air below toolbar.
+     Auto-height panes size the window to scrollHeight, so the extra bottom
+     padding here becomes the breathing room beneath the last row. */
   --control-panels-pref-content-inset-x: 16px;
-  padding: 18px 18px 18px;
+  padding: 18px 18px 28px;
 }
 
 /* Simple panes: grow with content, scroll on pane-scroll (not nested in pref-form). */

--- a/src/styles/themes/control-panels-mac.css
+++ b/src/styles/themes/control-panels-mac.css
@@ -294,9 +294,11 @@
 }
 
 :root[data-os-theme="macosx"] .control-panels-mac-pane-inner {
-  /* Simple form panes (Appearance, International, etc.): more air below toolbar. */
+  /* Simple form panes (Appearance, International, etc.): more air below toolbar.
+     The larger bottom value is the auto-height window's breathing room beneath the
+     card; it now renders on Safari too (tabbed flex caps are gated to scrollable). */
   --control-panels-pref-content-inset-x: 16px;
-  padding: 18px 18px 18px;
+  padding: 18px 18px 28px;
 }
 
 /* Simple panes: grow with content, scroll on pane-scroll (not nested in pref-form). */

--- a/src/styles/themes/control-panels-mac.css
+++ b/src/styles/themes/control-panels-mac.css
@@ -24,55 +24,16 @@
   width: 100%;
 }
 
-/* Height-capped body: scroll inside preference panes (not the whole window). */
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]:has(.control-panels-mac-pane) {
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]:not(:has(.control-panels-mac-pane)) {
-  overflow-y: auto;
-}
-
-/* Scroll constraints live on the layout shell — keep the measure root from
-   height: 100% so scrollHeight stays stable and data-scrollable does not oscillate. */
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]:has(.control-panels-mac-pane)
-  .control-panels-mac-body-measure {
-  flex: 1 1 0;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]:has(.control-panels-mac-pane)
-  .control-panels-mac-body-layout {
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]
-  .control-panels-mac-pane {
-  flex: 1;
-  min-height: 0;
-}
-
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]
-  .control-panels-mac-pane-scroll:not(:has(.control-panels-pref-form-tabbed)):not(
-    :has(.control-panels-pref-theme-preview)
-  ) {
-  flex: 1;
-  min-height: 0;
+/* Auto-height body (single source of truth for scrolling):
+   The measure subtree (.control-panels-mac-body-measure → -layout → pane) always
+   lays out at its natural height — it is never flex/height-constrained. When that
+   natural height exceeds the window cap, the body element itself becomes the one
+   and only scroll container. Because the cap + overflow live on the *parent* of
+   the measured node, toggling data-scrollable can never change the measured
+   height: measurement is stable across the cap boundary, so there is no
+   measure↔layout feedback loop and none of the WebKit/Safari nested-flex
+   scrollHeight jank (which was worst for panes with an inner scroller). */
+:root[data-os-theme="macosx"] .control-panels-mac-body[data-scrollable] {
   overflow-y: auto;
 }
 
@@ -449,48 +410,12 @@
   color: #111;
 }
 
-/* Appearance pane: flex fill — preview well grows/shrinks like tab panel content */
-:root[data-os-theme="macosx"]
-  .control-panels-mac-pane-scroll:has(.control-panels-pref-theme-preview) {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
-}
-
-:root[data-os-theme="macosx"]
-  .control-panels-mac-pane-inner:has(.control-panels-pref-theme-preview) {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-}
-
-:root[data-os-theme="macosx"]
-  .control-panels-pref-form:has(.control-panels-pref-theme-preview) {
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
-}
-
-:root[data-os-theme="macosx"]
-  .control-panels-pref-form-section:has(.control-panels-pref-theme-preview) {
-  flex: 1;
-  min-height: 0;
-}
-
-:root[data-os-theme="macosx"]
-  .control-panels-pref-form-section:has(.control-panels-pref-theme-preview)
-  > .control-panels-pref-form-row {
-  flex-shrink: 0;
-}
-
-/* Appearance pane: recessed live theme preview well */
+/* Appearance pane: recessed live theme preview well.
+   Fixed natural height (min-height) — the window auto-sizes to content, so the
+   preview no longer needs flex-fill to absorb leftover space. */
 :root[data-os-theme="macosx"] .control-panels-pref-theme-preview {
   display: flex;
   flex-direction: column;
-  flex: 1;
   min-height: 180px;
   margin-top: 2px;
   padding: 10px 12px;
@@ -1041,10 +966,10 @@
 }
 
 /* Tabbed preference pane (Desktop | Screen Saver) — tabs on pinstripe, well below.
-   Structure (display/stacking) applies in both modes; the flex-fill + overflow
-   caps that make the tab panel scroll are gated to [data-scrollable] (see below).
-   In auto-height mode the chain flows naturally so the pane-inner's bottom padding
-   renders instead of being overlaid by an over-tall flex child (Safari clip). */
+   Always flows at natural height; the body scrolls if the pane exceeds the cap.
+   No inner scroller, so measurement stays reliable and the pane-inner's bottom
+   padding always renders (the old [data-scrollable] flex/overflow caps that broke
+   Safari measurement have been removed). */
 :root[data-os-theme="macosx"] .control-panels-mac-pane-scroll:has(.control-panels-pref-form-tabbed) {
   display: flex;
   flex-direction: column;
@@ -1119,52 +1044,6 @@
 
 :root[data-os-theme="macosx"] .control-panels-pref-form-tabbed .control-panels-pref-tab-panel {
   grid-area: 1 / 1;
-}
-
-/* Scrollable (height-capped) tabbed panes only: fill the capped body and scroll
-   inside the tab panel. In auto-height mode these are off, so the content flows
-   naturally and the pane-inner bottom padding is preserved (Safari fix). */
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]
-  .control-panels-mac-pane-scroll:has(.control-panels-pref-form-tabbed),
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]
-  .control-panels-mac-pane-inner:has(.control-panels-pref-form-tabbed),
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]
-  .control-panels-pref-form-tabbed,
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]
-  .control-panels-pref-tabbed {
-  flex: 1;
-  min-height: 0;
-}
-
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]
-  .control-panels-mac-pane-scroll:has(.control-panels-pref-form-tabbed),
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]
-  .control-panels-pref-form-tabbed {
-  overflow: hidden;
-}
-
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]
-  .control-panels-pref-tabbed
-  > .control-panels-pref-well {
-  grid-template-rows: minmax(0, 1fr);
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
-}
-
-:root[data-os-theme="macosx"]
-  .control-panels-mac-body[data-scrollable]
-  .control-panels-pref-form-tabbed
-  .control-panels-pref-tab-panel {
-  min-height: 0;
-  overflow-y: auto;
 }
 
 /* Stack both panels in one grid cell; keep mounted content without collapsing the well */

--- a/src/styles/themes/control-panels-mac.css
+++ b/src/styles/themes/control-panels-mac.css
@@ -294,11 +294,9 @@
 }
 
 :root[data-os-theme="macosx"] .control-panels-mac-pane-inner {
-  /* Simple form panes (Appearance, International, etc.): more air below toolbar.
-     Auto-height panes size the window to scrollHeight, so the extra bottom
-     padding here becomes the breathing room beneath the last row. */
+  /* Simple form panes (Appearance, International, etc.): more air below toolbar. */
   --control-panels-pref-content-inset-x: 16px;
-  padding: 18px 18px 28px;
+  padding: 18px 18px 18px;
 }
 
 /* Simple panes: grow with content, scroll on pane-scroll (not nested in pref-form). */

--- a/src/styles/themes/control-panels-mac.css
+++ b/src/styles/themes/control-panels-mac.css
@@ -1038,35 +1038,26 @@
   pointer-events: none;
 }
 
-/* Tabbed preference pane (Desktop | Screen Saver) — tabs on pinstripe, well below */
+/* Tabbed preference pane (Desktop | Screen Saver) — tabs on pinstripe, well below.
+   Structure (display/stacking) applies in both modes; the flex-fill + overflow
+   caps that make the tab panel scroll are gated to [data-scrollable] (see below).
+   In auto-height mode the chain flows naturally so the pane-inner's bottom padding
+   renders instead of being overlaid by an over-tall flex child (Safari clip). */
 :root[data-os-theme="macosx"] .control-panels-mac-pane-scroll:has(.control-panels-pref-form-tabbed) {
   display: flex;
   flex-direction: column;
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
 }
 
 :root[data-os-theme="macosx"] .control-panels-mac-pane-inner:has(.control-panels-pref-form-tabbed) {
   display: flex;
   flex-direction: column;
-  flex: 1;
-  min-height: 0;
   /* Tabbed panes: tabs sit on pinstripe — less air above tab bar than simple wells. */
   padding-top: 4px;
-}
-
-:root[data-os-theme="macosx"] .control-panels-pref-form-tabbed {
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
 }
 
 :root[data-os-theme="macosx"] .control-panels-pref-tabbed {
   display: flex;
   flex-direction: column;
-  flex: 1;
-  min-height: 0;
   gap: 0;
 }
 
@@ -1113,12 +1104,11 @@
 }
 
 :root[data-os-theme="macosx"] .control-panels-pref-tabbed > .control-panels-pref-well {
+  /* Single-cell grid stacks both tab panels (one hidden) so the well sizes to the
+     tallest and tab swaps don't shift layout. Auto rows in auto-height mode. */
   display: grid;
-  grid-template: minmax(0, 1fr) / minmax(0, 1fr);
-  flex: 1;
-  min-height: 0;
+  grid-template-columns: minmax(0, 1fr);
   padding: 0;
-  overflow: hidden;
 }
 
 :root[data-os-theme="macosx"] .control-panels-pref-tab-panel {
@@ -1127,6 +1117,50 @@
 
 :root[data-os-theme="macosx"] .control-panels-pref-form-tabbed .control-panels-pref-tab-panel {
   grid-area: 1 / 1;
+}
+
+/* Scrollable (height-capped) tabbed panes only: fill the capped body and scroll
+   inside the tab panel. In auto-height mode these are off, so the content flows
+   naturally and the pane-inner bottom padding is preserved (Safari fix). */
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-mac-pane-scroll:has(.control-panels-pref-form-tabbed),
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-mac-pane-inner:has(.control-panels-pref-form-tabbed),
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-form-tabbed,
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-tabbed {
+  flex: 1;
+  min-height: 0;
+}
+
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-mac-pane-scroll:has(.control-panels-pref-form-tabbed),
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-form-tabbed {
+  overflow: hidden;
+}
+
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-tabbed
+  > .control-panels-pref-well {
+  grid-template-rows: minmax(0, 1fr);
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-form-tabbed
+  .control-panels-pref-tab-panel {
   min-height: 0;
   overflow-y: auto;
 }

--- a/src/styles/themes/control-panels-mac.css
+++ b/src/styles/themes/control-panels-mac.css
@@ -144,7 +144,8 @@
 /* Home grid — one continuous pinstripe on the scroll area; zebra tint on even sections only */
 :root[data-os-theme="macosx"] .control-panels-category-grid {
   --control-panels-section-inset-x: 16px;
-  padding: 0 var(--control-panels-section-inset-x);
+  /* Breathing room after the last section row on the Show All screen. */
+  padding: 0 var(--control-panels-section-inset-x) 16px;
   background-image: var(--os-pinstripe-window);
 }
 

--- a/src/styles/themes/control-panels-mac.css
+++ b/src/styles/themes/control-panels-mac.css
@@ -1047,6 +1047,79 @@
   grid-area: 1 / 1;
 }
 
+/* Tabbed panes at the cap: keep the tab bar pinned and scroll INSIDE the active
+   tab panel rather than scrolling the whole body. Safe with the decoupled
+   measurement: the body only gains data-scrollable AFTER the first (unconstrained)
+   measure captures the natural height, and the JS high-water mark freezes it — so
+   constraining this chain can't reopen the measure↔layout feedback loop, and
+   there is no collapsed-scroller recovery math to bounce on Safari. Gated to
+   tabbed panes; simple panes still scroll the body. */
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]:has(.control-panels-pref-form-tabbed) {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]:has(.control-panels-pref-form-tabbed)
+  .control-panels-mac-body-measure,
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]:has(.control-panels-pref-form-tabbed)
+  .control-panels-mac-body-layout {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-mac-pane:has(.control-panels-pref-form-tabbed),
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-mac-pane-scroll:has(.control-panels-pref-form-tabbed),
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-mac-pane-inner:has(.control-panels-pref-form-tabbed),
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-form-tabbed,
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-tabbed {
+  flex: 1;
+  min-height: 0;
+}
+
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-mac-pane-scroll:has(.control-panels-pref-form-tabbed),
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-form-tabbed {
+  overflow: hidden;
+}
+
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-tabbed
+  > .control-panels-pref-well {
+  grid-template-rows: minmax(0, 1fr);
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+:root[data-os-theme="macosx"]
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-form-tabbed
+  .control-panels-pref-tab-panel {
+  min-height: 0;
+  overflow-y: auto;
+}
+
 /* Stack both panels in one grid cell; keep mounted content without collapsing the well */
 :root[data-os-theme="macosx"] .control-panels-pref-form-tabbed .control-panels-pref-tab-panel[hidden] {
   display: block !important;

--- a/tests/test-control-panels-mac-layout.test.ts
+++ b/tests/test-control-panels-mac-layout.test.ts
@@ -119,9 +119,11 @@ describe("Control Panels macOS 10.3 layout", () => {
     );
     // Measurement is decoupled from display: the measure subtree is never
     // height-constrained (the body itself scrolls past the cap), so the natural
-    // height is read straight off the measure node's border box — no scrollHeight
-    // / flex / collapsed-inner-scroller hacks that broke Safari auto-sizing.
-    expect(animatedBodySource.includes("getBoundingClientRect")).toBe(true);
+    // height is read off the measure node's layout box via offsetHeight — which
+    // ignores ancestor transforms (open animation), unlike getBoundingClientRect,
+    // and needs no scrollHeight / flex / collapsed-inner-scroller hacks.
+    expect(animatedBodySource.includes("offsetHeight")).toBe(true);
+    expect(animatedBodySource.includes("getBoundingClientRect")).toBe(false);
     expect(animatedBodySource.includes("scrollHeight")).toBe(false);
     expect(animatedBodySource.includes("collapsedOverflow")).toBe(false);
     expect(animatedBodySource.includes("data-scrollable")).toBe(true);

--- a/tests/test-control-panels-mac-layout.test.ts
+++ b/tests/test-control-panels-mac-layout.test.ts
@@ -117,12 +117,17 @@ describe("Control Panels macOS 10.3 layout", () => {
     expect(animatedBodySource.includes("CONTROL_PANELS_MAC_SIZE_TRANSITION")).toBe(
       true
     );
-    expect(animatedBodySource.includes("scrollHeight")).toBe(true);
+    // Measurement is decoupled from display: the measure subtree is never
+    // height-constrained (the body itself scrolls past the cap), so the natural
+    // height is read straight off the measure node's border box — no scrollHeight
+    // / flex / collapsed-inner-scroller hacks that broke Safari auto-sizing.
+    expect(animatedBodySource.includes("getBoundingClientRect")).toBe(true);
+    expect(animatedBodySource.includes("scrollHeight")).toBe(false);
+    expect(animatedBodySource.includes("collapsedOverflow")).toBe(false);
     expect(animatedBodySource.includes("data-scrollable")).toBe(true);
     expect(animatedBodySource.includes("control-panels-mac-body-layout")).toBe(
       true
     );
-    expect(animatedBodySource.includes("CONTENT_MEASURE_SELECTOR")).toBe(true);
     expect(animatedBodySource.includes("naturalHeightRef")).toBe(true);
     expect(animatedBodySource.includes("isMeasuring")).toBe(true);
     expect(animatedBodySource.includes("overflow-y-auto")).toBe(false);
@@ -130,21 +135,17 @@ describe("Control Panels macOS 10.3 layout", () => {
     expect(motionSource.includes("0.25, 0.1, 0.25, 1")).toBe(true);
     expect(appSource.includes("minHeight: 200")).toBe(true);
     expect(appSource.includes("maxHeight: 600")).toBe(true);
+    // Single scroll container: cap + overflow live on the body (parent of the
+    // measured node), and there is no inner tab-panel scroller anymore.
     expect(cssSource.includes(".control-panels-mac-body[data-scrollable]")).toBe(
       true
     );
-    expect(cssSource.includes(".control-panels-mac-body-layout")).toBe(true);
-    expect(
-      cssSource.includes(
-        ".control-panels-mac-pane-scroll:not(:has(.control-panels-pref-form-tabbed))"
-      )
-    ).toBe(true);
     expect(cssSource.includes("overflow-y: auto")).toBe(true);
     expect(
       cssSource.match(
         /\.control-panels-pref-form-tabbed \.control-panels-pref-tab-panel[\s\S]*?overflow-y:\s*auto/
       )
-    ).not.toBeNull();
+    ).toBeNull();
   });
 
   test("macosx layout starts on Show All unless deep-linked", () => {

--- a/tests/test-control-panels-mac-layout.test.ts
+++ b/tests/test-control-panels-mac-layout.test.ts
@@ -117,11 +117,13 @@ describe("Control Panels macOS 10.3 layout", () => {
     expect(animatedBodySource.includes("CONTROL_PANELS_MAC_SIZE_TRANSITION")).toBe(
       true
     );
-    // Measurement is decoupled from display: the measure subtree is never
-    // height-constrained (the body itself scrolls past the cap), so the natural
-    // height is read off the measure node's layout box via offsetHeight — which
-    // ignores ancestor transforms (open animation), unlike getBoundingClientRect,
-    // and needs no scrollHeight / flex / collapsed-inner-scroller hacks.
+    // Measurement is decoupled from display: the first/per-pane measure runs
+    // unconstrained (data-scrollable is only set once natural height is known),
+    // so the natural height is read off the measure node's layout box via
+    // offsetHeight — which ignores ancestor transforms (open animation), unlike
+    // getBoundingClientRect, and needs no scrollHeight / collapsed-inner-scroller
+    // recovery hacks. The high-water guard then freezes it when tabbed panes
+    // constrain the subtree to scroll the inner tab panel.
     expect(animatedBodySource.includes("offsetHeight")).toBe(true);
     expect(animatedBodySource.includes("getBoundingClientRect")).toBe(false);
     expect(animatedBodySource.includes("scrollHeight")).toBe(false);
@@ -137,17 +139,20 @@ describe("Control Panels macOS 10.3 layout", () => {
     expect(motionSource.includes("0.25, 0.1, 0.25, 1")).toBe(true);
     expect(appSource.includes("minHeight: 200")).toBe(true);
     expect(appSource.includes("maxHeight: 600")).toBe(true);
-    // Single scroll container: cap + overflow live on the body (parent of the
-    // measured node), and there is no inner tab-panel scroller anymore.
+    // Cap lives on the body (parent of the measured node). Simple panes scroll
+    // the body; tabbed panes pin the tab bar and scroll INSIDE the active tab
+    // panel once capped.
     expect(cssSource.includes(".control-panels-mac-body[data-scrollable]")).toBe(
       true
     );
     expect(cssSource.includes("overflow-y: auto")).toBe(true);
+    // Tabbed panes re-introduce the inner tab-panel scroller, gated to the
+    // scrollable (capped) state so it never constrains the first measure.
     expect(
       cssSource.match(
-        /\.control-panels-pref-form-tabbed \.control-panels-pref-tab-panel[\s\S]*?overflow-y:\s*auto/
+        /\.control-panels-mac-body\[data-scrollable\][\s\S]*?\.control-panels-pref-form-tabbed[\s\S]*?\.control-panels-pref-tab-panel[\s\S]*?overflow-y:\s*auto/
       )
-    ).toBeNull();
+    ).not.toBeNull();
   });
 
   test("macosx layout starts on Show All unless deep-linked", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A series of fixes to the macOS (Aqua) Control Panels, which auto-size their window to fit content via `ControlPanelsMacAnimatedBody`.

### 1. Reliable auto-height (the main fix)
The previous approach measured the **same subtree** it height-constrained: when content exceeded the cap, `data-scrollable` applied `flex:1; min-height:0; overflow-y:auto` down the chain, collapsing the inner tab-panel scroller. `scrollHeight` then underreported, so the code bolted on `Math.max(...)` + `collapsedOverflow = scrollHeight - clientHeight`. On WebKit, nested-flex `scrollHeight` is unreliable and toggling `data-scrollable` changed the measured node's size → a **measure↔layout feedback loop** (jank, worst for inner-scroller panes like Accounts/Cloud Sync).

**Fix — decouple measurement from display:**
- The **first/per-pane measure always runs unconstrained**: `data-scrollable` is only set once the natural height is known, so the measure node's layout box is the true natural height on every engine.
- A per-pane high-water mark keeps tab swaps from resizing the window (the inactive tab panel is `display:none`, so the stacked well only reports the active tab); it re-baselines on pane navigation. Because the natural height is captured *before* any constraint applies and then frozen — with no `scrollHeight`/`collapsedOverflow` recovery math — the feedback loop can't reopen.

### 2. Initial Show All too short (open-animation fix)
Measuring with `getBoundingClientRect().height` is **transform-sensitive**. The first measurement runs at mount *during the window's open/scale animation*, so it read a scaled-down height and locked it in — and a transform end fires no `ResizeObserver`, so it never grew (initial Show All ~396px vs the correct ~411px; a pane nav re-measured correctly). Switched to `offsetHeight` (layout box, transform-independent), which the always-natural measure node makes exact.

### 3. Respect min height on shrink
Clamp the programmatic auto-height to `CONTROL_PANELS_MAC_MIN_WINDOW_HEIGHT` (200, in sync with `windowConstraints.minHeight`) so short panes don't shrink the window below its minimum.

### 4. Safari bottom padding (earlier in this branch)
Tabbed panes lost their bottom padding on iPhone Safari; the pane-inner padding now always renders. Padding bumped to `28px`.

### 5. Account avatar nudge
Shift the unfilled fallback account-avatar silhouette down `8%` so it sits lower in the circle.

### 6. Scroll inside the tab panel when capped
Tabbed panes keep the **tab bar pinned** and scroll **inside the active tab panel** (not the whole body) once the pane exceeds the window cap. The inner-scroll chain is gated to the scrollable (capped) state, so it only constrains the subtree *after* the natural height has been captured and frozen — preserving the stable measurement above. Simple (non-tabbed) panes still scroll the body.

### 7. Show All bottom padding
Add bottom padding after the last section row on the macOS Show All screen so the final row isn't flush against the window bottom.

## Changes
- `ControlPanelsMacAnimatedBody.tsx`: measure always-natural subtree via `offsetHeight`; high-water mark; min-height clamp; removed `scrollHeight`/`collapsedOverflow`/`CONTENT_MEASURE_SELECTOR` and the temporary diagnostics.
- `control-panels-mac.css`: simple panes scroll the body (`[data-scrollable] { overflow-y:auto }`); tabbed panes pin the tab bar and scroll inside the tab panel when capped; Show All grid bottom padding; pane-inner padding `28px`.
- `controlPanelsMacMotion.ts`: add `CONTROL_PANELS_MAC_MIN_WINDOW_HEIGHT`.
- `AccountProfileHeader.tsx` / `SystemTabContent.tsx`: nudge fallback avatar down.
- `tests/test-control-panels-mac-layout.test.ts`: assert the decoupled `offsetHeight` approach and the gated inner tab-panel scroller.

## Testing
- `bun test tests/test-control-panels-mac-layout.test.ts` — 23 pass.
- `bun run test:unit`.
- WebKit (Playwright, iPhone):
  - Initial Show All now opens at **411px**, matching re-nav, across 4 fresh loads (was 396px).
  - All panes auto-size STABLE with no oscillation; Accounts tab swaps hold the window steady.
  - Avatar nudge is code-verified only — the logged-in fallback avatar can't be exercised in the sandbox (no persistent auth session).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ee572-f2ec-7d52-a7a7-96f62f433318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ee572-f2ec-7d52-a7a7-96f62f433318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

