### PR TITLE
Fix Books shelf load performance

### DIFF
--- a/src/apps/books/utils/useBookCover.ts
+++ b/src/apps/books/utils/useBookCover.ts
@@ -13,6 +13,32 @@ export interface BookCoverInfo {
 // for the session.
 const coverCache = new Map<string, BookCoverInfo>();
 const inflight = new Map<string, Promise<BookCoverInfo>>();
+const MAX_CONCURRENT_COVER_LOADS = 3;
+let activeCoverLoads = 0;
+const pendingCoverLoadSlots: Array<() => void> = [];
+
+async function acquireCoverLoadSlot(): Promise<void> {
+  if (activeCoverLoads >= MAX_CONCURRENT_COVER_LOADS) {
+    await new Promise<void>((resolve) => {
+      pendingCoverLoadSlots.push(resolve);
+    });
+  }
+  activeCoverLoads += 1;
+}
+
+function releaseCoverLoadSlot(): void {
+  activeCoverLoads = Math.max(0, activeCoverLoads - 1);
+  pendingCoverLoadSlots.shift()?.();
+}
+
+async function runWithCoverLoadSlot<T>(task: () => Promise<T>): Promise<T> {
+  await acquireCoverLoadSlot();
+  try {
+    return await task();
+  } finally {
+    releaseCoverLoadSlot();
+  }
+}
 
 function cacheKey(path: string, modifiedAt?: number): string {
   return `${path}::${modifiedAt ?? 0}`;
@@ -28,7 +54,7 @@ async function loadCover(
   const existing = inflight.get(key);
   if (existing) return existing;
 
-  const promise = (async (): Promise<BookCoverInfo> => {
+  const promise = runWithCoverLoadSlot(async (): Promise<BookCoverInfo> => {
     const result: BookCoverInfo = {
       coverUrl: null,
       title: null,
@@ -36,36 +62,41 @@ async function loadCover(
     };
     try {
       const blob = await readBookBlobContent(path);
-      if (!blob) return result;
-      const buffer = await blob.arrayBuffer();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const book = ePub(buffer as any);
-      await book.ready;
-      try {
-        const metadata = await book.loaded.metadata;
-        result.title = metadata?.title || null;
-        result.author = metadata?.creator || null;
-      } catch {
-        // ignore metadata failures
-      }
-      try {
-        const url = await book.coverUrl();
-        if (url) {
-          const response = await fetch(url);
-          const coverBlob = await response.blob();
-          result.coverUrl = URL.createObjectURL(coverBlob);
+      if (blob) {
+        const buffer = await blob.arrayBuffer();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const book = ePub(buffer as any);
+        try {
+          await book.ready;
+          try {
+            const metadata = await book.loaded.metadata;
+            result.title = metadata?.title || null;
+            result.author = metadata?.creator || null;
+          } catch {
+            // ignore metadata failures
+          }
+          try {
+            const url = await book.coverUrl();
+            if (url) {
+              const response = await fetch(url);
+              const coverBlob = await response.blob();
+              result.coverUrl = URL.createObjectURL(coverBlob);
+            }
+          } catch {
+            // no cover available
+          }
+        } finally {
+          book.destroy();
         }
-      } catch {
-        // no cover available
       }
-      book.destroy();
     } catch (err) {
       console.warn("[Books] Failed to load cover for", path, err);
     }
     coverCache.set(key, result);
-    inflight.delete(key);
     return result;
-  })();
+  }).finally(() => {
+    inflight.delete(key);
+  });
 
   inflight.set(key, promise);
   return promise;

--- a/src/apps/books/utils/useBookCover.ts
+++ b/src/apps/books/utils/useBookCover.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import ePub from "epubjs";
 import { readBookBlobContent } from "@/services/vfs/FileContentRepository";
+import { STORES, dbOperations } from "@/utils/indexedDB";
 
 export interface BookCoverInfo {
   coverUrl: string | null;
@@ -14,8 +15,16 @@ export interface BookCoverInfo {
 const coverCache = new Map<string, BookCoverInfo>();
 const inflight = new Map<string, Promise<BookCoverInfo>>();
 const MAX_CONCURRENT_COVER_LOADS = 3;
+const THUMBNAIL_CACHE_VERSION = 1;
 let activeCoverLoads = 0;
 const pendingCoverLoadSlots: Array<() => void> = [];
+
+interface StoredBookThumbnail {
+  version: number;
+  title: string | null;
+  author: string | null;
+  coverBlob: Blob | null;
+}
 
 async function acquireCoverLoadSlot(): Promise<void> {
   if (activeCoverLoads >= MAX_CONCURRENT_COVER_LOADS) {
@@ -44,6 +53,61 @@ function cacheKey(path: string, modifiedAt?: number): string {
   return `${path}::${modifiedAt ?? 0}`;
 }
 
+function isBlobLike(value: unknown): value is Blob {
+  return (
+    value instanceof Blob ||
+    (typeof value === "object" &&
+      value !== null &&
+      typeof (value as Blob).arrayBuffer === "function" &&
+      typeof (value as Blob).size === "number")
+  );
+}
+
+function infoFromStoredThumbnail(
+  stored: StoredBookThumbnail | undefined
+): BookCoverInfo | null {
+  if (!stored || stored.version !== THUMBNAIL_CACHE_VERSION) return null;
+  return {
+    title: stored.title ?? null,
+    author: stored.author ?? null,
+    coverUrl: isBlobLike(stored.coverBlob)
+      ? URL.createObjectURL(stored.coverBlob)
+      : null,
+  };
+}
+
+async function readStoredThumbnail(key: string): Promise<BookCoverInfo | null> {
+  try {
+    return infoFromStoredThumbnail(
+      await dbOperations.get<StoredBookThumbnail>(STORES.BOOK_THUMBNAILS, key)
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function writeStoredThumbnail(
+  key: string,
+  info: BookCoverInfo,
+  coverBlob: Blob | null
+): Promise<void> {
+  try {
+    await dbOperations.put<StoredBookThumbnail>(
+      STORES.BOOK_THUMBNAILS,
+      {
+        version: THUMBNAIL_CACHE_VERSION,
+        title: info.title,
+        author: info.author,
+        coverBlob,
+      },
+      key
+    );
+  } catch {
+    // Thumbnail persistence is an optimization; shelf rendering should continue
+    // even if the browser denies the cache write.
+  }
+}
+
 async function loadCover(
   path: string,
   modifiedAt?: number
@@ -54,47 +118,57 @@ async function loadCover(
   const existing = inflight.get(key);
   if (existing) return existing;
 
-  const promise = runWithCoverLoadSlot(async (): Promise<BookCoverInfo> => {
-    const result: BookCoverInfo = {
-      coverUrl: null,
-      title: null,
-      author: null,
-    };
-    try {
-      const blob = await readBookBlobContent(path);
-      if (blob) {
-        const buffer = await blob.arrayBuffer();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const book = ePub(buffer as any);
-        try {
-          await book.ready;
-          try {
-            const metadata = await book.loaded.metadata;
-            result.title = metadata?.title || null;
-            result.author = metadata?.creator || null;
-          } catch {
-            // ignore metadata failures
-          }
-          try {
-            const url = await book.coverUrl();
-            if (url) {
-              const response = await fetch(url);
-              const coverBlob = await response.blob();
-              result.coverUrl = URL.createObjectURL(coverBlob);
-            }
-          } catch {
-            // no cover available
-          }
-        } finally {
-          book.destroy();
-        }
-      }
-    } catch (err) {
-      console.warn("[Books] Failed to load cover for", path, err);
+  const promise = (async (): Promise<BookCoverInfo> => {
+    const stored = await readStoredThumbnail(key);
+    if (stored) {
+      coverCache.set(key, stored);
+      return stored;
     }
-    coverCache.set(key, result);
-    return result;
-  }).finally(() => {
+
+    return runWithCoverLoadSlot(async (): Promise<BookCoverInfo> => {
+      const result: BookCoverInfo = {
+        coverUrl: null,
+        title: null,
+        author: null,
+      };
+      let coverBlob: Blob | null = null;
+      try {
+        const blob = await readBookBlobContent(path);
+        if (blob) {
+          const buffer = await blob.arrayBuffer();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const book = ePub(buffer as any);
+          try {
+            await book.ready;
+            try {
+              const metadata = await book.loaded.metadata;
+              result.title = metadata?.title || null;
+              result.author = metadata?.creator || null;
+            } catch {
+              // ignore metadata failures
+            }
+            try {
+              const url = await book.coverUrl();
+              if (url) {
+                const response = await fetch(url);
+                coverBlob = await response.blob();
+                result.coverUrl = URL.createObjectURL(coverBlob);
+              }
+            } catch {
+              // no cover available
+            }
+          } finally {
+            book.destroy();
+          }
+        }
+      } catch (err) {
+        console.warn("[Books] Failed to load cover for", path, err);
+      }
+      await writeStoredThumbnail(key, result, coverBlob);
+      coverCache.set(key, result);
+      return result;
+    });
+  })().finally(() => {
     inflight.delete(key);
   });
 

--- a/src/services/vfs/FileContentRepository.ts
+++ b/src/services/vfs/FileContentRepository.ts
@@ -99,22 +99,52 @@ export async function readImageBlobContent(path: string): Promise<Blob | null> {
   return isBlobLike(item?.content) ? item.content : null;
 }
 
-export async function readBookBlobContent(path: string): Promise<Blob | null> {
-  const uuid = getFileContentUuid(path);
-  if (uuid) {
-    // Safari can throw "UnknownError: Internal error" just by reading a Blob
-    // previously persisted in IndexedDB. For bundled default books, overwrite
-    // from the same-origin asset before any read so the bad record is replaced
-    // without touching it.
-    await ensureFileContentLoaded(path, uuid, { forceReload: true });
+function blobFromBookContent(
+  content: StoredContent["content"] | undefined
+): Blob | null {
+  if (content instanceof ArrayBuffer) {
+    return new Blob([content], { type: "application/epub+zip" });
   }
+  return isBlobLike(content) ? content : null;
+}
+
+async function isBlobReadable(blob: Blob): Promise<boolean> {
+  try {
+    const probe =
+      typeof blob.slice === "function" ? blob.slice(0, Math.min(blob.size, 1)) : blob;
+    await probe.arrayBuffer();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readBookBlobContent(path: string): Promise<Blob | null> {
   const item = await readContentForPath<StoredContent>(path, {
     expectedStore: STORES.BOOKS,
   });
-  if (item?.content instanceof ArrayBuffer) {
-    return new Blob([item.content], { type: "application/epub+zip" });
+  const blob = blobFromBookContent(item?.content);
+  if (!blob) {
+    return null;
   }
-  return isBlobLike(item?.content) ? item.content : null;
+  if (item?.content instanceof ArrayBuffer || (await isBlobReadable(blob))) {
+    return blob;
+  }
+
+  const uuid = getFileContentUuid(path);
+  if (!uuid) return null;
+
+  // Safari can throw "UnknownError: Internal error" when reading a Blob
+  // previously persisted in IndexedDB. Only pay the reload cost after proving
+  // the stored Blob is unreadable; bundled defaults can then recover from the
+  // same-origin asset without re-fetching on every normal read.
+  const recovered = await ensureFileContentLoaded(path, uuid, { forceReload: true });
+  if (!recovered) return null;
+
+  const recoveredItem = await readContentForPath<StoredContent>(path, {
+    expectedStore: STORES.BOOKS,
+  });
+  return blobFromBookContent(recoveredItem?.content);
 }
 
 export async function readAppletTextContent(path: string): Promise<string | null> {

--- a/src/utils/indexedDB.ts
+++ b/src/utils/indexedDB.ts
@@ -1,13 +1,14 @@
 // Utility helpers for IndexedDB operations used across ryOS
 
 const DB_NAME = "ryOS";
-const DB_VERSION = 11;
+const DB_VERSION = 12;
 let hasLoggedOpenSuccess = false;
 
 export const STORES = {
   DOCUMENTS: "documents",
   IMAGES: "images",
   BOOKS: "books",
+  BOOK_THUMBNAILS: "book_thumbnails",
   TRASH: "trash",
   CUSTOM_WALLPAPERS: "custom_wallpapers",
   APPLETS: "applets",

--- a/tests/test-books-cover-load-queue.test.ts
+++ b/tests/test-books-cover-load-queue.test.ts
@@ -1,7 +1,17 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import React from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { dbOperations, STORES } from "../src/utils/indexedDB";
 
 let activeReads = 0;
 let maxActiveReads = 0;
@@ -35,8 +45,17 @@ mock.module("epubjs", () => ({
 
 const { useBookCover } = await import("../src/apps/books/utils/useBookCover");
 
-function CoverProbe({ path }: { path: string }) {
-  useBookCover(path, 1);
+function CoverProbe({
+  path,
+  onSnapshot,
+}: {
+  path: string;
+  onSnapshot?: (snapshot: ReturnType<typeof useBookCover>) => void;
+}) {
+  const snapshot = useBookCover(path, 1);
+  React.useEffect(() => {
+    onSnapshot?.(snapshot);
+  }, [onSnapshot, snapshot]);
   return null;
 }
 
@@ -101,5 +120,50 @@ describe("Books cover loading queue", () => {
 
     expect(readCalls).toBe(12);
     expect(maxActiveReads).toBeLessThanOrEqual(3);
+
+    const cached = await dbOperations.get<{ title?: string; author?: string }>(
+      STORES.BOOK_THUMBNAILS,
+      "/Books/queued-book-0.epub::1"
+    );
+    expect(cached).toMatchObject({ title: "T", author: "A" });
+  });
+
+  test("uses cached shelf thumbnail metadata without reading EPUB bytes", async () => {
+    const path = "/Books/cached-thumbnail.epub";
+    await dbOperations.put(
+      STORES.BOOK_THUMBNAILS,
+      {
+        version: 1,
+        title: "Cached title",
+        author: "Cached author",
+        coverBlob: null,
+      },
+      `${path}::1`
+    );
+
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+    let latest: ReturnType<typeof useBookCover> | null = null;
+
+    root.render(
+      React.createElement(CoverProbe, {
+        path,
+        onSnapshot: (snapshot) => {
+          latest = snapshot;
+        },
+      })
+    );
+
+    await waitFor(
+      () => latest?.loading === false && latest.info?.title === "Cached title"
+    );
+
+    expect(latest?.info).toMatchObject({
+      title: "Cached title",
+      author: "Cached author",
+    });
+    expect(readCalls).toBe(0);
+    expect(epubCreates).toBe(0);
   });
 });

--- a/tests/test-books-cover-load-queue.test.ts
+++ b/tests/test-books-cover-load-queue.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+let activeReads = 0;
+let maxActiveReads = 0;
+let readCalls = 0;
+let epubCreates = 0;
+
+mock.module("@/services/vfs/FileContentRepository", () => ({
+  readBookBlobContent: mock(async () => {
+    readCalls += 1;
+    activeReads += 1;
+    maxActiveReads = Math.max(maxActiveReads, activeReads);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    activeReads -= 1;
+    return new Blob([new Uint8Array([0x50, 0x4b, 0x03, 0x04])], {
+      type: "application/epub+zip",
+    });
+  }),
+}));
+
+mock.module("epubjs", () => ({
+  default: mock(() => {
+    epubCreates += 1;
+    return {
+      ready: Promise.resolve(),
+      loaded: { metadata: Promise.resolve({ title: "T", creator: "A" }) },
+      coverUrl: async () => null,
+      destroy: () => {},
+    };
+  }),
+}));
+
+const { useBookCover } = await import("../src/apps/books/utils/useBookCover");
+
+function CoverProbe({ path }: { path: string }) {
+  useBookCover(path, 1);
+  return null;
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 30; i += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("Timed out waiting for cover probes");
+}
+
+describe("Books cover loading queue", () => {
+  let root: Root | null = null;
+
+  beforeAll(() => {
+    if (typeof document === "undefined") {
+      GlobalRegistrator.register();
+    }
+  });
+
+  beforeEach(() => {
+    activeReads = 0;
+    maxActiveReads = 0;
+    readCalls = 0;
+    epubCreates = 0;
+  });
+
+  afterEach(async () => {
+    root?.unmount();
+    root = null;
+    document.body.replaceChildren();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  afterAll(async () => {
+    root?.unmount();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (GlobalRegistrator.isRegistered) {
+      GlobalRegistrator.unregister();
+    }
+  });
+
+  test("limits concurrent shelf EPUB cover reads", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    root.render(
+      React.createElement(
+        React.Fragment,
+        null,
+        Array.from({ length: 12 }, (_, index) =>
+          React.createElement(CoverProbe, {
+            key: index,
+            path: `/Books/queued-book-${index}.epub`,
+          })
+        )
+      )
+    );
+
+    await waitFor(() => epubCreates === 12);
+
+    expect(readCalls).toBe(12);
+    expect(maxActiveReads).toBeLessThanOrEqual(3);
+  });
+});

--- a/tests/test-books-default-epub.test.ts
+++ b/tests/test-books-default-epub.test.ts
@@ -29,6 +29,7 @@ const { ensureFileContentLoaded } = await import("../src/stores/useFilesStore");
 const BOOK_PATH = "/Books/Meditations - Marcus Aurelius.epub";
 const BOOK_ASSET_PATH = "/assets/books/meditations-marcus-aurelius.epub";
 const originalFetch = globalThis.fetch;
+let bookAssetFetchCount = 0;
 
 const filesystemJson = readFileSync("public/data/filesystem.json", "utf8");
 const meditationsEpub = readFileSync(
@@ -45,6 +46,7 @@ async function deleteRyOsDatabase(): Promise<void> {
 }
 
 beforeEach(async () => {
+  bookAssetFetchCount = 0;
   await deleteRyOsDatabase();
   useFilesStore.setState({
     items: {},
@@ -62,6 +64,7 @@ beforeEach(async () => {
         });
       }
       if (url === BOOK_ASSET_PATH) {
+        bookAssetFetchCount += 1;
         return new Response(meditationsEpub, {
           status: 200,
           headers: { "Content-Type": "application/epub+zip" },
@@ -110,6 +113,23 @@ describe("default Books EPUB", () => {
       item!.uuid!
     );
     expect(stored?.content).toBeInstanceOf(ArrayBuffer);
+    expect(bookAssetFetchCount).toBe(1);
+  });
+
+  test("reuses cached default EPUB bytes across repeated reads", async () => {
+    await useFilesStore.getState().resetLibrary();
+
+    const item = useFilesStore.getState().getItem(BOOK_PATH);
+    expect(item?.uuid).toBeTruthy();
+
+    await dbOperations.delete(STORES.BOOKS, item!.uuid!);
+
+    const first = await readBookBlobContent(BOOK_PATH);
+    const second = await readBookBlobContent(BOOK_PATH);
+
+    expect(first?.size).toBe(meditationsEpub.byteLength);
+    expect(second?.size).toBe(meditationsEpub.byteLength);
+    expect(bookAssetFetchCount).toBe(1);
   });
 
   test("force-reloads default EPUB bytes over an unreadable stored record", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Limit concurrent Books shelf cover extraction to avoid parsing every EPUB at once when the shelf mounts.
- Cache Books shelf thumbnail metadata and cover blobs in a dedicated `book_thumbnails` IndexedDB store so reloads can skip EPUB parsing for known covers.
- Reuse cached default EPUB bytes on normal reads and only force-reload the bundled asset after a stored Blob proves unreadable.
- Add regression tests for the cover-load queue, thumbnail cache reuse, and repeated default EPUB reads.

### Testing
- `bun test tests/test-books-default-epub.test.ts tests/test-books-cover-load-queue.test.ts`
- `bunx eslint "src/apps/books/utils/useBookCover.ts" "src/utils/indexedDB.ts" "tests/test-books-cover-load-queue.test.ts"`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019efd20-5a77-7fc8-8847-72127e1b21e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019efd20-5a77-7fc8-8847-72127e1b21e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

