### PR TITLE
Codebase audit roadmap + "do first" API hardening

### DIFF
--- a/api/_utils/auth/_tokens.ts
+++ b/api/_utils/auth/_tokens.ts
@@ -69,16 +69,33 @@ export async function storeToken(
 }
 
 /**
- * Delete a single token
+ * Delete a single token.
+ *
+ * When the owning `username` is known (the common case — logout, refresh,
+ * login rotation), the token hash is removed from that user's session set
+ * directly. Without it, we fall back to a full keyspace SCAN of
+ * `auth:user:*:sessions`, which is O(all users) and should be avoided.
  */
 export async function deleteToken(
   redis: Redis,
-  token: string
+  token: string,
+  username?: string
 ): Promise<void> {
   if (!token) return;
   const tokenHash = await sha256RedisIdentifier(token);
   await redis.del(redisKeys.auth.session(tokenHash));
 
+  const normalizedUsername = username?.toLowerCase();
+  if (normalizedUsername) {
+    await redis.srem(
+      redisKeys.auth.userSessions(normalizedUsername),
+      tokenHash
+    );
+    return;
+  }
+
+  // Fallback: owner unknown — scan all user session sets. Kept for safety,
+  // but callers should pass `username` to avoid the full keyspace scan.
   let canonicalCursor = 0;
   do {
     const [newCursor, foundKeys] = await redis.scan(canonicalCursor, {

--- a/api/auth/login.ts
+++ b/api/auth/login.ts
@@ -133,7 +133,7 @@ export default apiHandler(
         Date.now(),
         TOKEN_GRACE_PERIOD
       );
-      await deleteToken(redis, oldToken);
+      await deleteToken(redis, oldToken, username);
     }
 
     // Generate new token

--- a/api/auth/logout.ts
+++ b/api/auth/logout.ts
@@ -22,7 +22,7 @@ export default apiHandler(
     const username = user?.username || "";
     const token = user?.token || "";
 
-    await deleteToken(redis, token);
+    await deleteToken(redis, token, username);
 
     res.setHeader("Set-Cookie", buildClearAuthCookie());
     logger.info("User logged out", { username });

--- a/api/auth/token/refresh.ts
+++ b/api/auth/token/refresh.ts
@@ -110,7 +110,7 @@ export default apiHandler<RefreshRequest>(
     await storeLastValidToken(redis, username, oldToken, Date.now(), TOKEN_GRACE_PERIOD);
 
     // Delete old token
-    await deleteToken(redis, oldToken);
+    await deleteToken(redis, oldToken, username);
 
     // Generate new token
     const newToken = generateAuthToken();

--- a/api/currency-rate.ts
+++ b/api/currency-rate.ts
@@ -1,8 +1,13 @@
 import { apiHandler } from "./_utils/api-handler.js";
+import * as RateLimit from "./_utils/_rate-limit.js";
+import { getClientIp } from "./_utils/_rate-limit.js";
 import { crossRateFromUsdRates } from "./_utils/currency-cross-rate.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 10;
+
+const RL_BURST_WINDOW = 60;
+const RL_DAILY_WINDOW = 60 * 60 * 24;
 
 const FRANKFURTER_V2 = "https://api.frankfurter.dev/v2";
 
@@ -78,6 +83,28 @@ async function fetchOpenErApiPair(
 export default apiHandler(
   { methods: ["GET"] },
   async ({ req, res, logger, startTime }) => {
+    // Rate limit this external proxy per IP: burst 30/min + daily 2000.
+    try {
+      const ip = getClientIp(req);
+      const rl = await RateLimit.checkBurstAndDailyLimits({
+        namespace: "currency-rate",
+        identifierParts: ["ip", ip],
+        burst: { windowSeconds: RL_BURST_WINDOW, limit: 30 },
+        daily: { windowSeconds: RL_DAILY_WINDOW, limit: 2000 },
+      });
+      if (!rl.ok) {
+        const fallbackWindow =
+          rl.scope === "burst" ? RL_BURST_WINDOW : RL_DAILY_WINDOW;
+        logger.warn(`Rate limit exceeded (${rl.scope})`, { ip });
+        logger.response(429, Date.now() - startTime);
+        res.setHeader("Retry-After", String(rl.result?.resetSeconds ?? fallbackWindow));
+        res.status(429).json({ error: "rate_limit_exceeded", scope: rl.scope });
+        return;
+      }
+    } catch (e) {
+      logger.error("Rate limit check failed", e);
+    }
+
     const from = normalizeCurrency(req.query.from);
     const to = normalizeCurrency(req.query.to);
 

--- a/api/rooms/index.ts
+++ b/api/rooms/index.ts
@@ -6,6 +6,8 @@
  */
 
 import { apiHandler } from "../_utils/api-handler.js";
+import * as RateLimit from "../_utils/_rate-limit.js";
+import { getClientIp } from "../_utils/_rate-limit.js";
 import { isProfaneUsername } from "../_utils/_validation.js";
 import { getRoomsWithCountsFast } from "./_helpers/_presence.js";
 import { generateId, getCurrentTimestamp, setRoom, registerRoom } from "./_helpers/_redis.js";
@@ -31,6 +33,26 @@ export default apiHandler(
 
     // GET - List rooms
     if (method === "GET") {
+      // Loose rate limit (the chat UI polls this): burst 60/min + daily 5000.
+      try {
+        const identifier = user?.username || getClientIp(req);
+        const rl = await RateLimit.checkBurstAndDailyLimits({
+          namespace: "rooms-list",
+          identifierParts: [user ? "user" : "ip", identifier],
+          burst: { windowSeconds: 60, limit: 60 },
+          daily: { windowSeconds: 60 * 60 * 24, limit: 5000 },
+        });
+        if (!rl.ok) {
+          logger.warn(`Rate limit exceeded (${rl.scope})`, { identifier });
+          logger.response(429, Date.now() - startTime);
+          res.setHeader("Retry-After", String(rl.result?.resetSeconds ?? 60));
+          res.status(429).json({ error: "rate_limit_exceeded", scope: rl.scope });
+          return;
+        }
+      } catch (e) {
+        logger.error("Rate limit check failed", e);
+      }
+
       try {
         const claimedUsername = (req.query.username as string | undefined)?.toLowerCase() || null;
         const allRooms = await getRoomsWithCountsFast();

--- a/api/stocks.ts
+++ b/api/stocks.ts
@@ -1,7 +1,12 @@
 import { apiHandler } from "./_utils/api-handler.js";
+import * as RateLimit from "./_utils/_rate-limit.js";
+import { getClientIp } from "./_utils/_rate-limit.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
+
+const RL_BURST_WINDOW = 60;
+const RL_DAILY_WINDOW = 60 * 60 * 24;
 
 interface StockQuote {
   symbol: string;
@@ -49,6 +54,28 @@ function rangeToDate(range: string): { period1: Date; interval: string } {
 export default apiHandler(
   { methods: ["GET"] },
   async ({ req, res, logger, startTime }) => {
+    // Rate limit this external proxy per IP: burst 30/min + daily 2000.
+    try {
+      const ip = getClientIp(req);
+      const rl = await RateLimit.checkBurstAndDailyLimits({
+        namespace: "stocks",
+        identifierParts: ["ip", ip],
+        burst: { windowSeconds: RL_BURST_WINDOW, limit: 30 },
+        daily: { windowSeconds: RL_DAILY_WINDOW, limit: 2000 },
+      });
+      if (!rl.ok) {
+        const fallbackWindow =
+          rl.scope === "burst" ? RL_BURST_WINDOW : RL_DAILY_WINDOW;
+        logger.warn(`Rate limit exceeded (${rl.scope})`, { ip });
+        logger.response(429, Date.now() - startTime);
+        res.setHeader("Retry-After", String(rl.result?.resetSeconds ?? fallbackWindow));
+        res.status(429).json({ error: "rate_limit_exceeded", scope: rl.scope });
+        return;
+      }
+    } catch (e) {
+      logger.error("Rate limit check failed", e);
+    }
+
     const symbolsParam = req.query.symbols as string | undefined;
     const chartSymbol = req.query.chart as string | undefined;
     const range = (req.query.range as string) || "6mo";

--- a/api/users/index.ts
+++ b/api/users/index.ts
@@ -4,15 +4,53 @@
  */
 
 import { apiHandler } from "../_utils/api-handler.js";
+import * as RateLimit from "../_utils/_rate-limit.js";
+import { getClientIp } from "../_utils/_rate-limit.js";
 import { handleGetUsers } from "../rooms/_helpers/_users.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
 
+const RL_BURST_WINDOW = 60;
+const RL_DAILY_WINDOW = 60 * 60 * 24;
+const MIN_QUERY_LENGTH = 2;
+
 export default apiHandler(
-  { methods: ["GET"] },
-  async ({ req, res, logger, startTime }) => {
-    const searchQuery = (req.query.search as string) || "";
+  { methods: ["GET"], auth: "required" },
+  async ({ req, res, logger, startTime, user }) => {
+    const searchQuery = ((req.query.search as string) || "").trim();
+
+    // Require a minimum query length: prevents enumerating the whole user
+    // base via empty / single-character SCAN-backed searches.
+    if (searchQuery.length < MIN_QUERY_LENGTH) {
+      logger.response(400, Date.now() - startTime);
+      res
+        .status(400)
+        .json({ error: `Search query must be at least ${MIN_QUERY_LENGTH} characters` });
+      return;
+    }
+
+    // Rate limit per authenticated user: burst 20/min + daily 1000.
+    try {
+      const identifier = user?.username || getClientIp(req);
+      const rl = await RateLimit.checkBurstAndDailyLimits({
+        namespace: "users-search",
+        identifierParts: ["user", identifier],
+        burst: { windowSeconds: RL_BURST_WINDOW, limit: 20 },
+        daily: { windowSeconds: RL_DAILY_WINDOW, limit: 1000 },
+      });
+      if (!rl.ok) {
+        const fallbackWindow =
+          rl.scope === "burst" ? RL_BURST_WINDOW : RL_DAILY_WINDOW;
+        logger.warn(`Rate limit exceeded (${rl.scope})`, { user: user?.username });
+        logger.response(429, Date.now() - startTime);
+        res.setHeader("Retry-After", String(rl.result?.resetSeconds ?? fallbackWindow));
+        res.status(429).json({ error: "rate_limit_exceeded", scope: rl.scope });
+        return;
+      }
+    } catch (e) {
+      logger.error("Rate limit check failed", e);
+    }
 
     try {
       const response = await handleGetUsers("users-search", searchQuery);

--- a/docs/proposals/next-improvements.md
+++ b/docs/proposals/next-improvements.md
@@ -1,0 +1,266 @@
+# Next Improvements — Codebase Audit & Proposals
+
+Status: **proposal** (audit + roadmap; nothing implemented yet)
+
+This document is a point-in-time audit of the ryOS codebase and a prioritized
+set of proposals for the next round of refactoring, reliability/performance
+work, hardening, and new features. It is meant to be read top-to-bottom by a
+maintainer deciding what to pick up next; each item is sized by *which
+subsystems change and how invasive the edit is*, not by calendar time.
+
+Audit basis: full-tree review of `src/` and `api/`, plus the last ~4 months of
+git history (~1,600 commits between 2026-02 and 2026-06).
+
+- [1. Where the codebase is today](#1-where-the-codebase-is-today)
+- [2. Refactoring proposals](#2-refactoring-proposals)
+- [3. Reliability & performance](#3-reliability--performance)
+- [4. Security & hardening](#4-security--hardening)
+- [5. New features](#5-new-features)
+- [6. Prioritization](#6-prioritization)
+
+---
+
+## 1. Where the codebase is today
+
+Recent work has been dominated by a few large efforts that are now in their
+final-cleanup phase:
+
+- **Cloud Sync v2** — journal-based delta sync, shipped via direct cutover
+  (`docs/proposals/cloud-sync-v2.md`). v1 backup routes (`api/sync/backup.ts`,
+  `status.ts`, `backup-token.ts`) still run in parallel.
+- **Canonical Redis key scheme** — `src/shared/redisKeys.ts` is now the source
+  of truth, but several hot paths still carry legacy dual-read fallbacks
+  (listen sessions, airdrop presence, rate-limit counters).
+- **macOS Aqua / "Aqua Glass" theme overhaul** — large CSS surface
+  (`src/styles/themes/aqua.css` ~2.8k lines, `aqua-glass.css` ~1.4k,
+  `dark-aqua.css` ~1.9k, `control-panels-mac.css` ~1.6k). This is the single
+  most fix-prone area in recent history (browser-specific `backdrop-filter`).
+- **Tauri → Electron desktop shell** — migration is **complete**; only
+  changelog/test references to Tauri remain. No `src-tauri/` directory.
+- **Self-service account recovery & deletion**, dynamic/shader wallpapers with
+  a 3-tier perf classifier, and a menu-descriptor + keyboard-shortcut refactor.
+
+The architecture is healthy overall: `*AppComponent.tsx` files are mostly thin
+shells delegating to `use*Logic` hooks + `AppWindowShell`, the API layer has a
+shared `apiHandler` wrapper, and there are 210 `bun:test` suites. The debt is
+concentrated in a handful of **god-files** (logic hooks and a few API handlers)
+and in **incomplete migrations** that left dual-code paths behind.
+
+Quantitative hotspots (lines):
+
+| File | Lines | Kind |
+|------|------:|------|
+| `src/apps/ipod/hooks/useIpodLogic.ts` | 5,143 | logic hook |
+| `src/stores/useIpodStore.ts` | 2,535 | store (persist v40) |
+| `src/apps/chats/hooks/useAiChat.ts` | 1,920 | logic hook |
+| `src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts` | 1,833 | logic hook |
+| `api/songs/[id].ts` | 1,694 | API handler |
+| `api/chat/tools/executors.ts` | 1,642 | AI tool executors |
+| `src/apps/finder/hooks/useFileSystem.ts` | 1,729 | logic hook |
+| `api/_utils/_memory.ts` | 1,265 | memory store |
+| `api/admin.ts` | 1,203 | admin monolith |
+| `api/iframe-check.ts` | 1,126 | IE proxy |
+
+---
+
+## 2. Refactoring proposals
+
+### 2.1 Decompose the iPod stack (highest debt concentration)
+
+`useIpodLogic.ts` (5,143) + `useIpodStore.ts` (2,535) + `useAppleMusicLibrary.ts`
+(1,778) ≈ 9.4k lines, and recent history shows recurring Apple Music
+playback-race and render-loop fixes here.
+
+Proposal:
+- Split `useIpodLogic` into cohesive sub-hooks: menu/wheel navigation, Cover
+  Flow, playback transport, Apple Music bridge, lyrics, and the mini-games.
+- Slice `useIpodStore` persisted state by concern (playback vs library/catalog
+  vs lyrics/display preferences) so the v40 migration chain stops touching
+  unrelated state, and replace the `as any` casts in `migrate`.
+- Treat the existing satellite modules (`ipodPreload`, `ipodTrackMetadataSync`,
+  `ipodTrackOrder`, `ipodCatalogTrackMapping`, `playbackTime`) as the template
+  for the boundary.
+
+Risk: high (most-touched user-facing app) — do behind the existing test suite
+(`test-ipod-*`) and add playback-race regression tests first.
+
+### 2.2 Generalize store persistence
+
+~25 stores hand-roll `STORE_VERSION` + `partialize` + bespoke `migrate`, and the
+biggest ones leave verbose `console.log` in the production migrate path
+(`useChatsStore` ~56 logs, `useFileSystem` ~69, `useIpodStore` ~32).
+
+Proposal: introduce a `createPersistedStore({ name, version, migrate,
+partialize })` helper with typed, registered migrations and a debug logger that
+is silent in production. Generalize the already-good `createDebouncedPersistStorage`
+(currently only in `useFilesStore`/`useIpodStore`/`useChatsStore`).
+
+### 2.3 Split the API god-files
+
+- `api/songs/[id].ts` (1,694) → facet modules (CRUD, lyrics, streaming,
+  furigana, Kugou).
+- `api/chat/tools/executors.ts` (1,642) → per-tool files (web-fetch, memory,
+  songs, documents, maps, HTML).
+- `api/admin.ts` (1,203) → replace the single `action`-string POST dispatch
+  with discrete sub-handlers (also improves testability).
+
+### 2.4 Finish the migrations that left dual paths
+
+- **Sync v1 retirement**: remove `api/sync/backup*.ts` + `status.ts` once v2
+  adoption is confirmed (telemetry on v1 route hits first).
+- **Legacy Redis dual-reads**: drop fallback reads in `listen/_helpers/_redis.ts`,
+  `airdrop/send.ts`, and the `rl:*` → `rate:*` translation once the migration
+  CLI has been run everywhere. Reuse the handler-injected `redis` client in
+  `rooms/_helpers/_redis.ts` and `listen/_helpers/_redis.ts` instead of calling
+  `createRedisClient()` per operation.
+- **Theme-token consolidation**: ~20 components still branch on raw theme-id
+  strings (`AdminToolbar`, `WindowsTaskbar`, `EditorToolbar`, etc.) despite
+  `useThemeFlags` + `themes/index.ts` helpers. Finish routing these through the
+  helpers / `data-os-platform` tokens.
+
+### 2.5 Adopt shared UI primitives everywhere
+
+- **Help/About**: `useAppHelpAboutDialogs` + `AppHelpAboutDialogs` exist and are
+  used by ~15 apps, but iPod, Karaoke, Videos, Chats, Admin, IE, and Applet
+  Viewer still hand-roll `isHelpDialogOpen`/`isAboutDialogOpen`.
+- **Media menu bars**: iPod/Karaoke/Videos/TV share the `AppMenuBarShell` +
+  File/Controls/View/Library structure but duplicate `use*MenuBar.ts`
+  view-models — extract a media-menu factory.
+- **Long-press**: deprecate touch-only `useLongPress` in favor of
+  `usePointerLongPress`.
+- **Admin prop-drilling**: `AdminAppComponent` passes 40+ props from a flat
+  `useAdminLogic` bag — group into context or sub-view-models.
+
+---
+
+## 3. Reliability & performance
+
+### 3.1 Fix `deleteToken` full-keyspace SCAN
+
+`api/_utils/auth/_tokens.ts` runs `SCAN auth:user:*:sessions` across **every
+user** on every single-token delete (logout / refresh). This is O(all users)
+per logout. Use the reverse index: the session record already knows its owner,
+so delete from `auth:user:{owner}:sessions` directly.
+
+### 3.2 Attack the recurring bug classes
+
+History shows repeated, similar fixes — worth structural guards rather than
+one-off patches:
+- **Duplicate React keys / missing effect cleanups** (multiple PRs). Add an
+  eslint rule pass (`react-hooks/exhaustive-deps`) and a dev-time duplicate-key
+  detector around the mapped lists (dock slots, chat rooms) that regress most.
+- **Aqua Glass `backdrop-filter`** (Safari/Chrome). Centralize the glass
+  material into a small set of tested utility classes + a feature-detection
+  shim, instead of per-component prefixed CSS that drifts.
+- **Apple Music playback races** (see 2.1) — add deterministic state-machine
+  tests around `setQueue`/pause transitions.
+
+### 3.3 Rate-limit the unprotected proxies
+
+`/api/stocks`, `/api/currency-rate`, `/api/users` (search), and `GET /api/rooms`
+have no rate limits and proxy/scan on every call. Add `checkCounterLimit`
+buckets (these are cheap, high-abuse-potential relays).
+
+### 3.4 Generalize debounced persistence & worker offload
+
+The Spotlight index already runs in a worker. Audit whether the largest store
+writes (files, iPod library) should batch through the shared debounced storage
+helper to reduce main-thread serialization jank on big libraries.
+
+---
+
+## 4. Security & hardening
+
+### 4.1 Replace the hardcoded-`ryo` admin gate with a role flag
+
+`api/_utils/api-handler.ts` treats username `ryo` as admin. A stolen `ryo`
+session = full admin, and there is no second admin or audit trail. Add an
+`isAdmin`/role field to the user profile, gate `auth: "admin"` on it, and log
+admin actions.
+
+### 4.2 Authenticate (or at least rate-limit) `/api/users`
+
+`api/users/index.ts` is `auth: none` and runs a Redis SCAN-backed username
+search with no limits. At minimum require `optional`→`required` auth for the
+full search and add a rate bucket.
+
+### 4.3 Add a Zod validation layer at the `apiHandler` boundary
+
+Zod is used in only ~12 API files. High-value untyped bodies: `POST /api/chat`
+(messages/systemState validated only with `Array.isArray`), `speech.ts`,
+`rooms` message bodies, `analytics/events`. Add an optional `schema` option to
+`apiHandler` that parses + 400s on invalid input, returning structured error
+codes.
+
+### 4.4 Session lifetime & cookie review
+
+1-year session TTL (`USER_TTL_SECONDS`) is long. Consider shorter sliding
+sessions with refresh, and reconcile the `PASSWORD_BCRYPT_ROUNDS` constant with
+the hardcoded `10` in `_password.ts`.
+
+---
+
+## 5. New features
+
+These build naturally on systems that already exist; ordered by leverage.
+
+### 5.1 Self-host one-click realtime (drop the Upstash limitation)
+
+Local WebSocket realtime requires `REDIS_URL` (Upstash REST can't pub/sub), so
+Upstash-only deploys silently lose live chat/presence/sync. Ship a bundled
+lightweight pub/sub fallback (or document a managed Redis path in the
+self-host guide) so a single deploy gets full realtime.
+
+### 5.2 Role-based multi-admin + audit log
+
+Once 4.1 lands, expose an admin "team" management pane and an append-only audit
+log of admin actions in the existing Admin app — useful for the growing
+moderation surface (rooms, bans, Redis browser).
+
+### 5.3 Applet Store enhancements
+
+`applet-viewer` + `share-applet` already exist. Natural additions: applet
+versioning/forking, a public gallery with the existing OG-share pipeline, and
+per-applet rate-limited AI regeneration.
+
+### 5.4 Cross-device "handoff" for media + documents
+
+Cloud Sync v2 + realtime already carry per-user state. Add a handoff affordance
+(continue iPod playback / open TextEdit doc on another device) using the
+existing sync ops channel — low new surface, high "wow".
+
+### 5.5 OpenAPI spec + typed client generation
+
+The API is large (82 route files) and `src/api/` only covers 8 domains by hand.
+Generate an OpenAPI document from the route manifest + Zod schemas (after 4.3),
+then codegen typed clients to replace ad-hoc `fetch` calls scattered in app
+code.
+
+---
+
+## 6. Prioritization
+
+**Do first (low risk, high payoff):**
+- 3.1 `deleteToken` SCAN fix
+- 3.3 rate-limit unprotected proxies
+- 4.2 `/api/users` auth/limit
+- 2.2 shared persisted-store helper (+ strip prod migrate logs)
+
+**Foundational (enables later work):**
+- 4.1 role-based admin → unlocks 5.2
+- 4.3 Zod-at-`apiHandler` → unlocks 5.5
+- 2.4 finish dual-path migrations (sync v1 retirement, legacy Redis reads)
+
+**Large but high-value:**
+- 2.1 iPod stack decomposition
+- 2.3 API god-file splits
+- 3.2 structural fixes for the recurring bug classes (esp. Aqua Glass)
+
+**Feature bets:**
+- 5.1 self-host realtime fallback
+- 5.4 cross-device handoff
+- 5.3 applet store enhancements
+
+> Scope note: every item above is independently shippable. The "do first" bucket
+> is intentionally small and self-contained so it can land without coordinating
+> with the in-flight migrations.

--- a/docs/proposals/next-improvements.md
+++ b/docs/proposals/next-improvements.md
@@ -243,10 +243,12 @@ code.
 ## 6. Prioritization
 
 **Do first (low risk, high payoff):**
-- 3.1 `deleteToken` SCAN fix
-- 3.3 rate-limit unprotected proxies
-- 4.2 `/api/users` auth/limit
-- 2.2 shared persisted-store helper (+ strip prod migrate logs)
+- 3.1 `deleteToken` SCAN fix — **shipped**
+- 3.3 rate-limit unprotected proxies — **shipped** (`stocks`, `currency-rate`, rooms list)
+- 4.2 `/api/users` auth/limit — **shipped** (required auth + min query length + per-user limit)
+- 2.2 shared persisted-store helper (+ strip prod migrate logs) — *deferred to its own PR;
+  it touches ~25 stores in the most fix-prone area, so it is not actually low-risk and
+  warrants separate review + targeted testing*
 
 **Foundational (enables later work):**
 - 4.1 admin audit trail (keep `ryo` gate) → unlocks 5.2

--- a/docs/proposals/next-improvements.md
+++ b/docs/proposals/next-improvements.md
@@ -171,12 +171,14 @@ helper to reduce main-thread serialization jank on big libraries.
 
 ## 4. Security & hardening
 
-### 4.1 Replace the hardcoded-`ryo` admin gate with a role flag
+### 4.1 Keep the single `ryo` admin — add an audit trail
 
-`api/_utils/api-handler.ts` treats username `ryo` as admin. A stolen `ryo`
-session = full admin, and there is no second admin or audit trail. Add an
-`isAdmin`/role field to the user profile, gate `auth: "admin"` on it, and log
-admin actions.
+`api/_utils/api-handler.ts` treats username `ryo` as admin. This single-admin
+model is intentional and stays as-is. The one gap worth closing without
+changing the gate: there is no record of admin actions. Add an append-only
+audit log of `auth: "admin"` calls (action, target, timestamp) so the growing
+moderation surface (rooms, bans, Redis browser) is reviewable. No role system
+is introduced.
 
 ### 4.2 Authenticate (or at least rate-limit) `/api/users`
 
@@ -211,11 +213,11 @@ Upstash-only deploys silently lose live chat/presence/sync. Ship a bundled
 lightweight pub/sub fallback (or document a managed Redis path in the
 self-host guide) so a single deploy gets full realtime.
 
-### 5.2 Role-based multi-admin + audit log
+### 5.2 Admin audit-log view + moderation tooling
 
-Once 4.1 lands, expose an admin "team" management pane and an append-only audit
-log of admin actions in the existing Admin app — useful for the growing
-moderation surface (rooms, bans, Redis browser).
+Building on 4.1's audit trail (the `ryo` single-admin gate stays), surface the
+admin action log inside the existing Admin app and round out moderation tooling
+(rooms, bans, Redis browser) on top of it.
 
 ### 5.3 Applet Store enhancements
 
@@ -247,7 +249,7 @@ code.
 - 2.2 shared persisted-store helper (+ strip prod migrate logs)
 
 **Foundational (enables later work):**
-- 4.1 role-based admin → unlocks 5.2
+- 4.1 admin audit trail (keep `ryo` gate) → unlocks 5.2
 - 4.3 Zod-at-`apiHandler` → unlocks 5.5
 - 2.4 finish dual-path migrations (sync v1 retirement, legacy Redis reads)
 

--- a/tests/test-auth-extra.test.ts
+++ b/tests/test-auth-extra.test.ts
@@ -354,30 +354,64 @@ describe("Auth Extra API Tests", () => {
       expect(res.status).toBe(405);
     });
 
-    test("User search - no query", async () => {
-      const res = await fetchWithOrigin(`${BASE_URL}/api/users`);
-      expect(res.status).toBe(200);
-      const data = await res.json();
-      expect(Array.isArray(data.users)).toBe(true);
-    });
-
-    test("User search - with query", async () => {
+    test("User search - requires auth → 401", async () => {
       const res = await fetchWithOrigin(`${BASE_URL}/api/users?search=test`);
+      expect(res.status).toBe(401);
+    });
+
+    test("User search - no query (authed) → 400", async () => {
+      if (!testToken || !testUsername) return;
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/users`,
+        testUsername,
+        testToken,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(res.status).toBe(400);
+    });
+
+    test("User search - with query (authed) → 200", async () => {
+      if (!testToken || !testUsername) return;
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/users?search=test`,
+        testUsername,
+        testToken,
+        { headers: makeRateLimitBypassHeaders() }
+      );
       expect(res.status).toBe(200);
       const data = await res.json();
       expect(Array.isArray(data.users)).toBe(true);
     });
 
-    test("User search - empty query", async () => {
-      const res = await fetchWithOrigin(`${BASE_URL}/api/users?search=`);
-      expect(res.status).toBe(200);
-      const data = await res.json();
-      expect(Array.isArray(data.users)).toBe(true);
+    test("User search - empty query (authed) → 400", async () => {
+      if (!testToken || !testUsername) return;
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/users?search=`,
+        testUsername,
+        testToken,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(res.status).toBe(400);
     });
 
-    test("User search - special characters", async () => {
-      const res = await fetchWithOrigin(
-        `${BASE_URL}/api/users?search=${encodeURIComponent("test@#$%")}`
+    test("User search - single character (authed) → 400", async () => {
+      if (!testToken || !testUsername) return;
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/users?search=a`,
+        testUsername,
+        testToken,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(res.status).toBe(400);
+    });
+
+    test("User search - special characters (authed)", async () => {
+      if (!testToken || !testUsername) return;
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/users?search=${encodeURIComponent("test@#$%")}`,
+        testUsername,
+        testToken,
+        { headers: makeRateLimitBypassHeaders() }
       );
       expect(res.status === 200 || res.status === 400).toBe(true);
       const data = await res.json();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

1. Adds `docs/proposals/next-improvements.md` — a point-in-time audit + prioritized roadmap (refactoring, reliability/performance, security, new features).
2. Implements the low-risk, high-payoff **"do first"** API items from that roadmap.

## Implemented "do first" items

**3.1 — `deleteToken` no longer scans the whole keyspace**
`api/_utils/auth/_tokens.ts` ran `SCAN auth:user:*:sessions` (O(all users)) on every logout/refresh/login-rotation. Now takes the owning `username` and removes the token hash from that user's session set directly; the SCAN remains only as a fallback when the owner is unknown. Callers (`logout`, `token/refresh`, `login`) pass the username.

**3.3 — rate-limit unprotected external proxies**
- `GET /api/stocks` — per-IP burst 30/min + daily 2000.
- `GET /api/currency-rate` — per-IP burst 30/min + daily 2000.
- `GET /api/rooms` (list) — loose burst 60/min + daily 5000 (UI polls this).

**4.2 — harden `GET /api/users` search**
- `auth: none` → `auth: "required"` (was unauthenticated username enumeration).
- Enforce a minimum query length (2) server-side.
- Per-user burst 20/min + daily 1000.

All use the existing `checkBurstAndDailyLimits` helper; new namespaces flow through the canonical `rate:*` key scheme automatically.

> 2.2 (shared persisted-store helper + stripping production migrate logs) is intentionally **deferred** to its own PR — it touches ~25 client stores in the most fix-prone area and is not actually low-risk.

## Testing

- ✅ `bun run test:new-api` (30 pass) — covers login/logout/refresh (`deleteToken`) and rooms list.
- ✅ `bun run test:auth-extra` (23 pass) — updated `/api/users` tests for the new auth + min-length behavior.
- ✅ Manual: bursting `/api/currency-rate` from a fixed IP returns exactly 30×`200` then `429`; `/api/users` without auth returns `401`.
- ⚠️ `bun run test:rooms-extra` — pre-existing environmental `beforeAll` timeout (the `GET /api/rooms` Upstash round-trip is ~4.4s and overruns the 5s hook). Reproduced identically with the original handler, so it's unrelated to this change.
- ⚠️ `tsc -p api/tsconfig.json` — pre-existing errors only (DOM globals in `src/utils/*`, loose helper typing); none in edited files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ee7d9-d2cb-7445-9641-1dc910f1b3ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ee7d9-d2cb-7445-9641-1dc910f1b3ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

