### PR TITLE
Fix mobile desktop context menu taps

### DIFF
--- a/src/components/ui/right-click-menu.tsx
+++ b/src/components/ui/right-click-menu.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuCheckboxItem,
 } from "@/components/ui/dropdown-menu";
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useCallback, useEffect } from "react";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { useSound, Sounds } from "@/hooks/useSound";
 
@@ -183,6 +183,9 @@ export function RightClickMenu({
   align = "start",
 }: RightClickMenuProps) {
   const { play: playMenuOpen } = useSound(Sounds.MENU_OPEN);
+  const stopMenuEventPropagation = useCallback((event: React.SyntheticEvent) => {
+    event.stopPropagation();
+  }, []);
 
   // Play open sound when menu appears
   useEffect(() => {
@@ -211,6 +214,11 @@ export function RightClickMenu({
         sideOffset={4}
         alignOffset={4}
         className="px-0"
+        onPointerDown={stopMenuEventPropagation}
+        onMouseDown={stopMenuEventPropagation}
+        onTouchStart={stopMenuEventPropagation}
+        onClick={stopMenuEventPropagation}
+        onContextMenu={stopMenuEventPropagation}
       >
         {renderItems(items)}
       </DropdownMenuContent>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Stop pointer, mouse, touch, click, and context-menu events inside the shared right-click menu from bubbling back into desktop handlers.
- Keep mobile long-press desktop menus actionable after they appear.

## Walkthrough
<a href="https://cursor.com/agents/bc-019ef023-6256-72b2-a43e-7655efdc2407/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_context_menu_long_press_set_wallpaper.mp4"><img src="https://cursor.com/artifacts/c/art-f6320821-6548-4b54-96fd-9fcb1f152a2d" alt="mobile_context_menu_long_press_set_wallpaper.mp4" /></a>
![System Preferences opened from mobile context menu](https://cursor.com/artifacts/c/art-1ff7aeae-fbe6-4aab-8944-644a521b5c58)

## Testing
- `bun run build` passed.
- `bunx eslint src/components/ui/right-click-menu.tsx` passed.
- Mobile Playwright/Chrome touch validation passed: CDP `touchStart`, 700ms hold, `touchEnd`, tap `Set Wallpaper`, then `System Preferences` opens.
- `bun run lint src/components/ui/right-click-menu.tsx` still expands to full-repo lint and fails on pre-existing unrelated lint errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ef023-6256-72b2-a43e-7655efdc2407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ef023-6256-72b2-a43e-7655efdc2407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

