### PR TITLE
Control Panels: use the macOS System Preferences layout for all themes

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/AccountsPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AccountsPaneContent.tsx
@@ -35,6 +35,7 @@ import {
 import { RecoveryEmailDialog } from "@/components/dialogs/RecoveryEmailDialog";
 import type { EmailStatusResponse } from "@/shared/contracts/auth";
 import { SecurityPaneContent } from "./SecurityPaneContent";
+import { useControlPanelsTabClasses } from "./useControlPanelsTabClasses";
 import type { ControlPanelPaneId } from "./controlPanelsCategories";
 
 export type AccountsPaneContentProps = {
@@ -129,6 +130,8 @@ export function AccountsPaneContent({
 }: AccountsPaneContentProps) {
   const [accountsTab, setAccountsTab] = useState<AccountsPaneTab>("accounts");
   const [isRecoveryEmailOpen, setIsRecoveryEmailOpen] = useState(false);
+  const { barClassName, triggerClassName, triggerStyle } =
+    useControlPanelsTabClasses();
   const selectedSystemFont =
     SYSTEM_FONT_OPTIONS.find((option) => option.id === systemFont) ??
     SYSTEM_FONT_OPTIONS[0];
@@ -186,13 +189,14 @@ export function AccountsPaneContent({
       <div className="control-panels-pref-tabbed">
         <div
           role="tablist"
-          className="aqua-tab-bar control-panels-pref-tab-bar"
+          className={cn("control-panels-pref-tab-bar", barClassName)}
           aria-label={t("apps.control-panels.panes.accounts")}
         >
           <button
             type="button"
             role="tab"
-            className="aqua-tab"
+            className={triggerClassName}
+            style={triggerStyle}
             data-state={accountsTab === "accounts" ? "active" : "inactive"}
             aria-selected={accountsTab === "accounts"}
             onClick={() => setAccountsTab("accounts")}
@@ -202,7 +206,8 @@ export function AccountsPaneContent({
           <button
             type="button"
             role="tab"
-            className="aqua-tab"
+            className={triggerClassName}
+            style={triggerStyle}
             data-state={accountsTab === "security" ? "active" : "inactive"}
             aria-selected={accountsTab === "security"}
             onClick={() => setAccountsTab("security")}
@@ -213,7 +218,8 @@ export function AccountsPaneContent({
             <button
               type="button"
               role="tab"
-              className="aqua-tab"
+              className={triggerClassName}
+              style={triggerStyle}
               data-state={accountsTab === "debug" ? "active" : "inactive"}
               aria-selected={accountsTab === "debug"}
               onClick={() => setAccountsTab("debug")}

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsAppComponent.tsx
@@ -1,24 +1,15 @@
 import React from "react";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { ControlPanelsMenuBar } from "../ControlPanelsMenuBar";
-import { Tabs } from "@/components/ui/tabs";
-import {
-  ThemedTabsList,
-  ThemedTabsTrigger,
-  ThemedTabsContent,
-} from "@/components/shared/ThemedTabs";
 import { AppProps, ControlPanelsInitialData } from "@/apps/base/types";
 import { useControlPanelsLogic } from "../../hooks/useControlPanelsLogic";
 import { useContactsStore } from "@/stores/useContactsStore";
 import { getContactInitials } from "@/utils/contacts";
 import { useRealtimeConnectionStatus } from "@/hooks/useRealtimeConnectionStatus";
-import { AppearanceTabContent } from "./AppearanceTabContent";
-import { SoundTabContent } from "./SoundTabContent";
-import { SyncTabContent } from "./SyncTabContent";
-import { SystemTabContent } from "./SystemTabContent";
 import { ControlPanelsDialogs } from "./ControlPanelsDialogs";
 import { ControlPanelsMacLayout } from "./ControlPanelsMacLayout";
 import { ControlPanelsMacPaneRenderer } from "./ControlPanelsMacPaneRenderer";
+import { getControlPanelsTitlebarHeight } from "./controlPanelsMacMotion";
 import {
   getControlPanelsMacWindowTitle,
   normalizeControlPanelPaneId,
@@ -43,7 +34,6 @@ export function ControlPanelsAppComponent({
     t,
     translatedHelpItems,
     windowTitle,
-    defaultTab,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,
@@ -97,8 +87,6 @@ export function ControlPanelsAppComponent({
     tabStyles,
     isWindowsTheme,
     isMacOSTheme,
-    isClassicMacTheme,
-    isWindowsLegacyTheme,
     uiSoundsEnabled,
     handleUISoundsChange,
     speechEnabled,
@@ -222,15 +210,19 @@ export function ControlPanelsAppComponent({
   } = logic;
 
   const isAdmin = useIsRyoAdmin();
-  const [macCurrentEntry, setMacCurrentEntry] =
+  const isSystem7Theme = currentTheme === "system7";
+  const isWin98 = currentTheme === "win98";
+  const titlebarHeight = getControlPanelsTitlebarHeight(currentTheme);
+  const [currentEntry, setCurrentEntry] =
     React.useState<ControlPanelMacNavigationEntry>(() =>
       normalizeControlPanelPaneId(initialData?.defaultTab) ?? "home"
     );
-  const macWindowTitle = React.useMemo(
-    () => getControlPanelsMacWindowTitle(macCurrentEntry, t, windowTitle),
-    [macCurrentEntry, t, windowTitle]
+  // The unified System Preferences layout reflects the active pane in the
+  // window title across every theme (Show All falls back to the default title).
+  const effectiveWindowTitle = React.useMemo(
+    () => getControlPanelsMacWindowTitle(currentEntry, t, windowTitle),
+    [currentEntry, t, windowTitle]
   );
-  const effectiveWindowTitle = isMacOSTheme ? macWindowTitle : windowTitle;
   const myContact = useContactsStore((state) =>
     state.myContactId
       ? state.contacts.find((contact) => contact.id === state.myContactId) ?? null
@@ -424,9 +416,7 @@ export function ControlPanelsAppComponent({
         instanceId,
         onNavigateNext,
         onNavigatePrevious,
-        ...(isMacOSTheme
-          ? { windowConstraints: { maxWidth: 440, minHeight: 200, maxHeight: 600 } }
-          : {}),
+        windowConstraints: { maxWidth: 440, minHeight: 200, maxHeight: 600 },
       }}
       trailing={
         <ControlPanelsDialogs
@@ -496,198 +486,19 @@ export function ControlPanelsAppComponent({
         />
       }
     >
-        <div
-          className={`flex flex-col ${isMacOSTheme ? "w-full h-full min-h-0" : "size-full"} ${
-            isWindowsLegacyTheme ? "pt-0 pb-2 px-2" : ""
-          } ${
-            isClassicMacTheme
-              ? isMacOSTheme
-                ? ""
-                : "p-4 pt-2"
-              : ""
-          } ${
-            isClassicMacTheme && !isMacOSTheme ? "bg-[#E3E3E3]" : ""
-          }`}
-        >
-          {isMacOSTheme ? (
-            <ControlPanelsMacLayout
-              t={t}
-              instanceId={instanceId}
-              defaultPane={initialData?.defaultTab}
-              onCurrentEntryChange={setMacCurrentEntry}
-              renderPane={renderMacPane}
-            />
-          ) : (
-          <Tabs defaultValue={defaultTab} className="size-full">
-            <ThemedTabsList>
-              <ThemedTabsTrigger value="appearance">
-                {t("apps.control-panels.appearance")}
-              </ThemedTabsTrigger>
-              <ThemedTabsTrigger value="sound">
-                {t("apps.control-panels.sound")}
-              </ThemedTabsTrigger>
-              <ThemedTabsTrigger value="sync">
-                {t("apps.control-panels.sync")}
-              </ThemedTabsTrigger>
-              <ThemedTabsTrigger value="system">
-                {t("apps.control-panels.system")}
-              </ThemedTabsTrigger>
-            </ThemedTabsList>
-
-            <ThemedTabsContent value="appearance">
-              <AppearanceTabContent
-                t={t}
-                currentTheme={currentTheme}
-                setTheme={setTheme}
-                aquaMaterial={aquaMaterial}
-                setAquaMaterial={setAquaMaterial}
-                supportsDarkMode={supportsDarkMode}
-                darkModePreference={darkModePreference}
-                setDarkMode={setDarkMode}
-                supportsAccent={supportsAccent}
-                accent={accent}
-                accentChrome={accentChrome}
-                setAccent={setAccent}
-                wallpaperAccentColor={wallpaperAccentColor}
-                currentLanguage={currentLanguage}
-                setLanguage={setLanguage}
-                tabStyles={tabStyles}
-              />
-            </ThemedTabsContent>
-
-            <ThemedTabsContent value="sound">
-              <SoundTabContent
-                t={t}
-                uiSoundsEnabled={uiSoundsEnabled}
-                handleUISoundsChange={handleUISoundsChange}
-                speechEnabled={speechEnabled}
-                handleSpeechChange={handleSpeechChange}
-                terminalSoundsEnabled={terminalSoundsEnabled}
-                setTerminalSoundsEnabled={setTerminalSoundsEnabled}
-                synthPreset={synthPreset}
-                handleSynthPresetChange={handleSynthPresetChange}
-                tabStyles={tabStyles}
-                masterVolume={masterVolume}
-                setMasterVolume={setMasterVolume}
-                setPrevMasterVolume={setPrevMasterVolume}
-                handleMasterMuteToggle={handleMasterMuteToggle}
-                uiVolume={uiVolume}
-                setUiVolume={setUiVolume}
-                setPrevUiVolume={setPrevUiVolume}
-                handleUiMuteToggle={handleUiMuteToggle}
-                speechVolume={speechVolume}
-                setSpeechVolume={setSpeechVolume}
-                setPrevSpeechVolume={setPrevSpeechVolume}
-                handleSpeechMuteToggle={handleSpeechMuteToggle}
-                chatSynthVolume={chatSynthVolume}
-                setChatSynthVolume={setChatSynthVolume}
-                setPrevChatSynthVolume={setPrevChatSynthVolume}
-                handleChatSynthMuteToggle={handleChatSynthMuteToggle}
-                ipodVolume={ipodVolume}
-                setIpodVolume={setIpodVolume}
-                setPrevIpodVolume={setPrevIpodVolume}
-                handleIpodMuteToggle={handleIpodMuteToggle}
-                isIOS={isIOS}
-              />
-            </ThemedTabsContent>
-
-            <ThemedTabsContent value="sync">
-              <SyncTabContent
-                t={t}
-                tabStyles={tabStyles}
-                isMacOSTheme={isMacOSTheme}
-                username={username}
-                promptSetUsername={promptSetUsername}
-                autoSyncEnabled={autoSyncEnabled}
-                setAutoSyncEnabled={setAutoSyncEnabled}
-                isAutoSyncChecking={isAutoSyncChecking}
-                autoSyncLastCheckedAt={autoSyncLastCheckedAt}
-                autoSyncLastError={autoSyncLastError}
-                autoSyncDomainStatus={autoSyncDomainStatus}
-                syncFiles={syncFiles}
-                syncSettings={syncSettings}
-                syncCalendar={syncCalendar}
-                syncContacts={syncContacts}
-                syncMaps={syncMaps}
-                syncSongs={syncSongs}
-                syncVideos={syncVideos}
-                syncTv={syncTv}
-                syncStickies={syncStickies}
-                setSyncFiles={setSyncFiles}
-                setSyncSettings={setSyncSettings}
-                setSyncCalendar={setSyncCalendar}
-                setSyncContacts={setSyncContacts}
-                setSyncMaps={setSyncMaps}
-                setSyncSongs={setSyncSongs}
-                setSyncVideos={setSyncVideos}
-                setSyncTv={setSyncTv}
-                setSyncStickies={setSyncStickies}
-                isCloudForceSyncing={isCloudForceSyncing}
-                isCloudBackingUp={isCloudBackingUp}
-                isCloudRestoring={isCloudRestoring}
-                isCloudForceUploading={isCloudForceUploading}
-                isCloudForceDownloading={isCloudForceDownloading}
-                setIsConfirmForceUploadOpen={setIsConfirmForceUploadOpen}
-                setIsConfirmForceDownloadOpen={setIsConfirmForceDownloadOpen}
-                handleCloudBackup={handleCloudBackup}
-                setIsConfirmCloudRestoreOpen={setIsConfirmCloudRestoreOpen}
-                cloudSyncStatus={cloudSyncStatus}
-                cloudProgress={cloudProgress}
-                isCloudStatusLoading={isCloudStatusLoading}
-                CLOUD_BACKUP_MAX_SIZE={CLOUD_BACKUP_MAX_SIZE}
-              />
-            </ThemedTabsContent>
-
-            <ThemedTabsContent value="system">
-              <SystemTabContent
-                t={t}
-                tabStyles={tabStyles}
-                username={username}
-                myContact={myContact}
-                accountAvatarLabel={accountAvatarLabel}
-                accountAvatarInitials={accountAvatarInitials}
-                realtimeStatus={realtimeStatus}
-                debugMode={debugMode}
-                isAdmin={isAdmin}
-                promptSetUsername={promptSetUsername}
-                promptVerifyToken={promptVerifyToken}
-                hasPassword={hasPassword}
-                setPasswordInput={setPasswordInput}
-                setPasswordError={setPasswordError}
-                setIsPasswordDialogOpen={setIsPasswordDialogOpen}
-                logout={logout}
-                handleLogoutAllDevices={handleLogoutAllDevices}
-                isLoggingOutAllDevices={isLoggingOutAllDevices}
-                telegramLinkedAccount={telegramLinkedAccount}
-                openTelegramDialog={openTelegramDialog}
-                isTelegramStatusLoading={isTelegramStatusLoading}
-                handleCheckForUpdates={handleCheckForUpdates}
-                handleBackup={handleBackup}
-                fileInputRef={fileInputRef}
-                handleRestore={handleRestore}
-                handleResetAll={handleResetAll}
-                setIsConfirmFormatOpen={setIsConfirmFormatOpen}
-                setDebugMode={setDebugMode}
-                showResizers={showResizers}
-                setShowResizers={setShowResizers}
-                shaderEffectEnabled={shaderEffectEnabled}
-                setShaderEffectEnabled={setShaderEffectEnabled}
-                systemFont={systemFont}
-                setSystemFont={setSystemFont}
-                AI_MODELS={AI_MODELS}
-                aiModel={aiModel}
-                setAiModel={setAiModel}
-                ttsModel={ttsModel}
-                setTtsModel={setTtsModel}
-                ttsVoice={ttsVoice}
-                setTtsVoice={setTtsVoice}
-                handleShowBootScreen={handleShowBootScreen}
-                handleTriggerAppCrashTest={handleTriggerAppCrashTest}
-                handleTriggerDesktopCrashTest={handleTriggerDesktopCrashTest}
-              />
-            </ThemedTabsContent>
-          </Tabs>
-          )}
+        <div className="flex flex-col w-full h-full min-h-0">
+          <ControlPanelsMacLayout
+            t={t}
+            instanceId={instanceId}
+            defaultPane={initialData?.defaultTab}
+            onCurrentEntryChange={setCurrentEntry}
+            isMacOSTheme={isMacOSTheme}
+            isSystem7Theme={isSystem7Theme}
+            isWindowsTheme={isWindowsTheme}
+            isWin98={isWin98}
+            titlebarHeight={titlebarHeight}
+            renderPane={renderMacPane}
+          />
         </div>
     </AppWindowShell>
   );

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsCategoryGrid.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsCategoryGrid.tsx
@@ -77,6 +77,11 @@ export function ControlPanelsCategoryGrid({
                 <span className="control-panels-category-icon-shell">
                   <ThemedIcon
                     name={category.icon}
+                    // The category artwork is the macOS System Preferences icon
+                    // set (the only complete set); the unified layout reuses it
+                    // across every theme so the grid never falls back to broken
+                    // images on System 7 / Windows where these assets are absent.
+                    themeOverride="macosx"
                     alt={t(category.labelKey)}
                     className="control-panels-category-icon"
                     draggable={false}

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacAnimatedBody.tsx
@@ -20,6 +20,12 @@ import {
 export type ControlPanelsMacAnimatedBodyProps = {
   instanceId?: string;
   toolbarHeight: number;
+  /**
+   * Title-bar height for the current theme (Aqua's 24px notitlebar spacer by
+   * default). Used to convert the measured content height into a total window
+   * height when auto-resizing.
+   */
+  titlebarHeight?: number;
   /** Changes when Show All ↔ pane navigation occurs (drives re-measure). */
   navKey: string;
   children: ReactNode;
@@ -29,6 +35,7 @@ export type ControlPanelsMacAnimatedBodyProps = {
 export function ControlPanelsMacAnimatedBody({
   instanceId,
   toolbarHeight,
+  titlebarHeight = CONTROL_PANELS_MACOSX_TITLEBAR_HEIGHT,
   navKey,
   children,
   className,
@@ -41,9 +48,7 @@ export function ControlPanelsMacAnimatedBody({
 
   const maxBodyHeight = Math.max(
     0,
-    CONTROL_PANELS_MAC_MAX_WINDOW_HEIGHT -
-      CONTROL_PANELS_MACOSX_TITLEBAR_HEIGHT -
-      toolbarHeight
+    CONTROL_PANELS_MAC_MAX_WINDOW_HEIGHT - titlebarHeight - toolbarHeight
   );
 
   const readNaturalHeight = useCallback(() => {
@@ -124,9 +129,7 @@ export function ControlPanelsMacAnimatedBody({
   // measure loop — the floor lives on the body, the parent of the measured node.
   const bodyFillMinHeight = Math.max(
     0,
-    CONTROL_PANELS_MAC_MIN_WINDOW_HEIGHT -
-      CONTROL_PANELS_MACOSX_TITLEBAR_HEIGHT -
-      toolbarHeight
+    CONTROL_PANELS_MAC_MIN_WINDOW_HEIGHT - titlebarHeight - toolbarHeight
   );
 
   useLayoutEffect(() => {
@@ -138,7 +141,7 @@ export function ControlPanelsMacAnimatedBody({
       CONTROL_PANELS_MAC_MIN_WINDOW_HEIGHT,
       Math.min(
         CONTROL_PANELS_MAC_MAX_WINDOW_HEIGHT,
-        CONTROL_PANELS_MACOSX_TITLEBAR_HEIGHT + toolbarHeight + animatedHeight
+        titlebarHeight + toolbarHeight + animatedHeight
       )
     );
 

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacLayout.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacLayout.tsx
@@ -27,6 +27,13 @@ export type ControlPanelsMacLayoutProps = {
   instanceId?: string;
   defaultPane?: string;
   onCurrentEntryChange?: (entry: ControlPanelMacNavigationEntry) => void;
+  /** Theme flags so the toolbar chrome is translated per OS theme. */
+  isMacOSTheme: boolean;
+  isSystem7Theme: boolean;
+  isWindowsTheme: boolean;
+  isWin98: boolean;
+  /** Title-bar height for the active theme (drives auto-resize math). */
+  titlebarHeight: number;
   renderPane: (
     paneId: ControlPanelPaneId,
     onNavigateToPane: (paneId: ControlPanelPaneId) => void
@@ -94,6 +101,11 @@ export function ControlPanelsMacLayout({
   instanceId,
   defaultPane,
   onCurrentEntryChange,
+  isMacOSTheme,
+  isSystem7Theme,
+  isWindowsTheme,
+  isWin98,
+  titlebarHeight,
   renderPane,
 }: ControlPanelsMacLayoutProps) {
   const toolbarRef = useRef<HTMLDivElement>(null);
@@ -190,12 +202,17 @@ export function ControlPanelsMacLayout({
           searchResults={searchResults}
           onSelectResult={selectPane}
           onFocusResult={setFocusedPaneId}
+          isMacOSTheme={isMacOSTheme}
+          isSystem7Theme={isSystem7Theme}
+          isWindowsTheme={isWindowsTheme}
+          isWin98={isWin98}
         />
       </div>
 
       <ControlPanelsMacAnimatedBody
         instanceId={instanceId}
         toolbarHeight={toolbarHeight}
+        titlebarHeight={titlebarHeight}
         navKey={currentEntry}
       >
         {showHome ? (

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacToolbar.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacToolbar.tsx
@@ -170,7 +170,9 @@ export function ControlPanelsMacToolbar({
       );
     }
 
-    const buttonVariant = isSystem7Theme ? "player" : "ghost";
+    // Every non-Aqua theme uses simple flat (ghost) icon buttons for the
+    // back/forward nav — System 7 included (no beveled "player" chrome).
+    const buttonVariant = "ghost";
     const iconButtonClassName = cn(
       "size-6 px-0",
       isWindowsTheme && "text-black"

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsMacToolbar.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsMacToolbar.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useRef, useState } from "react";
-import { CaretLeft, CaretRight } from "@phosphor-icons/react";
+import {
+  CaretLeft,
+  CaretRight,
+  ArrowLeft,
+  ArrowRight,
+} from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { osToolbarSurfaceClassName } from "@/components/shared/osThemePrimitives";
 import { SearchInput } from "@/components/ui/search-input";
+import { Button } from "@/components/ui/button";
 import {
   ToolbarButton,
   ToolbarButtonGroup,
@@ -24,6 +30,11 @@ export type ControlPanelsMacToolbarProps = {
   onSelectResult: (paneId: ControlPanelPaneId) => void;
   /** Highlight (spotlight) a result's pane, or clear with null. */
   onFocusResult: (paneId: ControlPanelPaneId | null) => void;
+  /** Theme flags so the toolbar chrome is translated per OS theme. */
+  isMacOSTheme: boolean;
+  isSystem7Theme: boolean;
+  isWindowsTheme: boolean;
+  isWin98: boolean;
 };
 
 export function ControlPanelsMacToolbar({
@@ -38,6 +49,10 @@ export function ControlPanelsMacToolbar({
   searchResults,
   onSelectResult,
   onFocusResult,
+  isMacOSTheme,
+  isSystem7Theme,
+  isWindowsTheme,
+  isWin98,
 }: ControlPanelsMacToolbarProps) {
   const [isSearchFocused, setIsSearchFocused] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
@@ -102,47 +117,122 @@ export function ControlPanelsMacToolbar({
     }
   };
 
+  const backLabel = t("apps.control-panels.toolbar.back");
+  const forwardLabel = t("apps.control-panels.toolbar.forward");
+  const showAllLabel = t("apps.control-panels.toolbar.showAll");
+
+  // Aqua renders metal-inset toolbar buttons; the classic Mac / Windows themes
+  // use the shared ghost/player buttons (matching Finder's legacy toolbar) so
+  // the chrome reads native in each OS.
+  const renderNavButtons = () => {
+    if (isMacOSTheme) {
+      return (
+        <>
+          <ToolbarButtonGroup>
+            <ToolbarButton
+              icon
+              onClick={onGoBack}
+              disabled={!canGoBack}
+              aria-label={backLabel}
+              title={backLabel}
+            >
+              <CaretLeft
+                size={14}
+                weight="fill"
+                className="scale-x-150 scale-y-90"
+              />
+            </ToolbarButton>
+            <ToolbarButton
+              icon
+              onClick={onGoForward}
+              disabled={!canGoForward}
+              aria-label={forwardLabel}
+              title={forwardLabel}
+            >
+              <CaretRight
+                size={14}
+                weight="fill"
+                className="scale-x-150 scale-y-90"
+              />
+            </ToolbarButton>
+          </ToolbarButtonGroup>
+
+          <ToolbarButtonGroup>
+            <ToolbarButton
+              onClick={onShowAll}
+              aria-label={showAllLabel}
+              title={showAllLabel}
+            >
+              {showAllLabel}
+            </ToolbarButton>
+          </ToolbarButtonGroup>
+        </>
+      );
+    }
+
+    const buttonVariant = isSystem7Theme ? "player" : "ghost";
+    const iconButtonClassName = cn(
+      "size-6 px-0",
+      isWindowsTheme && "text-black"
+    );
+
+    return (
+      <>
+        <Button
+          variant={buttonVariant}
+          size="icon"
+          className={iconButtonClassName}
+          onClick={onGoBack}
+          disabled={!canGoBack}
+          aria-label={backLabel}
+          title={backLabel}
+        >
+          <ArrowLeft size={16} weight="bold" />
+        </Button>
+        <Button
+          variant={buttonVariant}
+          size="icon"
+          className={iconButtonClassName}
+          onClick={onGoForward}
+          disabled={!canGoForward}
+          aria-label={forwardLabel}
+          title={forwardLabel}
+        >
+          <ArrowRight size={16} weight="bold" />
+        </Button>
+        <Button
+          variant={buttonVariant}
+          className={cn(
+            "h-6 px-2 text-[11px] font-geneva-12",
+            isWindowsTheme && "text-black"
+          )}
+          onClick={onShowAll}
+          aria-label={showAllLabel}
+          title={showAllLabel}
+        >
+          {showAllLabel}
+        </Button>
+      </>
+    );
+  };
+
   return (
     <div
       className={cn(
         "control-panels-mac-toolbar flex items-stretch gap-2 px-2 py-0 shrink-0",
         osToolbarSurfaceClassName(
-          { isMacOSTheme: true, isSystem7Theme: false, isWindowsTheme: false },
+          {
+            isMacOSTheme,
+            isSystem7Theme,
+            isWindowsTheme,
+            isWin98,
+          },
           { border: "bottom" }
         )
       )}
     >
       <div className="control-panels-mac-toolbar-nav flex items-center gap-1.5 min-w-0 flex-1">
-        <ToolbarButtonGroup>
-          <ToolbarButton
-            icon
-            onClick={onGoBack}
-            disabled={!canGoBack}
-            aria-label={t("apps.control-panels.toolbar.back")}
-            title={t("apps.control-panels.toolbar.back")}
-          >
-            <CaretLeft size={14} weight="fill" className="scale-x-150 scale-y-90" />
-          </ToolbarButton>
-          <ToolbarButton
-            icon
-            onClick={onGoForward}
-            disabled={!canGoForward}
-            aria-label={t("apps.control-panels.toolbar.forward")}
-            title={t("apps.control-panels.toolbar.forward")}
-          >
-            <CaretRight size={14} weight="fill" className="scale-x-150 scale-y-90" />
-          </ToolbarButton>
-        </ToolbarButtonGroup>
-
-        <ToolbarButtonGroup>
-          <ToolbarButton
-            onClick={onShowAll}
-            aria-label={t("apps.control-panels.toolbar.showAll")}
-            title={t("apps.control-panels.toolbar.showAll")}
-          >
-            {t("apps.control-panels.toolbar.showAll")}
-          </ToolbarButton>
-        </ToolbarButtonGroup>
+        {renderNavButtons()}
       </div>
 
       <div className="control-panels-mac-toolbar-search relative flex items-center shrink-0">

--- a/src/apps/control-panels/components/control-panels-app/DesktopScreenSaverPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/DesktopScreenSaverPaneContent.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
+import { cn } from "@/lib/utils";
 import { WallpaperPicker } from "../WallpaperPicker";
 import { ScreenSaverPicker } from "../ScreenSaverPicker";
+import { useControlPanelsTabClasses } from "./useControlPanelsTabClasses";
 
 export type DesktopScreenSaverPaneContentProps = {
   t: (key: string, opts?: Record<string, unknown>) => string;
@@ -12,19 +14,22 @@ export function DesktopScreenSaverPaneContent({
   t,
 }: DesktopScreenSaverPaneContentProps) {
   const [desktopTab, setDesktopTab] = useState<DesktopPaneTab>("desktop");
+  const { barClassName, triggerClassName, triggerStyle } =
+    useControlPanelsTabClasses();
 
   return (
     <div className="control-panels-pref-form control-panels-pref-form-tabbed">
       <div className="control-panels-pref-tabbed">
         <div
           role="tablist"
-          className="aqua-tab-bar control-panels-pref-tab-bar"
+          className={cn("control-panels-pref-tab-bar", barClassName)}
           aria-label={t("apps.control-panels.desktopAndScreenSaver")}
         >
           <button
             type="button"
             role="tab"
-            className="aqua-tab"
+            className={triggerClassName}
+            style={triggerStyle}
             data-state={desktopTab === "desktop" ? "active" : "inactive"}
             aria-selected={desktopTab === "desktop"}
             onClick={() => setDesktopTab("desktop")}
@@ -34,7 +39,8 @@ export function DesktopScreenSaverPaneContent({
           <button
             type="button"
             role="tab"
-            className="aqua-tab"
+            className={triggerClassName}
+            style={triggerStyle}
             data-state={desktopTab === "screenSaver" ? "active" : "inactive"}
             aria-selected={desktopTab === "screenSaver"}
             onClick={() => setDesktopTab("screenSaver")}

--- a/src/apps/control-panels/components/control-panels-app/DotMacPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/DotMacPaneContent.tsx
@@ -8,6 +8,7 @@ import { AUTO_SYNC_ITEM_ICONS } from "./constants";
 import { SyncDomainRow } from "./SyncDomainRow";
 import { SyncSectionTitle } from "./SyncSectionTitle";
 import { formatRelativeTime, formatSyncStatus, type SyncAuditStatus } from "./syncUtils";
+import { useControlPanelsTabClasses } from "./useControlPanelsTabClasses";
 
 export type DotMacPaneContentProps = {
   t: (key: string, opts?: Record<string, unknown>) => string;
@@ -109,19 +110,22 @@ export function DotMacPaneContent({
   CLOUD_BACKUP_MAX_SIZE,
 }: DotMacPaneContentProps) {
   const [dotMacTab, setDotMacTab] = useState<DotMacPaneTab>("sync");
+  const { barClassName, triggerClassName, triggerStyle } =
+    useControlPanelsTabClasses();
 
   return (
     <div className="control-panels-pref-form control-panels-pref-form-tabbed h-full overflow-y-auto">
       <div className="control-panels-pref-tabbed">
         <div
           role="tablist"
-          className="aqua-tab-bar control-panels-pref-tab-bar"
+          className={cn("control-panels-pref-tab-bar", barClassName)}
           aria-label={t("apps.control-panels.panes.dotMac")}
         >
           <button
             type="button"
             role="tab"
-            className="aqua-tab"
+            className={triggerClassName}
+            style={triggerStyle}
             data-state={dotMacTab === "sync" ? "active" : "inactive"}
             aria-selected={dotMacTab === "sync"}
             onClick={() => setDotMacTab("sync")}
@@ -131,7 +135,8 @@ export function DotMacPaneContent({
           <button
             type="button"
             role="tab"
-            className="aqua-tab"
+            className={triggerClassName}
+            style={triggerStyle}
             data-state={dotMacTab === "backup" ? "active" : "inactive"}
             aria-selected={dotMacTab === "backup"}
             onClick={() => setDotMacTab("backup")}

--- a/src/apps/control-panels/components/control-panels-app/SoundPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/SoundPaneContent.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { cn } from "@/lib/utils";
 import { Switch } from "@/components/ui/switch";
 import {
   Select,
@@ -11,6 +12,7 @@ import { SYNTH_PRESETS } from "@/hooks/chatSynthPresets";
 import { VolumeMixer } from "../VolumeMixer";
 import { ControlPanelsPrefFormRow } from "./ControlPanelsPrefFormRow";
 import type { SoundTabContentProps } from "./SoundTabContent";
+import { useControlPanelsTabClasses } from "./useControlPanelsTabClasses";
 
 export type SoundPaneContentProps = Omit<
   SoundTabContentProps,
@@ -52,19 +54,22 @@ export function SoundPaneContent({
   isIOS,
 }: SoundPaneContentProps) {
   const [soundTab, setSoundTab] = useState<SoundPaneTab>("effects");
+  const { barClassName, triggerClassName, triggerStyle } =
+    useControlPanelsTabClasses();
 
   return (
     <div className="control-panels-pref-form control-panels-pref-form-tabbed">
       <div className="control-panels-pref-tabbed">
         <div
           role="tablist"
-          className="aqua-tab-bar control-panels-pref-tab-bar"
+          className={cn("control-panels-pref-tab-bar", barClassName)}
           aria-label={t("apps.control-panels.sound")}
         >
           <button
             type="button"
             role="tab"
-            className="aqua-tab"
+            className={triggerClassName}
+            style={triggerStyle}
             data-state={soundTab === "effects" ? "active" : "inactive"}
             aria-selected={soundTab === "effects"}
             onClick={() => setSoundTab("effects")}
@@ -74,7 +79,8 @@ export function SoundPaneContent({
           <button
             type="button"
             role="tab"
-            className="aqua-tab"
+            className={triggerClassName}
+            style={triggerStyle}
             data-state={soundTab === "output" ? "active" : "inactive"}
             aria-selected={soundTab === "output"}
             onClick={() => setSoundTab("output")}

--- a/src/apps/control-panels/components/control-panels-app/controlPanelsMacMotion.ts
+++ b/src/apps/control-panels/components/control-panels-app/controlPanelsMacMotion.ts
@@ -12,6 +12,26 @@ export const CONTROL_PANELS_MAC_SIZE_TRANSITION: Transition = {
 /** macosx notitlebar spacer in WindowFrame / themes.css */
 export const CONTROL_PANELS_MACOSX_TITLEBAR_HEIGHT = 24;
 
+/**
+ * Title-bar height per OS theme, used by the auto-resize body to convert the
+ * measured content height into a total window height. Mirrors the table used by
+ * Infinite Mac/PC window sizing. Aqua uses the 24px notitlebar spacer.
+ */
+export const CONTROL_PANELS_TITLEBAR_HEIGHT_BY_THEME: Record<string, number> = {
+  macosx: CONTROL_PANELS_MACOSX_TITLEBAR_HEIGHT,
+  system7: 24,
+  xp: 30,
+  win98: 22,
+};
+
+/** Resolve the title-bar height for a theme, falling back to the Aqua spacer. */
+export function getControlPanelsTitlebarHeight(themeId: string): number {
+  return (
+    CONTROL_PANELS_TITLEBAR_HEIGHT_BY_THEME[themeId] ??
+    CONTROL_PANELS_MACOSX_TITLEBAR_HEIGHT
+  );
+}
+
 /** control-panels appRegistry windowConfig.maxSize.height */
 export const CONTROL_PANELS_MAC_MAX_WINDOW_HEIGHT = 600;
 

--- a/src/apps/control-panels/components/control-panels-app/useControlPanelsTabClasses.ts
+++ b/src/apps/control-panels/components/control-panels-app/useControlPanelsTabClasses.ts
@@ -29,14 +29,13 @@ export function useControlPanelsTabClasses(): ControlPanelsTabClasses {
   }
 
   if (isWindowsTheme) {
+    // Windows XP / 98: render as native folder tabs. The visual chrome is
+    // owned by control-panels-themed.css (targeting [role="tab"]) so it can
+    // override the XP/98 library's raised `button` bevel; here we only supply
+    // the pixel font so the labels match the rest of the OS.
     return {
-      barClassName:
-        "h-7! flex justify-start! p-0 -mt-1 -mb-[2px] bg-transparent shadow-none",
-      triggerClassName: cn(
-        "relative px-4 py-1.5 rounded-none bg-white",
-        "data-[state=active]:bg-black data-[state=active]:text-white data-[state=active]:z-10",
-        "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
-      ),
+      barClassName: "",
+      triggerClassName: "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]",
       triggerStyle: {
         fontFamily: '"Pixelated MS Sans Serif", "ArkPixel", Arial',
         fontSize: "11px",

--- a/src/apps/control-panels/components/control-panels-app/useControlPanelsTabClasses.ts
+++ b/src/apps/control-panels/components/control-panels-app/useControlPanelsTabClasses.ts
@@ -1,0 +1,56 @@
+import type { CSSProperties } from "react";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { getTabStyles } from "@/utils/tabStyles";
+import { cn } from "@/lib/utils";
+
+export interface ControlPanelsTabClasses {
+  /** Classes for the role="tablist" strip. */
+  barClassName: string;
+  /** Classes for each role="tab" button (reads data-state for active styling). */
+  triggerClassName: string;
+  /** Inline style for each trigger (Windows pixel font). */
+  triggerStyle?: CSSProperties;
+}
+
+/**
+ * Returns the tab strip / trigger classes for Control Panels preference panes,
+ * mirroring the shared ThemedTabs (ThemedTabsList / ThemedTabsTrigger) styling
+ * so the custom (always-mounted) pane tabs read native in every OS theme:
+ *   - macOS Aqua  → global `aqua-tab` chrome (unchanged)
+ *   - System 7    → getTabStyles() System 7 tabs (Geneva 12)
+ *   - Windows XP/98 → white tabs with a black active tab + pixel font
+ */
+export function useControlPanelsTabClasses(): ControlPanelsTabClasses {
+  const { currentTheme, isMacOSTheme, isWindowsTheme } = useThemeFlags();
+  const tabStyles = getTabStyles(currentTheme);
+
+  if (isMacOSTheme) {
+    return { barClassName: "aqua-tab-bar", triggerClassName: "aqua-tab" };
+  }
+
+  if (isWindowsTheme) {
+    return {
+      barClassName:
+        "h-7! flex justify-start! p-0 -mt-1 -mb-[2px] bg-transparent shadow-none",
+      triggerClassName: cn(
+        "relative px-4 py-1.5 rounded-none bg-white",
+        "data-[state=active]:bg-black data-[state=active]:text-white data-[state=active]:z-10",
+        "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
+      ),
+      triggerStyle: {
+        fontFamily: '"Pixelated MS Sans Serif", "ArkPixel", Arial',
+        fontSize: "11px",
+      },
+    };
+  }
+
+  // System 7 (and any other non-mac, non-Windows theme).
+  return {
+    barClassName: tabStyles.tabListClasses,
+    triggerClassName: cn(
+      tabStyles.tabTriggerClasses,
+      "px-4 py-1.5",
+      "font-geneva-12 text-[12px]"
+    ),
+  };
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -18,3 +18,4 @@
 @import "./themes/dark-aqua.css";
 @import "./themes/aqua-glass.css";
 @import "./themes/control-panels-mac.css";
+@import "./themes/control-panels-themed.css";

--- a/src/styles/themes/control-panels-themed.css
+++ b/src/styles/themes/control-panels-themed.css
@@ -1,0 +1,1009 @@
+/* Control Panels — System Preferences layout translated to the non-Aqua themes
+   (System 7, Windows XP, Windows 98). The Aqua (macosx) skin lives in
+   control-panels-mac.css; everything here is scoped to :not([data-os-theme="macosx"])
+   so the Aqua styling is never touched. Most colors/borders/fonts come from the
+   shared --os-* design tokens so the three classic themes share one rule set,
+   with small per-theme deltas where the chrome differs (bevels, active tabs). */
+
+/* ----------------------------------------------------------------------------
+   Layout mechanics (shared with Aqua, replicated for the classic themes so the
+   auto-height body + scroll behaviour works identically).
+---------------------------------------------------------------------------- */
+:root:not([data-os-theme="macosx"]) .control-panels-mac {
+  flex: 1 0 auto;
+  min-height: 0;
+  color: var(--os-color-text-primary, #000);
+  font-family: var(--os-font-ui);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-mac-body-measure {
+  width: 100%;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-mac-body {
+  flex-grow: 1;
+  min-height: var(--control-panels-mac-body-fill-min-height, 0);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-mac-body[data-scrollable] {
+  overflow-y: auto;
+}
+
+/* ----------------------------------------------------------------------------
+   Toolbar — surface chrome comes from osToolbarSurfaceClassName; just tune the
+   vertical rhythm so the back/forward/Show All controls have breathing room.
+---------------------------------------------------------------------------- */
+:root:not([data-os-theme="macosx"]) .control-panels-mac-toolbar {
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-mac-toolbar-search {
+  padding: 0 2px;
+}
+
+/* ----------------------------------------------------------------------------
+   Home grid (Show All)
+---------------------------------------------------------------------------- */
+:root:not([data-os-theme="macosx"]) .control-panels-category-grid {
+  --control-panels-section-inset-x: 14px;
+  padding: 0 var(--control-panels-section-inset-x) 14px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-section {
+  margin: 0 calc(-1 * var(--control-panels-section-inset-x));
+  padding: 10px var(--control-panels-section-inset-x);
+  position: relative;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-section:not(:first-of-type)::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--os-color-separator);
+  pointer-events: none;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-section-header {
+  font-family: var(--os-font-ui);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--os-color-text-primary, #111);
+  margin: 0;
+  padding: 0 0 6px;
+  text-align: left;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-section-grid {
+  --control-panels-grid-col-width: 80px;
+  display: grid;
+  grid-template-columns: repeat(
+    var(--control-panels-section-cols, 1),
+    var(--control-panels-grid-col-width)
+  );
+  width: fit-content;
+  max-width: 100%;
+  column-gap: 6px;
+  row-gap: 8px;
+  align-items: start;
+  justify-items: center;
+  padding-bottom: 4px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-category-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  width: var(--control-panels-grid-col-width, 80px);
+  max-width: var(--control-panels-grid-col-width, 80px);
+  border: none;
+  background: transparent;
+  cursor: default;
+  padding: 4px 2px;
+  border-radius: 4px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-category-item:hover,
+:root:not([data-os-theme="macosx"]) .control-panels-category-item:focus,
+:root:not([data-os-theme="macosx"]) .control-panels-category-item:focus-visible {
+  background: transparent;
+  outline: none;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-category-icon-shell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  position: relative;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-category-icon {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+  position: relative;
+  z-index: 1;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-category-item:active
+  .control-panels-category-icon {
+  filter: brightness(0.8);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-category-label {
+  font-family: var(--os-font-ui);
+  font-size: 11px;
+  line-height: 1.2;
+  color: var(--os-color-text-primary, #111);
+  max-width: 80px;
+  min-height: 2.4em;
+  text-align: center;
+  position: relative;
+  z-index: 1;
+}
+
+/* Spotlight search — dim the grid and knock matching icons out of the wash. */
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body:has(.control-panels-category-grid--searching) {
+  position: relative;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-category-grid--searching {
+  min-height: var(--control-panels-mac-body-fill-min-height, 0);
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-category-grid--searching::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: rgba(70, 72, 80, 0.32);
+  pointer-events: none;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-category-grid--searching
+  .control-panels-category-item.is-spotlight-match {
+  position: relative;
+  z-index: 2;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-category-item.is-spotlight-match
+  .control-panels-category-icon-shell::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 52px;
+  height: 52px;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(248, 248, 250, 0.5) 0%,
+    rgba(248, 248, 250, 0.5) 64%,
+    rgba(248, 248, 250, 0) 86%
+  );
+  z-index: 0;
+  pointer-events: none;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-category-item.is-spotlight-focused
+  .control-panels-category-icon-shell::before {
+  background: radial-gradient(
+    circle,
+    rgba(248, 248, 250, 0.85) 0%,
+    rgba(248, 248, 250, 0.85) 64%,
+    rgba(248, 248, 250, 0) 86%
+  );
+}
+
+/* ----------------------------------------------------------------------------
+   Toolbar typeahead search menu
+---------------------------------------------------------------------------- */
+:root:not([data-os-theme="macosx"]) .control-panels-search-menu {
+  --control-panels-search-item-h: 24px;
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 50;
+  min-width: 200px;
+  max-width: 280px;
+  max-height: calc(var(--control-panels-search-item-h) * 5.5 + 8px);
+  overflow-y: auto;
+  padding: 3px;
+  background: var(--os-color-window-bg, #fff);
+  border: 1px solid var(--os-color-separator);
+  box-shadow: 2px 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-search-item {
+  display: block;
+  width: 100%;
+  height: var(--control-panels-search-item-h, 24px);
+  line-height: var(--control-panels-search-item-h, 24px);
+  padding: 0 10px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: default;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--os-color-text-primary, #111);
+  font-family: var(--os-font-ui);
+  font-size: 11px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-search-item.is-highlighted {
+  background: var(--os-color-selection-bg);
+  color: var(--os-color-selection-text);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-search-empty {
+  padding: 6px 10px;
+  font-family: var(--os-font-ui);
+  font-size: 11px;
+  text-align: left;
+  color: var(--os-color-text-secondary);
+}
+
+/* System 7 search menu — hard black border, square drop shadow. */
+:root[data-os-theme="system7"] .control-panels-search-menu {
+  border: 1px solid #000;
+  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.5);
+}
+
+/* Win98 / XP — raised bevel panel. */
+:root[data-os-theme="win98"] .control-panels-search-menu {
+  border: 2px solid;
+  border-color: #fff #808080 #808080 #fff;
+  box-shadow: 1px 1px 0 #000;
+}
+
+/* ----------------------------------------------------------------------------
+   Preference pane
+---------------------------------------------------------------------------- */
+:root:not([data-os-theme="macosx"]) .control-panels-mac-pane {
+  display: flex;
+  flex-direction: column;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-mac-pane-inner {
+  --control-panels-pref-content-inset-x: 16px;
+  padding: 14px 16px 22px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-mac-pane-inner label {
+  font-size: 11px;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-pane-inner
+  .text-neutral-600 {
+  color: var(--os-color-text-secondary);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-mac-pane-inner > .space-y-4 {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-pane-inner
+  > .space-y-4
+  > * {
+  margin-top: 0;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-pane-inner
+  > .space-y-4
+  > hr,
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-pane-inner
+  > .space-y-4
+  > .border-t {
+  margin: 12px 0;
+  border: none;
+  height: 1px;
+  background: var(--os-color-separator);
+}
+
+/* ----------------------------------------------------------------------------
+   10.3-style form rows — labels left-aligned for the classic themes (matching
+   how System 7 / Windows settings dialogs read), controls on the right.
+---------------------------------------------------------------------------- */
+:root:not([data-os-theme="macosx"]) .control-panels-pref-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-form:not(.control-panels-pref-form-tabbed) {
+  height: auto;
+  min-height: min-content;
+  overflow: visible;
+  flex: none;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 4px;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-well
+  .control-panels-pref-form-section,
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-tab-panel
+  .control-panels-pref-form-section {
+  padding: 0;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-form-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(140px, 1.2fr);
+  gap: 12px;
+  align-items: start;
+  min-height: 30px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-form-label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  align-self: start;
+  text-align: left;
+  gap: 2px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-form-label-text {
+  font-family: var(--os-font-ui);
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--os-color-text-primary, #111);
+  line-height: 1.2;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-form-label-desc {
+  font-family: var(--os-font-ui);
+  font-size: 10px;
+  color: var(--os-color-text-secondary);
+  line-height: 1.25;
+  max-width: 200px;
+  text-wrap: pretty;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-form-control {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  align-self: start;
+  min-height: 22px;
+  padding-top: 1px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-divider {
+  margin: 12px 0;
+  border: none;
+  height: 1px;
+  background: var(--os-color-separator);
+}
+
+/* ----------------------------------------------------------------------------
+   Wells — recessed/raised panels per theme
+---------------------------------------------------------------------------- */
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-pane-inner
+  .control-panels-pref-well {
+  border: 1px solid var(--os-color-separator);
+  background: var(--os-color-window-bg, #fff);
+  padding: 12px var(--control-panels-pref-content-inset-x, 16px) 14px;
+}
+
+:root[data-os-theme="system7"]
+  .control-panels-mac-pane-inner
+  .control-panels-pref-well {
+  border: 1px solid #000;
+  background: #fff;
+  box-shadow: 1px 1px 0 rgba(0, 0, 0, 0.4);
+}
+
+:root[data-os-theme="win98"]
+  .control-panels-mac-pane-inner
+  .control-panels-pref-well {
+  border: 2px solid;
+  border-color: #808080 #fff #fff #808080;
+  background: var(--os-color-window-bg, #c0c0c0);
+  box-shadow: inset 1px 1px 0 #000, inset -1px -1px 0 #dfdfdf;
+}
+
+:root[data-os-theme="xp"]
+  .control-panels-mac-pane-inner
+  .control-panels-pref-well {
+  border: 1px solid var(--os-color-separator);
+  border-radius: 3px;
+  background: #fff;
+}
+
+/* International locale preview / format samples */
+:root:not([data-os-theme="macosx"]) .control-panels-pref-format-samples {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 2px;
+  padding: 8px 10px;
+  border: 1px solid var(--os-color-separator);
+  background: rgba(0, 0, 0, 0.035);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-format-sample-row {
+  display: grid;
+  grid-template-columns: minmax(80px, 1fr) minmax(140px, 1.2fr);
+  gap: 12px;
+  align-items: start;
+  font-family: var(--os-font-ui);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-format-sample-label {
+  text-align: left;
+  color: var(--os-color-text-primary, #111);
+  padding-top: 1px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-format-sample-value {
+  color: var(--os-color-text-primary, #111);
+}
+
+/* ----------------------------------------------------------------------------
+   Tabbed preference panes (Desktop | Screen Saver, Cloud Sync, Accounts).
+   The markup keeps the .aqua-tab / .aqua-tab-bar classes; here we strip the
+   Aqua chrome and reskin the tabs per theme.
+---------------------------------------------------------------------------- */
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-pane-inner:has(.control-panels-pref-form-tabbed) {
+  display: flex;
+  flex-direction: column;
+  padding-top: 6px;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-pane-scroll:has(.control-panels-pref-form-tabbed) {
+  display: flex;
+  flex-direction: column;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-tabbed {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding-top: 8px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-tab-bar {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  min-height: 28px;
+  height: 28px;
+  overflow: visible;
+  border-bottom: 1px solid var(--os-color-separator);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-tab-bar.aqua-tab-bar::after {
+  display: none !important;
+  content: none !important;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-tab-bar .aqua-tab {
+  position: static;
+  min-width: 96px;
+  padding: 0 14px;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  height: 24px;
+  margin-top: 0;
+  margin-bottom: -1px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--os-color-panel-bg);
+  border: 1px solid var(--os-color-separator);
+  border-bottom: 1px solid var(--os-color-separator);
+  border-radius: 4px 4px 0 0;
+  box-shadow: none;
+  color: var(--os-color-text-primary, #111);
+  font-family: var(--os-font-ui);
+  font-size: 11px;
+  overflow: visible;
+  transition: none;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-tab-bar .aqua-tab::before,
+:root:not([data-os-theme="macosx"]) .control-panels-pref-tab-bar .aqua-tab::after {
+  display: none !important;
+  content: none !important;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-tab-bar
+  .aqua-tab[data-state="active"] {
+  background: var(--os-color-window-bg, #fff);
+  border-bottom-color: var(--os-color-window-bg, #fff);
+  color: var(--os-color-text-primary, #111);
+  z-index: 1;
+}
+
+/* System 7 — flat bordered tabs on the gray strip. */
+:root[data-os-theme="system7"] .control-panels-pref-tab-bar .aqua-tab {
+  border: 1px solid #000;
+  border-radius: 0;
+  background: #d4d4d4;
+}
+
+:root[data-os-theme="system7"]
+  .control-panels-pref-tab-bar
+  .aqua-tab[data-state="active"] {
+  background: var(--os-color-window-bg, #fff);
+  border-bottom-color: var(--os-color-window-bg, #fff);
+}
+
+/* Windows XP / 98 — black active tab, pixel font, matching the app's other tabs. */
+:root[data-os-theme="xp"] .control-panels-pref-tab-bar,
+:root[data-os-theme="win98"] .control-panels-pref-tab-bar {
+  justify-content: flex-start;
+}
+
+:root[data-os-theme="xp"] .control-panels-pref-tab-bar .aqua-tab,
+:root[data-os-theme="win98"] .control-panels-pref-tab-bar .aqua-tab {
+  border-radius: 0;
+  background: #fff;
+  border: 1px solid var(--os-color-separator);
+}
+
+:root[data-os-theme="xp"]
+  .control-panels-pref-tab-bar
+  .aqua-tab[data-state="active"],
+:root[data-os-theme="win98"]
+  .control-panels-pref-tab-bar
+  .aqua-tab[data-state="active"] {
+  background: #000;
+  border-color: #000;
+  color: #fff;
+}
+
+/* Tabbed well: stack both tab panels in one grid cell, sized to the tallest. */
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-tabbed
+  > .control-panels-pref-well {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  padding: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-pref-tab-panel {
+  padding: 16px var(--control-panels-pref-content-inset-x, 16px) 14px;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-form-tabbed
+  .control-panels-pref-tab-panel {
+  grid-area: 1 / 1;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-form-tabbed
+  .control-panels-pref-tab-panel[hidden] {
+  display: block !important;
+  visibility: hidden;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+/* When the pane exceeds the window cap, pin the tab bar and scroll inside the
+   active tab panel (mirrors the Aqua behaviour). */
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body[data-scrollable]:has(.control-panels-pref-form-tabbed) {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body[data-scrollable]:has(.control-panels-pref-form-tabbed)
+  .control-panels-mac-body-measure,
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body[data-scrollable]:has(.control-panels-pref-form-tabbed)
+  .control-panels-mac-body-layout {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-mac-pane:has(.control-panels-pref-form-tabbed),
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-mac-pane-scroll:has(.control-panels-pref-form-tabbed),
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-mac-pane-inner:has(.control-panels-pref-form-tabbed),
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-form-tabbed,
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-tabbed {
+  flex: 1;
+  min-height: 0;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-mac-pane-scroll:has(.control-panels-pref-form-tabbed),
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-form-tabbed {
+  overflow: hidden;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-tabbed
+  > .control-panels-pref-well {
+  grid-template-rows: minmax(0, 1fr);
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-mac-body[data-scrollable]
+  .control-panels-pref-form-tabbed
+  .control-panels-pref-tab-panel {
+  min-height: 0;
+  overflow-y: auto;
+}
+
+/* ----------------------------------------------------------------------------
+   Account profile header (Security / Accounts panes)
+---------------------------------------------------------------------------- */
+:root:not([data-os-theme="macosx"]) .control-panels-account-profile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 0 14px;
+  text-align: center;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-account-profile-avatar-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-account-profile-presence {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+  border: 1.5px solid var(--os-color-window-bg, #fff);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-account-profile-text {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-account-profile-username {
+  font-family: var(--os-font-ui);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.2;
+  color: var(--os-color-text-primary, #111);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-account-profile-status {
+  font-family: var(--os-font-ui);
+  font-size: 11px;
+  line-height: 1.2;
+  color: var(--os-color-text-secondary);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-account-profile-login {
+  margin-top: 2px;
+}
+
+/* ----------------------------------------------------------------------------
+   Appearance live theme preview — the mini-mockups of each OS. These render the
+   currently-selected theme's window mock; the markup/classes are shared with the
+   Aqua skin, so replicate the System 7 / XP / Win98 mockups here scoped off Aqua.
+---------------------------------------------------------------------------- */
+:root:not([data-os-theme="macosx"]) .control-panels-pref-theme-preview {
+  display: flex;
+  flex-direction: column;
+  min-height: 170px;
+  margin-top: 2px;
+  padding: 10px 12px;
+  border: 1px solid var(--os-color-separator);
+  background: rgba(0, 0, 0, 0.035);
+  overflow: hidden;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-scene {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-apple {
+  font-size: 10px;
+  line-height: 1;
+  filter: var(--os-accent-apple-filter, none);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-menu-item-active {
+  background: var(--os-color-selection-bg, #000);
+  color: var(--os-color-selection-text, #fff);
+  border-radius: 2px;
+  padding: 2px 5px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 9px;
+  line-height: 1.35;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-list-row {
+  padding: 2px 4px;
+  border-radius: 3px;
+}
+
+/* --- System 7 mock --- */
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="system7"]
+  .control-panels-theme-preview-menubar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 16px;
+  padding: 0 5px;
+  border: 1px solid #000;
+  background: repeating-linear-gradient(180deg, #fff 0 1px, #000 1px 2px);
+  font-family: "Chicago", "Geneva-12", monospace;
+  font-size: 9px;
+  color: #000;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="system7"]
+  .control-panels-theme-preview-window {
+  border: 2px solid #000;
+  background: #fff;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="system7"]
+  .control-panels-theme-preview-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 16px;
+  padding: 0 4px;
+  border-bottom: 1px solid #000;
+  background: #fff;
+  font-family: "Chicago", "Geneva-12", monospace;
+  font-size: 9px;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-s7-close {
+  width: 11px;
+  height: 11px;
+  border: 1px solid #000;
+  background: #fff;
+  box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="system7"]
+  .control-panels-theme-preview-window-body {
+  padding: 6px;
+  font-family: "Geneva-12", monospace;
+  font-size: 9px;
+  color: #000;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="system7"]
+  .control-panels-theme-preview-list-row-selected {
+  background: var(--os-color-selection-bg, #000);
+  color: var(--os-color-selection-text, #fff);
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-s7-button {
+  margin-top: 6px;
+  padding: 2px 10px;
+  border: 1px solid #000;
+  background: #fff;
+  box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080;
+  font-family: "Geneva-12", monospace;
+  font-size: 9px;
+  color: #000;
+  pointer-events: none;
+}
+
+/* --- Windows XP mock --- */
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="xp"]
+  .control-panels-theme-preview-window {
+  border: 1px solid #0054e3;
+  box-shadow: 1px 1px 0 #fff inset, -1px -1px 0 #aca899;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="xp"]
+  .control-panels-theme-preview-titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 20px;
+  padding: 0 4px 0 6px;
+  background: linear-gradient(to bottom, #0058e6, #1941a5);
+  color: #fff;
+  font-family: Tahoma, sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-win-controls {
+  display: flex;
+  gap: 2px;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="xp"]
+  .control-panels-theme-preview-win-controls > span {
+  width: 14px;
+  height: 13px;
+  border: 1px solid #0a246a;
+  background: linear-gradient(to bottom, #3c8ef3, #2d6fd6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="xp"]
+  .control-panels-theme-preview-win-controls .close {
+  background: linear-gradient(to bottom, #e88, #c44);
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="xp"]
+  .control-panels-theme-preview-window-body {
+  padding: 6px;
+  background: #ece9d8;
+  font-family: Tahoma, sans-serif;
+  font-size: 9px;
+  color: #000;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="xp"]
+  .control-panels-theme-preview-list-row-selected {
+  background: #316ac5;
+  color: #fff;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-xp-button {
+  margin-top: 6px;
+  padding: 2px 12px;
+  border: 1px solid #aca899;
+  border-radius: 3px;
+  background: linear-gradient(to bottom, #fff, #ece9d8);
+  box-shadow: inset 0 1px 0 #fff;
+  font-family: Tahoma, sans-serif;
+  font-size: 9px;
+  pointer-events: none;
+}
+
+/* --- Windows 98 mock --- */
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="win98"]
+  .control-panels-theme-preview-window {
+  border: 2px solid #000;
+  box-shadow: inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="win98"]
+  .control-panels-theme-preview-titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 18px;
+  padding: 0 3px 0 4px;
+  background: linear-gradient(to right, #000084, #1084d0);
+  color: #fff;
+  font-family: "MS Sans Serif", Tahoma, sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="win98"]
+  .control-panels-theme-preview-win-controls > span {
+  width: 13px;
+  height: 12px;
+  border: 1px solid #000;
+  background: #c0c0c0;
+  box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="win98"]
+  .control-panels-theme-preview-window-body {
+  padding: 6px;
+  background: #c0c0c0;
+  font-family: "MS Sans Serif", Tahoma, sans-serif;
+  font-size: 9px;
+  color: #000;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="win98"]
+  .control-panels-theme-preview-list-row-selected {
+  background: #000080;
+  color: #fff;
+}
+
+:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-98-button {
+  margin-top: 6px;
+  padding: 2px 12px;
+  border: 2px solid #000;
+  background: #c0c0c0;
+  box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080;
+  font-family: "MS Sans Serif", Tahoma, sans-serif;
+  font-size: 9px;
+  pointer-events: none;
+}

--- a/src/styles/themes/control-panels-themed.css
+++ b/src/styles/themes/control-panels-themed.css
@@ -13,7 +13,16 @@
   flex: 1 0 auto;
   min-height: 0;
   color: var(--os-color-text-primary, #000);
-  font-family: var(--os-font-ui);
+  /* Control Panels UI font, defaults to the theme's UI font. */
+  --control-panels-font: var(--os-font-ui);
+  font-family: var(--control-panels-font);
+}
+
+/* System 7 uses Geneva 12 across the Control Panels app instead of Chicago,
+   matching the System 7 settings dialogs (Chicago stays on window chrome). */
+:root[data-os-theme="system7"] .control-panels-mac {
+  --control-panels-font: "Geneva-12", "ArkPixel", "SerenityOS-Emoji", system-ui,
+    sans-serif;
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-mac-body-measure {
@@ -69,7 +78,7 @@
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-section-header {
-  font-family: var(--os-font-ui);
+  font-family: var(--control-panels-font);
   font-size: 11px;
   font-weight: 700;
   color: var(--os-color-text-primary, #111);
@@ -140,7 +149,7 @@
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-category-label {
-  font-family: var(--os-font-ui);
+  font-family: var(--control-panels-font);
   font-size: 11px;
   line-height: 1.2;
   color: var(--os-color-text-primary, #111);
@@ -243,7 +252,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   color: var(--os-color-text-primary, #111);
-  font-family: var(--os-font-ui);
+  font-family: var(--control-panels-font);
   font-size: 11px;
 }
 
@@ -254,7 +263,7 @@
 
 :root:not([data-os-theme="macosx"]) .control-panels-search-empty {
   padding: 6px 10px;
-  font-family: var(--os-font-ui);
+  font-family: var(--control-panels-font);
   font-size: 11px;
   text-align: left;
   color: var(--os-color-text-secondary);
@@ -376,7 +385,7 @@
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-pref-form-label-text {
-  font-family: var(--os-font-ui);
+  font-family: var(--control-panels-font);
   font-size: 11px;
   font-weight: 400;
   color: var(--os-color-text-primary, #111);
@@ -384,7 +393,7 @@
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-pref-form-label-desc {
-  font-family: var(--os-font-ui);
+  font-family: var(--control-panels-font);
   font-size: 10px;
   color: var(--os-color-text-secondary);
   line-height: 1.25;
@@ -460,7 +469,7 @@
   grid-template-columns: minmax(80px, 1fr) minmax(140px, 1.2fr);
   gap: 12px;
   align-items: start;
-  font-family: var(--os-font-ui);
+  font-family: var(--control-panels-font);
   font-size: 11px;
   line-height: 1.3;
 }
@@ -477,8 +486,9 @@
 
 /* ----------------------------------------------------------------------------
    Tabbed preference panes (Desktop | Screen Saver, Cloud Sync, Accounts).
-   The markup keeps the .aqua-tab / .aqua-tab-bar classes; here we strip the
-   Aqua chrome and reskin the tabs per theme.
+   The tab strip/triggers carry each theme's real tab classes (via
+   useControlPanelsTabClasses, mirroring ThemedTabs), so we only own the
+   container layout here; the tabbed well is skinned to match tab content.
 ---------------------------------------------------------------------------- */
 :root:not([data-os-theme="macosx"])
   .control-panels-mac-pane-inner:has(.control-panels-pref-form-tabbed) {
@@ -500,104 +510,16 @@
   padding-top: 8px;
 }
 
+/* The tab strip carries the theme's real tab-list classes (display/bg/border);
+   we only own sizing so it sits flush against the tabbed well below. */
 :root:not([data-os-theme="macosx"]) .control-panels-pref-tab-bar {
-  display: flex;
+  flex-shrink: 0;
+  box-sizing: border-box;
   width: 100%;
-  justify-content: center;
-  align-items: flex-end;
-  gap: 2px;
-  flex-shrink: 0;
-  box-sizing: border-box;
-  min-height: 28px;
-  height: 28px;
-  overflow: visible;
-  border-bottom: 1px solid var(--os-color-separator);
 }
 
-:root:not([data-os-theme="macosx"]) .control-panels-pref-tab-bar.aqua-tab-bar::after {
-  display: none !important;
-  content: none !important;
-}
-
-:root:not([data-os-theme="macosx"]) .control-panels-pref-tab-bar .aqua-tab {
-  position: static;
-  min-width: 96px;
-  padding: 0 14px;
-  flex-shrink: 0;
-  box-sizing: border-box;
-  height: 24px;
-  margin-top: 0;
-  margin-bottom: -1px;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--os-color-panel-bg);
-  border: 1px solid var(--os-color-separator);
-  border-bottom: 1px solid var(--os-color-separator);
-  border-radius: 4px 4px 0 0;
-  box-shadow: none;
-  color: var(--os-color-text-primary, #111);
-  font-family: var(--os-font-ui);
-  font-size: 11px;
-  overflow: visible;
-  transition: none;
-}
-
-:root:not([data-os-theme="macosx"]) .control-panels-pref-tab-bar .aqua-tab::before,
-:root:not([data-os-theme="macosx"]) .control-panels-pref-tab-bar .aqua-tab::after {
-  display: none !important;
-  content: none !important;
-}
-
-:root:not([data-os-theme="macosx"])
-  .control-panels-pref-tab-bar
-  .aqua-tab[data-state="active"] {
-  background: var(--os-color-window-bg, #fff);
-  border-bottom-color: var(--os-color-window-bg, #fff);
-  color: var(--os-color-text-primary, #111);
-  z-index: 1;
-}
-
-/* System 7 — flat bordered tabs on the gray strip. */
-:root[data-os-theme="system7"] .control-panels-pref-tab-bar .aqua-tab {
-  border: 1px solid #000;
-  border-radius: 0;
-  background: #d4d4d4;
-}
-
-:root[data-os-theme="system7"]
-  .control-panels-pref-tab-bar
-  .aqua-tab[data-state="active"] {
-  background: var(--os-color-window-bg, #fff);
-  border-bottom-color: var(--os-color-window-bg, #fff);
-}
-
-/* Windows XP / 98 — black active tab, pixel font, matching the app's other tabs. */
-:root[data-os-theme="xp"] .control-panels-pref-tab-bar,
-:root[data-os-theme="win98"] .control-panels-pref-tab-bar {
-  justify-content: flex-start;
-}
-
-:root[data-os-theme="xp"] .control-panels-pref-tab-bar .aqua-tab,
-:root[data-os-theme="win98"] .control-panels-pref-tab-bar .aqua-tab {
-  border-radius: 0;
-  background: #fff;
-  border: 1px solid var(--os-color-separator);
-}
-
-:root[data-os-theme="xp"]
-  .control-panels-pref-tab-bar
-  .aqua-tab[data-state="active"],
-:root[data-os-theme="win98"]
-  .control-panels-pref-tab-bar
-  .aqua-tab[data-state="active"] {
-  background: #000;
-  border-color: #000;
-  color: #fff;
-}
-
-/* Tabbed well: stack both tab panels in one grid cell, sized to the tallest. */
+/* Tabbed well: stack both tab panels in one grid cell, sized to the tallest,
+   and skin it like the active theme's tab content so the tabs connect to it. */
 :root:not([data-os-theme="macosx"])
   .control-panels-pref-tabbed
   > .control-panels-pref-well {
@@ -606,6 +528,28 @@
   padding: 0;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
+}
+
+/* System 7 — gray panel-bg content, separator border (no top, tabs sit on it). */
+:root[data-os-theme="system7"]
+  .control-panels-pref-tabbed
+  > .control-panels-pref-well {
+  background: var(--os-color-panel-bg, #e3e3e3);
+  border: 1px solid var(--os-color-separator);
+  border-top: none;
+  box-shadow: none;
+}
+
+/* Windows XP / 98 — white field with a hairline border, like a real tab body. */
+:root[data-os-theme="xp"]
+  .control-panels-pref-tabbed
+  > .control-panels-pref-well,
+:root[data-os-theme="win98"]
+  .control-panels-pref-tabbed
+  > .control-panels-pref-well {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  box-shadow: none;
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-pref-tab-panel {
@@ -734,7 +678,7 @@
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-account-profile-username {
-  font-family: var(--os-font-ui);
+  font-family: var(--control-panels-font);
   font-size: 13px;
   font-weight: 500;
   line-height: 1.2;
@@ -742,7 +686,7 @@
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-account-profile-status {
-  font-family: var(--os-font-ui);
+  font-family: var(--control-panels-font);
   font-size: 11px;
   line-height: 1.2;
   color: var(--os-color-text-secondary);
@@ -801,7 +745,9 @@
   border-radius: 3px;
 }
 
-/* --- System 7 mock --- */
+/* --- System 7 mock --- the menu bar / striped title bar are the real System 7
+   window chrome (Chicago menu bar, racing-stripe active title bar with the
+   title in a white notch and a square close box). --- */
 :root:not([data-os-theme="macosx"])
   .control-panels-pref-theme-preview[data-preview-theme="system7"]
   .control-panels-theme-preview-menubar {
@@ -811,7 +757,7 @@
   min-height: 16px;
   padding: 0 5px;
   border: 1px solid #000;
-  background: repeating-linear-gradient(180deg, #fff 0 1px, #000 1px 2px);
+  background: #fff;
   font-family: "Chicago", "Geneva-12", monospace;
   font-size: 9px;
   color: #000;
@@ -820,8 +766,9 @@
 :root:not([data-os-theme="macosx"])
   .control-panels-pref-theme-preview[data-preview-theme="system7"]
   .control-panels-theme-preview-window {
-  border: 2px solid #000;
+  border: 1px solid #000;
   background: #fff;
+  box-shadow: 1px 1px 0 rgba(0, 0, 0, 0.35);
 }
 
 :root:not([data-os-theme="macosx"])
@@ -829,21 +776,40 @@
   .control-panels-theme-preview-titlebar {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 5px;
   min-height: 16px;
   padding: 0 4px;
   border-bottom: 1px solid #000;
-  background: #fff;
+  /* Active System 7 title bar = six horizontal racing stripes. */
+  background: repeating-linear-gradient(
+    0deg,
+    #000 0,
+    #000 1px,
+    #fff 1px,
+    #fff 2px
+  );
   font-family: "Chicago", "Geneva-12", monospace;
   font-size: 9px;
 }
 
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="system7"]
+  .control-panels-theme-preview-window-title {
+  margin: 0 auto;
+  padding: 0 6px;
+  background: #fff;
+  color: #000;
+  line-height: 1.1;
+}
+
 :root:not([data-os-theme="macosx"]) .control-panels-theme-preview-s7-close {
-  width: 11px;
-  height: 11px;
+  position: relative;
+  z-index: 1;
+  width: 9px;
+  height: 9px;
   border: 1px solid #000;
   background: #fff;
-  box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080;
+  box-shadow: 0 0 0 2px #fff;
 }
 
 :root:not([data-os-theme="macosx"])
@@ -855,6 +821,21 @@
   color: #000;
 }
 
+/* System 7 list control — white box with a 1px black frame. */
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="system7"]
+  .control-panels-theme-preview-list {
+  padding: 2px;
+  border: 1px solid #000;
+  background: #fff;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="system7"]
+  .control-panels-theme-preview-list-row {
+  border-radius: 0;
+}
+
 :root:not([data-os-theme="macosx"])
   .control-panels-pref-theme-preview[data-preview-theme="system7"]
   .control-panels-theme-preview-list-row-selected {
@@ -862,24 +843,30 @@
   color: var(--os-color-selection-text, #fff);
 }
 
+/* System 7 default push button — rounded rect with a bold default ring. */
 :root:not([data-os-theme="macosx"]) .control-panels-theme-preview-s7-button {
+  align-self: flex-start;
   margin-top: 6px;
-  padding: 2px 10px;
+  padding: 1px 12px;
   border: 1px solid #000;
+  border-radius: 8px;
   background: #fff;
-  box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px #000;
   font-family: "Geneva-12", monospace;
   font-size: 9px;
   color: #000;
   pointer-events: none;
 }
 
-/* --- Windows XP mock --- */
+/* --- Windows XP mock --- Luna: rounded blue title bar with a glossy top
+   highlight, real caption buttons, ECE9D8 body, a sunken white listbox. --- */
 :root:not([data-os-theme="macosx"])
   .control-panels-pref-theme-preview[data-preview-theme="xp"]
   .control-panels-theme-preview-window {
-  border: 1px solid #0054e3;
-  box-shadow: 1px 1px 0 #fff inset, -1px -1px 0 #aca899;
+  border: 1px solid #0831d9;
+  border-radius: 7px 7px 0 0;
+  background: #ece9d8;
+  overflow: hidden;
 }
 
 :root:not([data-os-theme="macosx"])
@@ -888,13 +875,22 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: 20px;
-  padding: 0 4px 0 6px;
-  background: linear-gradient(to bottom, #0058e6, #1941a5);
+  min-height: 21px;
+  padding: 0 3px 0 6px;
+  background: linear-gradient(
+    to bottom,
+    #0997ff 0%,
+    #0053ee 8%,
+    #0050ee 40%,
+    #0e6dfb 88%,
+    #0531c9 100%
+  );
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
   color: #fff;
   font-family: Tahoma, sans-serif;
   font-size: 9px;
   font-weight: 700;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.45);
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-theme-preview-win-controls {
@@ -907,15 +903,16 @@
   .control-panels-theme-preview-win-controls > span {
   width: 14px;
   height: 13px;
-  border: 1px solid #0a246a;
-  background: linear-gradient(to bottom, #3c8ef3, #2d6fd6);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: 3px;
+  background: linear-gradient(to bottom, #4d9bff 0%, #1c5fd6 55%, #0e3fae 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 :root:not([data-os-theme="macosx"])
   .control-panels-pref-theme-preview[data-preview-theme="xp"]
   .control-panels-theme-preview-win-controls .close {
-  background: linear-gradient(to bottom, #e88, #c44);
+  background: linear-gradient(to bottom, #f08b6f 0%, #e1481f 55%, #c12f12 100%);
 }
 
 :root:not([data-os-theme="macosx"])
@@ -928,6 +925,21 @@
   color: #000;
 }
 
+/* XP listbox — white field with the Luna hairline frame. */
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="xp"]
+  .control-panels-theme-preview-list {
+  padding: 2px;
+  border: 1px solid #7f9db9;
+  background: #fff;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="xp"]
+  .control-panels-theme-preview-list-row {
+  border-radius: 0;
+}
+
 :root:not([data-os-theme="macosx"])
   .control-panels-pref-theme-preview[data-preview-theme="xp"]
   .control-panels-theme-preview-list-row-selected {
@@ -936,23 +948,34 @@
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-theme-preview-xp-button {
+  align-self: flex-start;
   margin-top: 6px;
   padding: 2px 12px;
-  border: 1px solid #aca899;
+  border: 1px solid #003c74;
   border-radius: 3px;
-  background: linear-gradient(to bottom, #fff, #ece9d8);
-  box-shadow: inset 0 1px 0 #fff;
+  background: linear-gradient(
+    to bottom,
+    #fff 0%,
+    #f3f3ee 48%,
+    #e3e1d2 52%,
+    #eceae0 100%
+  );
+  box-shadow: inset 0 0 0 1px #fff;
   font-family: Tahoma, sans-serif;
   font-size: 9px;
   pointer-events: none;
 }
 
-/* --- Windows 98 mock --- */
+/* --- Windows 98 mock --- raised silver window bevel, navy gradient title bar,
+   beveled caption buttons, and a sunken white listbox. --- */
 :root:not([data-os-theme="macosx"])
   .control-panels-pref-theme-preview[data-preview-theme="win98"]
   .control-panels-theme-preview-window {
-  border: 2px solid #000;
-  box-shadow: inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080;
+  background: #c0c0c0;
+  border: 1px solid #000;
+  /* Classic raised window bevel. */
+  box-shadow: inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080,
+    inset 2px 2px 0 #fff, inset -2px -2px 0 #000;
 }
 
 :root:not([data-os-theme="macosx"])
@@ -962,8 +985,9 @@
   align-items: center;
   justify-content: space-between;
   min-height: 18px;
-  padding: 0 3px 0 4px;
-  background: linear-gradient(to right, #000084, #1084d0);
+  margin: 2px;
+  padding: 0 2px 0 4px;
+  background: linear-gradient(to right, #000080, #1084d0);
   color: #fff;
   font-family: "MS Sans Serif", Tahoma, sans-serif;
   font-size: 9px;
@@ -973,11 +997,38 @@
 :root:not([data-os-theme="macosx"])
   .control-panels-pref-theme-preview[data-preview-theme="win98"]
   .control-panels-theme-preview-win-controls > span {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 13px;
   height: 12px;
   border: 1px solid #000;
   background: #c0c0c0;
   box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080;
+  color: #000;
+  font-family: "Marlett", "MS Sans Serif", sans-serif;
+  font-size: 7px;
+  line-height: 1;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="win98"]
+  .control-panels-theme-preview-win-controls .minimize::before {
+  content: "_";
+  transform: translateY(-2px);
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="win98"]
+  .control-panels-theme-preview-win-controls .maximize::before {
+  content: "\25A1";
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="win98"]
+  .control-panels-theme-preview-win-controls .close::before {
+  content: "\00D7";
+  font-size: 9px;
 }
 
 :root:not([data-os-theme="macosx"])
@@ -990,6 +1041,22 @@
   color: #000;
 }
 
+/* Win98 listbox — sunken white field. */
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="win98"]
+  .control-panels-theme-preview-list {
+  padding: 2px;
+  background: #fff;
+  border: 1px solid #808080;
+  box-shadow: inset 1px 1px 0 #000, inset -1px -1px 0 #dfdfdf;
+}
+
+:root:not([data-os-theme="macosx"])
+  .control-panels-pref-theme-preview[data-preview-theme="win98"]
+  .control-panels-theme-preview-list-row {
+  border-radius: 0;
+}
+
 :root:not([data-os-theme="macosx"])
   .control-panels-pref-theme-preview[data-preview-theme="win98"]
   .control-panels-theme-preview-list-row-selected {
@@ -998,11 +1065,13 @@
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-theme-preview-98-button {
+  align-self: flex-start;
   margin-top: 6px;
   padding: 2px 12px;
-  border: 2px solid #000;
+  border: 1px solid #000;
   background: #c0c0c0;
-  box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080;
+  box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080,
+    inset 2px 2px 0 #dfdfdf, inset -2px -2px 0 #000;
   font-family: "MS Sans Serif", Tahoma, sans-serif;
   font-size: 9px;
   pointer-events: none;

--- a/src/styles/themes/control-panels-themed.css
+++ b/src/styles/themes/control-panels-themed.css
@@ -510,9 +510,11 @@
   padding-top: 8px;
 }
 
-/* The tab strip carries the theme's real tab-list classes (display/bg/border);
-   we only own sizing so it sits flush against the tabbed well below. */
+/* The strip carries each theme's real tab-list classes (System 7 / Aqua);
+   we own its box so it sits flush on the tabbed well below. */
 :root:not([data-os-theme="macosx"]) .control-panels-pref-tab-bar {
+  display: flex;
+  align-items: flex-end;
   flex-shrink: 0;
   box-sizing: border-box;
   width: 100%;
@@ -540,20 +542,103 @@
   box-shadow: none;
 }
 
-/* Windows XP / 98 — white field with a hairline border, like a real tab body. */
+/* ---- Windows XP / 98 native folder tabs ----------------------------------
+   The XP/98 css libraries skin bare <button> with a raised bevel; override it
+   so the tab strip reads as real folder tabs connected to the content panel. */
+:root[data-os-theme="xp"] .control-panels-pref-tab-bar,
+:root[data-os-theme="win98"] .control-panels-pref-tab-bar {
+  justify-content: flex-start;
+  gap: 0;
+  padding-left: 3px;
+  margin-bottom: -1px;
+  border: none;
+  position: relative;
+  z-index: 2;
+}
+
+:root[data-os-theme="xp"] .control-panels-pref-tab-bar [role="tab"],
+:root[data-os-theme="win98"] .control-panels-pref-tab-bar [role="tab"] {
+  position: relative;
+  display: block;
+  min-width: unset;
+  padding: 3px 12px;
+  color: #222;
+  cursor: default;
+  outline: none;
+}
+
+/* Windows XP — light folder tabs, active tab matches the white content. */
+:root[data-os-theme="xp"] .control-panels-pref-tab-bar [role="tab"] {
+  border: 1px solid #919b9c;
+  border-bottom: none;
+  border-radius: 3px 3px 0 0;
+  background: linear-gradient(180deg, #fcfcfe, #f4f3ee);
+  box-shadow: none;
+  margin-left: -1px;
+}
+
 :root[data-os-theme="xp"]
-  .control-panels-pref-tabbed
-  > .control-panels-pref-well,
+  .control-panels-pref-tab-bar
+  [role="tab"]:first-child {
+  margin-left: 0;
+}
+
+:root[data-os-theme="xp"]
+  .control-panels-pref-tab-bar
+  [role="tab"][data-state="active"] {
+  z-index: 8;
+  margin-top: -2px;
+  padding-bottom: 5px;
+  background: #fff;
+}
+
+/* Windows 98 — raised silver folder tabs, active tab grows over the content. */
+:root[data-os-theme="win98"] .control-panels-pref-tab-bar [role="tab"] {
+  background: #c0c0c0;
+  border: none;
+  border-radius: 3px 3px 0 0;
+  box-shadow: inset 1px 1px 0 #fff, inset -1px 0 0 #808080,
+    inset -2px 0 0 #000;
+  margin-right: -1px;
+  top: 1px;
+}
+
 :root[data-os-theme="win98"]
+  .control-panels-pref-tab-bar
+  [role="tab"][data-state="active"] {
+  z-index: 8;
+  top: 0;
+  margin-top: -2px;
+  padding-bottom: 5px;
+}
+
+/* Windows XP / 98 — white field tab body with a hairline / sunken frame. */
+:root[data-os-theme="xp"]
   .control-panels-pref-tabbed
   > .control-panels-pref-well {
   background: #fff;
-  border: 1px solid rgba(0, 0, 0, 0.2);
+  border: 1px solid #919b9c;
   box-shadow: none;
+}
+
+:root[data-os-theme="win98"]
+  .control-panels-pref-tabbed
+  > .control-panels-pref-well {
+  background: var(--os-color-window-bg, #c0c0c0);
+  border: none;
+  box-shadow: inset 1px 1px 0 #fff, inset 2px 2px 0 #dfdfdf,
+    inset -1px -1px 0 #000, inset -2px -2px 0 #808080;
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-pref-tab-panel {
   padding: 16px var(--control-panels-pref-content-inset-x, 16px) 14px;
+}
+
+/* The XP/98 css libraries give [role="tabpanel"] a sunken bevel; the tabbed
+   well already owns that frame, so drop it on the stacked panels. */
+:root[data-os-theme="xp"] .control-panels-pref-tab-panel,
+:root[data-os-theme="win98"] .control-panels-pref-tab-panel {
+  box-shadow: none;
 }
 
 :root:not([data-os-theme="macosx"])

--- a/src/styles/themes/control-panels-themed.css
+++ b/src/styles/themes/control-panels-themed.css
@@ -333,8 +333,8 @@
 }
 
 /* ----------------------------------------------------------------------------
-   10.3-style form rows — labels left-aligned for the classic themes (matching
-   how System 7 / Windows settings dialogs read), controls on the right.
+   10.3-style form rows — labels right-aligned against the control column
+   (matching the Aqua System Preferences layout), controls on the right.
 ---------------------------------------------------------------------------- */
 :root:not([data-os-theme="macosx"]) .control-panels-pref-form {
   display: flex;
@@ -377,10 +377,10 @@
 :root:not([data-os-theme="macosx"]) .control-panels-pref-form-label {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: flex-end;
   justify-content: flex-start;
   align-self: start;
-  text-align: left;
+  text-align: right;
   gap: 2px;
 }
 
@@ -475,7 +475,7 @@
 }
 
 :root:not([data-os-theme="macosx"]) .control-panels-pref-format-sample-label {
-  text-align: left;
+  text-align: right;
   color: var(--os-color-text-primary, #111);
   padding-top: 1px;
 }

--- a/tests/test-control-panels-mac-layout.test.ts
+++ b/tests/test-control-panels-mac-layout.test.ts
@@ -25,13 +25,20 @@ const readSource = (relativePath: string): string =>
   readFileSync(resolve(process.cwd(), relativePath), "utf-8");
 
 describe("Control Panels macOS 10.3 layout", () => {
-  test("macosx theme uses ControlPanelsMacLayout instead of ThemedTabs", () => {
+  test("all themes use the unified ControlPanelsMacLayout (legacy tabs removed)", () => {
     const source = readSource(
       "src/apps/control-panels/components/control-panels-app/ControlPanelsAppComponent.tsx"
     );
     expect(source.includes("ControlPanelsMacLayout")).toBe(true);
-    expect(source.includes("isMacOSTheme ? (")).toBe(true);
     expect(source.includes("ControlPanelsMacPaneRenderer")).toBe(true);
+    // The System Preferences layout now renders for every theme, so the
+    // layout is no longer gated behind an isMacOSTheme ternary and the legacy
+    // 4-tab ThemedTabs UI is gone.
+    expect(source.includes("isMacOSTheme ? (")).toBe(false);
+    expect(source.includes("ThemedTabsList")).toBe(false);
+    // Theme flags are threaded into the layout so the chrome is re-skinned.
+    expect(source.includes("isSystem7Theme={isSystem7Theme}")).toBe(true);
+    expect(source.includes("titlebarHeight={titlebarHeight}")).toBe(true);
   });
 
   test("mac layout provides category grid, toolbar, and navigation reducer", () => {
@@ -60,7 +67,7 @@ describe("Control Panels macOS 10.3 layout", () => {
     expect(layoutSource.includes("navState.history[navState.index]")).toBe(true);
   });
 
-  test("macosx window title shows pane name or default on Show All", () => {
+  test("window title shows pane name or default on Show All", () => {
     const appSource = readSource(
       "src/apps/control-panels/components/control-panels-app/ControlPanelsAppComponent.tsx"
     );
@@ -78,12 +85,9 @@ describe("Control Panels macOS 10.3 layout", () => {
     expect(categoriesSource.includes("category.labelKey")).toBe(true);
 
     expect(appSource.includes("getControlPanelsMacWindowTitle")).toBe(true);
-    expect(appSource.includes("macCurrentEntry")).toBe(true);
+    expect(appSource.includes("currentEntry")).toBe(true);
     expect(appSource.includes("effectiveWindowTitle")).toBe(true);
-    expect(appSource.includes("isMacOSTheme ? macWindowTitle : windowTitle")).toBe(
-      true
-    );
-    expect(appSource.includes("onCurrentEntryChange={setMacCurrentEntry}")).toBe(
+    expect(appSource.includes("onCurrentEntryChange={setCurrentEntry}")).toBe(
       true
     );
     expect(appSource.includes("title: effectiveWindowTitle")).toBe(true);
@@ -538,6 +542,44 @@ describe("Control Panels macOS 10.3 layout", () => {
     expect(toolbarSource.includes("control-panels-toolbar-pin")).toBe(false);
     expect(toolbarSource.includes("control-panels-toolbar-divider")).toBe(false);
     expect(toolbarSource.includes("onSelectPane")).toBe(false);
+  });
+
+  test("toolbar is theme-aware (Aqua metal vs classic ghost buttons)", () => {
+    const toolbarSource = readSource(
+      "src/apps/control-panels/components/control-panels-app/ControlPanelsMacToolbar.tsx"
+    );
+    // Theme flags are accepted so the chrome is translated per OS theme.
+    expect(toolbarSource.includes("isMacOSTheme")).toBe(true);
+    expect(toolbarSource.includes("isSystem7Theme")).toBe(true);
+    expect(toolbarSource.includes("isWindowsTheme")).toBe(true);
+    // Surface chrome comes from the shared themed toolbar helper.
+    expect(toolbarSource.includes("osToolbarSurfaceClassName")).toBe(true);
+    // Aqua keeps the metal-inset toolbar buttons; classic themes use the shared
+    // ghost/player Button with arrow icons (Finder's legacy toolbar pattern).
+    expect(toolbarSource.includes("ToolbarButton")).toBe(true);
+    expect(toolbarSource.includes('from "@/components/ui/button"')).toBe(true);
+    expect(toolbarSource.includes("ArrowLeft")).toBe(true);
+    expect(toolbarSource.includes("ArrowRight")).toBe(true);
+  });
+
+  test("control panels themed stylesheet skins the classic themes", () => {
+    const cssSource = readSource(
+      "src/styles/themes/control-panels-themed.css"
+    );
+    // Everything is scoped off the Aqua theme so control-panels-mac.css is
+    // untouched, and the layout primitives are reskinned for the classic themes.
+    expect(cssSource.includes(':root:not([data-os-theme="macosx"])')).toBe(true);
+    expect(cssSource.includes("control-panels-category-grid")).toBe(true);
+    expect(cssSource.includes("control-panels-pref-form-row")).toBe(true);
+    expect(cssSource.includes("control-panels-pref-tab-bar")).toBe(true);
+    expect(cssSource.includes("control-panels-search-menu")).toBe(true);
+    // Per-theme deltas exist for the three classic themes.
+    expect(cssSource.includes(':root[data-os-theme="system7"]')).toBe(true);
+    expect(cssSource.includes(':root[data-os-theme="xp"]')).toBe(true);
+    expect(cssSource.includes(':root[data-os-theme="win98"]')).toBe(true);
+    // The themed stylesheet is wired into the global theme bundle.
+    const themesSource = readSource("src/styles/themes.css");
+    expect(themesSource.includes("control-panels-themed.css")).toBe(true);
   });
 
   test("category and pinned pane icons resolve on macosx theme", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adapts the macOS Aqua "System Preferences" Control Panels layout (toolbar with back/forward + search, category icon grid home, individual preference panes) to be the default for all four OS themes, re-skinned to each theme's visual language. The Aqua skin (`control-panels-mac.css`) is untouched; the classic themes are styled in a new `control-panels-themed.css` scoped to `:root:not([data-os-theme="macosx"])`.

### Included refinements

- **Theme-native pane tabs.** Tabbed panes (Sound, Desktop & Screen Saver, Cloud Sync, Accounts) render each theme's real tab style via `useControlPanelsTabClasses`: System 7 bordered gray/white tabs, Windows XP white folder tabs, Windows 98 raised silver folder tabs, macOS Aqua unchanged. XP/98 tab chrome overrides the css libraries' raised `<button>` bevel so the tabs read as real folder tabs connected to the content panel.
- **More accurate Appearance previews.** System 7 mock gains a racing-stripe active title bar with the title in a white notch + a default-ring push button; Windows XP mock gets a rounded Luna window, glossy caption buttons, and a sunken white listbox; Windows 98 mock gets a raised window bevel, navy gradient title bar, beveled caption buttons with glyphs, and a sunken white listbox.
- **System 7 uses Geneva 12** across the Control Panels content instead of Chicago, via a `--control-panels-font` token (window-chrome title bars stay Chicago).
- **Simple flat toolbar nav buttons** for the classic themes — System 7's back/forward (and Show All) now use flat ghost buttons instead of the beveled `player` chrome, matching XP/98.
- **Right-aligned form-row labels** in the classic themes, matching the Aqua System Preferences layout (labels flush against the control column).

## Walkthrough

System 7 — flat ghost toolbar buttons, Geneva font, right-aligned labels, real System 7 tabs:
![System 7 grid with flat ghost toolbar buttons](https://cursor.com/artifacts/c/art-f621f82e-097d-48ba-9f85-c1bbe8619c3a)
![System 7 Sound pane, right-aligned labels and native tabs](https://cursor.com/artifacts/c/art-cc4add0c-bfa1-4459-8d24-81b1219e745c)

Windows XP — folder tabs, right-aligned labels, Luna preview:
![Windows XP Sound pane](https://cursor.com/artifacts/c/art-092e18c3-7462-447b-996d-0d2eb3451b70)
![Windows XP Appearance preview](https://cursor.com/artifacts/c/art-4eff0138-e492-4e3f-a8f6-db6e7985a86d)

Windows 98 — silver folder tabs, right-aligned labels, 98 preview:
![Windows 98 Sound pane](https://cursor.com/artifacts/c/art-d908fe2c-2c41-4468-8431-de7512c60824)
![Windows 98 Appearance preview](https://cursor.com/artifacts/c/art-b2822d98-bbe2-4b7c-a783-13ab32d56e81)

macOS Aqua — unchanged baseline:
![macOS Aqua tabs unchanged](https://cursor.com/artifacts/c/art-1a99b9fc-d257-4043-80db-0099f85ae4e6)

## Testing

- `bunx tsc -b` — clean
- `bun test tests/test-control-panels-mac-layout.test.ts` — 25 pass
- `bun run test:unit` — 430 pass
- Manual visual verification across all four themes via Playwright (grid/toolbar, Appearance preview, tabbed panes with active-tab swap, right-aligned labels)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ee84d-4c8b-7b0b-b9ad-62e80b538e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ee84d-4c8b-7b0b-b9ad-62e80b538e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

