### PR TITLE
feat(admin): admin action audit log

### DIFF
--- a/api/_utils/_admin-audit.ts
+++ b/api/_utils/_admin-audit.ts
@@ -1,0 +1,102 @@
+/**
+ * Admin action audit log.
+ *
+ * Records state-changing admin (`ryo`) operations to a single bounded global
+ * Redis LIST (newest first). The `ryo` single-admin model is unchanged; this
+ * only adds an append-only trail so admin actions are reviewable.
+ *
+ * Recording is best-effort and never throws — an audit failure must never
+ * block the admin action it describes.
+ */
+
+import type { Redis } from "./redis.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
+
+export interface AdminAuditEntry {
+  /** Unique id for the entry. */
+  id: string;
+  /** Epoch milliseconds when the action was recorded. */
+  ts: number;
+  /** Admin username that performed the action (e.g. `ryo`). */
+  actor: string;
+  /** Action name (matches the admin API `action`, e.g. `banUser`). */
+  action: string;
+  /** Primary subject of the action (username, redis key, run id, …). */
+  target?: string;
+  /** Small JSON-serializable summary of the action. */
+  details?: Record<string, unknown>;
+  /** Client IP of the admin request, when available. */
+  ip?: string;
+}
+
+/** Maximum number of entries retained in the bounded list. */
+export const MAX_AUDIT_ENTRIES = 1000;
+
+/** Maximum serialized size of `details` before it is dropped/truncated. */
+const MAX_DETAILS_CHARS = 2000;
+
+function sanitizeDetails(
+  details?: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (!details) return undefined;
+  try {
+    const json = JSON.stringify(details);
+    if (json.length > MAX_DETAILS_CHARS) {
+      return { truncated: true };
+    }
+    return details;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function recordAdminAction(
+  redis: Redis,
+  entry: Omit<AdminAuditEntry, "id" | "ts"> & { ts?: number }
+): Promise<void> {
+  try {
+    const details = sanitizeDetails(entry.details);
+    const record: AdminAuditEntry = {
+      id: crypto.randomUUID(),
+      ts: entry.ts ?? Date.now(),
+      actor: entry.actor,
+      action: entry.action,
+      ...(entry.target ? { target: entry.target } : {}),
+      ...(details ? { details } : {}),
+      ...(entry.ip ? { ip: entry.ip } : {}),
+    };
+    const key = redisKeys.system.adminAuditLog();
+    await redis.lpush(key, JSON.stringify(record));
+    await redis.ltrim(key, 0, MAX_AUDIT_ENTRIES - 1);
+  } catch (error) {
+    console.error("Failed to record admin audit entry", error);
+  }
+}
+
+export async function getAdminAuditLog(
+  redis: Redis,
+  limit = 100
+): Promise<AdminAuditEntry[]> {
+  const clamped = Math.min(Math.max(Math.floor(limit) || 0, 1), MAX_AUDIT_ENTRIES);
+  const raw = await redis.lrange<string | AdminAuditEntry>(
+    redisKeys.system.adminAuditLog(),
+    0,
+    clamped - 1
+  );
+  const entries: AdminAuditEntry[] = [];
+  for (const item of raw) {
+    if (!item) continue;
+    try {
+      const parsed =
+        typeof item === "string"
+          ? (JSON.parse(item) as AdminAuditEntry)
+          : item;
+      if (parsed && typeof parsed.action === "string") {
+        entries.push(parsed);
+      }
+    } catch {
+      // skip malformed entries
+    }
+  }
+  return entries;
+}

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -20,6 +20,8 @@ import {
 } from "./_utils/redis.js";
 import { getRealtimeProvider } from "./_utils/runtime-config.js";
 import { getAnalyticsSummary, getAnalyticsDetail, type AnalyticsSummary, type AnalyticsDetail } from "./_utils/_analytics.js";
+import { recordAdminAction, getAdminAuditLog } from "./_utils/_admin-audit.js";
+import { getClientIp } from "./_utils/_rate-limit.js";
 import {
   CURSOR_REPO_AGENT_OWNER,
   executeCursorCloudAgent,
@@ -765,6 +767,21 @@ export default apiHandler<AdminRequest>(
 
     const action = req.query.action as string | undefined;
 
+    // Append-only audit trail for state-changing admin actions. Best-effort:
+    // never blocks or fails the underlying action.
+    const audit = (
+      auditAction: string,
+      target?: string,
+      details?: Record<string, unknown>
+    ): Promise<void> =>
+      recordAdminAction(redis, {
+        actor: user?.username || "ryo",
+        action: auditAction,
+        ...(target ? { target } : {}),
+        ...(details ? { details } : {}),
+        ip: getClientIp(req),
+      });
+
     if (req.method === "GET") {
       logger.info("GET request", { action });
 
@@ -955,8 +972,23 @@ export default apiHandler<AdminRequest>(
             keyCount: data.keyCount,
             truncated: data.truncated,
           });
+          await audit("backupRedisKeys", pattern, {
+            keyCount: data.keyCount,
+            truncated: data.truncated,
+          });
           logger.response(200, Date.now() - startTime);
           res.status(200).json(data);
+          return;
+        }
+        case "getAuditLog": {
+          const limit = Math.min(
+            Math.max(parseInt((req.query.limit as string) || "100", 10) || 100, 1),
+            500
+          );
+          const entries = await getAdminAuditLog(redis, limit);
+          logger.info("Admin audit log retrieved", { count: entries.length, limit });
+          logger.response(200, Date.now() - startTime);
+          res.status(200).json({ entries });
           return;
         }
         default:
@@ -982,6 +1014,7 @@ export default apiHandler<AdminRequest>(
           const result = await deleteUser(redis, targetUsername);
           if (result.success) {
             logger.info("User deleted", { targetUsername });
+            await audit("deleteUser", targetUsername);
             logger.response(200, Date.now() - startTime);
             res.status(200).json({ success: true });
             return;
@@ -1000,6 +1033,7 @@ export default apiHandler<AdminRequest>(
           const result = await banUser(redis, targetUsername, reason);
           if (result.success) {
             logger.info("User banned", { targetUsername, reason });
+            await audit("banUser", targetUsername, reason ? { reason } : undefined);
             logger.response(200, Date.now() - startTime);
             res.status(200).json({ success: true });
             return;
@@ -1018,6 +1052,7 @@ export default apiHandler<AdminRequest>(
           const result = await unbanUser(redis, targetUsername);
           if (result.success) {
             logger.info("User unbanned", { targetUsername });
+            await audit("unbanUser", targetUsername);
             logger.response(200, Date.now() - startTime);
             res.status(200).json({ success: true });
             return;
@@ -1037,6 +1072,9 @@ export default apiHandler<AdminRequest>(
             const memResult = await clearAllMemories(redis, targetUsername.toLowerCase());
             logger.info("User memories cleared", {
               targetUsername,
+              deletedCount: memResult.deletedCount,
+            });
+            await audit("clearUserMemories", targetUsername, {
               deletedCount: memResult.deletedCount,
             });
             logger.response(200, Date.now() - startTime);
@@ -1109,6 +1147,11 @@ export default apiHandler<AdminRequest>(
             async: "async" in result && result.async,
             runId: "runId" in result ? result.runId : undefined,
           });
+          await audit(
+            "startCursorAgent",
+            "runId" in result && result.runId ? String(result.runId) : undefined,
+            { modelId: modelId || undefined, promptChars: prompt.length }
+          );
           logger.response(200, Date.now() - startTime);
           res.status(200).json(result);
           return;
@@ -1142,6 +1185,12 @@ export default apiHandler<AdminRequest>(
               memoriesCreated: processResult.created,
               memoriesUpdated: processResult.updated,
               skippedDates: processResult.skippedDates,
+            });
+            await audit("forceProcessDailyNotes", targetUsername, {
+              notesReset: resetResult.resetCount,
+              notesProcessed: processResult.processed,
+              memoriesCreated: processResult.created,
+              memoriesUpdated: processResult.updated,
             });
             logger.response(200, Date.now() - startTime);
             res.status(200).json({
@@ -1182,6 +1231,7 @@ export default apiHandler<AdminRequest>(
           }
           const deletedCount = await redis.del(key);
           logger.info("Redis key delete requested", { key, deletedCount });
+          await audit("deleteRedisKey", key, { deletedCount });
           logger.response(200, Date.now() - startTime);
           res.status(200).json({
             success: deletedCount > 0,

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -126,6 +126,12 @@ export async function getAdminCursorAgentRuns<TResponse>(
   return adminGet<TResponse>("getCursorAgentRuns", { limit });
 }
 
+export async function getAdminAuditLog<TResponse>(
+  limit: number = 100
+): Promise<TResponse> {
+  return adminGet<TResponse>("getAuditLog", { limit });
+}
+
 export async function getAdminRedisKeys<TResponse>(input: {
   pattern?: string;
   cursor?: string;

--- a/src/apps/admin/components/AdminAuditLogPanel.tsx
+++ b/src/apps/admin/components/AdminAuditLogPanel.tsx
@@ -1,0 +1,243 @@
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "@/hooks/useAuth";
+import { getAdminAuditLog } from "@/api/admin";
+import { ApiRequestError } from "@/api/core";
+import { ArrowsClockwise } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import { ActivityIndicator } from "@/components/ui/activity-indicator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { useAdminDashboardStore } from "@/stores/useAdminDashboardStore";
+import { formatAdminRelativeTime } from "../utils/adminTime";
+import {
+  adminTableHeadClass,
+  adminTableRowClass,
+  adminToolbarClass,
+} from "../utils/adminStyles";
+
+interface AdminAuditEntry {
+  id: string;
+  ts: number;
+  actor: string;
+  action: string;
+  target?: string;
+  details?: Record<string, unknown>;
+  ip?: string;
+}
+
+interface AuditLogResponse {
+  entries: AdminAuditEntry[];
+}
+
+function summarizeDetails(details?: Record<string, unknown>): string {
+  if (!details) return "";
+  try {
+    return Object.entries(details)
+      .map(([key, value]) => `${key}: ${String(value)}`)
+      .join(", ");
+  } catch {
+    return "";
+  }
+}
+
+export function AdminAuditLogPanel() {
+  const { t } = useTranslation();
+  const { username, isAuthenticated } = useAuth();
+  const { isMacOSTheme, isWindowsTheme } = useThemeFlags();
+  const setAuditLogCount = useAdminDashboardStore((s) => s.setAuditLogCount);
+
+  const [entries, setEntries] = useState<AdminAuditEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchEntries = useCallback(async () => {
+    if (!username || !isAuthenticated) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await getAdminAuditLog<AuditLogResponse>(200);
+      const list = data.entries ?? [];
+      setEntries(list);
+      setAuditLogCount(list.length);
+    } catch (err) {
+      const message =
+        err instanceof ApiRequestError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : t("apps.admin.auditLog.loadFailed", "Could not load audit log");
+      setError(message);
+      setEntries([]);
+      setAuditLogCount(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [username, isAuthenticated, t, setAuditLogCount]);
+
+  useEffect(() => {
+    void fetchEntries();
+  }, [fetchEntries]);
+
+  useEffect(() => {
+    return () => setAuditLogCount(null);
+  }, [setAuditLogCount]);
+
+  const toolbar = (
+    <div className="shrink-0">
+      <div
+        className={cn(
+          adminToolbarClass,
+          "flex items-center justify-between gap-2 border-b px-2 py-1.5",
+          isWindowsTheme
+            ? "border-[#919b9c]"
+            : isMacOSTheme
+              ? "border-black/10"
+              : "border-black/20"
+        )}
+      >
+        <span className="text-[11px] text-os-text-secondary">
+          {t("apps.admin.auditLog.title", "Audit Log")}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => void fetchEntries()}
+          disabled={isLoading}
+          className="size-7 shrink-0 p-0"
+          aria-label={t("apps.admin.auditLog.refresh", "Refresh")}
+          title={t("apps.admin.auditLog.refresh", "Refresh")}
+        >
+          {isLoading ? (
+            <ActivityIndicator size={14} />
+          ) : (
+            <ArrowsClockwise size={14} weight="bold" />
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+
+  const panelShellClass =
+    "font-geneva-12 flex h-full min-h-0 flex-1 flex-col overflow-hidden";
+
+  if (isLoading && entries.length === 0) {
+    return (
+      <div className={panelShellClass}>
+        {toolbar}
+        <div className="flex flex-col items-center justify-center py-16 gap-3">
+          <ActivityIndicator size={24} />
+          <span className="text-[11px] text-neutral-500">
+            {t("apps.admin.auditLog.loading", "Loading audit log…")}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={panelShellClass}>
+        {toolbar}
+        <div className="flex flex-col items-center justify-center py-12 gap-3 px-4 text-center">
+          <p className="text-[12px] text-red-600">{error}</p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void fetchEntries()}
+            className="h-8 text-[11px]"
+          >
+            <ArrowsClockwise className="size-3.5 mr-1" weight="bold" />
+            {t("apps.admin.auditLog.retry", "Retry")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <div className={panelShellClass}>
+        {toolbar}
+        <div className="flex flex-col items-center justify-center py-16 gap-3">
+          <span className="text-[11px] text-neutral-500">
+            {t("apps.admin.auditLog.empty", "No admin actions recorded yet")}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={panelShellClass}>
+      {toolbar}
+      <div className="min-h-0 flex-1 overflow-auto">
+        <Table className="table-fixed">
+          <TableHeader>
+            <TableRow className="text-[10px] border-none font-normal">
+              <TableHead className={cn(adminTableHeadClass, "h-[28px] w-[22%]")}>
+                {t("apps.admin.auditLog.action", "Action")}
+              </TableHead>
+              <TableHead className={cn(adminTableHeadClass, "h-[28px] w-[28%]")}>
+                {t("apps.admin.auditLog.target", "Target")}
+              </TableHead>
+              <TableHead className={cn(adminTableHeadClass, "h-[28px]")}>
+                {t("apps.admin.auditLog.details", "Details")}
+              </TableHead>
+              <TableHead
+                className={cn(
+                  adminTableHeadClass,
+                  "h-[28px] w-[16%] whitespace-nowrap"
+                )}
+              >
+                {t("apps.admin.auditLog.time", "Time")}
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody className="text-[11px]">
+            {entries.map((entry) => {
+              const detailText = summarizeDetails(entry.details);
+              return (
+                <TableRow
+                  key={entry.id}
+                  className={cn(adminTableRowClass, "cursor-default align-top")}
+                >
+                  <TableCell className="py-1.5 font-medium truncate" title={entry.action}>
+                    {entry.action}
+                  </TableCell>
+                  <TableCell
+                    className="py-1.5 truncate text-neutral-700 os-mac-aqua-dark:text-neutral-300"
+                    title={entry.target || ""}
+                  >
+                    {entry.target || "—"}
+                  </TableCell>
+                  <TableCell
+                    className="py-1.5 text-neutral-600 os-mac-aqua-dark:text-neutral-400"
+                    title={detailText}
+                  >
+                    <span className="line-clamp-2">{detailText || "—"}</span>
+                  </TableCell>
+                  <TableCell
+                    className="py-1.5 whitespace-nowrap text-neutral-600 os-mac-aqua-dark:text-neutral-400"
+                    title={new Date(entry.ts).toLocaleString()}
+                  >
+                    {formatAdminRelativeTime(entry.ts, t)}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/src/apps/admin/components/AdminMenuBar.tsx
+++ b/src/apps/admin/components/AdminMenuBar.tsx
@@ -107,6 +107,10 @@ export function AdminMenuBar({
           "cursorAgents",
           t("apps.admin.sidebar.cursorAgents", "Cursor Agents")
         ),
+        sectionCheckbox(
+          "auditLog",
+          t("apps.admin.sidebar.auditLog", "Audit Log")
+        ),
         ...(roomItems.length > 0
           ? ([{ type: "separator" }, ...roomItems] as MenuDescriptor["items"])
           : []),

--- a/src/apps/admin/components/AdminSidebar.tsx
+++ b/src/apps/admin/components/AdminSidebar.tsx
@@ -132,6 +132,13 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({
             </div>
           </SelectableListItem>
 
+          <SelectableListItem
+            isSelected={activeSection === "auditLog"}
+            onClick={() => { playButtonClick(); onSectionChange("auditLog"); onRoomSelect(null); }}
+          >
+            {t("apps.admin.sidebar.auditLog", "Audit Log")}
+          </SelectableListItem>
+
           {/* Rooms Section Header */}
           <div
             className={cn(

--- a/src/apps/admin/components/admin-app/AdminMainPane.tsx
+++ b/src/apps/admin/components/admin-app/AdminMainPane.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent, Dispatch, RefObject, SetStateAction } from "react";
 import { AdminSidebar } from "../AdminSidebar";
 import { CursorAgentsPanel } from "../CursorAgentsPanel";
+import { AdminAuditLogPanel } from "../AdminAuditLogPanel";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { adminMainPaneClass } from "../../utils/adminStyles";
@@ -182,6 +183,12 @@ export function AdminMainPane({
     !selectedUserProfile &&
     !selectedSongId;
 
+  const showAuditLogPanel =
+    activeSection === "auditLog" &&
+    !selectedRoomId &&
+    !selectedUserProfile &&
+    !selectedSongId;
+
   return (
     <div ref={containerRef} className="flex size-full admin-force-font">
       <AdminSidebar
@@ -201,7 +208,8 @@ export function AdminMainPane({
           !selectedSongId &&
           activeSection !== "dashboard" &&
           activeSection !== "cursorAgents" &&
-          activeSection !== "redis" && (
+          activeSection !== "redis" &&
+          activeSection !== "auditLog" && (
             <AdminToolbar
               t={t}
               currentTheme={currentTheme}
@@ -254,11 +262,18 @@ export function AdminMainPane({
           </div>
         ) : null}
 
+        {showAuditLogPanel ? (
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <AdminAuditLogPanel />
+          </div>
+        ) : null}
+
         <ScrollArea
           ref={scrollAreaRef}
           className={cn(
             "min-h-0 min-w-0 flex-1",
-            (showCursorAgentsPanel || showRedisPanel) && "hidden",
+            (showCursorAgentsPanel || showRedisPanel || showAuditLogPanel) &&
+              "hidden",
           )}
         >
           <AdminScrollContent

--- a/src/apps/admin/components/admin-app/AdminStatusBar.tsx
+++ b/src/apps/admin/components/admin-app/AdminStatusBar.tsx
@@ -69,6 +69,7 @@ export function AdminStatusBar({
   const { i18n } = useTranslation();
   const dashboardRangeDays = useAdminDashboardStore((s) => s.rangeDays);
   const redisKeyCount = useAdminDashboardStore((s) => s.redisKeyCount);
+  const auditLogCount = useAdminDashboardStore((s) => s.auditLogCount);
   const locale = i18n.resolvedLanguage || i18n.language || "en";
 
   return (
@@ -84,6 +85,11 @@ export function AdminStatusBar({
             : activeSection === "redis"
               ? t("apps.admin.statusBar.redisKeysCount", {
                   count: redisKeyCount ?? 0,
+                })
+            : activeSection === "auditLog"
+              ? t("apps.admin.statusBar.auditLogCount", {
+                  count: auditLogCount ?? 0,
+                  defaultValue: `${auditLogCount ?? 0} entries`,
                 })
             : activeSection === "users" && !selectedRoomId
               ? t("apps.admin.statusBar.usersCount", {

--- a/src/apps/admin/utils/navigationState.ts
+++ b/src/apps/admin/utils/navigationState.ts
@@ -4,7 +4,8 @@ export type AdminSection =
   | "rooms"
   | "songs"
   | "redis"
-  | "cursorAgents";
+  | "cursorAgents"
+  | "auditLog";
 
 export interface AdminDetailSelectionState {
   selectedRoomId: string | null;

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -3929,9 +3929,22 @@
         "redis": "Redis",
         "server": "Server",
         "cursorAgents": "Cursor Agents",
+        "auditLog": "Audit Log",
         "private": "Private",
         "messagesCount": "{{count}} messages",
         "online": "online"
+      },
+      "auditLog": {
+        "title": "Audit Log",
+        "loading": "Loading audit log…",
+        "loadFailed": "Could not load audit log",
+        "retry": "Retry",
+        "refresh": "Refresh",
+        "empty": "No admin actions recorded yet",
+        "action": "Action",
+        "target": "Target",
+        "details": "Details",
+        "time": "Time"
       },
       "cursorAgents": {
         "loading": "Loading Cursor agent runs…",
@@ -4168,6 +4181,8 @@
         "redis": "Redis Browser",
         "redisKeysCount_one": "{{count}} key",
         "redisKeysCount_other": "{{count}} keys",
+        "auditLogCount_one": "{{count}} entry",
+        "auditLogCount_other": "{{count}} entries",
         "loggedInAs": "Logged in as {{username}}"
       },
       "accessDenied": {

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -268,5 +268,10 @@ export const redisKeys = {
      */
     migrationCopied: (legacyKey: string) =>
       redisKeyCaseSensitive("system", "migration", "copied", legacyKey),
+    /**
+     * Append-only audit log of admin (`ryo`) actions. A single bounded global
+     * LIST (newest first) recording state-changing admin operations.
+     */
+    adminAuditLog: () => redisKey("system", "admin", "audit-log"),
   },
 } as const;

--- a/src/stores/useAdminDashboardStore.ts
+++ b/src/stores/useAdminDashboardStore.ts
@@ -18,6 +18,13 @@ interface AdminDashboardState {
    */
   redisKeyCount: number | null;
   setRedisKeyCount: (count: number | null) => void;
+  /**
+   * Number of audit-log entries currently loaded in the Audit Log panel,
+   * surfaced here so the status bar can show the count without prop-drilling.
+   * `null` means the panel is inactive / hasn't loaded any entries.
+   */
+  auditLogCount: number | null;
+  setAuditLogCount: (count: number | null) => void;
 }
 
 export const useAdminDashboardStore = create<AdminDashboardState>((set) => ({
@@ -25,4 +32,6 @@ export const useAdminDashboardStore = create<AdminDashboardState>((set) => ({
   setRangeDays: (days) => set({ rangeDays: days }),
   redisKeyCount: null,
   setRedisKeyCount: (count) => set({ redisKeyCount: count }),
+  auditLogCount: null,
+  setAuditLogCount: (count) => set({ auditLogCount: count }),
 }));

--- a/tests/test-admin.test.ts
+++ b/tests/test-admin.test.ts
@@ -391,6 +391,78 @@ describe("admin", () => {
     );
   });
 
+  describe("Audit Log", () => {
+    test("GET getAuditLog - without auth (forbidden)", async () => {
+      const res = await fetchWithOrigin(
+        `${BASE_URL}/api/admin?action=getAuditLog`,
+        { method: "GET" }
+      );
+      expect(res.status).toBe(403);
+    });
+
+    test.skipIf(skipWithoutAdmin)(
+      "GET getAuditLog - returns entries array",
+      async () => {
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin?action=getAuditLog&limit=50`,
+          ADMIN_USERNAME,
+          adminToken!,
+          { method: "GET" }
+        );
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(Array.isArray(data.entries)).toBe(true);
+      }
+    );
+
+    test.skipIf(skipWithoutAdmin)(
+      "mutating action is recorded in the audit log",
+      async () => {
+        // A deterministic, side-effect-free mutation: delete a key that does
+        // not exist. It still records a `deleteRedisKey` audit entry.
+        const targetKey = `audit-test:${Date.now()}:${Math.floor(
+          Math.random() * 1e6
+        )}`;
+        const delRes = await fetchWithAuth(
+          `${BASE_URL}/api/admin`,
+          ADMIN_USERNAME,
+          adminToken!,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              action: "deleteRedisKey",
+              key: targetKey,
+              confirmKey: targetKey,
+            }),
+          }
+        );
+        expect(delRes.status).toBe(200);
+
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin?action=getAuditLog&limit=100`,
+          ADMIN_USERNAME,
+          adminToken!,
+          { method: "GET" }
+        );
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(Array.isArray(data.entries)).toBe(true);
+
+        const entry = data.entries.find(
+          (e: { action: string; target?: string }) =>
+            e.action === "deleteRedisKey" && e.target === targetKey
+        );
+        expect(entry).toBeTruthy();
+        expect(entry.actor.toLowerCase()).toBe(ADMIN_USERNAME.toLowerCase());
+        expect(typeof entry.ts).toBe("number");
+        expect(typeof entry.id).toBe("string");
+        // newest-first ordering: our just-written entry should be near the top
+        expect(data.entries.indexOf(entry)).toBeLessThan(10);
+      }
+    );
+  });
+
   describe("Error Cases", () => {
     test.skipIf(skipWithoutAdmin)("GET invalid action", async () => {
       const res = await fetchWithAuth(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds an append-only **audit trail of admin (`ryo`) actions** plus an **Audit Log view** in the Admin app. This is the agreed direction from the audit roadmap — the single `ryo` admin gate is unchanged; this only adds reviewability of state-changing admin operations.

## Backend

- New `api/_utils/_admin-audit.ts`: `recordAdminAction()` / `getAdminAuditLog()` backed by a single bounded Redis LIST (`system:admin:audit-log`, newest-first, capped at 1000). Recording is best-effort and never throws, so an audit failure can't block the admin action.
- New canonical key `redisKeys.system.adminAuditLog()`.
- `api/admin.ts`: records each **successful** state-changing action — `deleteUser`, `banUser`, `unbanUser`, `clearUserMemories`, `startCursorAgent`, `forceProcessDailyNotes`, `deleteRedisKey`, `backupRedisKeys` — with actor, target, a small details summary, and client IP. New read-only `getAuditLog` action (admin-gated, `limit` clamped 1–500).

## Frontend

- New self-contained `AdminAuditLogPanel` (mirrors `CursorAgentsPanel`): fetches via a new `getAdminAuditLog` client, renders an action/target/details/time table, with loading/error/empty states and refresh.
- New `auditLog` section wired into the sidebar, View menu, main pane, and status bar (entry count via `useAdminDashboardStore`). English locale keys added; other locales fall back to English via i18next + inline defaults.

## Testing

- ✅ `bun run test:admin` (18 pass) — includes 3 new tests: `getAuditLog` requires admin (403), returns an entries array, and a mutating action is recorded (correct `actor`/`target`, newest-first ordering).
- ✅ `bun run build` — `tsc -b` (incl. exhaustive `AdminSection` switches) + Vite build succeed.

Per the repo's AGENTS.md ("skip computer use / GUI-driven testing unless explicitly requested"), the new UI was verified via build + type check rather than browser testing; a screenshot can be provided on request.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ee7d9-d2cb-7445-9641-1dc910f1b3ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ee7d9-d2cb-7445-9641-1dc910f1b3ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

