### PR TITLE
Reduce Books reader side gutter

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -72,7 +72,7 @@ const FOOTER_HEIGHT = 30;
 // Horizontal gutter around the text column. Applied as a left/right inset on the
 // epub.js render host (rather than body padding) so epub.js's paginated column
 // math stays correct — it computes columns from the host width.
-const SIDE_CLEARANCE = 32;
+const SIDE_CLEARANCE = 24;
 // Width at which auto column mode switches to a two-page spread. epub.js
 // defaults to 800; a lower value shows two columns on narrower windows.
 const SPREAD_MIN_WIDTH = 560;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Reduce the Books reader left/right render inset from 32px to 24px so the text area uses a little more horizontal space.

### Testing
- Pending local verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eef9d-d8f6-7dda-8a8a-90c802e6493b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eef9d-d8f6-7dda-8a8a-90c802e6493b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

