### PR TITLE
Add body schema validation for chat and speech APIs

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -121,14 +121,14 @@ const SystemStateSchema = z
 interface ChatRequest {
   messages: SimpleConversationMessage[];
   systemState?: SystemState;
-  model?: string;
+  model?: string | null;
   proactiveGreeting?: boolean;
 }
 
 const ChatRequestSchema = z.object({
   messages: z.array(ChatMessageSchema),
   systemState: SystemStateSchema.optional(),
-  model: z.string().optional(),
+  model: z.string().nullable().optional(),
   proactiveGreeting: z.boolean().optional(),
 }) as z.ZodType<ChatRequest>;
 

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -1,6 +1,7 @@
 import { generateText, smoothStream } from "ai";
 import { geolocation } from "@vercel/functions";
 import { google } from "@ai-sdk/google";
+import { z } from "zod";
 import {
   DEFAULT_MODEL,
   SUPPORTED_AI_MODELS,
@@ -31,6 +32,106 @@ import {
 import { buildUserLocalTimeContext } from "./_utils/user-time-context.js";
 type SystemState = RyoConversationSystemState;
 
+const ChatMessagePartSchema = z
+  .object({
+    type: z.string().min(1),
+    text: z.string().optional(),
+  })
+  .passthrough();
+
+const ChatMessageSchema = z
+  .object({
+    id: z.string().optional(),
+    role: z.string().min(1),
+    content: z.string().optional(),
+    parts: z.array(ChatMessagePartSchema).optional(),
+  })
+  .passthrough();
+
+const NullableStringSchema = z.string().nullable().optional();
+
+const SystemStateSchema = z
+  .object({
+    username: NullableStringSchema,
+    userOS: z.string().optional(),
+    locale: z.string().optional(),
+    userLocalTime: z
+      .object({
+        timeString: z.string(),
+        dateString: z.string(),
+        timeZone: z.string(),
+      })
+      .optional(),
+    requestGeo: z
+      .object({
+        city: z.string().optional(),
+        region: z.string().optional(),
+        country: z.string().optional(),
+        latitude: z.string().optional(),
+        longitude: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    runningApps: z
+      .object({
+        foreground: z
+          .object({
+            instanceId: z.string(),
+            appId: z.string(),
+            title: z.string().optional(),
+            appletPath: z.string().optional(),
+            appletId: z.string().optional(),
+          })
+          .passthrough()
+          .nullable(),
+        background: z.array(
+          z
+            .object({
+              instanceId: z.string(),
+              appId: z.string(),
+              title: z.string().optional(),
+              appletPath: z.string().optional(),
+              appletId: z.string().optional(),
+            })
+            .passthrough()
+        ),
+      })
+      .passthrough()
+      .optional(),
+    internetExplorer: z
+      .object({
+        url: z.string().optional(),
+        year: z.string().optional(),
+        currentPageTitle: NullableStringSchema,
+        aiGeneratedMarkdown: NullableStringSchema,
+      })
+      .passthrough()
+      .optional(),
+    chatRoomContext: z
+      .object({
+        roomId: z.string(),
+        recentMessages: z.string(),
+        mentionedMessage: z.string(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+interface ChatRequest {
+  messages: SimpleConversationMessage[];
+  systemState?: SystemState;
+  model?: string;
+  proactiveGreeting?: boolean;
+}
+
+const ChatRequestSchema = z.object({
+  messages: z.array(ChatMessageSchema),
+  systemState: SystemStateSchema.optional(),
+  model: z.string().optional(),
+  proactiveGreeting: z.boolean().optional(),
+}) as z.ZodType<ChatRequest>;
+
 const CHAT_MODEL_ALIASES: Record<string, SupportedModel> = {
   "claude-sonnet": "sonnet-4.6",
 };
@@ -44,20 +145,16 @@ function normalizeChatModel(model: string): string {
 export const runtime = "nodejs";
 export const maxDuration = 80;
 
-export default apiHandler<{
-  messages: unknown[];
-  systemState?: SystemState;
-  model?: string;
-  proactiveGreeting?: boolean;
-}>(
+export default apiHandler<ChatRequest>(
   {
     methods: ["POST"],
     auth: "optional",
     allowExpiredAuth: true,
     parseJsonBody: true,
+    bodySchema: ChatRequestSchema,
     contentType: null,
   },
-  async ({ req, res, redis, logger, startTime, origin, user }) => {
+  async ({ req, res, redis, logger, startTime, origin, user, body }) => {
     const validOrigin = origin || "http://localhost";
     try {
     // Parse query string to get model parameter
@@ -70,23 +167,10 @@ export default apiHandler<{
       systemState: incomingSystemState, // still passed for dynamic prompt generation but NOT for auth
       model: bodyModel = DEFAULT_MODEL,
       proactiveGreeting: isProactiveGreeting,
-    } = req.body as {
-      messages: unknown[];
-      systemState?: SystemState;
-      model?: string;
-      proactiveGreeting?: boolean;
-    };
+    } = body!;
 
     // Use query parameter if available, otherwise use body parameter, otherwise use default
     const model = normalizeChatModel(queryModel || bodyModel || DEFAULT_MODEL);
-
-    if (!messages || !Array.isArray(messages)) {
-      logger.error("400 Error: Invalid messages format", { messages });
-      logger.response(400, Date.now() - startTime);
-      res.setHeader("Access-Control-Allow-Origin", validOrigin);
-      res.status(400).send("Invalid messages format");
-      return;
-    }
 
     // ---------------------------
     // Extract auth headers FIRST so we can use username for logging

--- a/api/speech.ts
+++ b/api/speech.ts
@@ -1,5 +1,6 @@
 import { experimental_generateSpeech as generateSpeech } from "ai";
 import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
 import * as RateLimit from "./_utils/_rate-limit.js";
 import { getClientIp } from "./_utils/_rate-limit.js";
 import { apiHandler } from "./_utils/api-handler.js";
@@ -29,10 +30,41 @@ interface SpeechRequest {
   voice_settings?: ElevenLabsVoiceSettings;
 }
 
+const ElevenLabsOutputFormatSchema = z.enum([
+  "mp3_44100_128",
+  "mp3_22050_32",
+  "pcm_16000",
+  "pcm_22050",
+  "pcm_24000",
+  "pcm_44100",
+  "ulaw_8000",
+]);
+
+const ElevenLabsVoiceSettingsSchema = z
+  .object({
+    stability: z.number().finite().min(0).max(1).optional(),
+    similarity_boost: z.number().finite().min(0).max(1).optional(),
+    use_speaker_boost: z.boolean().optional(),
+    speed: z.number().finite().min(0.7).max(1.2).optional(),
+  })
+  .passthrough();
+
+const SpeechRequestSchema = z.object({
+  text: z.string().trim().min(1, "'text' is required"),
+  voice: z.string().min(1).nullable().optional(),
+  speed: z.number().finite().min(0.25).max(4).optional(),
+  model: z.enum(["openai", "elevenlabs"]).nullable().optional(),
+  voice_id: z.string().min(1).nullable().optional(),
+  model_id: z.string().min(1).optional(),
+  output_format: ElevenLabsOutputFormatSchema.optional(),
+  voice_settings: ElevenLabsVoiceSettingsSchema.optional(),
+}) satisfies z.ZodType<SpeechRequest>;
+
 export default apiHandler<SpeechRequest>(
   {
     methods: ["POST"],
     parseJsonBody: true,
+    bodySchema: SpeechRequestSchema,
     auth: "optional",
     contentType: null,
   },
@@ -147,13 +179,6 @@ export default apiHandler<SpeechRequest>(
         output_format,
         voice_settings,
       });
-
-      if (!text || typeof text !== "string" || text.trim().length === 0) {
-        logger.error("'text' is required");
-        logger.response(400, Date.now() - startTime);
-        res.status(400).json({ error: "'text' is required" });
-        return;
-      }
 
       let audioData: ArrayBuffer;
       let mimeType = "audio/mpeg";

--- a/docs/proposals/next-improvements.md
+++ b/docs/proposals/next-improvements.md
@@ -183,14 +183,12 @@ helper to reduce main-thread serialization jank on big libraries.
 
 ## 4. Security & hardening
 
-### 4.1 Keep the single `ryo` admin — add an audit trail
+### 4.1 Keep the single `ryo` admin — add an audit trail — **shipped**
 
 `api/_utils/api-handler.ts` treats username `ryo` as admin. This single-admin
-model is intentional and stays as-is. The one gap worth closing without
-changing the gate: there is no record of admin actions. Add an append-only
-audit log of `auth: "admin"` calls (action, target, timestamp) so the growing
-moderation surface (rooms, bans, Redis browser) is reviewable. No role system
-is introduced.
+model is intentional and stays as-is. The append-only audit log for
+state-changing admin calls has shipped, along with the Admin app Audit Log view.
+No role system is introduced.
 
 ### 4.2 Authenticate (or at least rate-limit) `/api/users`
 
@@ -230,11 +228,11 @@ Upstash-only deploys silently lose live chat/presence/sync. Ship a bundled
 lightweight pub/sub fallback (or document a managed Redis path in the
 self-host guide) so a single deploy gets full realtime.
 
-### 5.2 Admin audit-log view + moderation tooling
+### 5.2 Admin audit-log view + moderation tooling — **partial**
 
-Building on 4.1's audit trail (the `ryo` single-admin gate stays), surface the
-admin action log inside the existing Admin app and round out moderation tooling
-(rooms, bans, Redis browser) on top of it.
+Building on 4.1's shipped audit trail (the `ryo` single-admin gate stays), the
+Admin app now surfaces the action log. Remaining follow-up: round out moderation
+tooling (rooms, bans, Redis browser) on top of it.
 
 ### 5.3 Applet Store enhancements
 
@@ -268,7 +266,7 @@ code.
   warrants separate review + targeted testing*
 
 **Foundational (enables later work):**
-- 4.1 admin audit trail (keep `ryo` gate) → unlocks 5.2
+- 4.1 admin audit trail (keep `ryo` gate) → unlocks 5.2 — **shipped**
 - 4.3 Zod-at-`apiHandler` → unlocks 5.5 — **started**
 - 2.4 finish dual-path migrations — **legacy Redis reads shipped; sync v1
   retirement remains blocked by live backup UI**

--- a/tests/test-api-validation.test.ts
+++ b/tests/test-api-validation.test.ts
@@ -152,6 +152,19 @@ describe("apiHandler bodySchema validation", () => {
         data.issues.some((i: { path: string }) => i.path === "systemState")
       ).toBe(true);
     });
+
+    test("valid body reaches chat handler", async () => {
+      const res = await fetchWithOrigin(`${BASE_URL}/api/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [],
+          model: "not-a-real-model",
+        }),
+      });
+      expect(res.status).toBe(400);
+      expect(await res.text()).toContain("Unsupported model");
+    });
   });
 
   describe("POST /api/tv/create-channel", () => {

--- a/tests/test-api-validation.test.ts
+++ b/tests/test-api-validation.test.ts
@@ -3,6 +3,8 @@
  *
  * Exercised through endpoints that opt into a Zod body schema:
  * - POST /api/analytics/events (optional auth — easy to drive without a token)
+ * - POST /api/speech (optional auth — invalid-body path avoids TTS providers)
+ * - POST /api/chat (optional auth — invalid-body path avoids AI providers)
  * - POST /api/tv/create-channel (required auth — invalid-body path only, so
  *   no AI/YouTube quota is spent)
  */
@@ -65,6 +67,90 @@ describe("apiHandler bodySchema validation", () => {
         }),
       });
       expect(res.status).toBe(204);
+    });
+  });
+
+  describe("POST /api/speech", () => {
+    test("missing text → 400 validation_error", async () => {
+      const res = await fetchWithOrigin(`${BASE_URL}/api/speech`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("validation_error");
+      expect(data.issues.some((i: { path: string }) => i.path === "text")).toBe(
+        true
+      );
+    });
+
+    test("invalid speech options → 400 validation_error", async () => {
+      const res = await fetchWithOrigin(`${BASE_URL}/api/speech`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          text: "hello",
+          model: "bad-provider",
+          speed: 99,
+        }),
+      });
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("validation_error");
+      expect(data.issues.some((i: { path: string }) => i.path === "model")).toBe(
+        true
+      );
+      expect(data.issues.some((i: { path: string }) => i.path === "speed")).toBe(
+        true
+      );
+    });
+  });
+
+  describe("POST /api/chat", () => {
+    test("missing messages → 400 validation_error", async () => {
+      const res = await fetchWithOrigin(`${BASE_URL}/api/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("validation_error");
+      expect(data.issues.some((i: { path: string }) => i.path === "messages")).toBe(
+        true
+      );
+    });
+
+    test("invalid message shape → 400 validation_error", async () => {
+      const res = await fetchWithOrigin(`${BASE_URL}/api/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: [{ content: "missing role" }] }),
+      });
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("validation_error");
+      expect(
+        data.issues.some((i: { path: string }) => i.path === "messages.0.role")
+      ).toBe(true);
+    });
+
+    test("invalid system state → 400 validation_error", async () => {
+      const res = await fetchWithOrigin(`${BASE_URL}/api/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [],
+          systemState: "not-an-object",
+        }),
+      });
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("validation_error");
+      expect(
+        data.issues.some((i: { path: string }) => i.path === "systemState")
+      ).toBe(true);
     });
   });
 

--- a/tests/test-api-validation.test.ts
+++ b/tests/test-api-validation.test.ts
@@ -165,6 +165,22 @@ describe("apiHandler bodySchema validation", () => {
       expect(res.status).toBe(400);
       expect(await res.text()).toContain("Unsupported model");
     });
+
+    test("null model reaches chat handler", async () => {
+      const res = await fetchWithOrigin(
+        `${BASE_URL}/api/chat?model=not-a-real-model`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            messages: [],
+            model: null,
+          }),
+        }
+      );
+      expect(res.status).toBe(400);
+      expect(await res.text()).toContain("Unsupported model");
+    });
   });
 
   describe("POST /api/tv/create-channel", () => {

--- a/tests/test-speech.test.ts
+++ b/tests/test-speech.test.ts
@@ -31,7 +31,9 @@ describe("speech", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
       });
-      expect([400, 429]).toContain(res.status);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("validation_error");
     });
 
     test("Empty text", async () => {
@@ -40,7 +42,9 @@ describe("speech", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text: "" }),
       });
-      expect([400, 429]).toContain(res.status);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("validation_error");
     });
 
     test("Whitespace only text", async () => {
@@ -49,7 +53,9 @@ describe("speech", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text: "   " }),
       });
-      expect([400, 429]).toContain(res.status);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("validation_error");
     });
 
     test("Invalid JSON", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Mark the admin audit trail and Admin audit-log view as shipped in the improvements roadmap.
- Add Zod `bodySchema` validation to `/api/speech` and `/api/chat`.
- Allow nullable chat `model` payloads so clients that send `model: null` continue to fall back to the default model.
- Extend API validation coverage for structured `validation_error` responses, chat handler pass-through, and nullable model regression coverage.

## Testing
- `bun run test:api-validation` — 14 passing tests covering analytics, speech, chat, nullable chat model payloads, and authenticated TV schema validation.
- `bun run test:speech` — 13 passing tests covering speech validation, generation branches, headers, and CORS.
- `bun run build` — TypeScript project build and Vite production build completed successfully; existing CSS/Vite warnings remain non-blocking.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019efd52-d7e3-7737-bdc8-1638353bf3b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019efd52-d7e3-7737-bdc8-1638353bf3b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

