### PR TITLE
Show EPUB files as Books in Finder

### DIFF
--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -5,6 +5,10 @@ import { isTouchDevice } from "@/utils/device";
 import { usePointerLongPress } from "@/hooks/usePointerLongPress";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
+import {
+  BOOK_FILE_ICON_PATH,
+  isEpubFile,
+} from "@/apps/finder/utils/fileSystemHelpers";
 
 interface FileIconProps {
   name: string;
@@ -151,6 +155,7 @@ export const FileIcon = memo(function FileIcon({
   };
 
   const getIconPath = () => {
+    if (!isDirectory && isEpubFile(name)) return BOOK_FILE_ICON_PATH;
     if (icon) return icon;
     if (isDirectory) return "/icons/directory.png"; // legacy logical path
     if (name.endsWith(".txt") || name.endsWith(".md"))

--- a/src/apps/finder/components/file-list/fileListUtils.ts
+++ b/src/apps/finder/components/file-list/fileListUtils.ts
@@ -1,4 +1,8 @@
 import type { FileItem } from "./types";
+import {
+  BOOK_FILE_ICON_PATH,
+  isEpubFile,
+} from "@/apps/finder/utils/fileSystemHelpers";
 
 export function isImageFile(file: FileItem): boolean {
   const ext = file.name.split(".").pop()?.toLowerCase();
@@ -39,6 +43,9 @@ export function shouldShowThumbnail(file: FileItem): boolean {
 }
 
 export function getIconPath(file: FileItem): string {
+  if (!file.isDirectory && isEpubFile(file.name, file.type)) {
+    return BOOK_FILE_ICON_PATH;
+  }
   if (file.icon) return file.icon;
   if (file.isDirectory) return "/icons/directory.png";
   if (file.name.endsWith(".txt") || file.name.endsWith(".md"))

--- a/src/apps/finder/hooks/useFileSystem.ts
+++ b/src/apps/finder/hooks/useFileSystem.ts
@@ -35,6 +35,8 @@ import {
   getCloudSyncDomainForContentStore,
   getCloudSyncDeletionBucketForContentStore,
   getFileTypeFromExtension,
+  BOOK_FILE_ICON_PATH,
+  isEpubFile,
 } from "../utils/fileSystemHelpers";
 
 // Interface for content stored in IndexedDB. The persisted shape is the shared
@@ -98,6 +100,10 @@ function getFileIcon(item: FileSystemItem): string {
       }
       return "/icons/default/file.png";
     }
+  }
+
+  if (isEpubFile(item.name, item.type)) {
+    return BOOK_FILE_ICON_PATH;
   }
 
   // Use stored icon if available (but only if not an alias, since aliases should resolve)

--- a/src/apps/finder/hooks/useFinderLogic.ts
+++ b/src/apps/finder/hooks/useFinderLogic.ts
@@ -112,6 +112,8 @@ const getFileType = (
       return t("apps.finder.fileTypes.quicktimeMovie");
     case "html":
       return t("apps.finder.fileTypes.htmlApplet");
+    case "epub":
+      return t("apps.finder.fileTypes.book");
     default:
       return t("apps.finder.fileTypes.unknown");
   }

--- a/src/apps/finder/utils/fileSystemHelpers.ts
+++ b/src/apps/finder/utils/fileSystemHelpers.ts
@@ -55,6 +55,16 @@ export const DEFAULT_FILE_PATHS = new Set([
   "/Images/susan-kare.png",
 ]);
 
+export const BOOK_FILE_ICON_PATH = "/icons/default/books.png";
+
+export function isEpubFile(fileName: string, type?: string): boolean {
+  return (
+    fileName.toLowerCase().endsWith(".epub") ||
+    type === "epub" ||
+    type === "application/epub+zip"
+  );
+}
+
 export const getCloudSyncDomainForContentStore = (
   storeName: string
 ):
@@ -123,6 +133,8 @@ export function getFileTypeFromExtension(fileName: string): string {
     case "html":
     case "htm":
       return "html";
+    case "epub":
+      return "epub";
     default:
       return "unknown";
   }

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -2076,6 +2076,7 @@
       },
       "fileTypes": {
         "application": "Anwendung",
+        "book": "Buch",
         "bmpImage": "BMP-Bild",
         "directory": "Verzeichnis",
         "document": "Dokument",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -428,6 +428,7 @@
         "gifImage": "GIF Image",
         "webpImage": "WebP Image",
         "bmpImage": "BMP Image",
+        "book": "Book",
         "document": "Document",
         "htmlApplet": "HTML Applet",
         "unknown": "Unknown"

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -2076,6 +2076,7 @@
       },
       "fileTypes": {
         "application": "Aplicación",
+        "book": "Libro",
         "bmpImage": "Imagen BMP",
         "directory": "Directorio",
         "document": "Documento",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -2076,6 +2076,7 @@
       },
       "fileTypes": {
         "application": "Application",
+        "book": "Livre",
         "bmpImage": "Image BMP",
         "directory": "Dossier",
         "document": "Document",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -2076,6 +2076,7 @@
       },
       "fileTypes": {
         "application": "Applicazione",
+        "book": "Libro",
         "bmpImage": "Immagine BMP",
         "directory": "Cartella",
         "document": "Documento",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -2076,6 +2076,7 @@
       },
       "fileTypes": {
         "application": "アプリケーション",
+        "book": "本",
         "bmpImage": "BMP 画像",
         "directory": "ディレクトリ",
         "document": "ドキュメント",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -2076,6 +2076,7 @@
       },
       "fileTypes": {
         "application": "애플리케이션",
+        "book": "책",
         "bmpImage": "BMP 이미지",
         "directory": "디렉터리",
         "document": "문서",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -2076,6 +2076,7 @@
       },
       "fileTypes": {
         "application": "Aplicativo",
+        "book": "Livro",
         "bmpImage": "Imagem BMP",
         "directory": "Diretório",
         "document": "Documento",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -2076,6 +2076,7 @@
       },
       "fileTypes": {
         "application": "Приложение",
+        "book": "Книга",
         "bmpImage": "Изображение BMP",
         "directory": "Каталог",
         "document": "Документ",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -2076,6 +2076,7 @@
       },
       "fileTypes": {
         "application": "應用程式",
+        "book": "書籍",
         "bmpImage": "BMP 影像",
         "directory": "目錄",
         "document": "檔案",

--- a/tests/test-finder-epub-file-metadata.test.ts
+++ b/tests/test-finder-epub-file-metadata.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BOOK_FILE_ICON_PATH,
+  getFileTypeFromExtension,
+  isEpubFile,
+} from "../src/apps/finder/utils/fileSystemHelpers";
+import { getIconPath } from "../src/apps/finder/components/file-list/fileListUtils";
+
+describe("Finder EPUB file metadata", () => {
+  test("classifies EPUB files as books", () => {
+    expect(getFileTypeFromExtension("Meditations.epub")).toBe("epub");
+    expect(isEpubFile("Meditations.epub")).toBe(true);
+    expect(isEpubFile("Meditations", "application/epub+zip")).toBe(true);
+  });
+
+  test("uses the Books app icon for EPUB files", () => {
+    expect(
+      getIconPath({
+        name: "Meditations.epub",
+        isDirectory: false,
+        path: "/Books/Meditations.epub",
+        icon: "/icons/file.png",
+        type: "epub",
+      })
+    ).toBe(BOOK_FILE_ICON_PATH);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Show `.epub` files as `Book` in Finder's Type/Kind column.
- Use the Books app icon for EPUB files, including stale generic file icons.
- Add localized Finder file type labels and a focused regression test.

## Testing
- `bun test tests/test-finder-epub-file-metadata.test.ts tests/test-books-default-epub.test.ts`
- `bun run build`
- Manual browser verification in Finder Books folder

## Walkthrough
<a href="https://cursor.com/agents/bc-019eef96-a2c1-7c91-a430-aba2ca90d1a0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffinder_epub_book_type_icon.mp4"><img src="https://cursor.com/artifacts/c/art-72ef2468-b7af-4ea4-8b5f-4b4f48996c81" alt="finder_epub_book_type_icon.mp4" /></a>
![Finder Books folder showing EPUB as Book](https://cursor.com/artifacts/c/art-c0010ba0-c9b1-4fd8-a551-b4c720001c69)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eef96-a2c1-7c91-a430-aba2ca90d1a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eef96-a2c1-7c91-a430-aba2ca90d1a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

