### PR TITLE
Use metal radius for Aqua Glass notitlebar windows

### DIFF
--- a/src/components/layout/window-frame/WindowFrame.tsx
+++ b/src/components/layout/window-frame/WindowFrame.tsx
@@ -401,6 +401,9 @@ export function WindowFrame({
                     ...(!isWindowsTheme
                       ? getSwipeStyle(isPhone, isSwiping, swipeDirection)
                       : undefined),
+                    ...(isGlassNoTitlebar
+                      ? { borderRadius: "var(--os-glass-r-metal)" }
+                      : undefined),
                   }}
                   onMouseEnter={noTitlebarMouseHandlers.onMouseEnter}
                   onMouseMove={noTitlebarMouseHandlers.onMouseMove}

--- a/src/components/layout/window-frame/WindowFrame.tsx
+++ b/src/components/layout/window-frame/WindowFrame.tsx
@@ -123,9 +123,11 @@ export function WindowFrame({
   // glass pane. Brushed-metal windows keep their `window-material-brushedmetal`
   // class and are converted to glass purely via CSS overrides (so apps can
   // still opt into the metal material). Transparent / notitlebar materials keep
-  // their own treatment.
+  // their own treatment, with a small glass-only radius adjustment for
+  // immersive notitlebar apps.
   const isGlassRegular =
     isAquaGlass && !isTransparent && !isBrushedMetal;
+  const isGlassNoTitlebar = isAquaGlass && isNoTitlebar && isMacOSTheme;
   const effectiveTransparentBackground =
     isMacOSTheme ? true : isTransparent;
 
@@ -392,7 +394,8 @@ export function WindowFrame({
                     isBrushedMetal &&
                       isMacOSTheme &&
                       "window-material-brushedmetal",
-                    isGlassRegular && "window-material-glass"
+                    isGlassRegular && "window-material-glass",
+                    isGlassNoTitlebar && "window-material-notitlebar-glass"
                   )}
                   style={{
                     ...(!isWindowsTheme

--- a/src/components/layout/window-frame/WindowFrame.tsx
+++ b/src/components/layout/window-frame/WindowFrame.tsx
@@ -413,6 +413,7 @@ export function WindowFrame({
                     isForeground={isForeground}
                     isNoTitlebar={isNoTitlebar}
                     disableTitlebarAutoHide={disableTitlebarAutoHide}
+                    isGlassNoTitlebar={isGlassNoTitlebar}
                     isTitlebarHovered={isTitlebarHovered}
                     effectiveTransparentBackground={
                       effectiveTransparentBackground

--- a/src/components/layout/window-frame/WindowFrameTitleBar.tsx
+++ b/src/components/layout/window-frame/WindowFrameTitleBar.tsx
@@ -221,11 +221,14 @@ export function WindowFrameTitleBar({
             isNoTitlebar
               ? "absolute top-0 left-0 right-0 transition-opacity duration-200"
               : "shrink-0",
-            isGlassNoTitlebar && "window-titlebar-notitlebar-glass",
             effectiveTransparentBackground && !isNoTitlebar && "mt-0"
           )}
           style={{
-            borderRadius: isNoTitlebar ? "8px 8px 0px 0px" : "8px 8px 0px 0px",
+            borderRadius: isNoTitlebar
+              ? isGlassNoTitlebar
+                ? "var(--os-glass-r-metal) var(--os-glass-r-metal) 0px 0px"
+                : "8px 8px 0px 0px"
+              : "8px 8px 0px 0px",
             // For notitlebar: gradient background for visibility, opacity based on hover
             ...(isNoTitlebar
               ? {

--- a/src/components/layout/window-frame/WindowFrameTitleBar.tsx
+++ b/src/components/layout/window-frame/WindowFrameTitleBar.tsx
@@ -15,6 +15,7 @@ export interface WindowFrameTitleBarProps {
   isForeground: boolean;
   isNoTitlebar: boolean;
   disableTitlebarAutoHide: boolean;
+  isGlassNoTitlebar: boolean;
   effectiveTransparentBackground: boolean;
   isBrushedMetal: boolean;
   isGlassSurface: boolean;
@@ -48,6 +49,7 @@ export function WindowFrameTitleBar({
   isForeground,
   isNoTitlebar,
   disableTitlebarAutoHide,
+  isGlassNoTitlebar,
   effectiveTransparentBackground,
   isBrushedMetal,
   isGlassSurface,
@@ -219,6 +221,7 @@ export function WindowFrameTitleBar({
             isNoTitlebar
               ? "absolute top-0 left-0 right-0 transition-opacity duration-200"
               : "shrink-0",
+            isGlassNoTitlebar && "window-titlebar-notitlebar-glass",
             effectiveTransparentBackground && !isNoTitlebar && "mt-0"
           )}
           style={{

--- a/src/styles/themes/aqua-glass.css
+++ b/src/styles/themes/aqua-glass.css
@@ -226,19 +226,6 @@
   backdrop-filter: blur(26px) saturate(80%);
 }
 
-/* Immersive no-titlebar windows use the larger brushed-metal corner proportion
-   in Aqua Glass so map/video-like content clips with the same soft chrome arc. */
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
-  .window.window-material-notitlebar-glass {
-  border-radius: var(--os-glass-r-metal) !important;
-}
-
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
-  .window.window-material-notitlebar-glass
-  > .window-titlebar-notitlebar-glass {
-  border-radius: var(--os-glass-r-metal) var(--os-glass-r-metal) 0 0 !important;
-}
-
 /* Drop the hard titlebar divider — on a single frosted pane the seam reads as
    an ugly line, so the titlebar blends straight into the window body. */
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]

--- a/src/styles/themes/aqua-glass.css
+++ b/src/styles/themes/aqua-glass.css
@@ -235,7 +235,7 @@
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]
   .window.window-material-notitlebar-glass
-  > .title-bar.absolute {
+  > .window-titlebar-notitlebar-glass {
   border-radius: var(--os-glass-r-metal) var(--os-glass-r-metal) 0 0 !important;
 }
 

--- a/src/styles/themes/aqua-glass.css
+++ b/src/styles/themes/aqua-glass.css
@@ -226,6 +226,19 @@
   backdrop-filter: blur(26px) saturate(80%);
 }
 
+/* Immersive no-titlebar windows use the larger brushed-metal corner proportion
+   in Aqua Glass so map/video-like content clips with the same soft chrome arc. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window.window-material-notitlebar-glass {
+  border-radius: var(--os-glass-r-metal) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window.window-material-notitlebar-glass
+  > .title-bar.absolute {
+  border-radius: var(--os-glass-r-metal) var(--os-glass-r-metal) 0 0 !important;
+}
+
 /* Drop the hard titlebar divider — on a single frosted pane the seam reads as
    an ugly line, so the titlebar blends straight into the window body. */
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Apply a dedicated marker class to macOS Aqua Glass notitlebar windows.
- Reuse `--os-glass-r-metal` inline for Aqua Glass notitlebar frames and titlebar top corners.

## Walkthrough
<a href="https://cursor.com/agents/bc-019efd3c-01de-7e4f-833a-f86bf72651d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faqua_glass_notitlebar_radius_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-5e27261a-c222-40bf-bb78-dd5fcc1b7716" alt="aqua_glass_notitlebar_radius_walkthrough.mp4" /></a>
![Aqua Glass notitlebar Photo Booth radius](https://cursor.com/artifacts/c/art-caa39885-a244-4dc8-a6ed-7aa8aad31a7b)

## Testing
- `bun run build` passed; existing CSS/minifier warnings remain in unrelated generated Aqua Glass CSS.
- Headless Chrome computed-style verification passed: Photo Booth Aqua Glass notitlebar window had `window-material-notitlebar-glass`, window radius matched `--os-glass-r-metal`, and the absolute titlebar top corners matched the same value.
- Manual browser walkthrough passed; video shows the Photo Booth Aqua Glass notitlebar window and console checks for material/class/radius.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019efd3c-01de-7e4f-833a-f86bf72651d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019efd3c-01de-7e4f-833a-f86bf72651d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

