### PR TITLE
Show cloud sync upload progress in menubar

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/syncUtils.ts
+++ b/src/apps/control-panels/components/control-panels-app/syncUtils.ts
@@ -9,6 +9,7 @@ export type SyncAuditStatus = {
   lastAppliedRemoteAt: string | null;
   isUploading?: boolean;
   isDownloading?: boolean;
+  uploadProgress?: number | null;
 };
 
 const AUTO_SYNC_TIME_KEYS: RelativeTimeKeys = {
@@ -38,7 +39,7 @@ export function formatSyncStatus(
   const parts: string[] = [];
 
   if (status.isUploading) {
-    parts.push(t("apps.control-panels.autoSync.uploading"));
+    parts.push(formatUploadingStatus(status.uploadProgress, t));
   } else {
     parts.push(
       uploadedRelative
@@ -62,6 +63,17 @@ export function formatSyncStatus(
   }
 
   return parts.join(" · ");
+}
+
+export function formatUploadingStatus(
+  uploadProgress: number | null | undefined,
+  t: (key: string, opts?: Record<string, unknown>) => string
+): string {
+  const label = t("apps.control-panels.autoSync.uploading");
+  if (typeof uploadProgress !== "number" || !Number.isFinite(uploadProgress)) {
+    return label;
+  }
+  return `${label} ${Math.round(Math.max(0, Math.min(100, uploadProgress)))}%`;
 }
 
 export function getUsernameInitials(username: string): string {

--- a/src/apps/control-panels/components/control-panels-app/syncUtils.ts
+++ b/src/apps/control-panels/components/control-panels-app/syncUtils.ts
@@ -10,6 +10,7 @@ export type SyncAuditStatus = {
   isUploading?: boolean;
   isDownloading?: boolean;
   uploadProgress?: number | null;
+  downloadProgress?: number | null;
 };
 
 const AUTO_SYNC_TIME_KEYS: RelativeTimeKeys = {
@@ -51,7 +52,7 @@ export function formatSyncStatus(
   }
 
   if (status.isDownloading) {
-    parts.push(t("apps.control-panels.autoSync.fetching"));
+    parts.push(formatFetchingStatus(status.downloadProgress, t));
   } else {
     parts.push(
       fetchedRelative
@@ -74,6 +75,17 @@ export function formatUploadingStatus(
     return label;
   }
   return `${label} ${Math.round(Math.max(0, Math.min(100, uploadProgress)))}%`;
+}
+
+export function formatFetchingStatus(
+  downloadProgress: number | null | undefined,
+  t: (key: string, opts?: Record<string, unknown>) => string
+): string {
+  const label = t("apps.control-panels.autoSync.fetching");
+  if (typeof downloadProgress !== "number" || !Number.isFinite(downloadProgress)) {
+    return label;
+  }
+  return `${label} ${Math.round(Math.max(0, Math.min(100, downloadProgress)))}%`;
 }
 
 export function getUsernameInitials(username: string): string {

--- a/src/components/layout/menu-bar/CloudSyncIndicator.tsx
+++ b/src/components/layout/menu-bar/CloudSyncIndicator.tsx
@@ -184,54 +184,63 @@ export function CloudSyncIndicator() {
           className="min-w-[200px]"
         >
           <AnimatePresence initial={false}>
-            {activeCategories.map(({ category, isUploading, uploadProgress, downloadProgress }) => {
-              const meta = SYNC_CATEGORY_META[category];
-              const activeProgress = isUploading ? uploadProgress : downloadProgress;
-              const progress =
-                typeof activeProgress === "number"
-                  ? Math.round(Math.max(0, Math.min(100, activeProgress)))
-                  : null;
-              return (
-                <motion.div
-                  key={category}
-                  initial={{ opacity: 0, height: 0 }}
-                  animate={{ opacity: 1, height: "auto" }}
-                  exit={{ opacity: 0, height: 0 }}
-                  transition={{ duration: 0.15, ease: "easeOut" }}
-                  className="overflow-hidden"
-                >
-                  <MenubarItem
-                    className="text-md min-h-7 px-3 flex items-center gap-2"
-                    onSelect={(event) => event.preventDefault()}
+            {activeCategories.map(
+              ({ category, isUploading, uploadProgress, downloadProgress }) => {
+                const meta = SYNC_CATEGORY_META[category];
+                const activeProgress = isUploading
+                  ? uploadProgress
+                  : downloadProgress;
+                const progress =
+                  typeof activeProgress === "number"
+                    ? Math.round(Math.max(0, Math.min(100, activeProgress)))
+                    : null;
+                const transferLabel = isUploading
+                  ? t("apps.control-panels.autoSync.uploading")
+                  : t("apps.control-panels.autoSync.fetching");
+                const transferStatusLabel = isUploading
+                  ? formatUploadingStatus(uploadProgress, t)
+                  : formatFetchingStatus(downloadProgress, t);
+                return (
+                  <motion.div
+                    key={category}
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: "auto" }}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={{ duration: 0.15, ease: "easeOut" }}
+                    className="overflow-hidden"
                   >
-                    <ThemedIcon
-                      name={getAppIconPath(meta.appId)}
-                      alt=""
-                      className="size-4 shrink-0 object-contain"
-                    />
-                    <span className="min-w-0 flex-1">
-                      <span>{t(meta.labelKey)}</span>
-                      {progress !== null && (
-                        <span
-                          className="mt-1 block h-1 overflow-hidden rounded-full bg-black/15 os-dark:bg-white/20"
-                          aria-hidden="true"
-                        >
+                    <MenubarItem
+                      className="text-md min-h-7 px-3 flex items-center gap-2"
+                      onSelect={(event) => event.preventDefault()}
+                    >
+                      <ThemedIcon
+                        name={getAppIconPath(meta.appId)}
+                        alt=""
+                        className="size-4 shrink-0 object-contain"
+                      />
+                      <span className="min-w-0 flex-1">{t(meta.labelKey)}</span>
+                      <span
+                        className="ml-auto pl-3 text-xs opacity-60 flex items-center gap-1.5"
+                        aria-label={transferStatusLabel}
+                      >
+                        <span>{transferLabel}</span>
+                        {progress !== null && (
                           <span
-                            className="block h-full rounded-full bg-current opacity-70"
-                            style={{ width: `${progress}%` }}
-                          />
-                        </span>
-                      )}
-                    </span>
-                    <span className="ml-auto pl-3 text-xs tabular-nums opacity-60">
-                      {isUploading
-                        ? formatUploadingStatus(uploadProgress, t)
-                        : formatFetchingStatus(downloadProgress, t)}
-                    </span>
-                  </MenubarItem>
-                </motion.div>
-              );
-            })}
+                            className="block h-1 w-12 overflow-hidden rounded-full bg-black/15 os-dark:bg-white/20"
+                            aria-hidden="true"
+                          >
+                            <span
+                              className="block h-full rounded-full bg-current opacity-70"
+                              style={{ width: `${progress}%` }}
+                            />
+                          </span>
+                        )}
+                      </span>
+                    </MenubarItem>
+                  </motion.div>
+                );
+              }
+            )}
           </AnimatePresence>
           {activeCategories.length === 0 && (
             <MenubarItem disabled className="text-md h-6 px-3 opacity-70">

--- a/src/components/layout/menu-bar/CloudSyncIndicator.tsx
+++ b/src/components/layout/menu-bar/CloudSyncIndicator.tsx
@@ -22,7 +22,10 @@ import {
   formatRelativeTime,
   type RelativeTimeKeys,
 } from "@/utils/formatRelativeTime";
-import { formatUploadingStatus } from "@/apps/control-panels/components/control-panels-app/syncUtils";
+import {
+  formatFetchingStatus,
+  formatUploadingStatus,
+} from "@/apps/control-panels/components/control-panels-app/syncUtils";
 
 const AUTO_SYNC_TIME_KEYS: RelativeTimeKeys = {
   justNow: "apps.control-panels.autoSync.justNow",
@@ -79,6 +82,7 @@ interface SyncCategoryActivity {
   isUploading: boolean;
   isDownloading: boolean;
   uploadProgress: number | null;
+  downloadProgress: number | null;
 }
 
 export function CloudSyncIndicator() {
@@ -108,18 +112,21 @@ export function CloudSyncIndicator() {
       isUploading: categoryStatus[category].isUploading,
       isDownloading: categoryStatus[category].isDownloading,
       uploadProgress: categoryStatus[category].uploadProgress,
+      downloadProgress: categoryStatus[category].downloadProgress,
     })
   ).filter((entry) => entry.isUploading || entry.isDownloading);
 
   const isCloudSyncActive = isCheckingRemote || activeCategories.length > 0;
-  const activeUploadProgress = activeCategories
-    .map((entry) => entry.uploadProgress)
+  const activeTransferProgress = activeCategories
+    .map((entry) =>
+      entry.isUploading ? entry.uploadProgress : entry.downloadProgress
+    )
     .filter((progress): progress is number => typeof progress === "number");
-  const triggerUploadProgress =
-    activeUploadProgress.length > 0
+  const triggerTransferProgress =
+    activeTransferProgress.length > 0
       ? Math.round(
-          activeUploadProgress.reduce((sum, progress) => sum + progress, 0) /
-            activeUploadProgress.length
+          activeTransferProgress.reduce((sum, progress) => sum + progress, 0) /
+            activeTransferProgress.length
         )
       : null;
 
@@ -164,9 +171,9 @@ export function CloudSyncIndicator() {
                   : undefined,
               }}
             />
-            {triggerUploadProgress !== null && (
+            {triggerTransferProgress !== null && (
               <span className="min-w-[2.1em] text-[10px] leading-none tabular-nums opacity-80">
-                {triggerUploadProgress}%
+                {triggerTransferProgress}%
               </span>
             )}
           </motion.span>
@@ -177,11 +184,12 @@ export function CloudSyncIndicator() {
           className="min-w-[200px]"
         >
           <AnimatePresence initial={false}>
-            {activeCategories.map(({ category, isUploading, uploadProgress }) => {
+            {activeCategories.map(({ category, isUploading, uploadProgress, downloadProgress }) => {
               const meta = SYNC_CATEGORY_META[category];
+              const activeProgress = isUploading ? uploadProgress : downloadProgress;
               const progress =
-                typeof uploadProgress === "number"
-                  ? Math.round(Math.max(0, Math.min(100, uploadProgress)))
+                typeof activeProgress === "number"
+                  ? Math.round(Math.max(0, Math.min(100, activeProgress)))
                   : null;
               return (
                 <motion.div
@@ -203,7 +211,7 @@ export function CloudSyncIndicator() {
                     />
                     <span className="min-w-0 flex-1">
                       <span>{t(meta.labelKey)}</span>
-                      {isUploading && progress !== null && (
+                      {progress !== null && (
                         <span
                           className="mt-1 block h-1 overflow-hidden rounded-full bg-black/15 os-dark:bg-white/20"
                           aria-hidden="true"
@@ -218,7 +226,7 @@ export function CloudSyncIndicator() {
                     <span className="ml-auto pl-3 text-xs tabular-nums opacity-60">
                       {isUploading
                         ? formatUploadingStatus(uploadProgress, t)
-                        : t("apps.control-panels.autoSync.fetching")}
+                        : formatFetchingStatus(downloadProgress, t)}
                     </span>
                   </MenubarItem>
                 </motion.div>

--- a/src/components/layout/menu-bar/CloudSyncIndicator.tsx
+++ b/src/components/layout/menu-bar/CloudSyncIndicator.tsx
@@ -22,6 +22,7 @@ import {
   formatRelativeTime,
   type RelativeTimeKeys,
 } from "@/utils/formatRelativeTime";
+import { formatUploadingStatus } from "@/apps/control-panels/components/control-panels-app/syncUtils";
 
 const AUTO_SYNC_TIME_KEYS: RelativeTimeKeys = {
   justNow: "apps.control-panels.autoSync.justNow",
@@ -77,6 +78,7 @@ interface SyncCategoryActivity {
   category: CloudSyncCategory;
   isUploading: boolean;
   isDownloading: boolean;
+  uploadProgress: number | null;
 }
 
 export function CloudSyncIndicator() {
@@ -105,10 +107,21 @@ export function CloudSyncIndicator() {
       category,
       isUploading: categoryStatus[category].isUploading,
       isDownloading: categoryStatus[category].isDownloading,
+      uploadProgress: categoryStatus[category].uploadProgress,
     })
   ).filter((entry) => entry.isUploading || entry.isDownloading);
 
   const isCloudSyncActive = isCheckingRemote || activeCategories.length > 0;
+  const activeUploadProgress = activeCategories
+    .map((entry) => entry.uploadProgress)
+    .filter((progress): progress is number => typeof progress === "number");
+  const triggerUploadProgress =
+    activeUploadProgress.length > 0
+      ? Math.round(
+          activeUploadProgress.reduce((sum, progress) => sum + progress, 0) /
+            activeUploadProgress.length
+        )
+      : null;
 
   const syncLabel = t("apps.control-panels.autoSync.title");
 
@@ -138,7 +151,7 @@ export function CloudSyncIndicator() {
             initial={{ opacity: 0, scale: 0.85 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.15, ease: "easeOut" }}
-            className="flex items-center justify-center"
+            className="flex items-center justify-center gap-1"
           >
             <ArrowsClockwise
               aria-hidden="true"
@@ -151,6 +164,11 @@ export function CloudSyncIndicator() {
                   : undefined,
               }}
             />
+            {triggerUploadProgress !== null && (
+              <span className="min-w-[2.1em] text-[10px] leading-none tabular-nums opacity-80">
+                {triggerUploadProgress}%
+              </span>
+            )}
           </motion.span>
         </MenubarTrigger>
         <MenubarContent
@@ -159,8 +177,12 @@ export function CloudSyncIndicator() {
           className="min-w-[200px]"
         >
           <AnimatePresence initial={false}>
-            {activeCategories.map(({ category, isUploading }) => {
+            {activeCategories.map(({ category, isUploading, uploadProgress }) => {
               const meta = SYNC_CATEGORY_META[category];
+              const progress =
+                typeof uploadProgress === "number"
+                  ? Math.round(Math.max(0, Math.min(100, uploadProgress)))
+                  : null;
               return (
                 <motion.div
                   key={category}
@@ -171,7 +193,7 @@ export function CloudSyncIndicator() {
                   className="overflow-hidden"
                 >
                   <MenubarItem
-                    className="text-md h-6 px-3 flex items-center gap-2"
+                    className="text-md min-h-7 px-3 flex items-center gap-2"
                     onSelect={(event) => event.preventDefault()}
                   >
                     <ThemedIcon
@@ -179,10 +201,23 @@ export function CloudSyncIndicator() {
                       alt=""
                       className="size-4 shrink-0 object-contain"
                     />
-                    <span>{t(meta.labelKey)}</span>
-                    <span className="ml-auto pl-3 text-xs opacity-60">
+                    <span className="min-w-0 flex-1">
+                      <span>{t(meta.labelKey)}</span>
+                      {isUploading && progress !== null && (
+                        <span
+                          className="mt-1 block h-1 overflow-hidden rounded-full bg-black/15 os-dark:bg-white/20"
+                          aria-hidden="true"
+                        >
+                          <span
+                            className="block h-full rounded-full bg-current opacity-70"
+                            style={{ width: `${progress}%` }}
+                          />
+                        </span>
+                      )}
+                    </span>
+                    <span className="ml-auto pl-3 text-xs tabular-nums opacity-60">
                       {isUploading
-                        ? t("apps.control-panels.autoSync.uploading")
+                        ? formatUploadingStatus(uploadProgress, t)
                         : t("apps.control-panels.autoSync.fetching")}
                     </span>
                   </MenubarItem>

--- a/src/stores/useCloudSyncStore.ts
+++ b/src/stores/useCloudSyncStore.ts
@@ -17,6 +17,7 @@ export interface CloudSyncCategoryStatus {
   isUploading: boolean;
   isDownloading: boolean;
   uploadProgress: number | null;
+  downloadProgress: number | null;
 }
 
 export type CloudSyncCategoryStatusMap = Record<
@@ -76,6 +77,7 @@ function createInitialCategoryStatus(): CloudSyncCategoryStatusMap {
     isUploading: false,
     isDownloading: false,
     uploadProgress: null,
+    downloadProgress: null,
   });
   return {
     files: empty(),
@@ -106,6 +108,7 @@ export function mergePersistedCloudSyncCategoryStatus(
         isUploading: false,
         isDownloading: false,
         uploadProgress: null,
+        downloadProgress: null,
       };
     }
   }
@@ -142,6 +145,10 @@ interface CloudSyncStoreState {
     active: boolean
   ) => void;
   markCategoryUploadProgress: (
+    category: SyncCategory,
+    progress: number | null
+  ) => void;
+  markCategoryDownloadProgress: (
     category: SyncCategory,
     progress: number | null
   ) => void;
@@ -233,7 +240,10 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
                     isUploading: active,
                     ...(!active ? { uploadProgress: null } : {}),
                   }
-                : { isDownloading: active }),
+                : {
+                    isDownloading: active,
+                    ...(!active ? { downloadProgress: null } : {}),
+                  }),
             },
           },
         })),
@@ -250,6 +260,23 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
               [category]: {
                 ...state.categoryStatus[category],
                 uploadProgress: normalized,
+              },
+            },
+          };
+        }),
+
+      markCategoryDownloadProgress: (category, progress) =>
+        set((state) => {
+          const normalized =
+            typeof progress === "number" && Number.isFinite(progress)
+              ? Math.max(0, Math.min(100, progress))
+              : null;
+          return {
+            categoryStatus: {
+              ...state.categoryStatus,
+              [category]: {
+                ...state.categoryStatus[category],
+                downloadProgress: normalized,
               },
             },
           };
@@ -276,6 +303,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
               ...state.categoryStatus[category],
               lastFetchedAt: appliedAt,
               lastAppliedRemoteAt: appliedAt,
+              downloadProgress: null,
             },
           },
           lastError: null,
@@ -380,6 +408,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
               isUploading: false,
               isDownloading: false,
               uploadProgress: null,
+              downloadProgress: null,
             },
           ])
         ) as CloudSyncCategoryStatusMap,
@@ -434,6 +463,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
               isUploading: false,
               isDownloading: false,
               uploadProgress: null,
+              downloadProgress: null,
             };
           }
         } else if (candidate?.categoryStatus) {
@@ -447,6 +477,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
                 isUploading: false,
                 isDownloading: false,
                 uploadProgress: null,
+                downloadProgress: null,
               };
             }
           }

--- a/src/stores/useCloudSyncStore.ts
+++ b/src/stores/useCloudSyncStore.ts
@@ -16,6 +16,7 @@ export interface CloudSyncCategoryStatus {
   lastAppliedRemoteAt: string | null;
   isUploading: boolean;
   isDownloading: boolean;
+  uploadProgress: number | null;
 }
 
 export type CloudSyncCategoryStatusMap = Record<
@@ -74,6 +75,7 @@ function createInitialCategoryStatus(): CloudSyncCategoryStatusMap {
     lastAppliedRemoteAt: null,
     isUploading: false,
     isDownloading: false,
+    uploadProgress: null,
   });
   return {
     files: empty(),
@@ -103,6 +105,7 @@ export function mergePersistedCloudSyncCategoryStatus(
         lastAppliedRemoteAt: row.lastAppliedRemoteAt ?? null,
         isUploading: false,
         isDownloading: false,
+        uploadProgress: null,
       };
     }
   }
@@ -137,6 +140,10 @@ interface CloudSyncStoreState {
     category: SyncCategory,
     direction: "upload" | "download",
     active: boolean
+  ) => void;
+  markCategoryUploadProgress: (
+    category: SyncCategory,
+    progress: number | null
   ) => void;
   markCategoryUploaded: (category: SyncCategory, uploadedAt: string) => void;
   markCategoryApplied: (category: SyncCategory, appliedAt: string) => void;
@@ -222,11 +229,31 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
             [category]: {
               ...state.categoryStatus[category],
               ...(direction === "upload"
-                ? { isUploading: active }
+                ? {
+                    isUploading: active,
+                    ...(!active ? { uploadProgress: null } : {}),
+                  }
                 : { isDownloading: active }),
             },
           },
         })),
+
+      markCategoryUploadProgress: (category, progress) =>
+        set((state) => {
+          const normalized =
+            typeof progress === "number" && Number.isFinite(progress)
+              ? Math.max(0, Math.min(100, progress))
+              : null;
+          return {
+            categoryStatus: {
+              ...state.categoryStatus,
+              [category]: {
+                ...state.categoryStatus[category],
+                uploadProgress: normalized,
+              },
+            },
+          };
+        }),
 
       markCategoryUploaded: (category, uploadedAt) =>
         set((state) => ({
@@ -235,6 +262,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
             [category]: {
               ...state.categoryStatus[category],
               lastUploadedAt: uploadedAt,
+              uploadProgress: null,
             },
           },
           lastError: null,
@@ -351,6 +379,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
               lastAppliedRemoteAt: status.lastAppliedRemoteAt,
               isUploading: false,
               isDownloading: false,
+              uploadProgress: null,
             },
           ])
         ) as CloudSyncCategoryStatusMap,
@@ -404,6 +433,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
               ),
               isUploading: false,
               isDownloading: false,
+              uploadProgress: null,
             };
           }
         } else if (candidate?.categoryStatus) {
@@ -416,6 +446,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
                 lastAppliedRemoteAt: row.lastAppliedRemoteAt ?? null,
                 isUploading: false,
                 isDownloading: false,
+                uploadProgress: null,
               };
             }
           }

--- a/src/sync/blobs.ts
+++ b/src/sync/blobs.ts
@@ -68,6 +68,17 @@ interface BlobUploadItemsOptions {
   onProgress?: (progress: BlobUploadBatchProgress) => void;
 }
 
+export interface BlobDownloadProgress {
+  loadedBytes: number;
+  totalBytes: number;
+  percentage: number;
+}
+
+interface BlobDownloadOptions {
+  expectedBytes?: number;
+  onProgress?: (progress: BlobDownloadProgress) => void;
+}
+
 /**
  * Upload a batch of blob items, skipping content the server already has.
  * Returns a map key → SyncBlobRef for inclusion in docs.
@@ -187,13 +198,70 @@ export async function resolveBlobDownloadUrls(
   return resolved;
 }
 
+async function readResponseWithProgress(
+  response: Response,
+  options: BlobDownloadOptions
+): Promise<ArrayBuffer> {
+  const contentLength = Number(response.headers.get("content-length") || 0);
+  const totalBytes =
+    typeof options.expectedBytes === "number" && options.expectedBytes > 0
+      ? options.expectedBytes
+      : Number.isFinite(contentLength) && contentLength > 0
+        ? contentLength
+        : 0;
+
+  const emitProgress = (loadedBytes: number) => {
+    options.onProgress?.({
+      loadedBytes,
+      totalBytes,
+      percentage: totalBytes > 0 ? (loadedBytes / totalBytes) * 100 : 0,
+    });
+  };
+  options.onProgress?.({
+    loadedBytes: 0,
+    totalBytes,
+    percentage: 0,
+  });
+
+  if (!response.body) {
+    const buffer = await response.arrayBuffer();
+    emitProgress(totalBytes || buffer.byteLength);
+    return buffer;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let loadedBytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    chunks.push(value);
+    loadedBytes += value.byteLength;
+    emitProgress(loadedBytes);
+  }
+
+  const result = new Uint8Array(loadedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result.buffer;
+}
+
 /** Download and decode one blob item (v2 bare item or v1 envelope). */
-export async function downloadBlobItem(downloadUrl: string): Promise<unknown> {
+export async function downloadBlobItem(
+  downloadUrl: string,
+  options: BlobDownloadOptions = {}
+): Promise<unknown> {
   const response = await fetch(downloadUrl);
   if (!response.ok) {
     throw new Error(`Failed to fetch sync blob: ${response.status}`);
   }
-  const parsed = await gunzipJson<unknown>(await response.arrayBuffer());
+  const parsed = await gunzipJson<unknown>(
+    await readResponseWithProgress(response, options)
+  );
   // v1 per-item envelopes wrap the item as { domain, key, version, data }.
   if (
     parsed &&

--- a/src/sync/blobs.ts
+++ b/src/sync/blobs.ts
@@ -56,12 +56,25 @@ export interface BlobUploadItem {
   item: unknown;
 }
 
+export interface BlobUploadBatchProgress {
+  loadedBytes: number;
+  totalBytes: number;
+  percentage: number;
+  completedItems: number;
+  totalItems: number;
+}
+
+interface BlobUploadItemsOptions {
+  onProgress?: (progress: BlobUploadBatchProgress) => void;
+}
+
 /**
  * Upload a batch of blob items, skipping content the server already has.
  * Returns a map key → SyncBlobRef for inclusion in docs.
  */
 export async function uploadBlobItems(
-  items: BlobUploadItem[]
+  items: BlobUploadItem[],
+  options: BlobUploadItemsOptions = {}
 ): Promise<Map<string, SyncBlobRef>> {
   const refs = new Map<string, SyncBlobRef>();
   if (items.length === 0) return refs;
@@ -87,6 +100,28 @@ export async function uploadBlobItems(
   });
 
   const uploads = response.uploads || [];
+  const uploadResults = uploads.filter((result) => result.upload);
+  const totalUploadBytes = uploadResults.reduce((sum, result) => {
+    const entry = byDigest.get(result.sha256);
+    return sum + (entry?.compressed.length ?? 0);
+  }, 0);
+  const totalUploadItems = uploadResults.length;
+  let completedUploadBytes = 0;
+  let completedUploadItems = 0;
+  const emitProgress = (loadedBytes: number) => {
+    options.onProgress?.({
+      loadedBytes,
+      totalBytes: totalUploadBytes,
+      percentage:
+        totalUploadBytes > 0 ? (loadedBytes / totalUploadBytes) * 100 : 100,
+      completedItems: completedUploadItems,
+      totalItems: totalUploadItems,
+    });
+  };
+  if (options.onProgress) {
+    emitProgress(0);
+  }
+
   for (const result of uploads) {
     const entry = byDigest.get(result.sha256);
     if (!entry) continue;
@@ -99,9 +134,15 @@ export async function uploadBlobItems(
         new Blob([entry.compressed.slice().buffer as ArrayBuffer], {
           type: "application/gzip",
         }),
-        result.upload as StorageUploadInstruction
+        result.upload as StorageUploadInstruction,
+        (progress) => {
+          emitProgress(completedUploadBytes + progress.loaded);
+        }
       );
       url = uploadResult.storageUrl;
+      completedUploadBytes += entry.compressed.length;
+      completedUploadItems += 1;
+      emitProgress(completedUploadBytes);
     }
 
     if (!url) {

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -595,8 +595,12 @@ export class CloudSyncEngine {
 
     const prefix = `${namespace}/item:`;
     const deletes: string[] = [];
-    const downloads: Array<{ op: AppliedSyncOp; contentHash: string; url: string }> =
-      [];
+    const downloads: Array<{
+      op: AppliedSyncOp;
+      contentHash: string;
+      url: string;
+      size: number;
+    }> = [];
 
     for (const op of ops) {
       if (!op.k.startsWith(prefix)) continue;
@@ -614,7 +618,7 @@ export class CloudSyncEngine {
         this.state.setShadow(op.k, { t: op.t, h: contentHash });
         continue;
       }
-      downloads.push({ op, contentHash, url: ref.url });
+      downloads.push({ op, contentHash, url: ref.url, size: ref.size });
     }
 
     if (deletes.length > 0) {
@@ -623,18 +627,39 @@ export class CloudSyncEngine {
 
     if (downloads.length > 0) {
       const urls = await resolveBlobDownloadUrls(
-        downloads.map((d) => ({ url: d.url, size: 0 }))
+        downloads.map((d) => ({ url: d.url, size: d.size }))
       );
       const items: StoreItemWithKey[] = [];
+      const totalDownloadBytes = downloads.reduce(
+        (sum, download) => sum + Math.max(0, download.size || 0),
+        0
+      );
+      let completedDownloadBytes = 0;
+      const category = getSyncNamespaceCategory(namespace);
+      const emitProgress = (loadedBytes: number) => {
+        syncStore.markCategoryDownloadProgress(
+          category,
+          totalDownloadBytes > 0 ? (loadedBytes / totalDownloadBytes) * 100 : 0
+        );
+      };
+      emitProgress(0);
+
       for (let index = 0; index < downloads.length; index += 1) {
-        const { op, contentHash } = downloads[index];
+        const { op, contentHash, size } = downloads[index];
         const downloadUrl = urls[index];
         if (!downloadUrl) {
           console.warn(`[sync2] No download URL for ${op.k}`);
+          completedDownloadBytes += Math.max(0, size || 0);
+          emitProgress(completedDownloadBytes);
           continue;
         }
         try {
-          const item = (await downloadBlobItem(downloadUrl)) as StoreItemWithKey;
+          const item = (await downloadBlobItem(downloadUrl, {
+            expectedBytes: size,
+            onProgress: (progress) => {
+              emitProgress(completedDownloadBytes + progress.loadedBytes);
+            },
+          })) as StoreItemWithKey;
           if (item && typeof item === "object" && typeof item.key === "string") {
             items.push(item);
             this.state.setShadow(op.k, {
@@ -644,6 +669,9 @@ export class CloudSyncEngine {
           }
         } catch (error) {
           console.error(`[sync2] Failed to download blob for ${op.k}:`, error);
+        } finally {
+          completedDownloadBytes += Math.max(0, size || 0);
+          emitProgress(completedDownloadBytes);
         }
       }
       if (items.length > 0) {

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -236,7 +236,23 @@ export class CloudSyncEngine {
               pendingTimestamps.set(key, this.state.nextTimestamp());
             }
             if (pendingUploads.length > 0) {
-              const refs = await uploadBlobItems(pendingUploads);
+              const category = getSyncNamespaceCategory(namespace);
+              syncStore.markCategorySyncing(category, "upload", true);
+              syncStore.markCategoryUploadProgress(category, 0);
+              let refs: Awaited<ReturnType<typeof uploadBlobItems>>;
+              try {
+                refs = await uploadBlobItems(pendingUploads, {
+                  onProgress: (progress) => {
+                    syncStore.markCategoryUploadProgress(
+                      category,
+                      progress.percentage
+                    );
+                  },
+                });
+              } catch (error) {
+                syncStore.markCategorySyncing(category, "upload", false);
+                throw error;
+              }
               for (const upload of pendingUploads) {
                 const ref = refs.get(upload.key);
                 if (!ref) continue;

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -592,6 +592,7 @@ export class CloudSyncEngine {
   ): Promise<void> {
     const codec = SYNC_CODECS[namespace];
     if (!isBlobCodec(codec)) return;
+    const syncStore = useCloudSyncStore.getState();
 
     const prefix = `${namespace}/item:`;
     const deletes: string[] = [];

--- a/tests/test-sync-v2-codecs.test.ts
+++ b/tests/test-sync-v2-codecs.test.ts
@@ -15,6 +15,10 @@ import {
   mergePersistedCloudSyncCategoryStatus,
   useCloudSyncStore,
 } from "../src/stores/useCloudSyncStore";
+import {
+  formatSyncStatus,
+  formatUploadingStatus,
+} from "../src/apps/control-panels/components/control-panels-app/syncUtils";
 
 /**
  * Cloud Sync v2 codec round-trips: collect must decompose store state into
@@ -497,6 +501,7 @@ describe("cloud sync store", () => {
     } as never);
     expect(merged.files.lastUploadedAt).toBe("2024-06-01T00:00:00.000Z");
     expect(merged.files.isUploading).toBe(false); // transient flags reset
+    expect(merged.files.uploadProgress).toBeNull();
     expect(merged.maps).toBeDefined();
     expect(merged.tv).toBeDefined();
   });
@@ -507,5 +512,49 @@ describe("cloud sync store", () => {
     expect(useCloudSyncStore.getState().isCategoryEnabled("tv")).toBe(false);
     store.setCategoryEnabled("tv", true);
     expect(useCloudSyncStore.getState().isCategoryEnabled("tv")).toBe(true);
+  });
+
+  test("upload progress is clamped and cleared with upload activity", () => {
+    const store = useCloudSyncStore.getState();
+    store.markCategorySyncing("files", "upload", true);
+    store.markCategoryUploadProgress("files", 41.6);
+    expect(useCloudSyncStore.getState().categoryStatus.files.uploadProgress).toBe(
+      41.6
+    );
+
+    store.markCategoryUploadProgress("files", 140);
+    expect(useCloudSyncStore.getState().categoryStatus.files.uploadProgress).toBe(
+      100
+    );
+
+    store.markCategorySyncing("files", "upload", false);
+    const status = useCloudSyncStore.getState().categoryStatus.files;
+    expect(status.isUploading).toBe(false);
+    expect(status.uploadProgress).toBeNull();
+  });
+
+  test("sync status includes upload percentage when available", () => {
+    const t = (key: string) => {
+      const labels: Record<string, string> = {
+        "apps.control-panels.autoSync.uploading": "Uploading",
+        "apps.control-panels.autoSync.neverFetched": "Never fetched",
+      };
+      return labels[key] || key;
+    };
+
+    expect(formatUploadingStatus(41.6, t)).toBe("Uploading 42%");
+    expect(
+      formatSyncStatus(
+        {
+          lastUploadedAt: null,
+          lastFetchedAt: null,
+          lastAppliedRemoteAt: null,
+          isUploading: true,
+          isDownloading: false,
+          uploadProgress: 41.6,
+        },
+        t
+      )
+    ).toBe("Uploading 42% · Never fetched");
   });
 });

--- a/tests/test-sync-v2-codecs.test.ts
+++ b/tests/test-sync-v2-codecs.test.ts
@@ -16,9 +16,11 @@ import {
   useCloudSyncStore,
 } from "../src/stores/useCloudSyncStore";
 import {
+  formatFetchingStatus,
   formatSyncStatus,
   formatUploadingStatus,
 } from "../src/apps/control-panels/components/control-panels-app/syncUtils";
+import { downloadBlobItem, gzipJson } from "../src/sync/blobs";
 
 /**
  * Cloud Sync v2 codec round-trips: collect must decompose store state into
@@ -502,6 +504,7 @@ describe("cloud sync store", () => {
     expect(merged.files.lastUploadedAt).toBe("2024-06-01T00:00:00.000Z");
     expect(merged.files.isUploading).toBe(false); // transient flags reset
     expect(merged.files.uploadProgress).toBeNull();
+    expect(merged.files.downloadProgress).toBeNull();
     expect(merged.maps).toBeDefined();
     expect(merged.tv).toBeDefined();
   });
@@ -533,16 +536,38 @@ describe("cloud sync store", () => {
     expect(status.uploadProgress).toBeNull();
   });
 
+  test("download progress is clamped and cleared with download activity", () => {
+    const store = useCloudSyncStore.getState();
+    store.markCategorySyncing("files", "download", true);
+    store.markCategoryDownloadProgress("files", 58.4);
+    expect(
+      useCloudSyncStore.getState().categoryStatus.files.downloadProgress
+    ).toBe(58.4);
+
+    store.markCategoryDownloadProgress("files", -20);
+    expect(
+      useCloudSyncStore.getState().categoryStatus.files.downloadProgress
+    ).toBe(0);
+
+    store.markCategorySyncing("files", "download", false);
+    const status = useCloudSyncStore.getState().categoryStatus.files;
+    expect(status.isDownloading).toBe(false);
+    expect(status.downloadProgress).toBeNull();
+  });
+
   test("sync status includes upload percentage when available", () => {
     const t = (key: string) => {
       const labels: Record<string, string> = {
+        "apps.control-panels.autoSync.fetching": "Fetching",
         "apps.control-panels.autoSync.uploading": "Uploading",
         "apps.control-panels.autoSync.neverFetched": "Never fetched",
+        "apps.control-panels.autoSync.neverUploaded": "Never uploaded",
       };
       return labels[key] || key;
     };
 
     expect(formatUploadingStatus(41.6, t)).toBe("Uploading 42%");
+    expect(formatFetchingStatus(58.4, t)).toBe("Fetching 58%");
     expect(
       formatSyncStatus(
         {
@@ -556,5 +581,46 @@ describe("cloud sync store", () => {
         t
       )
     ).toBe("Uploading 42% · Never fetched");
+    expect(
+      formatSyncStatus(
+        {
+          lastUploadedAt: null,
+          lastFetchedAt: null,
+          lastAppliedRemoteAt: null,
+          isUploading: false,
+          isDownloading: true,
+          downloadProgress: 58.4,
+        },
+        t
+      )
+    ).toBe("Never uploaded · Fetching 58%");
+  });
+});
+
+describe("cloud sync blob downloads", () => {
+  test("downloadBlobItem reports byte progress", async () => {
+    const originalFetch = globalThis.fetch;
+    const payload = { key: "book-1", value: { title: "Synced Book" } };
+    const compressed = await gzipJson(payload);
+    const progress: number[] = [];
+
+    globalThis.fetch = (async () =>
+      new Response(new Blob([compressed]), {
+        status: 200,
+        headers: { "content-length": String(compressed.byteLength) },
+      })) as typeof fetch;
+
+    try {
+      const item = await downloadBlobItem("https://example.test/book.gz", {
+        expectedBytes: compressed.byteLength,
+        onProgress: (next) => progress.push(next.percentage),
+      });
+
+      expect(item).toEqual(payload);
+      expect(progress[0]).toBe(0);
+      expect(progress.at(-1)).toBe(100);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Thread blob upload and download byte progress through Cloud Sync v2 and expose transient per-category transfer progress.
- Show upload/download percentages in the macOS menubar sync indicator and Control Panels sync status text.
- Move dropdown progress bars inline after the Uploading/Fetching label instead of under the file type; dropdown rows no longer show the percent text on the right.
- Add targeted coverage for progress clamping, clearing, formatted status labels, and blob download progress callbacks.

### Walkthrough
Upload progress:
[sync_progress_menubar_focused.webm](https://cursor.com/agents/bc-019ef0a6-e962-788e-a66f-5d1a720da1d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsync_progress_menubar_focused.webm)

Download progress:
<a href="https://cursor.com/agents/bc-019ef0a6-e962-788e-a66f-5d1a720da1d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsync_inline_menu_progress.webm"><img src="https://cursor.com/artifacts/c/art-c0aa4ff4-2748-4d9f-b4ed-73ebefeb0c8f" alt="sync_inline_menu_progress.webm" /></a>

### Testing
- `bun run build`
- Browser walkthrough against the running Vite app with the live cloud sync store set to a 58% download-progress state.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ef0a6-e962-788e-a66f-5d1a720da1d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ef0a6-e962-788e-a66f-5d1a720da1d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

