### PR TITLE
Show rounded corner mask during boot screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { DeferredAutoCloudSync } from "@/hooks/useDeferredAutoCloudSync";
 import { AirDropListener } from "@/components/AirDropListener";
 import { useFilesStore } from "@/stores/useFilesStore";
 import { WallpaperAccentRunner } from "@/hooks/WallpaperAccentRunner";
+import { DesktopCornerMask } from "@/components/layout/desktop/DesktopCornerMask";
 import { installNativeToastNotifications } from "@/utils/nativeToastNotifications";
 
 // Convert registry to array
@@ -234,16 +235,19 @@ export function App() {
 
   if (showBootScreen) {
     return (
-      <BootScreen
-        isOpen={true}
-        onOpenChange={() => {}}
-        title={bootScreenMessage || t("common.system.systemRestoring")}
-        debugMode={bootDebugMode}
-        onBootComplete={() => {
-          clearNextBootMessage();
-          setShowBootScreen(false);
-        }}
-      />
+      <>
+        <BootScreen
+          isOpen={true}
+          onOpenChange={() => {}}
+          title={bootScreenMessage || t("common.system.systemRestoring")}
+          debugMode={bootDebugMode}
+          onBootComplete={() => {
+            clearNextBootMessage();
+            setShowBootScreen(false);
+          }}
+        />
+        <DesktopCornerMask />
+      </>
     );
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `DesktopCornerMask` (the small black radial-gradient overlays that round off the four screen corners) was only rendered inside `AppManagerView`, which isn't mounted while the boot screen is showing. As a result the corners were square during boot.

This renders `DesktopCornerMask` alongside `BootScreen` in `App.tsx` so the rounded black corners appear above the boot screen too (matching the desktop). The mask still only shows for the macOS and System 7 themes and uses its existing high z-index (`10004`), so it paints above the boot screen portal.

## Testing

Verified with a headless Chrome (Playwright) capture of the boot screen in debug mode (macOS theme):
- Corner-mask DOM is present during boot: `maskPresent: true`, `zIndex: 10004`, 4 corner spans at the viewport corners.
- Visual confirmation of the rounded black corner over the boot screen.

![Boot screen with rounded black corners](https://cursor.com/artifacts/c/art-d853bb9b-a11b-4d13-bf8a-8d3b505f94bc)
![Zoomed top-left corner showing black rounded mask](https://cursor.com/artifacts/c/art-3424d5ed-1a45-4995-b9ae-4d51299ff913)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ee9ba-37ae-7518-91ad-ac55bae48ed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ee9ba-37ae-7518-91ad-ac55bae48ed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

