### PR TITLE
Add OG previews for newer apps

### DIFF
--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -24,7 +24,11 @@ const APP_NAMES: Record<string, string> = {
   stickies: "Stickies",
   "infinite-mac": "Infinite Mac",
   winamp: "Winamp",
+  calendar: "Calendar",
+  contacts: "Contacts",
   dashboard: "Dashboard",
+  maps: "Maps",
+  books: "Books",
 };
 
 // App descriptions
@@ -49,7 +53,11 @@ const APP_DESCRIPTIONS: Record<string, string> = {
   stickies: "Colorful sticky notes for reminders and quick notes",
   "infinite-mac": "Run classic Mac OS and NeXT in your browser",
   winamp: "Classic Winamp media player in your browser",
+  calendar: "Calendar with events",
+  contacts: "Address book with vCard import",
   dashboard: "Widgets dashboard with clock, calendar, and weather",
+  maps: "Find places with Apple Maps",
+  books: "Read EPUB books",
 };
 
 // App ID to macOS icon mapping
@@ -74,7 +82,11 @@ const APP_ICONS: Record<string, string> = {
   stickies: "stickies.png",
   "infinite-mac": "infinite-mac.png",
   winamp: "winamp.png",
+  calendar: "calendar.png",
+  contacts: "contacts.png",
   dashboard: "dashboard.png",
+  maps: "maps.png",
+  books: "books.png",
 };
 
 export type SongShareMetadata = {

--- a/middleware.ts
+++ b/middleware.ts
@@ -29,7 +29,11 @@ export const config = {
     "/applet-viewer/:path*",
     "/control-panels",
     "/winamp",
+    "/calendar",
+    "/contacts",
     "/dashboard",
+    "/maps",
+    "/books",
   ],
 };
 

--- a/tests/test-og-share.test.ts
+++ b/tests/test-og-share.test.ts
@@ -5,6 +5,7 @@ import {
   resolveSongShareId,
 } from "../api/_utils/og-share";
 import { UpdateSongSchema } from "../api/songs/_constants";
+import { config as middlewareConfig } from "../middleware";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -41,6 +42,60 @@ describe("og share response", () => {
     expect(body).toContain(
       'location.replace("https://coolify.example.com/finder?_ryo=1")'
     );
+  });
+
+  test("serves app icon OG previews for newer app routes", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const appCases = [
+      {
+        id: "calendar",
+        title: "Calendar on ryOS",
+        description: "Calendar with events",
+        icon: "calendar.png",
+      },
+      {
+        id: "contacts",
+        title: "Contacts on ryOS",
+        description: "Address book with vCard import",
+        icon: "contacts.png",
+      },
+      {
+        id: "maps",
+        title: "Maps on ryOS",
+        description: "Find places with Apple Maps",
+        icon: "maps.png",
+      },
+      {
+        id: "books",
+        title: "Books on ryOS",
+        description: "Read EPUB books",
+        icon: "books.png",
+      },
+    ];
+
+    for (const app of appCases) {
+      expect(middlewareConfig.matcher).toContain(`/${app.id}`);
+
+      const response = await createOgShareResponse(
+        new Request(`https://os.example.com/${app.id}`)
+      );
+
+      expect(response).not.toBeNull();
+      const body = await response!.text();
+      expect(body).toContain(
+        `<meta property="og:title" content="${app.title}">`
+      );
+      expect(body).toContain(
+        `<meta property="og:description" content="${app.description}">`
+      );
+      expect(body).toContain(
+        `<meta property="og:image" content="https://os.example.com/icons/macosx/${app.icon}">`
+      );
+      expect(body).toContain(
+        `location.replace("https://os.example.com/${app.id}?_ryo=1")`
+      );
+    }
   });
 
   test("skips requests that already include the bypass query", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add OG app metadata and icon previews for Calendar, Contacts, Maps, and Books.
- Include those app routes in the middleware matcher so Vercel serves OG share pages.
- Add regression coverage for newer app OG previews and route matching.

## Testing
- `bun test tests/test-og-share.test.ts tests/test-og-share-song-key-cutover.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eef42-3f7d-7890-b865-5b3064e47bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eef42-3f7d-7890-b865-5b3064e47bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

