### PR TITLE
refactor(stores): production-silent debug logger

### DIFF
--- a/src/stores/useChatsStore.ts
+++ b/src/stores/useChatsStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { debug } from "@/utils/debug";
 import { useStoreShallow } from "./helpers";
 import { persist } from "zustand/middleware";
 import { createDebouncedPersistStorage } from "@/utils/debouncedPersistStorage";
@@ -200,7 +201,7 @@ const clearApiUnavailable = (key: string): void => {
 function forceLogoutOnUnauthorized() {
   const store = useChatsStore.getState();
   if (!store.username) return;
-  console.log("[ChatsStore] Unauthorized — clearing auth state for", store.username);
+  debug("[ChatsStore] Unauthorized — clearing auth state for", store.username);
   localStorage.removeItem(USERNAME_RECOVERY_KEY);
   useChatsStore.setState({
     username: null,
@@ -213,7 +214,7 @@ function forceLogoutOnUnauthorized() {
 // Ensure username recovery key is set if username exists but recovery key doesn't.
 const ensureUsernameRecovery = (username: string | null) => {
   if (username && !localStorage.getItem(USERNAME_RECOVERY_KEY)) {
-    console.log(
+    debug(
       "[ChatsStore] Setting recovery key for existing username:",
       username
     );
@@ -517,13 +518,13 @@ export const useChatsStore = create<ChatsStoreState>()(
           });
 
           if (JSON.stringify(currentRooms) === JSON.stringify(sortedNewRooms)) {
-            console.log(
+            debug(
               "[ChatsStore] setRooms skipped: newRooms are identical to current rooms."
             );
             return; // Skip update if rooms haven't actually changed
           }
 
-          console.log("[ChatsStore] setRooms called. Updating rooms.");
+          debug("[ChatsStore] setRooms called. Updating rooms.");
           set({ rooms: sortedNewRooms });
         },
         setCurrentRoomId: (roomId) => set({ currentRoomId: roomId }),
@@ -721,7 +722,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           set(getInitialState());
         },
         logout: async () => {
-          console.log("[ChatsStore] Logging out user...");
+          debug("[ChatsStore] Logging out user...");
 
           const currentUsername = get().username;
 
@@ -764,7 +765,7 @@ export const useChatsStore = create<ChatsStoreState>()(
             );
           }
 
-          console.log("[ChatsStore] User logged out successfully");
+          debug("[ChatsStore] User logged out successfully");
         },
         deleteAccount: async ({ confirmUsername, currentPassword }) => {
           const currentUsername = get().username;
@@ -820,16 +821,16 @@ export const useChatsStore = create<ChatsStoreState>()(
         },
         fetchRooms: async (options = {}) => {
           if (roomsFetchPromise) {
-            console.log("[ChatsStore] Reusing in-flight rooms fetch...");
+            debug("[ChatsStore] Reusing in-flight rooms fetch...");
             return roomsFetchPromise;
           }
 
           if (!options.force && Date.now() < roomsFetchFreshUntil) {
-            console.log("[ChatsStore] Skipping rooms fetch; cache is fresh.");
+            debug("[ChatsStore] Skipping rooms fetch; cache is fresh.");
             return { ok: true };
           }
 
-          console.log("[ChatsStore] Fetching rooms...");
+          debug("[ChatsStore] Fetching rooms...");
           if (isApiTemporarilyUnavailable("rooms")) {
             return { ok: false, error: "Rooms API temporarily unavailable" };
           }
@@ -866,7 +867,7 @@ export const useChatsStore = create<ChatsStoreState>()(
         fetchMessagesForRoom: async (roomId: string) => {
           if (!roomId) return { ok: false, error: "Room ID required" };
 
-          console.log(`[ChatsStore] Fetching messages for room ${roomId}...`);
+          debug(`[ChatsStore] Fetching messages for room ${roomId}...`);
           if (isApiTemporarilyUnavailable("room-messages")) {
             return { ok: false, error: "Messages API temporarily unavailable" };
           }
@@ -909,7 +910,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           if (roomIds.length === 0)
             return { ok: false, error: "Room IDs required" };
 
-          console.log(
+          debug(
             `[ChatsStore] Fetching messages for rooms: ${roomIds.join(", ")}...`
           );
           if (isApiTemporarilyUnavailable("bulk-messages")) {
@@ -960,7 +961,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           const currentRoomId = get().currentRoomId;
           const username = get().username;
 
-          console.log(
+          debug(
             `[ChatsStore] Switching from ${currentRoomId} to ${newRoomId}`
           );
 
@@ -993,7 +994,7 @@ export const useChatsStore = create<ChatsStoreState>()(
             track(CHAT_ANALYTICS.ROOM_SWITCH, {
               hasPreviousRoom: !!currentRoomId,
             });
-            console.log(
+            debug(
               `[ChatsStore] Fetching latest messages for room ${newRoomId}`
             );
             await get().fetchMessagesForRoom(newRoomId);
@@ -1055,7 +1056,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           } catch (error) {
             if (error instanceof ApiRequestError) {
               if (error.status === 401) {
-                console.log("[ChatsStore] Received 401 — forcing logout");
+                debug("[ChatsStore] Received 401 — forcing logout");
                 forceLogoutOnUnauthorized();
               }
               return { ok: false, error: error.message || "Failed to create room" };
@@ -1085,7 +1086,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           } catch (error) {
             if (error instanceof ApiRequestError) {
               if (error.status === 401) {
-                console.log("[ChatsStore] Received 401 — forcing logout");
+                debug("[ChatsStore] Received 401 — forcing logout");
                 forceLogoutOnUnauthorized();
               }
               return { ok: false, error: error.message || "Failed to delete room" };
@@ -1128,7 +1129,7 @@ export const useChatsStore = create<ChatsStoreState>()(
             get().removeMessageFromRoom(roomId, tempId);
             if (error instanceof ApiRequestError) {
               if (error.status === 401) {
-                console.log("[ChatsStore] Received 401 — forcing logout");
+                debug("[ChatsStore] Received 401 — forcing logout");
                 forceLogoutOnUnauthorized();
               }
               return { ok: false, error: error.message || "Failed to send message" };
@@ -1240,14 +1241,14 @@ export const useChatsStore = create<ChatsStoreState>()(
       }),
       // --- Migration from old localStorage keys ---
       migrate: (persistedState, version) => {
-        console.log(
+        debug(
           "[ChatsStore] Migrate function started. Version:",
           version,
           "Persisted state exists:",
           !!persistedState
         );
         if (persistedState) {
-          console.log(
+          debug(
             "[ChatsStore] Persisted state type for rooms:",
             typeof (persistedState as ChatsStoreState).rooms,
             "Is Array:",
@@ -1256,7 +1257,7 @@ export const useChatsStore = create<ChatsStoreState>()(
         }
 
         if (version < STORE_VERSION && !persistedState) {
-          console.log(
+          debug(
             `[ChatsStore] Migrating from old localStorage keys to version ${STORE_VERSION}...`
           );
           try {
@@ -1283,7 +1284,7 @@ export const useChatsStore = create<ChatsStoreState>()(
               // Save to recovery mechanism as well
               saveUsernameToRecovery(oldUsername);
               localStorage.removeItem(oldUsernameKey); // Remove here during primary migration
-              console.log(
+              debug(
                 `[ChatsStore] Migrated and removed '${oldUsernameKey}' key during version upgrade.`
               );
             }
@@ -1334,7 +1335,7 @@ export const useChatsStore = create<ChatsStoreState>()(
               }
             }
 
-            console.log("[ChatsStore] Migration data:", migratedState);
+            debug("[ChatsStore] Migration data:", migratedState);
 
             // Clean up old keys (Optional - uncomment if desired after confirming migration)
             // localStorage.removeItem('chats:messages');
@@ -1342,17 +1343,17 @@ export const useChatsStore = create<ChatsStoreState>()(
             // localStorage.removeItem('chats:sidebarVisible');
             // localStorage.removeItem('chats:cachedRooms');
             // localStorage.removeItem('chats:cachedRoomMessages');
-            // console.log("[ChatsStore] Old localStorage keys potentially removed.");
+            // debug("[ChatsStore] Old localStorage keys potentially removed.");
 
             const finalMigratedState = {
               ...getInitialState(),
               ...migratedState,
             } as ChatsStoreState;
-            console.log(
+            debug(
               "[ChatsStore] Final migrated state:",
               finalMigratedState
             );
-            console.log(
+            debug(
               "[ChatsStore] Migrated rooms type:",
               typeof finalMigratedState.rooms,
               "Is Array:",
@@ -1364,7 +1365,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           }
         }
         if (persistedState) {
-          console.log("[ChatsStore] Using persisted state.");
+          debug("[ChatsStore] Using persisted state.");
           const state = persistedState as ChatsStoreState;
           const finalState = { ...state };
 
@@ -1385,8 +1386,8 @@ export const useChatsStore = create<ChatsStoreState>()(
             });
           }
 
-          console.log("[ChatsStore] Final state from persisted:", finalState);
-          console.log(
+          debug("[ChatsStore] Final state from persisted:", finalState);
+          debug(
             "[ChatsStore] Persisted state rooms type:",
             typeof finalState.rooms,
             "Is Array:",
@@ -1394,16 +1395,16 @@ export const useChatsStore = create<ChatsStoreState>()(
           );
           return finalState;
         }
-        console.log("[ChatsStore] Falling back to initial state.");
+        debug("[ChatsStore] Falling back to initial state.");
         return { ...getInitialState() } as ChatsStoreState;
       },
       onRehydrateStorage: () => {
-        console.log("[ChatsStore] Rehydrating storage...");
+        debug("[ChatsStore] Rehydrating storage...");
         return (state, error) => {
           if (error) {
             console.error("[ChatsStore] Error during rehydration:", error);
           } else if (state) {
-            console.log(
+            debug(
               "[ChatsStore] Rehydration complete. Current state username:",
               state.username
             );
@@ -1412,7 +1413,7 @@ export const useChatsStore = create<ChatsStoreState>()(
             if (state.username === null) {
               const recoveredUsername = getUsernameFromRecovery();
               if (recoveredUsername) {
-                console.log(
+                debug(
                   `[ChatsStore] Recovered username '${recoveredUsername}' from recovery storage.`
                 );
                 state.username = recoveredUsername;
@@ -1420,7 +1421,7 @@ export const useChatsStore = create<ChatsStoreState>()(
                 const oldUsernameKey = "chats:chatRoomUsername";
                 const oldUsername = localStorage.getItem(oldUsernameKey);
                 if (oldUsername) {
-                  console.log(
+                  debug(
                     `[ChatsStore] Recovered username '${oldUsername}' from legacy key.`
                   );
                   state.username = oldUsername;
@@ -1453,7 +1454,7 @@ async function restoreSessionFromCookie(expectedUsername: string) {
     const session = await getAuthSession();
 
     if (!session.ok) {
-      console.log("[ChatsStore] Session restore failed:", session.status);
+      debug("[ChatsStore] Session restore failed:", session.status);
       if (session.status === 401 || session.status === 403) {
         forceLogoutOnUnauthorized();
       }
@@ -1462,7 +1463,7 @@ async function restoreSessionFromCookie(expectedUsername: string) {
 
     const data = session.data;
     if (data.authenticated && data.username) {
-      console.log(
+      debug(
         "[ChatsStore] Session restored for",
         data.username,
         "(from cookie)"
@@ -1474,7 +1475,7 @@ async function restoreSessionFromCookie(expectedUsername: string) {
         store.checkHasPassword();
       }
     } else {
-      console.log("[ChatsStore] No valid session — logging out.");
+      debug("[ChatsStore] No valid session — logging out.");
       forceLogoutOnUnauthorized();
     }
   } catch (err) {

--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { debug } from "@/utils/debug";
 import { useStoreShallow } from "./helpers";
 import { persist } from "zustand/middleware";
 import { createDebouncedPersistStorage } from "@/utils/debouncedPersistStorage";
@@ -666,7 +667,7 @@ export const useFilesStore = create<FilesStoreState>()(
         useCloudSyncStore
           .getState()
           .clearDeletedKeys("fileMetadataPaths", [newItem.path]);
-        console.log(`[FilesStore:addItem] Attempting to add:`, newItem); // Log item being added
+        debug(`[FilesStore:addItem] Attempting to add:`, newItem); // Log item being added
         set((state) => {
           const parentPath = getParentPath(newItem.path);
           if (
@@ -685,7 +686,7 @@ export const useFilesStore = create<FilesStoreState>()(
           const existingItem = state.items[newItem.path];
           if (existingItem) {
             // Update existing item, preserving UUID and createdAt
-            console.log(
+            debug(
               `[FilesStore] Updating existing item at path "${newItem.path}"`
             );
             const updatedItem: FileSystemItem = {
@@ -719,7 +720,7 @@ export const useFilesStore = create<FilesStoreState>()(
               icon: "/icons/trash-full.png",
             };
           }
-          console.log(
+          debug(
             `[FilesStore:addItem] Successfully added: ${newItem.path}`
           ); // Log success
           return { items: updatedItems, libraryState: "loaded" };

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { debug } from "@/utils/debug";
 import { useStoreShallow } from "./helpers";
 import { persist } from "zustand/middleware";
 import {
@@ -949,11 +950,11 @@ async function saveLyricOffsetToServer(
   
   // Skip if not authenticated
   if (!username || !isAuthenticated) {
-    console.log(`[iPod Store] Skipping lyric offset save for ${trackId} - user not logged in`);
+    debug(`[iPod Store] Skipping lyric offset save for ${trackId} - user not logged in`);
     return false;
   }
 
-  console.log(`[iPod Store] Saving lyric offset for ${trackId}: ${lyricOffset}ms...`);
+  debug(`[iPod Store] Saving lyric offset for ${trackId}: ${lyricOffset}ms...`);
   
   try {
     const data = await patchSongMetadata(
@@ -962,7 +963,7 @@ async function saveLyricOffsetToServer(
       { username, isAuthenticated }
     );
     if (data.success) {
-      console.log(`[iPod Store] ✓ Saved lyric offset for ${trackId}: ${lyricOffset}ms (by ${data.createdBy || username})`);
+      debug(`[iPod Store] ✓ Saved lyric offset for ${trackId}: ${lyricOffset}ms (by ${data.createdBy || username})`);
       return true;
     }
     console.warn(`[iPod Store] Server returned failure for ${trackId}:`, data);
@@ -974,7 +975,7 @@ async function saveLyricOffsetToServer(
         return false;
       }
       if (error.status === 403) {
-        console.log(`[iPod Store] Cannot save lyric offset for ${trackId} - song owned by another user`);
+        debug(`[iPod Store] Cannot save lyric offset for ${trackId} - song owned by another user`);
         return false;
       }
       console.warn(`[iPod Store] Failed to save lyric offset for ${trackId}: ${error.status} - ${error.message}`);
@@ -1028,7 +1029,7 @@ export async function flushPendingLyricOffsetSave(trackId: string): Promise<void
     pendingLyricOffsets.delete(trackId);
     
     // Save immediately and wait for completion
-    console.log(`[iPod Store] Flushing pending lyric offset save for ${trackId}: ${pendingOffset}ms`);
+    debug(`[iPod Store] Flushing pending lyric offset save for ${trackId}: ${pendingOffset}ms`);
     await saveLyricOffsetToServer(trackId, pendingOffset);
   }
 }
@@ -1047,7 +1048,7 @@ async function saveLyricsSourceToServer(
   
   // Skip if not authenticated
   if (!username || !isAuthenticated) {
-    console.log(`[iPod Store] Skipping lyrics source save for ${trackId} - user not logged in`);
+    debug(`[iPod Store] Skipping lyrics source save for ${trackId} - user not logged in`);
     return;
   }
 
@@ -1070,7 +1071,7 @@ async function saveLyricsSourceToServer(
       },
       { username, isAuthenticated }
     );
-    console.log(`[iPod Store] Saved lyrics source for ${trackId}, cleared translations/furigana (by ${data.createdBy || username})`);
+    debug(`[iPod Store] Saved lyrics source for ${trackId}, cleared translations/furigana (by ${data.createdBy || username})`);
   } catch (error) {
     if (error instanceof ApiRequestError) {
       if (error.status === 401) {
@@ -1078,7 +1079,7 @@ async function saveLyricsSourceToServer(
         return;
       }
       if (error.status === 403) {
-        console.log(`[iPod Store] Cannot save lyrics source for ${trackId} - song owned by another user`);
+        debug(`[iPod Store] Cannot save lyrics source for ${trackId} - song owned by another user`);
         return;
       }
       console.warn(`[iPod Store] Failed to save lyrics source for ${trackId}: ${error.status}`);
@@ -1681,7 +1682,7 @@ export const useIpodStore = create<IpodState>()(
         // Check if track already exists in library - skip fetching metadata if so
         const existingTrack = get().tracks.find((track) => track.id === videoId);
         if (existingTrack) {
-          console.log(`[iPod Store] Track ${videoId} already exists in library, skipping metadata fetch`);
+          debug(`[iPod Store] Track ${videoId} already exists in library, skipping metadata fetch`);
           // Set as current track and optionally autoplay
           const currentState = get();
           const isSameTrack = currentState.currentSongId === videoId;
@@ -1702,7 +1703,7 @@ export const useIpodStore = create<IpodState>()(
         try {
           const cachedMetadata = await getCachedSongMetadata(videoId);
           if (cachedMetadata) {
-            console.log(`[iPod Store] Using cached metadata for ${videoId}`);
+            debug(`[iPod Store] Using cached metadata for ${videoId}`);
             const newTrack: Track = {
               id: videoId,
               url: youtubeUrl,
@@ -1779,7 +1780,7 @@ export const useIpodStore = create<IpodState>()(
           // Use metadata from server (Kugou source) if available
           if (fetchData.metadata?.lyricsSource) {
             const meta = fetchData.metadata;
-            console.log(`[iPod Store] Got metadata from Kugou for ${videoId}:`, {
+            debug(`[iPod Store] Got metadata from Kugou for ${videoId}:`, {
               title: meta.title,
               artist: meta.artist,
               cover: meta.cover,
@@ -1798,7 +1799,7 @@ export const useIpodStore = create<IpodState>()(
 
         // If no Kugou match found (no lyricsSource), fall back to AI title parsing
         if (!trackInfo.lyricsSource) {
-          console.log(`[iPod Store] No Kugou match for ${videoId}, falling back to AI parse`);
+          debug(`[iPod Store] No Kugou match for ${videoId}, falling back to AI parse`);
           const parsed = await parseYouTubeTitle(rawTitle, authorName);
           trackInfo.title = parsed.title;
           trackInfo.artist = parsed.artist;
@@ -1918,7 +1919,7 @@ export const useIpodStore = create<IpodState>()(
           );
 
           if (tracksNotInDefaultLibrary.length > 0) {
-            console.log(`[iPod Store] Fetching metadata for ${tracksNotInDefaultLibrary.length} tracks not in default library`);
+            debug(`[iPod Store] Fetching metadata for ${tracksNotInDefaultLibrary.length} tracks not in default library`);
             
             try {
               // Batch fetch metadata for tracks not in default library
@@ -2498,7 +2499,7 @@ export const useIpodStore = create<IpodState>()(
 
         // If the persisted version is older than the current version, update defaults
         if (version < CURRENT_IPOD_STORE_VERSION) {
-          console.log(
+          debug(
             `Migrating iPod store from version ${version} to ${CURRENT_IPOD_STORE_VERSION}`
           );
           

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,0 +1,54 @@
+/**
+ * Lightweight debug logger that is silent in production by default.
+ *
+ * Many stores/hooks emit `console.log` traces on routine actions (login, room
+ * fetch, sync, library migration). These are useful in development but spam
+ * the console in production. Route those debug-level traces through `debug()`
+ * so they only print when:
+ *
+ *  - running a dev build (`import.meta.env.DEV`), or
+ *  - the user opts in at runtime via `localStorage.setItem("ryos:debug", "1")`.
+ *
+ * `console.warn` / `console.error` should keep using `console` directly — they
+ * surface real problems and are always shown.
+ */
+
+const DEBUG_FLAG_KEY = "ryos:debug";
+
+let runtimeDebugEnabled: boolean | null = null;
+
+function isDebugEnabled(): boolean {
+  // Dev builds always log.
+  if (import.meta.env.DEV) return true;
+
+  if (runtimeDebugEnabled !== null) return runtimeDebugEnabled;
+  try {
+    runtimeDebugEnabled =
+      typeof localStorage !== "undefined" &&
+      localStorage.getItem(DEBUG_FLAG_KEY) === "1";
+  } catch {
+    runtimeDebugEnabled = false;
+  }
+  return runtimeDebugEnabled;
+}
+
+/** Production-silent `console.log`. */
+export function debug(...args: unknown[]): void {
+  if (isDebugEnabled()) console.log(...args);
+}
+
+/**
+ * Production-silent logger bound to a `[scope]` prefix.
+ *
+ * @example
+ *   const log = createDebugLogger("ChatsStore");
+ *   log("Fetching rooms…");
+ */
+export function createDebugLogger(
+  scope: string
+): (...args: unknown[]) => void {
+  const prefix = `[${scope}]`;
+  return (...args: unknown[]): void => {
+    if (isDebugEnabled()) console.log(prefix, ...args);
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Roadmap item **2.2** (the safe "strip production logs" slice). The biggest Zustand stores emit `console.log` traces on routine actions (login, room fetch, sync, library work) that spam the **production** console. This routes those debug-level logs through a small `debug()` helper that is silent in production by default.

## How

- New `src/utils/debug.ts`: `debug(...)` / `createDebugLogger(scope)` that print only when `import.meta.env.DEV` is true **or** the user opts in at runtime via `localStorage.setItem("ryos:debug", "1")`. So nothing is lost — prod debugging is still one flag away.
- Converted `console.log(` → `debug(` in the three noisiest stores: `useChatsStore` (35), `useIpodStore` (14), `useFilesStore` (3). `console.warn` / `console.error` are intentionally left as-is — they surface real problems and should always show.

No logic changes; purely logging hygiene.

## Testing

- ✅ `bun run build` (`tsc -b` + Vite) — compiles clean; no `console.log` remain in the three stores (52 converted), `warn`/`error` retained.
- ✅ `bun test tests/test-chat-store-guards-wiring.test.ts` (7 pass) — confirms the chats store still imports/behaves correctly at runtime.

Other stores/hooks with stray `console.log` (e.g. `useAppStore`, `useInternetExplorerStore`, and large app logic hooks) can adopt `debug()` incrementally in follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ee7d9-d2cb-7445-9641-1dc910f1b3ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ee7d9-d2cb-7445-9641-1dc910f1b3ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

