### PR TITLE
fix(ie): track history on proxied link navigation

### DIFF
--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -1666,6 +1666,11 @@ export function useInternetExplorerLogic({
         console.log(
           `[IE] Received navigation request from iframe: ${messageData.url}`
         );
+        // A link click inside the page is a brand-new navigation, not a
+        // back/forward traversal. Clear the history-navigation flag so the
+        // destination is recorded in history (and any forward stack is
+        // truncated) by loadSuccess.
+        useInternetExplorerStore.getState().setNavigatingHistory(false);
         latestNavigateRef.current(messageData.url, latestYearRef.current);
       } else if (messageData.type === "goBack") {
         console.log(`[IE] Received back button request from iframe`);
@@ -1677,6 +1682,9 @@ export function useInternetExplorerLogic({
         console.log(
           `[IE] Received navigation request from AI HTML preview: ${messageData.url}`
         );
+        // Same as above: clicking a link in AI-generated content is a new
+        // navigation and must be tracked in history.
+        useInternetExplorerStore.getState().setNavigatingHistory(false);
         // Fetch the most up-to-date HTML from the store in case the closure is stale
         const contextHtml =
           useInternetExplorerStore.getState().aiGeneratedHtml;

--- a/src/stores/useInternetExplorerStore.ts
+++ b/src/stores/useInternetExplorerStore.ts
@@ -690,29 +690,38 @@ export const useInternetExplorerStore = create<InternetExplorerStore>()(
               // No need to update historyIndex here, it's set by handleGoBack/Forward
               newState.historyIndex = state.historyIndex;
             } else {
-              const mostRecentEntry = state.history[0];
-              // Check for duplicates using normalized URL and year
+              // A genuinely new navigation. If the user had navigated back
+              // (historyIndex > 0), the entries newer than the current page are
+              // a "forward" stack that must be discarded, mirroring real
+              // browser behavior. Newest entries live at the front of the
+              // array, so the current page sits at `historyIndex` and the
+              // forward stack is everything before it.
+              const currentIndex = state.historyIndex > 0 ? state.historyIndex : 0;
+              const trimmedHistory = state.history.slice(currentIndex);
+              const currentEntry = trimmedHistory[0];
+              // Check for duplicates against the current page (post-truncation)
               const isDuplicate =
-                mostRecentEntry &&
-                normalizeUrlForHistory(mostRecentEntry.url) === newEntry.url &&
-                mostRecentEntry.year === newEntry.year;
+                currentEntry &&
+                normalizeUrlForHistory(currentEntry.url) === newEntry.url &&
+                currentEntry.year === newEntry.year;
 
               if (isDuplicate) {
-                // If it's a duplicate, potentially update the title if it changed
-                if (mostRecentEntry.title !== newEntry.title) {
-                  const updatedHistory = [...state.history];
-                  updatedHistory[0] = {
-                    ...mostRecentEntry,
-                    title: newEntry.title,
-                    url: newEntry.url,
-                  }; // Update URL too, just in case
-                  newState.history = updatedHistory;
-                  addedToHistory = true; // Considered an update
-                }
+                // Re-navigating to the current page: keep it at the top, drop
+                // any forward stack, and refresh the title if it changed.
+                const updatedHistory = [...trimmedHistory];
+                updatedHistory[0] = {
+                  ...currentEntry,
+                  title: newEntry.title,
+                  url: newEntry.url,
+                };
+                newState.history = updatedHistory;
                 newState.historyIndex = 0;
+                // History changed if the title changed or we dropped a forward stack
+                addedToHistory =
+                  currentEntry.title !== newEntry.title || currentIndex > 0;
               } else {
-                // Add new entry if not a duplicate
-                newState.history = [newEntry, ...state.history].slice(0, 100);
+                // Add new entry, discarding any forward stack
+                newState.history = [newEntry, ...trimmedHistory].slice(0, 100);
                 newState.historyIndex = 0;
                 addedToHistory = true; // New entry added
               }
@@ -778,15 +787,24 @@ export const useInternetExplorerStore = create<InternetExplorerStore>()(
               timestamp: Date.now(),
             };
 
-            const mostRecentEntry = state.history[0];
-            // Check for duplicates
+            // Discard any forward stack (entries newer than the current page)
+            // so an errored navigation behaves like a real new navigation.
+            const currentIndex =
+              state.historyIndex > 0 ? state.historyIndex : 0;
+            const trimmedHistory = state.history.slice(currentIndex);
+            const currentEntry = trimmedHistory[0];
+            // Check for duplicates against the current page (post-truncation)
             const isDuplicate =
-              mostRecentEntry &&
-              normalizeUrlForHistory(mostRecentEntry.url) === newEntry.url &&
-              mostRecentEntry.year === newEntry.year;
+              currentEntry &&
+              normalizeUrlForHistory(currentEntry.url) === newEntry.url &&
+              currentEntry.year === newEntry.year;
 
             if (!isDuplicate) {
-              newState.history = [newEntry, ...state.history].slice(0, 100);
+              newState.history = [newEntry, ...trimmedHistory].slice(0, 100);
+              newState.historyIndex = 0;
+            } else if (currentIndex > 0) {
+              // Same URL but we still need to drop the forward stack
+              newState.history = trimmedHistory;
               newState.historyIndex = 0;
             }
           }

--- a/tests/test-ie-history-link-nav.test.ts
+++ b/tests/test-ie-history-link-nav.test.ts
@@ -1,0 +1,177 @@
+import "./local-storage-stub";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { useInternetExplorerStore } from "../src/stores/useInternetExplorerStore";
+
+/**
+ * Unit tests for Internet Explorer history tracking, focused on link
+ * navigation via the proxy iframe.
+ *
+ * Bugs covered:
+ *  1. After a Back/Forward traversal (`isNavigatingHistory === true`), a link
+ *     click inside the proxied page must record the destination in history.
+ *     The fix clears `isNavigatingHistory` for iframe/AI link navigations
+ *     before calling `handleNavigate`, so `loadSuccess` records the page.
+ *  2. Navigating to a new page while "backed up" must truncate the forward
+ *     stack, mirroring real browser behavior.
+ *
+ * These exercise the store directly. The IE logic hook is what flips
+ * `isNavigatingHistory` to false for link clicks; here we simulate that exact
+ * sequence (setNavigatingHistory(false) + loadSuccess with addToHistory).
+ */
+
+// Avoid real network calls from fetchCachedYears triggered by loadSuccess.
+const originalFetch = globalThis.fetch;
+beforeAll(() => {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ years: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+});
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const store = useInternetExplorerStore;
+
+function resetHistory() {
+  store.setState({ history: [], historyIndex: -1, isNavigatingHistory: false });
+}
+
+// Simulate a fresh navigation that successfully loads (URL bar / link click).
+function navigateTo(url: string, year = "current") {
+  store.getState().setNavigatingHistory(false);
+  store.getState().loadSuccess({
+    title: url,
+    targetUrl: url,
+    targetYear: year,
+    addToHistory: true,
+  });
+}
+
+// Simulate pressing Back/Forward to land on an existing entry at `index`.
+// Mirrors handleGoBack/handleGoForward + handleIframeLoad in the hook, where
+// addToHistory = !isNavigatingHistory (so false during traversal).
+function traverseTo(index: number) {
+  const { history } = store.getState();
+  const entry = history[index];
+  store.getState().setNavigatingHistory(true);
+  store.getState().setHistoryIndex(index);
+  store.getState().loadSuccess({
+    title: entry.title,
+    targetUrl: entry.url,
+    targetYear: entry.year,
+    addToHistory: false,
+  });
+}
+
+const urls = (entries: { url: string }[]) => entries.map((e) => e.url);
+
+describe("IE history — link navigation after Back/Forward", () => {
+  beforeEach(() => {
+    resetHistory();
+  });
+
+  test("records a new page when clicking a link after going Back", () => {
+    navigateTo("a.com");
+    navigateTo("b.com");
+    // history: [b, a], index 0
+    expect(urls(store.getState().history)).toEqual(["b.com", "a.com"]);
+
+    traverseTo(1); // Back to a.com
+    expect(store.getState().historyIndex).toBe(1);
+    expect(store.getState().isNavigatingHistory).toBe(true);
+
+    // Link click inside a.com -> the hook clears isNavigatingHistory, then nav.
+    navigateTo("c.com");
+
+    // c is recorded; forward entry (b) is dropped.
+    expect(urls(store.getState().history)).toEqual(["c.com", "a.com"]);
+    expect(store.getState().historyIndex).toBe(0);
+    expect(store.getState().isNavigatingHistory).toBe(false);
+  });
+
+  test("truncates the forward stack when navigating from a back position", () => {
+    navigateTo("a.com");
+    navigateTo("b.com");
+    navigateTo("c.com");
+    // history: [c, b, a], index 0
+
+    traverseTo(1); // Back to b
+    traverseTo(2); // Back to a
+    expect(store.getState().historyIndex).toBe(2);
+
+    navigateTo("d.com");
+
+    // Forward stack [c, b] discarded; only [d, a] remains.
+    expect(urls(store.getState().history)).toEqual(["d.com", "a.com"]);
+    expect(store.getState().historyIndex).toBe(0);
+  });
+
+  test("Back/Forward traversal alone does not add history entries", () => {
+    navigateTo("a.com");
+    navigateTo("b.com");
+    const before = urls(store.getState().history);
+
+    traverseTo(1); // Back
+    traverseTo(0); // Forward
+
+    expect(urls(store.getState().history)).toEqual(before);
+  });
+});
+
+describe("IE history — duplicate / reload handling", () => {
+  beforeEach(() => {
+    resetHistory();
+  });
+
+  test("re-navigating to the current page does not add a duplicate", () => {
+    navigateTo("a.com");
+    navigateTo("a.com");
+    expect(urls(store.getState().history)).toEqual(["a.com"]);
+    expect(store.getState().historyIndex).toBe(0);
+  });
+
+  test("same URL across different years is kept as separate entries", () => {
+    navigateTo("a.com", "current");
+    navigateTo("a.com", "1999");
+    expect(store.getState().history.length).toBe(2);
+    expect(store.getState().history[0].year).toBe("1999");
+  });
+});
+
+describe("IE history — error navigation truncates forward stack", () => {
+  beforeEach(() => {
+    resetHistory();
+  });
+
+  test("errored navigation from a back position drops forward entries", () => {
+    navigateTo("a.com");
+    navigateTo("b.com");
+    navigateTo("c.com");
+
+    traverseTo(1);
+    traverseTo(2); // at a.com, index 2
+
+    store.getState().setNavigatingHistory(false);
+    store.getState().handleNavigationError(
+      {
+        error: true,
+        type: "connection_error",
+        status: 404,
+        message: "Cannot access bad.com.",
+      },
+      "bad.com"
+    );
+
+    expect(urls(store.getState().history)).toEqual(["bad.com", "a.com"]);
+    expect(store.getState().historyIndex).toBe(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In Internet Explorer, clicking a link inside a proxied page (intercepted via `/api/iframe-check`) did **not** reliably record the destination in browsing history.

Root cause: link clicks in the proxy iframe post an `iframeNavigation` message that calls `handleNavigate` directly, bypassing `handleNavigateWithHistory`. After a Back/Forward traversal the `isNavigatingHistory` flag stays `true`, so the subsequent `loadSuccess` runs with `addToHistory: !isNavigatingHistory` → `false` and the clicked page is silently dropped from history.

A second, related bug: navigating to a new page while "backed up" (`historyIndex > 0`) prepended the new entry to the full list **without truncating the forward stack**, leaving orphaned forward entries (unlike a real browser).

## Fix

- `useInternetExplorerLogic.ts`: clear `isNavigatingHistory` before handling `iframeNavigation` and `aiHtmlNavigation` messages — a link click is a brand-new navigation, not a Back/Forward traversal.
- `useInternetExplorerStore.ts` (`loadSuccess`): when recording a genuinely new navigation, drop the forward stack (entries newer than the current `historyIndex`) before prepending, and compare duplicates against the current page rather than `history[0]`.
- Applied the same forward-stack truncation to `handleNavigationError` so errored navigations behave consistently.

## Tests

Added `tests/test-ie-history-link-nav.test.ts` covering:
- link click after Back records the page and drops the forward entry
- forward stack truncation after multiple Backs
- Back/Forward traversal alone adds no entries
- duplicate/reload handling and same-URL-different-year separation
- error navigation truncates the forward stack

- ✅ `bun test tests/test-ie-history-link-nav.test.ts` (6 pass)
- ✅ `npx tsc -b`
- ✅ `bun run build`
- ✅ `npx eslint` on changed files (only pre-existing warnings)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eeb20-29b8-732f-90cc-97d9c392b5d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eeb20-29b8-732f-90cc-97d9c392b5d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

