### PR TITLE
Adopt shared Help/About dialog state

### DIFF
--- a/docs/proposals/next-improvements.md
+++ b/docs/proposals/next-improvements.md
@@ -31,8 +31,8 @@ final-cleanup phase:
   (`api/sync/backup.ts`, `status.ts`, `backup-token.ts`) still back the
   Control Panels backup UI and remain until that UI has a v2-only replacement.
 - **Canonical Redis key scheme** — `src/shared/redisKeys.ts` is now the source
-  of truth, but several hot paths still carry legacy dual-read fallbacks
-  (listen sessions, airdrop presence, rate-limit counters).
+  of truth. Listen-session and Airdrop presence dual reads are retired, and
+  `rl:*` rate-limit callers canonicalize through `makeKey` into `rate:*`.
 - **macOS Aqua / "Aqua Glass" theme overhaul** — large CSS surface
   (`src/styles/themes/aqua.css` ~2.8k lines, `aqua-glass.css` ~1.4k,
   `dark-aqua.css` ~1.9k, `control-panels-mac.css` ~1.6k). This is the single
@@ -67,7 +67,7 @@ Quantitative hotspots (lines):
 
 ## 2. Refactoring proposals
 
-### 2.1 Decompose the iPod stack (highest debt concentration) — **pending PR**
+### 2.1 Decompose the iPod stack (highest debt concentration) — **started**
 
 `useIpodLogic.ts` (5,143) + `useIpodStore.ts` (2,535) + `useAppleMusicLibrary.ts`
 (1,778) ≈ 9.4k lines, and recent history shows recurring Apple Music
@@ -86,7 +86,11 @@ Proposal:
 Risk: high (most-touched user-facing app) — do behind the existing test suite
 (`test-ipod-*`) and add playback-race regression tests first.
 
-### 2.2 Generalize store persistence — **partial pending PR**
+Current status: the first extraction landed (`useIpodScale`,
+`useIpodStatusBacklight`). The remaining cohesive clusters still need follow-up
+PRs.
+
+### 2.2 Generalize store persistence — **partial**
 
 ~25 stores hand-roll `STORE_VERSION` + `partialize` + bespoke `migrate`, and the
 biggest ones leave verbose `console.log` in the production migrate path
@@ -97,9 +101,9 @@ partialize })` helper with typed, registered migrations and a debug logger that
 is silent in production. Generalize the already-good `createDebouncedPersistStorage`
 (currently only in `useFilesStore`/`useIpodStore`/`useChatsStore`).
 
-Current status: PR #1566 covers the production-silent debug logger slice for the
-noisiest stores. The typed persisted-store factory remains pending because it
-touches ~25 stores and should stay isolated from unrelated cleanup.
+Current status: the production-silent debug logger slice landed for the noisiest
+stores. The typed persisted-store factory remains pending because it touches
+~25 stores and should stay isolated from unrelated cleanup.
 
 ### 2.3 Split the API god-files
 
@@ -126,9 +130,11 @@ touches ~25 stores and should stay isolated from unrelated cleanup.
 
 ### 2.5 Adopt shared UI primitives everywhere
 
-- **Help/About**: `useAppHelpAboutDialogs` + `AppHelpAboutDialogs` exist and are
-  used by ~15 apps, but iPod, Karaoke, Videos, Chats, Admin, IE, and Applet
-  Viewer still hand-roll `isHelpDialogOpen`/`isAboutDialogOpen`.
+- **Help/About**: **shipped** — `useAppHelpAboutDialogs` +
+  `AppHelpAboutDialogs` are now used directly or composed through
+  `useMediaAppDialogs` across the remaining app surfaces (including iPod,
+  Karaoke, Videos, IE, Applet Viewer, TextEdit, Soundboard, Photo Booth, and
+  Synth).
 - **Media menu bars**: iPod/Karaoke/Videos/TV share the `AppMenuBarShell` +
   File/Controls/View/Library structure but duplicate `use*MenuBar.ts`
   view-models — extract a media-menu factory.
@@ -192,13 +198,18 @@ is introduced.
 search with no limits. At minimum require `optional`→`required` auth for the
 full search and add a rate bucket.
 
-### 4.3 Add a Zod validation layer at the `apiHandler` boundary — **pending PR**
+### 4.3 Add a Zod validation layer at the `apiHandler` boundary — **started**
 
 Zod is used in only ~12 API files. High-value untyped bodies: `POST /api/chat`
 (messages/systemState validated only with `Array.isArray`), `speech.ts`,
 `rooms` message bodies, `analytics/events`. Add an optional `schema` option to
 `apiHandler` that parses + 400s on invalid input, returning structured error
 codes.
+
+Current status: `apiHandler` supports request-body schemas and a first set of
+endpoints adopted it (`analytics/events`, `tv/create-channel`,
+`youtube-search`). Additional high-value endpoints can adopt boundary schemas
+incrementally.
 
 ### 4.4 Session lifetime & cookie review
 
@@ -258,12 +269,12 @@ code.
 
 **Foundational (enables later work):**
 - 4.1 admin audit trail (keep `ryo` gate) → unlocks 5.2
-- 4.3 Zod-at-`apiHandler` → unlocks 5.5 — **pending PR #1565**
+- 4.3 Zod-at-`apiHandler` → unlocks 5.5 — **started**
 - 2.4 finish dual-path migrations — **legacy Redis reads shipped; sync v1
   retirement remains blocked by live backup UI**
 
 **Large but high-value:**
-- 2.1 iPod stack decomposition — **pending PR #1569**
+- 2.1 iPod stack decomposition — **started**
 - 2.3 API god-file splits
 - 3.2 structural fixes for the recurring bug classes (esp. Aqua Glass)
 

--- a/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
+++ b/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { helpItems, AppletViewerInitialData } from "../index";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
+import { useAppHelpAboutDialogs } from "@/hooks/useAppHelpAboutDialogs";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useAppletStore } from "@/stores/useAppletStore";
 import { useAppStore } from "@/stores/useAppStore";
@@ -47,8 +48,6 @@ interface UseAppletViewerLogicProps {
 }
 
 interface ViewerUiState {
-  isHelpDialogOpen: boolean;
-  isAboutDialogOpen: boolean;
   isShareDialogOpen: boolean;
   shareId: string;
   sharedContent: string;
@@ -58,8 +57,6 @@ interface ViewerUiState {
 }
 
 const initialState: ViewerUiState = {
-  isHelpDialogOpen: false,
-  isAboutDialogOpen: false,
   isShareDialogOpen: false,
   shareId: "",
   sharedContent: "",
@@ -69,8 +66,6 @@ const initialState: ViewerUiState = {
 };
 
 type ViewerUiAction =
-  | { type: "setHelpDialogOpen"; value: boolean }
-  | { type: "setAboutDialogOpen"; value: boolean }
   | { type: "setShareDialogOpen"; value: boolean }
   | { type: "setShareId"; value: string }
   | { type: "setSharedContent"; value: string }
@@ -89,10 +84,6 @@ type ViewerUiAction =
 
 function reducer(state: ViewerUiState, action: ViewerUiAction): ViewerUiState {
   switch (action.type) {
-    case "setHelpDialogOpen":
-      return { ...state, isHelpDialogOpen: action.value };
-    case "setAboutDialogOpen":
-      return { ...state, isAboutDialogOpen: action.value };
     case "setShareDialogOpen":
       return { ...state, isShareDialogOpen: action.value };
     case "setShareId":
@@ -136,7 +127,11 @@ export function useAppletViewerLogic({
   const [uiState, dispatch] = useReducer(reducer, initialState);
   const {
     isHelpDialogOpen,
+    setIsHelpDialogOpen,
     isAboutDialogOpen,
+    setIsAboutDialogOpen,
+  } = useAppHelpAboutDialogs();
+  const {
     isShareDialogOpen,
     shareId,
     sharedContent,
@@ -144,12 +139,6 @@ export function useAppletViewerLogic({
     sharedTitle,
     sharedCreatedBy,
   } = uiState;
-  const setIsHelpDialogOpen = useCallback((value: boolean) => {
-    dispatch({ type: "setHelpDialogOpen", value });
-  }, []);
-  const setIsAboutDialogOpen = useCallback((value: boolean) => {
-    dispatch({ type: "setAboutDialogOpen", value });
-  }, []);
   const setIsShareDialogOpen = useCallback((value: boolean) => {
     dispatch({ type: "setShareDialogOpen", value });
   }, []);

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -28,6 +28,7 @@ import { checkOfflineAndShowError } from "@/utils/offline";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
+import { useAppHelpAboutDialogs } from "@/hooks/useAppHelpAboutDialogs";
 import { useInternetExplorerStoreShallow } from "@/stores/useInternetExplorerStore";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { onAppUpdate } from "@/utils/appEventBus";
@@ -89,8 +90,6 @@ export function useInternetExplorerLogic({
     historyIndex,
     isTitleDialogOpen,
     newFavoriteTitle,
-    isHelpDialogOpen,
-    isAboutDialogOpen,
     isNavigatingHistory,
     isClearFavoritesDialogOpen,
     isClearHistoryDialogOpen,
@@ -121,8 +120,6 @@ export function useInternetExplorerLogic({
     clearHistory,
     setTitleDialogOpen,
     setNewFavoriteTitle,
-    setHelpDialogOpen,
-    setAboutDialogOpen,
     setNavigatingHistory,
     setClearFavoritesDialogOpen,
     setClearHistoryDialogOpen,
@@ -145,8 +142,6 @@ export function useInternetExplorerLogic({
     historyIndex: state.historyIndex,
     isTitleDialogOpen: state.isTitleDialogOpen,
     newFavoriteTitle: state.newFavoriteTitle,
-    isHelpDialogOpen: state.isHelpDialogOpen,
-    isAboutDialogOpen: state.isAboutDialogOpen,
     isNavigatingHistory: state.isNavigatingHistory,
     isClearFavoritesDialogOpen: state.isClearFavoritesDialogOpen,
     isClearHistoryDialogOpen: state.isClearHistoryDialogOpen,
@@ -177,8 +172,6 @@ export function useInternetExplorerLogic({
     clearHistory: state.clearHistory,
     setTitleDialogOpen: state.setTitleDialogOpen,
     setNewFavoriteTitle: state.setNewFavoriteTitle,
-    setHelpDialogOpen: state.setHelpDialogOpen,
-    setAboutDialogOpen: state.setAboutDialogOpen,
     setNavigatingHistory: state.setNavigatingHistory,
     setClearFavoritesDialogOpen: state.setClearFavoritesDialogOpen,
     setClearHistoryDialogOpen: state.setClearHistoryDialogOpen,
@@ -194,6 +187,12 @@ export function useInternetExplorerLogic({
   }));
 
   const { t } = useTranslation();
+  const {
+    isHelpDialogOpen,
+    setIsHelpDialogOpen: setHelpDialogOpen,
+    isAboutDialogOpen,
+    setIsAboutDialogOpen: setAboutDialogOpen,
+  } = useAppHelpAboutDialogs();
   const translatedHelpItems = useTranslatedHelpItems(
     "internet-explorer",
     helpItems ?? []

--- a/src/apps/photo-booth/hooks/usePhotoBoothLogic.ts
+++ b/src/apps/photo-booth/hooks/usePhotoBoothLogic.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TouchEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
+import { useAppHelpAboutDialogs } from "@/hooks/useAppHelpAboutDialogs";
 import { useSound, Sounds } from "@/hooks/useSound";
 import { useFileSystem } from "@/apps/finder/hooks/useFileSystem";
 import { usePhotoBoothStore } from "@/stores/usePhotoBoothStore";
@@ -70,8 +71,12 @@ export function usePhotoBoothLogic({
 }: UsePhotoBoothLogicProps) {
   const { t } = useTranslation();
   const translatedHelpItems = useTranslatedHelpItems("photo-booth", helpItems);
-  const [showHelp, setShowHelp] = useState(false);
-  const [showAbout, setShowAbout] = useState(false);
+  const {
+    isHelpDialogOpen: showHelp,
+    setIsHelpDialogOpen: setShowHelp,
+    isAboutDialogOpen: showAbout,
+    setIsAboutDialogOpen: setShowAbout,
+  } = useAppHelpAboutDialogs();
   const [showEffects, setShowEffects] = useState(false);
   const [showPhotoStrip, setShowPhotoStrip] = useState(false);
   const [currentEffectsPage, setCurrentEffectsPage] = useState(0); // 0 = CSS filters, 1 = distortions

--- a/src/apps/soundboard/hooks/useSoundboardLogic.ts
+++ b/src/apps/soundboard/hooks/useSoundboardLogic.ts
@@ -4,6 +4,7 @@ import { useSoundboard } from "@/hooks/useSoundboard";
 import { useAudioRecorder } from "@/hooks/useAudioRecorder";
 import type { DialogState, Soundboard } from "@/types/types";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
+import { useAppHelpAboutDialogs } from "@/hooks/useAppHelpAboutDialogs";
 import { useSoundboardStore } from "@/stores/useSoundboardStore";
 import { useTranslation } from "react-i18next";
 import { helpItems as sharedHelpItems } from "..";
@@ -90,8 +91,12 @@ export function useSoundboardLogic({
     value: "",
   });
 
-  const [helpDialogOpen, setHelpDialogOpen] = useState(false);
-  const [aboutDialogOpen, setAboutDialogOpen] = useState(false);
+  const {
+    isHelpDialogOpen: helpDialogOpen,
+    setIsHelpDialogOpen: setHelpDialogOpen,
+    isAboutDialogOpen: aboutDialogOpen,
+    setIsAboutDialogOpen: setAboutDialogOpen,
+  } = useAppHelpAboutDialogs();
   const [audioDevices, setAudioDevices] = useState<MediaDeviceInfo[]>([]);
   const importInputRef = useRef<HTMLInputElement>(null);
   const { t } = useTranslation();

--- a/src/apps/synth/hooks/useSynthLogic.ts
+++ b/src/apps/synth/hooks/useSynthLogic.ts
@@ -10,6 +10,7 @@ import { useSound, Sounds } from "@/hooks/useSound";
 import { useLatestRef } from "@/hooks/useLatestRef";
 import { useTranslation } from "react-i18next";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
+import { useAppHelpAboutDialogs } from "@/hooks/useAppHelpAboutDialogs";
 import { helpItems } from "..";
 import { useShallow } from "zustand/react/shallow";
 import { track } from "@/utils/analytics";
@@ -72,8 +73,6 @@ export const useSynthLogic = ({
   const handleKeyUpRef = useRef<(e: KeyboardEvent) => void>(() => {});
 
   interface SynthUiState {
-    isHelpOpen: boolean;
-    isAboutOpen: boolean;
     isPresetDialogOpen: boolean;
     isSavingNewPreset: boolean;
     presetName: string;
@@ -83,8 +82,6 @@ export const useSynthLogic = ({
   }
 
   const initialState: SynthUiState = {
-    isHelpOpen: false,
-    isAboutOpen: false,
     isPresetDialogOpen: false,
     isSavingNewPreset: true,
     presetName: "",
@@ -106,8 +103,6 @@ export const useSynthLogic = ({
 
   const [uiState, dispatchUi] = useReducer(reducer, initialState);
   const {
-    isHelpOpen,
-    isAboutOpen,
     isPresetDialogOpen,
     isSavingNewPreset,
     presetName,
@@ -115,12 +110,12 @@ export const useSynthLogic = ({
     isControlsVisible,
     visibleKeyCount,
   } = uiState;
-  const setIsHelpOpen = useCallback((value: boolean) => {
-    dispatchUi({ type: "patch", payload: { isHelpOpen: value } });
-  }, []);
-  const setIsAboutOpen = useCallback((value: boolean) => {
-    dispatchUi({ type: "patch", payload: { isAboutOpen: value } });
-  }, []);
+  const {
+    isHelpDialogOpen: isHelpOpen,
+    setIsHelpDialogOpen: setIsHelpOpen,
+    isAboutDialogOpen: isAboutOpen,
+    setIsAboutDialogOpen: setIsAboutOpen,
+  } = useAppHelpAboutDialogs();
   const setIsPresetDialogOpen = useCallback((value: boolean) => {
     dispatchUi({ type: "patch", payload: { isPresetDialogOpen: value } });
   }, []);

--- a/src/apps/textedit/components/DialogManager.tsx
+++ b/src/apps/textedit/components/DialogManager.tsx
@@ -4,6 +4,7 @@ import { InputDialog } from "@/components/dialogs/InputDialog";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { appMetadata, helpItems } from "..";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
+import { useAppHelpAboutDialogs } from "@/hooks/useAppHelpAboutDialogs";
 import { useTranslation } from "react-i18next";
 
 // Export type for the dialog controls
@@ -48,8 +49,12 @@ export function DialogManager({
 }: DialogManagerProps) {
   const { t } = useTranslation();
   const translatedHelpItems = useTranslatedHelpItems("textedit", helpItems);
-  const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
-  const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
+  const {
+    isHelpDialogOpen,
+    setIsHelpDialogOpen,
+    isAboutDialogOpen,
+    setIsAboutDialogOpen,
+  } = useAppHelpAboutDialogs();
   const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
   const [isConfirmNewDialogOpen, setIsConfirmNewDialogOpen] = useState(false);
   const [isCloseSaveDialogOpen, setIsCloseSaveDialogOpen] = useState(false);

--- a/src/apps/videos/hooks/useVideosLogic.ts
+++ b/src/apps/videos/hooks/useVideosLogic.ts
@@ -3,6 +3,7 @@ import ReactPlayer from "react-player";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
+import { useAppHelpAboutDialogs } from "@/hooks/useAppHelpAboutDialogs";
 import { useVideoStore, DEFAULT_VIDEOS } from "@/stores/useVideoStore";
 import { useSound, Sounds } from "@/hooks/useSound";
 import { useAppStore } from "@/stores/useAppStore";
@@ -114,8 +115,6 @@ export function useVideosLogic({
     originalOrder: Video[];
     urlInput: string;
     isAddDialogOpen: boolean;
-    isHelpDialogOpen: boolean;
-    isAboutDialogOpen: boolean;
     isConfirmClearOpen: boolean;
     isConfirmResetOpen: boolean;
     isAddingVideo: boolean;
@@ -135,8 +134,6 @@ export function useVideosLogic({
     originalOrder: videos,
     urlInput: "",
     isAddDialogOpen: false,
-    isHelpDialogOpen: false,
-    isAboutDialogOpen: false,
     isConfirmClearOpen: false,
     isConfirmResetOpen: false,
     isAddingVideo: false,
@@ -168,8 +165,6 @@ export function useVideosLogic({
     originalOrder,
     urlInput,
     isAddDialogOpen,
-    isHelpDialogOpen,
-    isAboutDialogOpen,
     isConfirmClearOpen,
     isConfirmResetOpen,
     isAddingVideo,
@@ -183,6 +178,12 @@ export function useVideosLogic({
     isDraggingSeek,
     dragSeekTime,
   } = uiState;
+  const {
+    isHelpDialogOpen,
+    setIsHelpDialogOpen,
+    isAboutDialogOpen,
+    setIsAboutDialogOpen,
+  } = useAppHelpAboutDialogs();
   const setAnimationDirection = useCallback((value: "next" | "prev") => {
     dispatchUi({ type: "patch", payload: { animationDirection: value } });
   }, []);
@@ -194,12 +195,6 @@ export function useVideosLogic({
   }, []);
   const setIsAddDialogOpen = useCallback((value: boolean) => {
     dispatchUi({ type: "patch", payload: { isAddDialogOpen: value } });
-  }, []);
-  const setIsHelpDialogOpen = useCallback((value: boolean) => {
-    dispatchUi({ type: "patch", payload: { isHelpDialogOpen: value } });
-  }, []);
-  const setIsAboutDialogOpen = useCallback((value: boolean) => {
-    dispatchUi({ type: "patch", payload: { isAboutDialogOpen: value } });
   }, []);
   const setIsConfirmClearOpen = useCallback((value: boolean) => {
     dispatchUi({ type: "patch", payload: { isConfirmClearOpen: value } });

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -247,11 +247,23 @@ export function HelpDialog({
       >
         {isWindowsTheme ? (
           <>
+            <DialogTitle className="sr-only">
+              {t("common.dialog.help")}
+            </DialogTitle>
+            <DialogDescription className="sr-only">
+              {t("common.dialog.informationAboutApp")}
+            </DialogDescription>
             <DialogHeader>{t("common.dialog.help")}</DialogHeader>
             <div className="window-body overflow-hidden">{dialogContent}</div>
           </>
         ) : isMacTheme ? (
           <>
+            <DialogTitle className="sr-only">
+              {t("common.dialog.help")}
+            </DialogTitle>
+            <DialogDescription className="sr-only">
+              {t("common.dialog.informationAboutApp")}
+            </DialogDescription>
             <DialogHeader>{t("common.dialog.help")}</DialogHeader>
             {dialogContent}
           </>

--- a/src/components/shared/menubar/AppMenuBarShell.tsx
+++ b/src/components/shared/menubar/AppMenuBarShell.tsx
@@ -41,23 +41,25 @@ export function AppMenuBarShell({
   onShowAbout,
 }: AppMenuBarShellProps) {
   return (
-    <MenuBar inWindowFrame={isWindowsTheme}>
-      {children}
-      <AppMenuBarHelpMenu
-        helpItemLabel={helpItemLabel}
-        aboutItemLabel={aboutItemLabel}
-        shareItemLabel={shareItemLabel}
-        isMacOSTheme={isMacOSTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
+    <>
+      <MenuBar inWindowFrame={isWindowsTheme}>
+        {children}
+        <AppMenuBarHelpMenu
+          helpItemLabel={helpItemLabel}
+          aboutItemLabel={aboutItemLabel}
+          shareItemLabel={shareItemLabel}
+          isMacOSTheme={isMacOSTheme}
+          onShowHelp={onShowHelp}
+          onShowAbout={onShowAbout}
+          onOpenShareDialog={() => setIsShareDialogOpen(true)}
+        />
+      </MenuBar>
       <AppShareItemDialog
         appId={appId}
         appName={appName}
         isOpen={isShareDialogOpen}
         onClose={() => setIsShareDialogOpen(false)}
       />
-    </MenuBar>
+    </>
   );
 }

--- a/src/hooks/useMediaAppDialogs.ts
+++ b/src/hooks/useMediaAppDialogs.ts
@@ -1,4 +1,5 @@
 import { useCallback, useReducer } from "react";
+import { useAppHelpAboutDialogs } from "@/hooks/useAppHelpAboutDialogs";
 
 /**
  * Reducer-based dialog/overlay open state shared by the media apps (iPod,
@@ -17,8 +18,6 @@ export type MediaAppDialogSetter = (
 ) => void;
 
 export interface MediaAppDialogState {
-  isHelpDialogOpen: boolean;
-  isAboutDialogOpen: boolean;
   isConfirmClearOpen: boolean;
   isShareDialogOpen: boolean;
   isLyricsSearchDialogOpen: boolean;
@@ -33,8 +32,6 @@ export interface MediaAppDialogState {
 }
 
 const initialState: MediaAppDialogState = {
-  isHelpDialogOpen: false,
-  isAboutDialogOpen: false,
   isConfirmClearOpen: false,
   isShareDialogOpen: false,
   isLyricsSearchDialogOpen: false,
@@ -69,6 +66,12 @@ function dialogReducer(
 
 export function useMediaAppDialogs() {
   const [state, dispatch] = useReducer(dialogReducer, initialState);
+  const {
+    isHelpDialogOpen,
+    setIsHelpDialogOpen,
+    isAboutDialogOpen,
+    setIsAboutDialogOpen,
+  } = useAppHelpAboutDialogs();
 
   const setBool = useCallback(
     (
@@ -80,14 +83,6 @@ export function useMediaAppDialogs() {
     []
   );
 
-  const setIsHelpDialogOpen = useCallback<MediaAppDialogSetter>(
-    (value) => setBool("isHelpDialogOpen", value),
-    [setBool]
-  );
-  const setIsAboutDialogOpen = useCallback<MediaAppDialogSetter>(
-    (value) => setBool("isAboutDialogOpen", value),
-    [setBool]
-  );
   const setIsConfirmClearOpen = useCallback<MediaAppDialogSetter>(
     (value) => setBool("isConfirmClearOpen", value),
     [setBool]
@@ -134,9 +129,11 @@ export function useMediaAppDialogs() {
   );
 
   return {
-    ...state,
+    isHelpDialogOpen,
     setIsHelpDialogOpen,
+    isAboutDialogOpen,
     setIsAboutDialogOpen,
+    ...state,
     setIsConfirmClearOpen,
     setIsShareDialogOpen,
     setIsLyricsSearchDialogOpen,

--- a/src/stores/useInternetExplorerStore.ts
+++ b/src/stores/useInternetExplorerStore.ts
@@ -434,8 +434,6 @@ interface InternetExplorerStore {
   // Dialog states
   isTitleDialogOpen: boolean;
   newFavoriteTitle: string;
-  isHelpDialogOpen: boolean;
-  isAboutDialogOpen: boolean;
   isNavigatingHistory: boolean;
   isClearFavoritesDialogOpen: boolean;
   isClearHistoryDialogOpen: boolean;
@@ -497,8 +495,6 @@ interface InternetExplorerStore {
   // Dialog actions
   setTitleDialogOpen: (isOpen: boolean) => void;
   setNewFavoriteTitle: (title: string) => void;
-  setHelpDialogOpen: (isOpen: boolean) => void;
-  setAboutDialogOpen: (isOpen: boolean) => void;
   setNavigatingHistory: (isNavigating: boolean) => void;
   setClearFavoritesDialogOpen: (isOpen: boolean) => void;
   setClearHistoryDialogOpen: (isOpen: boolean) => void;
@@ -585,8 +581,6 @@ const getInitialState = () => ({
   location: "auto" as LocationOption,
   isTitleDialogOpen: false,
   newFavoriteTitle: "",
-  isHelpDialogOpen: false,
-  isAboutDialogOpen: false,
   isNavigatingHistory: false,
   isClearFavoritesDialogOpen: false,
   isClearHistoryDialogOpen: false,
@@ -832,8 +826,6 @@ export const useInternetExplorerStore = create<InternetExplorerStore>()(
 
       setTitleDialogOpen: (isOpen) => set({ isTitleDialogOpen: isOpen }),
       setNewFavoriteTitle: (title) => set({ newFavoriteTitle: title }),
-      setHelpDialogOpen: (isOpen) => set({ isHelpDialogOpen: isOpen }),
-      setAboutDialogOpen: (isOpen) => set({ isAboutDialogOpen: isOpen }),
       setNavigatingHistory: (isNavigating) =>
         set({ isNavigatingHistory: isNavigating }),
       setClearFavoritesDialogOpen: (isOpen) =>

--- a/tests/test-shared-dialog-state.test.ts
+++ b/tests/test-shared-dialog-state.test.ts
@@ -1,9 +1,9 @@
 /**
  * Guardrail tests for the shared dialog-state hooks.
  *
- * App logic hooks must use `useAppHelpAboutDialogs` (or, for media apps,
- * `useMediaAppDialogs`) instead of re-declaring per-app
- * `useState(false)` pairs for the Help/About dialogs.
+ * App logic hooks must use `useAppHelpAboutDialogs` directly, or compose it
+ * through `useMediaAppDialogs`, instead of re-declaring per-app
+ * Help/About dialog state.
  */
 
 import { readFileSync, readdirSync, statSync } from "node:fs";
@@ -42,12 +42,15 @@ const collectAppHookFiles = (): string[] => {
 // Logic hooks that live outside a hooks/ directory but were migrated too.
 const EXTRA_MIGRATED_FILES = [
   "src/apps/chats/components/chats-app/useChatsAppController.tsx",
+  "src/apps/textedit/components/DialogManager.tsx",
 ];
 
 const HELP_DIALOG_USESTATE =
   /const \[isHelpDialogOpen,\s*setIsHelpDialogOpen\]\s*=\s*useState/;
 const ABOUT_DIALOG_USESTATE =
   /const \[isAboutDialogOpen,\s*setIsAboutDialogOpen\]\s*=\s*useState/;
+const HELP_ABOUT_INITIAL_STATE =
+  /(isHelpDialogOpen|isAboutDialogOpen|isHelpOpen|isAboutOpen):\s*false/;
 
 describe("Shared dialog state wiring", () => {
   test("no logic hook under src/apps/**/hooks declares useState for isHelpDialogOpen/isAboutDialogOpen", () => {
@@ -56,7 +59,8 @@ describe("Shared dialog state wiring", () => {
       const source = readFileSync(file, "utf-8");
       if (
         HELP_DIALOG_USESTATE.test(source) ||
-        ABOUT_DIALOG_USESTATE.test(source)
+        ABOUT_DIALOG_USESTATE.test(source) ||
+        HELP_ABOUT_INITIAL_STATE.test(source)
       ) {
         offenders.push(file);
       }
@@ -69,6 +73,7 @@ describe("Shared dialog state wiring", () => {
       const source = readSource(relativePath);
       expect(HELP_DIALOG_USESTATE.test(source)).toBe(false);
       expect(ABOUT_DIALOG_USESTATE.test(source)).toBe(false);
+      expect(HELP_ABOUT_INITIAL_STATE.test(source)).toBe(false);
       expect(source).toContain("useAppHelpAboutDialogs()");
     }
   });
@@ -103,6 +108,7 @@ describe("Shared dialog state wiring", () => {
 
     const mediaDialogs = readSource("src/hooks/useMediaAppDialogs.ts");
     expect(mediaDialogs).toContain("export function useMediaAppDialogs");
+    expect(mediaDialogs).toContain("useAppHelpAboutDialogs()");
     for (const key of [
       "isHelpDialogOpen",
       "isAboutDialogOpen",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Compose media app Help/About state through `useAppHelpAboutDialogs` while preserving the `useMediaAppDialogs` API for iPod and Karaoke.
- Move remaining app-level Help/About state in Videos, Internet Explorer, Applet Viewer, TextEdit, Soundboard, Photo Booth, and Synth to the shared hook.
- Fix the shared menubar/dialog structure exposed by Internet Explorer Help so Radix dialogs are no longer mounted inside the menubar root.
- Update the shared dialog guardrail test and refresh `docs/proposals/next-improvements.md` after the merged cleanup PRs.

## Walkthrough
<a href="https://cursor.com/agents/bc-019eec6a-5b7d-7521-950f-71c4550472ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhelp_about_dialogs_smoke_review.mp4"><img src="https://cursor.com/artifacts/c/art-40060e29-0c03-49eb-9011-b29a205e776c" alt="help_about_dialogs_smoke_review.mp4" /></a>

## Testing
- `bun test tests/test-shared-dialog-state.test.ts`
- `bun run build`
- Manual browser smoke: iPod, Videos, and Internet Explorer Help/About dialogs opened and closed successfully; IE remained stable after the prior SIGTRAP repro.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eec6a-5b7d-7521-950f-71c4550472ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eec6a-5b7d-7521-950f-71c4550472ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

