### PR TITLE
Dark mode for docs pages and Internet Explorer chrome

### DIFF
--- a/public/docs/admin.html
+++ b/public/docs/admin.html
@@ -577,7 +577,10 @@ The Admin app manages its state using a combination of local React state (<code>
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/admin.html
+++ b/public/docs/admin.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Admin - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -386,23 +531,63 @@ The Admin app manages its state using a combination of local React state (<code>
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/ai-generation-apis.html
+++ b/public/docs/ai-generation-apis.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI Endpoints - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -587,23 +732,63 @@
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/ai-generation-apis.html
+++ b/public/docs/ai-generation-apis.html
@@ -778,7 +778,10 @@
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/ai-system.html
+++ b/public/docs/ai-system.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI System - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -437,23 +582,63 @@
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/ai-system.html
+++ b/public/docs/ai-system.html
@@ -628,7 +628,10 @@
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/api-architecture.html
+++ b/public/docs/api-architecture.html
@@ -977,7 +977,10 @@ export const maxDuration = 60; // seconds (80 for AI endpoints)</code></pre>
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/api-architecture.html
+++ b/public/docs/api-architecture.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>API Architecture - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -786,23 +931,63 @@ export const maxDuration = 60; // seconds (80 for AI endpoints)</code></pre>
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/api-design-guide.html
+++ b/public/docs/api-design-guide.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ryOS API Design Guide - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -469,23 +614,63 @@ logger.response(200, Date.now() - startTime);</code></pre>
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/api-design-guide.html
+++ b/public/docs/api-design-guide.html
@@ -660,7 +660,10 @@ logger.response(200, Date.now() - startTime);</code></pre>
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/api-reference.html
+++ b/public/docs/api-reference.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>API Reference - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -433,23 +578,63 @@ X-Username: {username}</code></pre>
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/api-reference.html
+++ b/public/docs/api-reference.html
@@ -624,7 +624,10 @@ X-Username: {username}</code></pre>
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/applet-store.html
+++ b/public/docs/applet-store.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Applet Store - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -389,23 +534,63 @@ The Applet Store extensively uses Zustand stores for managing global application
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/applet-store.html
+++ b/public/docs/applet-store.html
@@ -580,7 +580,10 @@ The Applet Store extensively uses Zustand stores for managing global application
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/application-framework.html
+++ b/public/docs/application-framework.html
@@ -706,7 +706,10 @@ export function useIpodLogic({
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/application-framework.html
+++ b/public/docs/application-framework.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Application Framework - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -515,23 +660,63 @@ export function useIpodLogic({
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/apps.html
+++ b/public/docs/apps.html
@@ -578,7 +578,10 @@ App components are lazy-loaded through <code>appRegistry</code> for performance:
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/apps.html
+++ b/public/docs/apps.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Apps - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -387,23 +532,63 @@ App components are lazy-loaded through <code>appRegistry</code> for performance:
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/architecture.html
+++ b/public/docs/architecture.html
@@ -811,7 +811,10 @@ bun run electron:build:windows  # Build Windows NSIS installer</code></pre>
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/architecture.html
+++ b/public/docs/architecture.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Architecture & Build - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -620,23 +765,63 @@ bun run electron:build:windows  # Build Windows NSIS installer</code></pre>
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/audio-system.html
+++ b/public/docs/audio-system.html
@@ -722,7 +722,10 @@ Converts Blob/ArrayBuffer to base64 string for storage.
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/audio-system.html
+++ b/public/docs/audio-system.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Audio System - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -531,23 +676,63 @@ Converts Blob/ArrayBuffer to base64 string for storage.
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/auth-api.html
+++ b/public/docs/auth-api.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Auth API - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -329,7 +474,7 @@ X-Username: {username}</code></pre>
 <p>Optional request header for timezone persistence: <code>X-User-Timezone: America/Los_Angeles</code></p>
 <p>Most auth-protected endpoints resolve credentials through the shared <code>request-auth</code> utility (both headers required together for programmatic access). <code>register</code>, <code>login</code>, and <code>token/refresh</code> remain explicit handlers.</p>
 <h2>Endpoint Summary</h2>
-<table><thead><tr><th>Method</th><th>Endpoint</th><th>Description</th></tr></thead><tbody><tr><td>POST</td><td><code>/api/auth/register</code></td><td>Create user + issue session cookie</td></tr><tr><td>POST</td><td><code>/api/auth/login</code></td><td>Login with password</td></tr><tr><td>POST</td><td><code>/api/auth/logout</code></td><td>Logout current session</td></tr><tr><td>POST</td><td><code>/api/auth/logout-all</code></td><td>Logout all sessions</td></tr><tr><td>GET</td><td><code>/api/auth/session</code></td><td>Restore session from cookie; refresh cookie Max-Age</td></tr><tr><td>POST</td><td><code>/api/auth/token/verify</code></td><td>Verify token</td></tr><tr><td>POST</td><td><code>/api/auth/token/refresh</code></td><td>Refresh session cookie</td></tr><tr><td>GET</td><td><code>/api/auth/password/check</code></td><td>Check if password set</td></tr><tr><td>POST</td><td><code>/api/auth/password/set</code></td><td>Set or update password</td></tr><tr><td>GET</td><td><code>/api/auth/tokens</code></td><td>List active tokens</td></tr></tbody></table>
+<table><thead><tr><th>Method</th><th>Endpoint</th><th>Description</th></tr></thead><tbody><tr><td>POST</td><td><code>/api/auth/register</code></td><td>Create user + issue session cookie</td></tr><tr><td>POST</td><td><code>/api/auth/login</code></td><td>Login with password</td></tr><tr><td>POST</td><td><code>/api/auth/logout</code></td><td>Logout current session</td></tr><tr><td>POST</td><td><code>/api/auth/logout-all</code></td><td>Logout all sessions</td></tr><tr><td>GET</td><td><code>/api/auth/session</code></td><td>Restore session from cookie; refresh cookie Max-Age</td></tr><tr><td>POST</td><td><code>/api/auth/token/verify</code></td><td>Verify token</td></tr><tr><td>POST</td><td><code>/api/auth/token/refresh</code></td><td>Refresh session cookie</td></tr><tr><td>GET</td><td><code>/api/auth/password/check</code></td><td>Check if password set</td></tr><tr><td>POST</td><td><code>/api/auth/password/set</code></td><td>Set or update password</td></tr><tr><td>GET</td><td><code>/api/auth/tokens</code></td><td>List active tokens</td></tr><tr><td>POST</td><td><code>/api/auth/recovery/request</code></td><td>Send a password-reset code via Telegram/email</td></tr><tr><td>POST</td><td><code>/api/auth/recovery/reset</code></td><td>Reset password with a code; invalidates sessions</td></tr><tr><td>GET</td><td><code>/api/auth/email/status</code></td><td>Recovery-email status (masked)</td></tr><tr><td>POST</td><td><code>/api/auth/email/set</code></td><td>Set/replace recovery email + send verify code</td></tr><tr><td>POST</td><td><code>/api/auth/email/verify</code></td><td>Verify recovery email with a code</td></tr><tr><td>POST</td><td><code>/api/auth/email/remove</code></td><td>Remove recovery email</td></tr><tr><td>POST</td><td><code>/api/auth/account/delete</code></td><td>Permanently delete own account</td></tr></tbody></table>
 <h2>Endpoints</h2>
 <h3>Register User</h3>
 <p>Create a new user account and receive a session cookie.</p>
@@ -479,6 +624,75 @@ X-Username: alice</code></pre>
   ],
   "count": 1
 }</code></pre>
+<h2>Account Recovery</h2>
+<p>Self-service recovery lets a user who forgot their password set a new one using a single-use code delivered to a recovery channel: a <strong>linked Telegram chat</strong> or a <strong>verified recovery email</strong>.</p>
+<p>Codes are short numeric strings, stored only as salted SHA-256 hashes in Redis, single-use, with a short TTL (~15 min) and a per-code attempt cap. Requests are rate-limited per IP and per identifier.</p>
+<h3>Request a Reset Code</h3>
+<pre><code>POST /api/auth/recovery/request
+Content-Type: application/json
+
+{
+  "identifier": "alice",          // username OR verified recovery email
+  "channel": "telegram"            // "telegram" | "email"
+}</code></pre>
+<strong>Response (200) — always generic (anti-enumeration):</strong>
+<pre><code>{
+  "success": true,
+  "message": "If an account with that information exists, a reset code has been sent."
+}</code></pre>
+<p>The endpoint never reveals whether the account exists or which channels are configured. A code is only persisted/sent when a matching account has a usable channel.</p>
+<h3>Reset Password</h3>
+<pre><code>POST /api/auth/recovery/reset
+Content-Type: application/json
+
+{
+  "identifier": "alice",          // username OR verified recovery email
+  "code": "123456",
+  "newPassword": "newSecurePassword123"
+}</code></pre>
+<p>On success the password is replaced, <strong>all existing sessions are invalidated</strong>, and a fresh session cookie is issued. Invalid/expired/used codes and unknown accounts return a generic <code>400 Invalid or expired reset code</code>.</p>
+<strong>Response (200):</strong>
+<pre><code>{
+  "success": true,
+  "username": "alice"
+}</code></pre>
+<h2>Recovery Email</h2>
+<p>Email is an <strong>optional</strong> channel that requires <strong>both</strong> <code>RESEND_API_KEY</code> <strong>and</strong> <code>RECOVERY_EMAIL_FROM</code> to be set. If either is missing, <code>email/set</code> returns <code>503</code> and <code>email/status</code> reports <code>emailConfigured: false</code>; recovery still works via Telegram.</p>
+<h3>Email Status</h3>
+<pre><code>GET /api/auth/email/status
+Authorization: Bearer {token}
+X-Username: alice</code></pre>
+<pre><code>{
+  "hasEmail": true,
+  "email": "a***@example.com",
+  "emailVerified": true,
+  "emailConfigured": true
+}</code></pre>
+<h3>Set / Verify / Remove</h3>
+<pre><code>POST /api/auth/email/set      { "email": "alice@example.com" }   # sends a code
+POST /api/auth/email/verify   { "code": "123456" }              # marks verified
+POST /api/auth/email/remove                                      # clears email</code></pre>
+<code>set</code> and <code>remove</code> require a fresh (non-grace) token. <code>verify</code> writes a reverse
+index so the email can be used as a recovery identifier.
+<h2>Delete Account</h2>
+<p>Permanently delete the authenticated user's own account and all associated data (profile, password, sessions, recovery-email index, Telegram link, sync/backup data). Requires a fresh (non-grace) token.</p>
+<pre><code>POST /api/auth/account/delete
+Authorization: Bearer {token}
+X-Username: alice
+Content-Type: application/json
+
+{
+  "confirm": true,
+  "confirmUsername": "alice",
+  "currentPassword": "currentPassword123"   // required when a password is set
+}</code></pre>
+<p>The admin account (<code>ryo</code>) cannot self-delete. The clearing <code>Set-Cookie</code> header is returned on success.</p>
+<strong>Response (200):</strong>
+<pre><code>{
+  "success": true
+}</code></pre>
+<h2>Environment</h2>
+<table><thead><tr><th>Variable</th><th>Purpose</th></tr></thead><tbody><tr><td><code>TELEGRAM_BOT_TOKEN</code></td><td>Required to deliver reset codes over Telegram</td></tr><tr><td><code>RESEND_API_KEY</code></td><td>Required for the recovery-email channel (Resend); must be set together with <code>RECOVERY_EMAIL_FROM</code></td></tr><tr><td><code>RECOVERY_EMAIL_FROM</code></td><td>Required for the recovery-email channel — <code>From</code> address for recovery email (e.g. <code>ryOS &lt;noreply@os.ryo.lu&gt;</code>); must be set together with <code>RESEND_API_KEY</code></td></tr></tbody></table>
 <h2>Error Responses</h2>
 <table><thead><tr><th>Status</th><th>Error</th><th>Description</th></tr></thead><tbody><tr><td>400</td><td><code>Invalid request</code></td><td>Missing/invalid parameters (or partial auth headers)</td></tr><tr><td>401</td><td><code>Invalid credentials</code></td><td>Wrong username or password</td></tr><tr><td>401</td><td><code>Unauthorized - invalid token</code></td><td>Token is invalid for username</td></tr><tr><td>403</td><td><code>Unauthorized</code> / <code>Forbidden - Admin access required</code></td><td>Origin or permissions blocked</td></tr><tr><td>404</td><td><code>User not found</code></td><td>Username doesn't exist</td></tr><tr><td>409</td><td><code>Username already taken</code></td><td>Register collision with different password</td></tr><tr><td>429</td><td><code>Rate limit exceeded</code></td><td>Too many requests</td></tr></tbody></table>
 <h2>Related</h2>
@@ -524,23 +738,63 @@ X-Username: alice</code></pre>
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/auth-api.html
+++ b/public/docs/auth-api.html
@@ -784,7 +784,10 @@ Content-Type: application/json
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/calendar.html
+++ b/public/docs/calendar.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Calendar - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -385,23 +530,63 @@ Launch Calendar from the application launcher. Use the day, week, or month navig
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/calendar.html
+++ b/public/docs/calendar.html
@@ -576,7 +576,10 @@ Launch Calendar from the application launcher. Use the day, week, or month navig
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/changelog.html
+++ b/public/docs/changelog.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Changelog - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -473,23 +618,63 @@
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/changelog.html
+++ b/public/docs/changelog.html
@@ -664,7 +664,10 @@
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/chat-api.html
+++ b/public/docs/chat-api.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Chat API - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -717,23 +862,63 @@ export const maxDuration = 80;     // Max duration (seconds)</code></pre>
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/chat-api.html
+++ b/public/docs/chat-api.html
@@ -908,7 +908,10 @@ export const maxDuration = 80;     // Max duration (seconds)</code></pre>
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/chats.html
+++ b/public/docs/chats.html
@@ -577,7 +577,10 @@ The Chats app leverages a Zustand store, specifically <code>useChatsStore</code>
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/chats.html
+++ b/public/docs/chats.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Chats - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -386,23 +531,63 @@ The Chats app leverages a Zustand store, specifically <code>useChatsStore</code>
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/component-architecture.html
+++ b/public/docs/component-architecture.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Component Architecture - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -780,23 +925,63 @@ function InteractiveButton({ onClick, children }) {
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/component-architecture.html
+++ b/public/docs/component-architecture.html
@@ -971,7 +971,10 @@ function InteractiveButton({ onClick, children }) {
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/component-library.html
+++ b/public/docs/component-library.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Components - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -380,23 +525,63 @@
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/component-library.html
+++ b/public/docs/component-library.html
@@ -571,7 +571,10 @@
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/contacts.html
+++ b/public/docs/contacts.html
@@ -574,7 +574,10 @@ Launch Contacts from the application launcher. The window opens with the group s
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/contacts.html
+++ b/public/docs/contacts.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contacts - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -383,23 +528,63 @@ Launch Contacts from the application launcher. The window opens with the group s
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/control-panels.html
+++ b/public/docs/control-panels.html
@@ -575,7 +575,10 @@ The Control Panels app primarily manages its state using Zustand stores. It leve
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/control-panels.html
+++ b/public/docs/control-panels.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Control Panels - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -384,23 +529,63 @@ The Control Panels app primarily manages its state using Zustand stores. It leve
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/dashboard.html
+++ b/public/docs/dashboard.html
@@ -574,7 +574,10 @@ Dashboard typically runs as an overlay or full-screen panel rather than a standa
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/dashboard.html
+++ b/public/docs/dashboard.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dashboard - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -383,23 +528,63 @@ Dashboard typically runs as an overlay or full-screen panel rather than a standa
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/file-system.html
+++ b/public/docs/file-system.html
@@ -810,7 +810,10 @@ window.dispatchEvent(new CustomEvent("saveFile", {
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/file-system.html
+++ b/public/docs/file-system.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>File System - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -619,23 +764,63 @@ window.dispatchEvent(new CustomEvent("saveFile", {
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/finder.html
+++ b/public/docs/finder.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Finder - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -388,23 +533,63 @@ The Finder app employs a robust state management strategy combining global and l
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/finder.html
+++ b/public/docs/finder.html
@@ -579,7 +579,10 @@ The Finder app employs a robust state management strategy combining global and l
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/hooks-architecture.html
+++ b/public/docs/hooks-architecture.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hooks Architecture - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -866,23 +1011,63 @@ gainNode.gain.linearRampToValueAtTime(targetVolume, now + 0.01);</code></pre>
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/hooks-architecture.html
+++ b/public/docs/hooks-architecture.html
@@ -1057,7 +1057,10 @@ gainNode.gain.linearRampToValueAtTime(targetVolume, now + 0.01);</code></pre>
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/i18n.html
+++ b/public/docs/i18n.html
@@ -598,7 +598,10 @@ t("apps.admin.statusBar.usersCount_plural", { count: 5 })  // "5 users"</code></
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/i18n.html
+++ b/public/docs/i18n.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>i18n & Hooks - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -407,23 +552,63 @@ t("apps.admin.statusBar.usersCount_plural", { count: 5 })  // "5 users"</code></
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/infinite-mac.html
+++ b/public/docs/infinite-mac.html
@@ -585,7 +585,10 @@ The app integrates with Infinite Mac via a same-origin wrapper that enables cros
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/infinite-mac.html
+++ b/public/docs/infinite-mac.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Infinite Mac - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -394,23 +539,63 @@ The app integrates with Infinite Mac via a same-origin wrapper that enables cros
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/internet-explorer.html
+++ b/public/docs/internet-explorer.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Internet Explorer - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -386,23 +531,63 @@ Internet Explorer utilizes Zustand for its global state management. This include
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/internet-explorer.html
+++ b/public/docs/internet-explorer.html
@@ -577,7 +577,10 @@ Internet Explorer utilizes Zustand for its global state management. This include
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/ipod.html
+++ b/public/docs/ipod.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>iPod - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -388,23 +533,63 @@ The iPod app leverages Zustand for robust state management, utilizing several st
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/ipod.html
+++ b/public/docs/ipod.html
@@ -579,7 +579,10 @@ The iPod app leverages Zustand for robust state management, utilizing several st
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/karaoke.html
+++ b/public/docs/karaoke.html
@@ -577,7 +577,10 @@ The Karaoke app primarily manages its internal playback, lyric synchronization, 
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/karaoke.html
+++ b/public/docs/karaoke.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Karaoke - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -386,23 +531,63 @@ The Karaoke app primarily manages its internal playback, lyric synchronization, 
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/maps.html
+++ b/public/docs/maps.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Maps - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -382,23 +527,63 @@
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/maps.html
+++ b/public/docs/maps.html
@@ -573,7 +573,10 @@
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/media-api.html
+++ b/public/docs/media-api.html
@@ -766,7 +766,10 @@ results.forEach(video =&gt; {
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/media-api.html
+++ b/public/docs/media-api.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Media API - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -575,23 +720,63 @@ results.forEach(video =&gt; {
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/messages-api.html
+++ b/public/docs/messages-api.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Messages API - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -446,23 +591,63 @@ X-Username: ryo</code></pre>
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/messages-api.html
+++ b/public/docs/messages-api.html
@@ -637,7 +637,10 @@ X-Username: ryo</code></pre>
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/minesweeper.html
+++ b/public/docs/minesweeper.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Minesweeper - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -386,23 +531,63 @@ The Minesweeper app manages its core game state, including the board layout, min
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/minesweeper.html
+++ b/public/docs/minesweeper.html
@@ -577,7 +577,10 @@ The Minesweeper app manages its core game state, including the board layout, min
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/overview.html
+++ b/public/docs/overview.html
@@ -619,7 +619,10 @@
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/overview.html
+++ b/public/docs/overview.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Overview - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -428,23 +573,63 @@
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/paint.html
+++ b/public/docs/paint.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Paint - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -386,23 +531,63 @@ The Paint app primarily manages its state using the <code>usePaintLogic</code> c
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/paint.html
+++ b/public/docs/paint.html
@@ -577,7 +577,10 @@ The Paint app primarily manages its state using the <code>usePaintLogic</code> c
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/photo-booth.html
+++ b/public/docs/photo-booth.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Photo Booth - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -387,23 +532,63 @@ Photo Booth primarily manages its internal application state using local compone
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/photo-booth.html
+++ b/public/docs/photo-booth.html
@@ -578,7 +578,10 @@ Photo Booth primarily manages its internal application state using local compone
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/presence-api.html
+++ b/public/docs/presence-api.html
@@ -637,7 +637,10 @@ Content-Type: application/json
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/presence-api.html
+++ b/public/docs/presence-api.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Presence API - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -446,23 +591,63 @@ Content-Type: application/json
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/privacy.html
+++ b/public/docs/privacy.html
@@ -615,7 +615,10 @@
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/privacy.html
+++ b/public/docs/privacy.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privacy Policy - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -424,23 +569,63 @@
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/rooms-api.html
+++ b/public/docs/rooms-api.html
@@ -683,7 +683,10 @@ Content-Type: application/json
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/rooms-api.html
+++ b/public/docs/rooms-api.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Rooms API - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -492,23 +637,63 @@ Content-Type: application/json
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/self-hosting-vps.html
+++ b/public/docs/self-hosting-vps.html
@@ -714,7 +714,10 @@ sudo iptables-nft -S FORWARD</code></pre>
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/self-hosting-vps.html
+++ b/public/docs/self-hosting-vps.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Self-hosting ryOS on a VPS or Coolify (without Vercel) - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -523,23 +668,63 @@ sudo iptables-nft -S FORWARD</code></pre>
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/song-api.html
+++ b/public/docs/song-api.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Song API - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -869,23 +1014,63 @@ const importRes = await fetch('/api/songs', {
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/song-api.html
+++ b/public/docs/song-api.html
@@ -1060,7 +1060,10 @@ const importRes = await fetch('/api/songs', {
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/soundboard.html
+++ b/public/docs/soundboard.html
@@ -576,7 +576,10 @@ The Soundboard app primarily manages its state using Zustand stores, specificall
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/soundboard.html
+++ b/public/docs/soundboard.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Soundboard - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -385,23 +530,63 @@ The Soundboard app primarily manages its state using Zustand stores, specificall
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/state-management.html
+++ b/public/docs/state-management.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>State Management - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -842,23 +987,63 @@ set((state) =&gt; ({
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/state-management.html
+++ b/public/docs/state-management.html
@@ -1033,7 +1033,10 @@ set((state) =&gt; ({
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/stickies.html
+++ b/public/docs/stickies.html
@@ -579,7 +579,10 @@ The Stickies app manages its state primarily through the <code>useStickiesLogic<
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/stickies.html
+++ b/public/docs/stickies.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Stickies - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -388,23 +533,63 @@ The Stickies app manages its state primarily through the <code>useStickiesLogic<
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/synth.html
+++ b/public/docs/synth.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Synth - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -386,23 +531,63 @@ The Synth app utilizes Zustand for global state management, specifically through
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/synth.html
+++ b/public/docs/synth.html
@@ -577,7 +577,10 @@ The Synth app utilizes Zustand for global state management, specifically through
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/terminal.html
+++ b/public/docs/terminal.html
@@ -576,7 +576,10 @@ The Terminal app utilizes Zustand stores, specifically <code>useTerminalStore</c
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/terminal.html
+++ b/public/docs/terminal.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Terminal - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -385,23 +530,63 @@ The Terminal app utilizes Zustand stores, specifically <code>useTerminalStore</c
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/terms.html
+++ b/public/docs/terms.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Terms of Service - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -406,23 +551,63 @@
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/terms.html
+++ b/public/docs/terms.html
@@ -597,7 +597,10 @@
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/textedit.html
+++ b/public/docs/textedit.html
@@ -579,7 +579,10 @@ TextEdit primarily manages its complex rich text editor state locally within the
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/textedit.html
+++ b/public/docs/textedit.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TextEdit - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -388,23 +533,63 @@ TextEdit primarily manages its complex rich text editor state locally within the
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/theme-architecture.html
+++ b/public/docs/theme-architecture.html
@@ -578,7 +578,10 @@
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/theme-architecture.html
+++ b/public/docs/theme-architecture.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Theme architecture (implementation) - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -387,23 +532,63 @@
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/theme-system.html
+++ b/public/docs/theme-system.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Theme System - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -704,23 +849,63 @@ linear-gradient(to bottom, #ececec 0%, #ececec 100%);</code></pre>
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/theme-system.html
+++ b/public/docs/theme-system.html
@@ -895,7 +895,10 @@ linear-gradient(to bottom, #ececec 0%, #ececec 100%);</code></pre>
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/tv.html
+++ b/public/docs/tv.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TV - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -386,23 +531,63 @@ TV uses local React state for UI (drawer open, fullscreen, dialogs) and the shar
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/tv.html
+++ b/public/docs/tv.html
@@ -577,7 +577,10 @@ TV uses local React state for UI (drawer open, fullscreen, dialogs) and the shar
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/ui-components.html
+++ b/public/docs/ui-components.html
@@ -612,7 +612,10 @@
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/ui-components.html
+++ b/public/docs/ui-components.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>UI Components and Shared Systems - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -421,23 +566,63 @@
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/utility-apis.html
+++ b/public/docs/utility-apis.html
@@ -1155,7 +1155,10 @@ await fetch('/api/admin', {
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/utility-apis.html
+++ b/public/docs/utility-apis.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Utility APIs - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -964,23 +1109,63 @@ await fetch('/api/admin', {
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/videos.html
+++ b/public/docs/videos.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Videos - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -384,23 +529,63 @@
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/videos.html
+++ b/public/docs/videos.html
@@ -575,7 +575,10 @@
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/virtual-pc.html
+++ b/public/docs/virtual-pc.html
@@ -575,7 +575,10 @@ Virtual PC uses local React state for UI concerns and a Zustand store (<code>use
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/virtual-pc.html
+++ b/public/docs/virtual-pc.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Virtual PC - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -384,23 +529,63 @@ Virtual PC uses local React state for UI concerns and a Zustand store (<code>use
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/winamp.html
+++ b/public/docs/winamp.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Winamp - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -393,23 +538,63 @@ The app creates a Webamp instance on mount, rendering it into a positioned conta
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/public/docs/winamp.html
+++ b/public/docs/winamp.html
@@ -584,7 +584,10 @@ The app creates a Webamp instance on mount, rendering it into a positioned conta
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/window-management.html
+++ b/public/docs/window-management.html
@@ -894,7 +894,10 @@ useEffect(() =&gt; {
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/public/docs/window-management.html
+++ b/public/docs/window-management.html
@@ -5,9 +5,154 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Window Management - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -15,20 +160,20 @@
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -36,16 +181,16 @@
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -53,11 +198,11 @@
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -68,19 +213,19 @@
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -90,14 +235,14 @@
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -109,19 +254,19 @@
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -150,7 +295,7 @@
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -168,8 +313,8 @@
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -703,23 +848,63 @@ useEffect(() =&gt; {
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -330,9 +330,154 @@ function generatePage(doc: DocEntry, allDocs: DocEntry[], currentIndex: number):
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${doc.title} - ryOS Docs</title>
   <link rel="icon" href="/icons/mac-192.png">
+  <meta name="color-scheme" content="light dark">
+  <script>
+    // Resolve dark mode before paint to avoid a flash. Priority:
+    //   1. ryOS parent window color scheme (when embedded same-origin, e.g. the
+    //      Internet Explorer app) — follows the OS dark-mode toggle live.
+    //   2. The browser's prefers-color-scheme (standalone docs viewing).
+    (function () {
+      var root = document.documentElement;
+      function parentScheme() {
+        try {
+          if (window.parent && window.parent !== window) {
+            var pdoc = window.parent.document;
+            if (pdoc && pdoc.documentElement) {
+              return pdoc.documentElement.getAttribute("data-os-color-scheme");
+            }
+          }
+        } catch (e) {
+          // Cross-origin parent — not readable, fall back to media query.
+        }
+        return undefined;
+      }
+      function resolveDark() {
+        var scheme = parentScheme();
+        if (scheme === "dark") return true;
+        if (scheme === "light" || scheme === "") return false;
+        // A null attribute means the parent simply isn't in dark mode; when
+        // embedded that still implies light. Only fall back to the media query
+        // when standalone.
+        if (scheme === null && window.parent && window.parent !== window) {
+          try {
+            // Confirm the parent is actually readable (same-origin) before trusting null.
+            void window.parent.document.documentElement;
+            return false;
+          } catch (e) {
+            /* unreadable -> standalone-style fallback */
+          }
+        }
+        return !!(
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+      function apply() {
+        var dark = resolveDark();
+        root.setAttribute("data-color-scheme", dark ? "dark" : "light");
+        window.__ryosDocsDark = dark;
+        // Mermaid bakes its palette into the SVG at render time, so re-render
+        // any diagrams when the scheme changes after the initial paint.
+        if (typeof window.__ryosDocsRenderMermaid === "function") {
+          window.__ryosDocsRenderMermaid();
+        }
+      }
+      apply();
+      window.__ryosDocsApplyScheme = apply;
+      try {
+        if (window.matchMedia) {
+          window
+            .matchMedia("(prefers-color-scheme: dark)")
+            .addEventListener("change", apply);
+        }
+      } catch (e) {
+        /* ignore */
+      }
+      // Live-follow the ryOS dark-mode toggle when embedded same-origin.
+      try {
+        if (window.parent && window.parent !== window) {
+          var pdoc = window.parent.document;
+          if (pdoc && pdoc.documentElement && window.MutationObserver) {
+            new MutationObserver(apply).observe(pdoc.documentElement, {
+              attributes: true,
+              attributeFilter: ["data-os-color-scheme"],
+            });
+          }
+        }
+      } catch (e) {
+        /* cross-origin parent — nothing to observe */
+      }
+    })();
+  </script>
   <style>
     @font-face { font-family: "Geneva"; src: url("/fonts/geneva-12.woff2") format("woff2"); }
     @font-face { font-family: "Monaco"; src: url("/fonts/monacottf.woff2") format("woff2"); }
+
+    /* Color tokens — light defaults. Dark overrides live below, keyed on the
+       resolved data-color-scheme attribute (set by the head script) with a
+       prefers-color-scheme fallback for standalone viewing. */
+    :root {
+      --doc-bg: #fff;
+      --doc-text: #000;
+      --doc-text-secondary: #333;
+      --doc-text-tertiary: #666;
+      --doc-text-faint: #999;
+      --doc-link: #00f;
+      --doc-border: #ccc;
+      --doc-border-light: #ddd;
+      --doc-surface: #f0f0f0;
+      --doc-surface-alt: #f8f8f8;
+      --doc-hover-bg: #f0f0f0;
+      --doc-accent-bg: #000;
+      --doc-accent-text: #fff;
+      --doc-mermaid-node: #f8f8f8;
+      --doc-mermaid-stroke: #ccc;
+      --doc-mermaid-edge-label: #fff;
+      color-scheme: light;
+    }
+    :root[data-color-scheme="dark"] {
+      --doc-bg: #1e1e21;
+      --doc-text: #ededf0;
+      --doc-text-secondary: #c4c4ca;
+      --doc-text-tertiary: #9a9aa2;
+      --doc-text-faint: #6e6e74;
+      --doc-link: #6ba3ff;
+      --doc-border: rgba(255, 255, 255, 0.16);
+      --doc-border-light: rgba(255, 255, 255, 0.12);
+      --doc-surface: #2c2c30;
+      --doc-surface-alt: #27272b;
+      --doc-hover-bg: rgba(255, 255, 255, 0.08);
+      --doc-accent-bg: #ededf0;
+      --doc-accent-text: #1e1e21;
+      --doc-mermaid-node: #2c2c30;
+      --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+      --doc-mermaid-edge-label: #1e1e21;
+      color-scheme: dark;
+    }
+    /* Standalone fallback: honor the OS preference unless the page was explicitly
+       resolved to light (data-color-scheme="light" wins over this block). */
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-color-scheme="light"]) {
+        --doc-bg: #1e1e21;
+        --doc-text: #ededf0;
+        --doc-text-secondary: #c4c4ca;
+        --doc-text-tertiary: #9a9aa2;
+        --doc-text-faint: #6e6e74;
+        --doc-link: #6ba3ff;
+        --doc-border: rgba(255, 255, 255, 0.16);
+        --doc-border-light: rgba(255, 255, 255, 0.12);
+        --doc-surface: #2c2c30;
+        --doc-surface-alt: #27272b;
+        --doc-hover-bg: rgba(255, 255, 255, 0.08);
+        --doc-accent-bg: #ededf0;
+        --doc-accent-text: #1e1e21;
+        --doc-mermaid-node: #2c2c30;
+        --doc-mermaid-stroke: rgba(255, 255, 255, 0.22);
+        --doc-mermaid-edge-label: #1e1e21;
+        color-scheme: dark;
+      }
+    }
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: "Geneva", system-ui, sans-serif;
@@ -340,20 +485,20 @@ function generatePage(doc: DocEntry, allDocs: DocEntry[], currentIndex: number):
       line-height: 1.5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background: #fff;
-      color: #000;
+      background: var(--doc-bg);
+      color: var(--doc-text);
     }
-    a { color: #00f; }
+    a { color: var(--doc-link); }
     a:hover { text-decoration: none; }
     code, pre { font-family: "Monaco", monospace; font-size: 11px; }
-    code { background: #f0f0f0; padding: 1px 4px; }
-    pre { background: #f8f8f8; border: 1px solid #ddd; padding: 12px; overflow-x: auto; margin: 12px 0; }
+    code { background: var(--doc-surface); padding: 1px 4px; }
+    pre { background: var(--doc-surface-alt); border: 1px solid var(--doc-border-light); padding: 12px; overflow-x: auto; margin: 12px 0; }
     pre code { background: none; padding: 0; }
     
     /* Layout */
     .header {
       position: sticky; top: 0; z-index: 10;
-      background: #fff; border-bottom: 1px solid #ccc;
+      background: var(--doc-bg); border-bottom: 1px solid var(--doc-border);
       padding: 0 16px; height: 40px;
       display: flex; align-items: center; justify-content: space-between;
     }
@@ -361,16 +506,16 @@ function generatePage(doc: DocEntry, allDocs: DocEntry[], currentIndex: number):
     .header-left img { width: 20px; height: 20px; display: block; }
     .header-left span { font-weight: bold; }
     .header-right { display: flex; align-items: center; gap: 16px; }
-    .header-right a { text-decoration: none; color: #333; }
-    .header-right a:hover { color: #000; }
+    .header-right a { text-decoration: none; color: var(--doc-text-secondary); }
+    .header-right a:hover { color: var(--doc-text); }
     .header-right .github { display: flex; align-items: center; gap: 4px; }
-    .header-right .launch { background: #000; color: #fff; padding: 4px 12px; }
+    .header-right .launch { background: var(--doc-accent-bg); color: var(--doc-accent-text); padding: 4px 12px; }
     
     .container { display: flex; max-width: 1100px; margin: 0 auto; }
     
     .sidebar {
       width: 220px; flex-shrink: 0;
-      border-right: 1px solid #ccc;
+      border-right: 1px solid var(--doc-border);
       padding: 12px;
       position: sticky; top: 40px;
       height: calc(100vh - 40px);
@@ -378,11 +523,11 @@ function generatePage(doc: DocEntry, allDocs: DocEntry[], currentIndex: number):
     }
     .sidebar a {
       display: block; padding: 4px 8px; margin: 2px 0;
-      text-decoration: none; color: #333;
+      text-decoration: none; color: var(--doc-text-secondary);
       font-size: 11px;
     }
-    .sidebar a:hover { background: #f0f0f0; }
-    .sidebar a.active { background: #000; color: #fff; }
+    .sidebar a:hover { background: var(--doc-hover-bg); }
+    .sidebar a.active { background: var(--doc-accent-bg); color: var(--doc-accent-text); }
     
     /* Tree hierarchy styles */
     .nav-group { margin: 4px 0; }
@@ -393,19 +538,19 @@ function generatePage(doc: DocEntry, allDocs: DocEntry[], currentIndex: number):
       background: none; border: none; padding: 0; width: 100%;
       cursor: pointer; text-align: left; font: inherit; color: inherit;
     }
-    .nav-toggle:hover { background: #f0f0f0; }
+    .nav-toggle:hover { background: var(--doc-hover-bg); }
     .nav-toggle svg { flex-shrink: 0; opacity: 0.6; transition: transform 0.2s; }
     .nav-toggle a { flex: 1; padding: 4px 8px; margin: 0; pointer-events: auto; font-size: 11px; }
     .nav-children { margin-left: 12px; overflow: hidden; transition: height 0.2s ease-out; }
-    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: #555 !important; }
-    .nav-child:hover { color: #000 !important; }
-    .nav-child.active { color: #fff !important; }
+    .nav-child { padding-left: 8px !important; font-size: 10px !important; color: var(--doc-text-tertiary) !important; }
+    .nav-child:hover { color: var(--doc-text) !important; }
+    .nav-child.active { color: var(--doc-accent-text) !important; }
     
     .content { flex: 1; padding: 24px 32px; min-width: 0; }
     
     /* Typography */
-    h1 { font-size: 18px; border-bottom: 1px solid #ccc; padding-bottom: 8px; margin-bottom: 16px; }
-    hr { border: none; border-top: 1px solid #ccc; margin: 16px 0; }
+    h1 { font-size: 18px; border-bottom: 1px solid var(--doc-border); padding-bottom: 8px; margin-bottom: 16px; }
+    hr { border: none; border-top: 1px solid var(--doc-border); margin: 16px 0; }
     h2 { font-size: 14px; margin: 24px 0 12px; }
     h3 { font-size: 12px; margin: 16px 0 8px; }
     h4 { font-size: 11px; margin: 12px 0 6px; font-weight: bold; }
@@ -415,14 +560,14 @@ function generatePage(doc: DocEntry, allDocs: DocEntry[], currentIndex: number):
     
     /* Tables */
     table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 11px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f0f0f0; font-weight: bold; }
+    th, td { border: 1px solid var(--doc-border); padding: 6px 8px; text-align: left; }
+    th { background: var(--doc-surface); font-weight: bold; }
     
     /* Mermaid diagrams */
     pre.mermaid { background: none; border: none; padding: 0; text-align: center; margin: 16px 0; }
     .mermaid svg { max-width: 100%; height: auto; font-family: "Geneva", system-ui, sans-serif !important; }
-    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: #f8f8f8 !important; stroke: #ccc !important; }
-    .mermaid .edgeLabel { background: #fff !important; font-size: 10px !important; }
+    .mermaid .node rect, .mermaid .node circle, .mermaid .node polygon { fill: var(--doc-mermaid-node) !important; stroke: var(--doc-mermaid-stroke) !important; }
+    .mermaid .edgeLabel { background: var(--doc-mermaid-edge-label) !important; font-size: 10px !important; }
     .mermaid .label { font-size: 10px !important; }
     .mermaid .nodeLabel { font-size: 10px !important; }
     .mermaid .cluster-label { font-size: 10px !important; }
@@ -434,19 +579,19 @@ function generatePage(doc: DocEntry, allDocs: DocEntry[], currentIndex: number):
     details { margin: 8px 0; }
     details summary { 
       cursor: pointer; 
-      color: #666; 
+      color: var(--doc-text-tertiary); 
       font-size: 11px;
       padding: 4px 0;
       user-select: none;
     }
-    details summary:hover { color: #000; }
+    details summary:hover { color: var(--doc-text); }
     details[open] summary { margin-bottom: 8px; }
     details ul { margin-top: 0; }
     
     /* Navigation */
-    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid #ccc; }
-    .nav a { text-decoration: none; color: #333; }
-    .nav a:hover { color: #000; }
+    .nav { display: flex; justify-content: space-between; margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--doc-border); }
+    .nav a { text-decoration: none; color: var(--doc-text-secondary); }
+    .nav a:hover { color: var(--doc-text); }
     
     /* Mobile menu button */
     .menu-btn { 
@@ -475,7 +620,7 @@ function generatePage(doc: DocEntry, allDocs: DocEntry[], currentIndex: number):
       .sidebar { 
         position: fixed; left: -240px; top: 40px; 
         width: 240px; height: calc(100vh - 40px);
-        background: #fff; z-index: 20;
+        background: var(--doc-bg); z-index: 20;
         transition: left 0.2s;
       }
       .sidebar.open { left: 0; box-shadow: 2px 0 8px rgba(0,0,0,0.1); }
@@ -493,8 +638,8 @@ function generatePage(doc: DocEntry, allDocs: DocEntry[], currentIndex: number):
         <img src="/icons/mac-192.png" alt="ryOS" width="20" height="20">
         <span>ryOS</span>
       </a>
-      <span style="color:#999">/</span>
-      <span style="color:#666">Docs</span>
+      <span style="color:var(--doc-text-faint)">/</span>
+      <span style="color:var(--doc-text-tertiary)">Docs</span>
     </div>
     <div class="header-right">
       <a href="https://github.com/ryokun6/ryos" target="_blank" class="github">
@@ -554,23 +699,63 @@ function generatePage(doc: DocEntry, allDocs: DocEntry[], currentIndex: number):
   </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      securityLevel: 'loose',
-      themeVariables: {
-        fontFamily: '"Geneva", system-ui, sans-serif',
-        fontSize: '10px',
-        primaryColor: '#f0f0f0',
-        primaryBorderColor: '#ccc',
-        primaryTextColor: '#000',
-        lineColor: '#666',
-        secondaryColor: '#f8f8f8',
-        tertiaryColor: '#fff'
-      },
-      flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
-      sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+    // Stash each diagram's source so we can re-render with a fresh palette when
+    // the color scheme is toggled live (mermaid bakes colors into the SVG).
+    var diagrams = Array.prototype.slice.call(document.querySelectorAll('pre.mermaid'));
+    diagrams.forEach(function (el) {
+      if (el.getAttribute('data-mermaid-src') === null) {
+        el.setAttribute('data-mermaid-src', el.textContent);
+      }
     });
+    function themeVariables(dark) {
+      return dark
+        ? {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#2c2c30',
+            primaryBorderColor: 'rgba(255,255,255,0.22)',
+            primaryTextColor: '#ededf0',
+            lineColor: '#9a9aa2',
+            secondaryColor: '#27272b',
+            tertiaryColor: '#1e1e21'
+          }
+        : {
+            fontFamily: '"Geneva", system-ui, sans-serif',
+            fontSize: '10px',
+            primaryColor: '#f0f0f0',
+            primaryBorderColor: '#ccc',
+            primaryTextColor: '#000',
+            lineColor: '#666',
+            secondaryColor: '#f8f8f8',
+            tertiaryColor: '#fff'
+          };
+    }
+    async function renderMermaid() {
+      if (diagrams.length === 0) return;
+      var dark = !!window.__ryosDocsDark;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: themeVariables(dark),
+        flowchart: { curve: 'basis', padding: 8, nodeSpacing: 30, rankSpacing: 30 },
+        sequence: { actorFontSize: 10, messageFontSize: 10, noteFontSize: 10 }
+      });
+      diagrams.forEach(function (el) {
+        var src = el.getAttribute('data-mermaid-src');
+        if (src !== null) {
+          el.removeAttribute('data-processed');
+          el.innerHTML = src;
+        }
+      });
+      try {
+        await mermaid.run({ nodes: diagrams });
+      } catch (e) {
+        /* ignore mermaid parse/render errors */
+      }
+    }
+    window.__ryosDocsRenderMermaid = renderMermaid;
+    renderMermaid();
   </script>
 </body>
 </html>`;

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -745,7 +745,10 @@ function generatePage(doc: DocEntry, allDocs: DocEntry[], currentIndex: number):
         var src = el.getAttribute('data-mermaid-src');
         if (src !== null) {
           el.removeAttribute('data-processed');
-          el.innerHTML = src;
+          // Restore the raw diagram definition as text (not innerHTML): mermaid
+          // reads the source from textContent, and the definition contains
+          // characters like ">" / "-->" that must not be parsed as HTML.
+          el.textContent = src;
         }
       });
       try {

--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerFavoritesBar.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerFavoritesBar.tsx
@@ -153,7 +153,7 @@ export function InternetExplorerFavoritesBar({
         </div>
       </div>
       {favorites.length > 0 && hasMoreToScroll && (
-        <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-neutral-100 to-transparent pointer-events-none" />
+        <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-neutral-100 os-dark:from-[#2b2b2e] to-transparent pointer-events-none" />
       )}
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds dark-mode support to the generated documentation pages and tightens the Internet Explorer chrome for dark mode.

- **Docs dark mode** (`scripts/generate-docs.ts` + regenerated `public/docs/*.html`): the doc template now drives all colors through CSS variables with a dark override. A small head script resolves the scheme from the ryOS parent window's `data-os-color-scheme` (the exact relationship when docs are embedded in the Internet Explorer iframe, same-origin) and live-follows toggles via a `MutationObserver`; standalone viewing falls back to `prefers-color-scheme`. Mermaid diagrams re-render with a matching palette on scheme changes.
- **Internet Explorer**: the favorites-bar scroll-fade gradient (`from-neutral-100`) now darkens in dark mode via the `os-dark:` variant so it no longer shows a light smear over the dark toolbar. The rest of the IE chrome already inherits the macOS Aqua dark tokens through `.window-body`.

## How dark mode resolves in docs
1. Embedded in ryOS (e.g. Internet Explorer) → follows the parent's `data-os-color-scheme` (live).
2. Viewed standalone at `/docs/...` → follows the browser's `prefers-color-scheme`.

## Walkthrough

Docs page embedded the same way Internet Explorer embeds it (parent `data-os-color-scheme="dark"`) — header, sidebar, body, tables, and the mermaid diagram all render dark:

![Docs embedded with parent dark scheme](https://cursor.com/artifacts/c/art-b007bea0-c2bc-4427-a4f2-c6f22b35568c)

Toggling the parent scheme to light updates the page live without a reload, including a mermaid re-render:

![Docs follow parent toggle to light](https://cursor.com/artifacts/c/art-06618f33-2882-421a-b088-6bfb412ec14a)

Standalone docs honoring `prefers-color-scheme: dark`:

![Standalone docs dark via prefers-color-scheme](https://cursor.com/artifacts/c/art-f47b3fe8-65c4-4f0c-9a6a-7aef4a14ed0e)

Internet Explorer chrome in dark mode (title bar, toolbar, URL bar, favorites bar, menu bar). The white content panel is the external page response itself (`localhost` is blocked by the proxy), not app chrome:

![Internet Explorer chrome in dark mode](https://cursor.com/artifacts/c/art-4c562846-87cf-474f-ae8d-4f8a6e9a307c)

Light mode is unchanged (regression check):

![Standalone docs light, unchanged](https://cursor.com/artifacts/c/art-b0607ef5-3459-495d-b574-4aeb50040021)

## Testing
- `bun run build` — passes (tsc + vite).
- `bunx eslint` on changed files — clean.
- `bun run scripts/generate-docs.ts` — regenerated 57 pages.
- Playwright-captured screenshots (above) across embedded dark, live toggle to light, standalone dark, standalone light, and IE chrome dark.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ee9c4-2627-754d-865d-0911d362e1ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ee9c4-2627-754d-865d-0911d362e1ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

