### PR TITLE
Auto-hide Books titlebar while reading

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -88,8 +88,8 @@ interface BooksDebugEvent {
   data?: unknown;
 }
 
-// Extra top clearance so the page never sits under the always-visible window
-// title bar (the window uses the full-bleed "notitlebar" material).
+// Extra top clearance so the page never sits under the hover-revealed window
+// titlebar (the window uses the full-bleed "notitlebar" material).
 const TOP_CLEARANCE = 36;
 // Footer that holds the reading-progress bar.
 const FOOTER_HEIGHT = 30;

--- a/src/apps/books/components/books-app/BooksAppComponent.tsx
+++ b/src/apps/books/components/books-app/BooksAppComponent.tsx
@@ -129,13 +129,13 @@ export function BooksAppComponent({
       menuBar={menuBar}
       windowFrameProps={{
         // Shelf has its own header, so the window titlebar shows nothing there;
-        // only the open book's title appears in the titlebar while reading.
+        // while reading, the book title appears in hover-revealed chrome.
         title: isReading && activeBook ? activeBookTitle || activeBook.name : "",
         onClose,
         isForeground,
         appId: "books",
         material: "notitlebar",
-        disableTitlebarAutoHide: true,
+        disableTitlebarAutoHide: !isReading,
         skipInitialSound,
         instanceId,
         onNavigateNext,

--- a/src/components/layout/window-frame/hooks/useWindowFrameTitlebarAutoHide.ts
+++ b/src/components/layout/window-frame/hooks/useWindowFrameTitlebarAutoHide.ts
@@ -15,6 +15,10 @@ export function useWindowFrameTitlebarAutoHide(
   // view where it had been hidden.
   useEffect(() => {
     if (disableTitlebarAutoHide && isNoTitlebar) {
+      if (titlebarHideTimeoutRef.current) {
+        clearTimeout(titlebarHideTimeoutRef.current);
+        titlebarHideTimeoutRef.current = null;
+      }
       setIsTitlebarHovered(true);
     }
   }, [disableTitlebarAutoHide, isNoTitlebar]);
@@ -36,6 +40,14 @@ export function useWindowFrameTitlebarAutoHide(
       startTitlebarAutoHideTimer();
     }
   }, [startTitlebarAutoHideTimer, disableTitlebarAutoHide]);
+
+  // When auto-hide becomes active after a pinned state, let the currently
+  // visible titlebar linger briefly and then hide.
+  useEffect(() => {
+    if (isNoTitlebar && !disableTitlebarAutoHide) {
+      startTitlebarAutoHideTimer();
+    }
+  }, [isNoTitlebar, disableTitlebarAutoHide, startTitlebarAutoHideTimer]);
 
   const hideTitlebar = useCallback(() => {
     setIsTitlebarHovered(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Auto-hide the Books window titlebar while a book is open, while keeping it pinned on the bookshelf.
- Ensure the shared notitlebar auto-hide state resets correctly when switching between pinned and auto-hide modes.

### Testing
- `bun test tests/test-books-default-epub.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0197-e2d1-7772-abd0-0e40bc656561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0197-e2d1-7772-abd0-0e40bc656561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

