### PR TITLE
Allow multi-day all-day calendar events

### DIFF
--- a/api/chat/tools/index.ts
+++ b/api/chat/tools/index.ts
@@ -208,7 +208,7 @@ export const TOOL_DESCRIPTIONS = {
     "Manage calendar events and todos in ryOS. " +
     "Event actions: " +
     "'list' returns all events (optionally filter by date); " +
-    "'create' adds a new event (requires title and date in YYYY-MM-DD format, optional startTime/endTime in HH:MM, color, notes); " +
+    "'create' adds a new event (requires title and date in YYYY-MM-DD format, optional startTime/endTime in HH:MM for timed events, optional inclusive endDate for multi-day all-day events, color, notes); " +
     "'update' modifies an existing event by ID; " +
     "'delete' removes an event by ID. " +
     "Todo actions: " +

--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -667,6 +667,11 @@ export const calendarControlSchema = z.object({
     .regex(/^\d{4}-\d{2}-\d{2}$/, { message: "Date must be YYYY-MM-DD format" })
     .optional()
     .describe("For events: event date (YYYY-MM-DD). For 'createTodo': optional due date. For 'list': filter events by date. For 'listTodos': filter by due date — OMIT to return ALL todos (most todos have no due date)."),
+  endDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, { message: "End date must be YYYY-MM-DD format" })
+    .optional()
+    .describe("For all-day events only: inclusive end date (YYYY-MM-DD). Omit for single-day or timed events."),
   startTime: z
     .string()
     .regex(/^\d{2}:\d{2}$/, { message: "Time must be HH:MM format" })
@@ -707,6 +712,20 @@ export const calendarControlSchema = z.object({
       code: z.ZodIssueCode.custom,
       message: "The 'create' action requires the 'date' parameter (YYYY-MM-DD).",
       path: ["date"],
+    });
+  }
+  if (data.endDate && data.date && data.endDate < data.date) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "The 'endDate' parameter must be on or after 'date'.",
+      path: ["endDate"],
+    });
+  }
+  if (data.endDate && (data.startTime || data.endTime)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Use 'endDate' only for all-day events; omit startTime/endTime for multi-day all-day events.",
+      path: ["endDate"],
     });
   }
   if ((data.action === "update" || data.action === "delete") && !data.id) {

--- a/src/apps/calendar/components/calendar-app/MonthGrid.tsx
+++ b/src/apps/calendar/components/calendar-app/MonthGrid.tsx
@@ -1,6 +1,9 @@
 import { useRef, useCallback } from "react";
 import type { CalendarEvent } from "@/stores/useCalendarStore";
-import { getCalendarEventEndDate } from "@/shared/calendarEventDates";
+import {
+  calendarEventOccursOnDate,
+  getCalendarEventEndDate,
+} from "@/shared/calendarEventDates";
 import type { CalendarDayCell } from "../../hooks/useCalendarLogic";
 import { osSeparatorBorderClassName } from "@/components/shared/osThemePrimitives";
 import {
@@ -80,17 +83,16 @@ export function MonthGrid({
                     const rangeEndDate = getCalendarEventEndDate(ev);
                     const continuesFromPreviousDay = isAllDayRange && ev.date < cell.date;
                     const continuesToNextDay = isAllDayRange && rangeEndDate > cell.date;
-                    const showTitle = !continuesFromPreviousDay || cell.date === week[0]?.date;
+                    const firstVisibleDateInWeek =
+                      week.find((day) => calendarEventOccursOnDate(ev, day.date))?.date;
+                    const showTitle = cell.date === firstVisibleDateInWeek;
 
                     return (
                       <button key={ev.id} type="button" onClick={(e) => handleEventTap(ev, e)}
                         className="text-[8px] truncate rounded px-0.5 leading-snug w-full text-left"
                         style={{ backgroundColor: EVENT_COLOR_LIGHT[ev.color] || EVENT_COLOR_LIGHT.blue, color: EVENT_COLOR_MAP[ev.color] || EVENT_COLOR_MAP.blue,
                           border: selectedEventId === ev.id ? `1px solid ${EVENT_COLOR_MAP[ev.color]}` : "1px solid transparent",
-                          borderTopLeftRadius: continuesFromPreviousDay ? 0 : undefined,
-                          borderBottomLeftRadius: continuesFromPreviousDay ? 0 : undefined,
-                          borderTopRightRadius: continuesToNextDay ? 0 : undefined,
-                          borderBottomRightRadius: continuesToNextDay ? 0 : undefined,
+                          borderRadius: `${continuesFromPreviousDay ? 0 : 3}px ${continuesToNextDay ? 0 : 3}px ${continuesToNextDay ? 0 : 3}px ${continuesFromPreviousDay ? 0 : 3}px`,
                           marginLeft: continuesFromPreviousDay ? "-2px" : undefined,
                           marginRight: continuesToNextDay ? "-2px" : undefined,
                           opacity: getEventOpacity(ev, searchQuery) }}

--- a/src/apps/calendar/components/calendar-app/MonthGrid.tsx
+++ b/src/apps/calendar/components/calendar-app/MonthGrid.tsx
@@ -1,5 +1,6 @@
 import { useRef, useCallback } from "react";
 import type { CalendarEvent } from "@/stores/useCalendarStore";
+import { getCalendarEventEndDate } from "@/shared/calendarEventDates";
 import type { CalendarDayCell } from "../../hooks/useCalendarLogic";
 import { osSeparatorBorderClassName } from "@/components/shared/osThemePrimitives";
 import {
@@ -74,14 +75,28 @@ export function MonthGrid({
                     backgroundColor: cell.isToday ? (isWindowsTheme ? TODAY_RED_XP : TODAY_RED) : "transparent", color: cell.isToday ? "#FFF" : undefined }}
                 >{cell.day}</span>
                 <div className="flex flex-col gap-px mt-px w-full">
-                  {cell.events.slice(0, 2).map((ev) => (
-                    <button key={ev.id} type="button" onClick={(e) => handleEventTap(ev, e)}
-                      className="text-[8px] truncate rounded px-0.5 leading-snug w-full text-left"
-                      style={{ backgroundColor: EVENT_COLOR_LIGHT[ev.color] || EVENT_COLOR_LIGHT.blue, color: EVENT_COLOR_MAP[ev.color] || EVENT_COLOR_MAP.blue,
-                        border: selectedEventId === ev.id ? `1px solid ${EVENT_COLOR_MAP[ev.color]}` : "1px solid transparent",
-                        opacity: getEventOpacity(ev, searchQuery) }}
-                    >{ev.title}</button>
-                  ))}
+                  {cell.events.slice(0, 2).map((ev) => {
+                    const isAllDayRange = !ev.startTime;
+                    const rangeEndDate = getCalendarEventEndDate(ev);
+                    const continuesFromPreviousDay = isAllDayRange && ev.date < cell.date;
+                    const continuesToNextDay = isAllDayRange && rangeEndDate > cell.date;
+                    const showTitle = !continuesFromPreviousDay || cell.date === week[0]?.date;
+
+                    return (
+                      <button key={ev.id} type="button" onClick={(e) => handleEventTap(ev, e)}
+                        className="text-[8px] truncate rounded px-0.5 leading-snug w-full text-left"
+                        style={{ backgroundColor: EVENT_COLOR_LIGHT[ev.color] || EVENT_COLOR_LIGHT.blue, color: EVENT_COLOR_MAP[ev.color] || EVENT_COLOR_MAP.blue,
+                          border: selectedEventId === ev.id ? `1px solid ${EVENT_COLOR_MAP[ev.color]}` : "1px solid transparent",
+                          borderTopLeftRadius: continuesFromPreviousDay ? 0 : undefined,
+                          borderBottomLeftRadius: continuesFromPreviousDay ? 0 : undefined,
+                          borderTopRightRadius: continuesToNextDay ? 0 : undefined,
+                          borderBottomRightRadius: continuesToNextDay ? 0 : undefined,
+                          marginLeft: continuesFromPreviousDay ? "-2px" : undefined,
+                          marginRight: continuesToNextDay ? "-2px" : undefined,
+                          opacity: getEventOpacity(ev, searchQuery) }}
+                      >{showTitle ? ev.title : "\u00a0"}</button>
+                    );
+                  })}
                   {cell.events.length > 2 && <span className="text-[8px] opacity-40 px-0.5">+{cell.events.length - 2}</span>}
                 </div>
               </button>

--- a/src/apps/calendar/components/calendar-app/WeekTimeGrid.tsx
+++ b/src/apps/calendar/components/calendar-app/WeekTimeGrid.tsx
@@ -3,7 +3,10 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { osSeparatorBorderClassName } from "@/components/shared/osThemePrimitives";
 import type { CalendarEvent } from "@/stores/useCalendarStore";
-import { getCalendarEventEndDate } from "@/shared/calendarEventDates";
+import {
+  calendarEventOccursOnDate,
+  getCalendarEventEndDate,
+} from "@/shared/calendarEventDates";
 import type { WeekDay } from "../../hooks/useCalendarLogic";
 import {
   DEFAULT_TIME_GRID_HOUR_HEIGHT,
@@ -162,7 +165,11 @@ export function WeekTimeGrid({
                   const rangeEndDate = getCalendarEventEndDate(ev);
                   const continuesFromPreviousDay = ev.date < day.date;
                   const continuesToNextDay = rangeEndDate > day.date;
-                  const showTitle = !continuesFromPreviousDay || day.date === weekDates[0]?.date;
+                  const firstVisibleDateInWeek =
+                    weekDates.find((weekDay) =>
+                      calendarEventOccursOnDate(ev, weekDay.date)
+                    )?.date;
+                  const showTitle = day.date === firstVisibleDateInWeek;
 
                   return (
                     <button
@@ -176,10 +183,7 @@ export function WeekTimeGrid({
                         border: selectedEventId === ev.id
                           ? `1px solid ${EVENT_COLOR_MAP[ev.color] || EVENT_COLOR_MAP.blue}`
                           : "1px solid transparent",
-                        borderTopLeftRadius: continuesFromPreviousDay ? 0 : undefined,
-                        borderBottomLeftRadius: continuesFromPreviousDay ? 0 : undefined,
-                        borderTopRightRadius: continuesToNextDay ? 0 : undefined,
-                        borderBottomRightRadius: continuesToNextDay ? 0 : undefined,
+                        borderRadius: `${continuesFromPreviousDay ? 0 : 4}px ${continuesToNextDay ? 0 : 4}px ${continuesToNextDay ? 0 : 4}px ${continuesFromPreviousDay ? 0 : 4}px`,
                         marginLeft: continuesFromPreviousDay ? "-1px" : undefined,
                         marginRight: continuesToNextDay ? "-1px" : undefined,
                         opacity: getEventOpacity(ev, searchQuery),

--- a/src/apps/calendar/components/calendar-app/WeekTimeGrid.tsx
+++ b/src/apps/calendar/components/calendar-app/WeekTimeGrid.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { osSeparatorBorderClassName } from "@/components/shared/osThemePrimitives";
 import type { CalendarEvent } from "@/stores/useCalendarStore";
+import { getCalendarEventEndDate } from "@/shared/calendarEventDates";
 import type { WeekDay } from "../../hooks/useCalendarLogic";
 import {
   DEFAULT_TIME_GRID_HOUR_HEIGHT,
@@ -157,24 +158,37 @@ export function WeekTimeGrid({
             </div>
             {weekDates.map((day) => (
               <div key={day.date} className="flex-1 flex flex-col gap-px py-px px-px min-w-0">
-                {day.allDayEvents.map((ev) => (
-                  <button
-                    key={ev.id}
-                    type="button"
-                    onClick={() => handleEventTap(ev)}
-                    className="text-[9px] truncate rounded px-1 leading-snug text-left"
-                    style={{
-                      backgroundColor: EVENT_COLOR_LIGHT[ev.color] || EVENT_COLOR_LIGHT.blue,
-                      color: EVENT_COLOR_MAP[ev.color] || EVENT_COLOR_MAP.blue,
-                      border: selectedEventId === ev.id
-                        ? `1px solid ${EVENT_COLOR_MAP[ev.color] || EVENT_COLOR_MAP.blue}`
-                        : "1px solid transparent",
-                      opacity: getEventOpacity(ev, searchQuery),
-                    }}
-                  >
-                    {ev.title}
-                  </button>
-                ))}
+                {day.allDayEvents.map((ev) => {
+                  const rangeEndDate = getCalendarEventEndDate(ev);
+                  const continuesFromPreviousDay = ev.date < day.date;
+                  const continuesToNextDay = rangeEndDate > day.date;
+                  const showTitle = !continuesFromPreviousDay || day.date === weekDates[0]?.date;
+
+                  return (
+                    <button
+                      key={ev.id}
+                      type="button"
+                      onClick={() => handleEventTap(ev)}
+                      className="text-[9px] truncate rounded px-1 leading-snug text-left"
+                      style={{
+                        backgroundColor: EVENT_COLOR_LIGHT[ev.color] || EVENT_COLOR_LIGHT.blue,
+                        color: EVENT_COLOR_MAP[ev.color] || EVENT_COLOR_MAP.blue,
+                        border: selectedEventId === ev.id
+                          ? `1px solid ${EVENT_COLOR_MAP[ev.color] || EVENT_COLOR_MAP.blue}`
+                          : "1px solid transparent",
+                        borderTopLeftRadius: continuesFromPreviousDay ? 0 : undefined,
+                        borderBottomLeftRadius: continuesFromPreviousDay ? 0 : undefined,
+                        borderTopRightRadius: continuesToNextDay ? 0 : undefined,
+                        borderBottomRightRadius: continuesToNextDay ? 0 : undefined,
+                        marginLeft: continuesFromPreviousDay ? "-1px" : undefined,
+                        marginRight: continuesToNextDay ? "-1px" : undefined,
+                        opacity: getEventOpacity(ev, searchQuery),
+                      }}
+                    >
+                      {showTitle ? ev.title : "\u00a0"}
+                    </button>
+                  );
+                })}
               </div>
             ))}
           </div>

--- a/src/apps/calendar/components/calendar-app/calendarAppConstants.ts
+++ b/src/apps/calendar/components/calendar-app/calendarAppConstants.ts
@@ -29,7 +29,7 @@ export function matchesSearchQuery(value: string | undefined, normalizedQuery: s
 }
 
 export function getEventSearchText(event: CalendarEvent) {
-  return [event.title, event.notes, event.date, event.startTime, event.endTime].filter(Boolean).join(" ");
+  return [event.title, event.notes, event.date, event.endDate, event.startTime, event.endTime].filter(Boolean).join(" ");
 }
 
 export function getEventOpacity(event: CalendarEvent, normalizedQuery: string) {

--- a/src/apps/calendar/components/tray-details/EventTrayEditor.tsx
+++ b/src/apps/calendar/components/tray-details/EventTrayEditor.tsx
@@ -11,6 +11,7 @@ import {
 import { TrayFieldRow } from "./TrayFieldRow";
 import type { TrayThemeProps } from "./types";
 import { formatDateLabel } from "./utils";
+import { normalizeAllDayEndDate } from "@/shared/calendarEventDates";
 
 export function EventTrayEditor({
   event,
@@ -32,11 +33,12 @@ export function EventTrayEditor({
   onDelete: (id: string) => void;
 }) {
   const [state, dispatch] = useReducer(eventEditorReducer, event, getEventEditorState);
-  const { title, location, notes, date, startTime, endTime } = state;
+  const { title, location, notes, date, endDate, startTime, endTime } = state;
   const setTitle = (value: string) => dispatch({ type: "setTitle", value });
   const setLocation = (value: string) => dispatch({ type: "setLocation", value });
   const setNotes = (value: string) => dispatch({ type: "setNotes", value });
   const setDate = (value: string) => dispatch({ type: "setDate", value });
+  const setEndDate = (value: string) => dispatch({ type: "setEndDate", value });
   const allDay = !event.startTime;
   useEffect(() => {
     dispatch({ type: "resetFromEvent", event });
@@ -47,6 +49,7 @@ export function EventTrayEditor({
     event.location,
     event.notes,
     event.date,
+    event.endDate,
     event.startTime,
     event.endTime,
   ]);
@@ -75,15 +78,41 @@ export function EventTrayEditor({
   };
 
   const commitDate = (nextDate: string) => {
+    if (!nextDate) return;
     setDate(nextDate);
-    if (nextDate !== event.date) onUpdate(event.id, { date: nextDate });
+    if (!allDay) {
+      if (nextDate !== event.date) onUpdate(event.id, { date: nextDate });
+      return;
+    }
+
+    const clampedEndDate = endDate < nextDate ? nextDate : endDate;
+    if (clampedEndDate !== endDate) setEndDate(clampedEndDate);
+    const nextStoredEndDate = normalizeAllDayEndDate(nextDate, clampedEndDate);
+    if (nextDate !== event.date || nextStoredEndDate !== event.endDate) {
+      onUpdate(event.id, { date: nextDate, endDate: nextStoredEndDate });
+    }
+  };
+
+  const commitEndDate = (nextEndDate: string) => {
+    if (!nextEndDate) return;
+    const clampedEndDate = nextEndDate < date ? date : nextEndDate;
+    setEndDate(clampedEndDate);
+    const nextStoredEndDate = normalizeAllDayEndDate(date, clampedEndDate);
+    if (nextStoredEndDate !== event.endDate) {
+      onUpdate(event.id, { endDate: nextStoredEndDate });
+    }
   };
 
   const setAllDay = (next: boolean) => {
     if (next) {
-      onUpdate(event.id, { startTime: undefined, endTime: undefined });
+      onUpdate(event.id, {
+        startTime: undefined,
+        endTime: undefined,
+        endDate: normalizeAllDayEndDate(date, endDate),
+      });
     } else {
       onUpdate(event.id, {
+        endDate: undefined,
         startTime: startTime || "09:00",
         endTime: endTime || "10:00",
       });
@@ -93,7 +122,7 @@ export function EventTrayEditor({
   const commitTimes = (st: string, et: string) => {
     dispatch({ type: "setTimes", startTime: st, endTime: et });
     if (!allDay && (st !== event.startTime || et !== (event.endTime || ""))) {
-      onUpdate(event.id, { startTime: st, endTime: et });
+      onUpdate(event.id, { startTime: st, endTime: et, endDate: undefined });
     }
   };
 
@@ -239,23 +268,43 @@ export function EventTrayEditor({
             </TrayFieldRow>
           </>
         ) : (
-          <TrayFieldRow label={t("apps.calendar.tray.from")} useGeneva={useGeneva}>
-            <input
-              type="date"
-              value={date}
-              onChange={(e) => commitDate(e.target.value)}
-              onKeyDown={(e) => e.stopPropagation()}
-              className={fieldInputClass}
-            />
-            <p
-              className={cn(
-                "text-[10px] text-black/45 mt-0.5 truncate",
-                useGeneva && "font-geneva-12"
-              )}
-            >
-              {formatDateLabel(date, locale)}
-            </p>
-          </TrayFieldRow>
+          <>
+            <TrayFieldRow label={t("apps.calendar.tray.from")} useGeneva={useGeneva}>
+              <input
+                type="date"
+                value={date}
+                onChange={(e) => commitDate(e.target.value)}
+                onKeyDown={(e) => e.stopPropagation()}
+                className={fieldInputClass}
+              />
+              <p
+                className={cn(
+                  "text-[10px] text-black/45 mt-0.5 truncate",
+                  useGeneva && "font-geneva-12"
+                )}
+              >
+                {formatDateLabel(date, locale)}
+              </p>
+            </TrayFieldRow>
+            <TrayFieldRow label={t("apps.calendar.tray.to")} useGeneva={useGeneva}>
+              <input
+                type="date"
+                value={endDate}
+                min={date}
+                onChange={(e) => commitEndDate(e.target.value)}
+                onKeyDown={(e) => e.stopPropagation()}
+                className={fieldInputClass}
+              />
+              <p
+                className={cn(
+                  "text-[10px] text-black/45 mt-0.5 truncate",
+                  useGeneva && "font-geneva-12"
+                )}
+              >
+                {formatDateLabel(endDate, locale)}
+              </p>
+            </TrayFieldRow>
+          </>
         )}
 
         <TrayFieldRow label={t("apps.calendar.event.calendar")} useGeneva={useGeneva}>

--- a/src/apps/calendar/components/tray-details/EventTrayEditor.tsx
+++ b/src/apps/calendar/components/tray-details/EventTrayEditor.tsx
@@ -10,7 +10,6 @@ import {
 } from "./eventEditorReducer";
 import { TrayFieldRow } from "./TrayFieldRow";
 import type { TrayThemeProps } from "./types";
-import { formatDateLabel } from "./utils";
 import { normalizeAllDayEndDate } from "@/shared/calendarEventDates";
 
 export function EventTrayEditor({
@@ -20,7 +19,6 @@ export function EventTrayEditor({
   isMacOSTheme,
   isSystem7Theme,
   isWindowsTheme,
-  locale,
   t,
   onUpdate,
   onDelete,
@@ -277,14 +275,6 @@ export function EventTrayEditor({
                 onKeyDown={(e) => e.stopPropagation()}
                 className={fieldInputClass}
               />
-              <p
-                className={cn(
-                  "text-[10px] text-black/45 mt-0.5 truncate",
-                  useGeneva && "font-geneva-12"
-                )}
-              >
-                {formatDateLabel(date, locale)}
-              </p>
             </TrayFieldRow>
             <TrayFieldRow label={t("apps.calendar.tray.to")} useGeneva={useGeneva}>
               <input
@@ -295,14 +285,6 @@ export function EventTrayEditor({
                 onKeyDown={(e) => e.stopPropagation()}
                 className={fieldInputClass}
               />
-              <p
-                className={cn(
-                  "text-[10px] text-black/45 mt-0.5 truncate",
-                  useGeneva && "font-geneva-12"
-                )}
-              >
-                {formatDateLabel(endDate, locale)}
-              </p>
             </TrayFieldRow>
           </>
         )}

--- a/src/apps/calendar/components/tray-details/eventEditorReducer.ts
+++ b/src/apps/calendar/components/tray-details/eventEditorReducer.ts
@@ -5,6 +5,7 @@ export interface EventEditorState {
   location: string;
   notes: string;
   date: string;
+  endDate: string;
   startTime: string;
   endTime: string;
 }
@@ -14,6 +15,7 @@ export const getEventEditorState = (event: CalendarEvent): EventEditorState => (
   location: event.location || "",
   notes: event.notes || "",
   date: event.date,
+  endDate: event.endDate || event.date,
   startTime: event.startTime || "09:00",
   endTime: event.endTime || "10:00",
 });
@@ -24,6 +26,7 @@ export type EventEditorAction =
   | { type: "setLocation"; value: string }
   | { type: "setNotes"; value: string }
   | { type: "setDate"; value: string }
+  | { type: "setEndDate"; value: string }
   | { type: "setStartTime"; value: string }
   | { type: "setEndTime"; value: string }
   | { type: "setTimes"; startTime: string; endTime: string };
@@ -43,6 +46,8 @@ export function eventEditorReducer(
       return { ...state, notes: action.value };
     case "setDate":
       return { ...state, date: action.value };
+    case "setEndDate":
+      return { ...state, endDate: action.value };
     case "setStartTime":
       return { ...state, startTime: action.value };
     case "setEndTime":

--- a/src/apps/calendar/hooks/useCalendarLogic.ts
+++ b/src/apps/calendar/hooks/useCalendarLogic.ts
@@ -13,6 +13,7 @@ import { parseIcalString, toIcalString } from "../utils/parseIcal";
 import { toast } from "@/hooks/useToast";
 import { CALENDAR_ANALYTICS, track } from "@/utils/analytics";
 import { openNativeFile, saveBlobToDevice } from "@/utils/nativeFileDialogs";
+import { calendarEventOccursOnDate } from "@/shared/calendarEventDates";
 
 type CalendarUndoAction =
   | { type: "addEvent"; event: CalendarEvent }
@@ -246,19 +247,14 @@ export function useCalendarLogic() {
     const sunday = new Date(sel);
     sunday.setDate(sunday.getDate() - dayOfWeek);
 
-    const eventsByDate = new Map<string, CalendarEvent[]>();
-    for (const ev of visibleEvents) {
-      const existing = eventsByDate.get(ev.date);
-      if (existing) existing.push(ev);
-      else eventsByDate.set(ev.date, [ev]);
-    }
-
     const days: WeekDay[] = [];
     for (let i = 0; i < 7; i++) {
       const date = new Date(sunday);
       date.setDate(date.getDate() + i);
       const dateStr = formatDate(date);
-      const dayEvents = eventsByDate.get(dateStr) || [];
+      const dayEvents = visibleEvents.filter((ev) =>
+        calendarEventOccursOnDate(ev, dateStr)
+      );
 
       days.push({
         date: dateStr,
@@ -305,13 +301,6 @@ export function useCalendarLogic() {
     const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate();
     const daysInPrevMonth = new Date(currentYear, currentMonth, 0).getDate();
 
-    const eventsByDate = new Map<string, CalendarEvent[]>();
-    for (const ev of visibleEvents) {
-      const existing = eventsByDate.get(ev.date);
-      if (existing) existing.push(ev);
-      else eventsByDate.set(ev.date, [ev]);
-    }
-
     const weeks: CalendarDayCell[][] = [];
     let dayCounter = 1;
     let nextMonthCounter = 1;
@@ -332,7 +321,9 @@ export function useCalendarLogic() {
             isCurrentMonth: false,
             isToday: dateStr === todayStr,
             isSelected: dateStr === selectedDate,
-            events: eventsByDate.get(dateStr) || [],
+            events: visibleEvents.filter((ev) =>
+              calendarEventOccursOnDate(ev, dateStr)
+            ),
           });
         } else if (dayCounter <= daysInMonth) {
           const dateStr = `${currentYear}-${String(currentMonth + 1).padStart(2, "0")}-${String(dayCounter).padStart(2, "0")}`;
@@ -342,7 +333,9 @@ export function useCalendarLogic() {
             isCurrentMonth: true,
             isToday: dateStr === todayStr,
             isSelected: dateStr === selectedDate,
-            events: eventsByDate.get(dateStr) || [],
+            events: visibleEvents.filter((ev) =>
+              calendarEventOccursOnDate(ev, dateStr)
+            ),
           });
           dayCounter++;
         } else {
@@ -355,7 +348,9 @@ export function useCalendarLogic() {
             isCurrentMonth: false,
             isToday: dateStr === todayStr,
             isSelected: dateStr === selectedDate,
-            events: eventsByDate.get(dateStr) || [],
+            events: visibleEvents.filter((ev) =>
+              calendarEventOccursOnDate(ev, dateStr)
+            ),
           });
           nextMonthCounter++;
         }
@@ -368,7 +363,7 @@ export function useCalendarLogic() {
   // Events for the selected date (filtered)
   const selectedDateEvents = useMemo(() => {
     return visibleEvents
-      .filter((ev) => ev.date === selectedDate)
+      .filter((ev) => calendarEventOccursOnDate(ev, selectedDate))
       .sort((a, b) => {
         if (!a.startTime && b.startTime) return -1;
         if (a.startTime && !b.startTime) return 1;

--- a/src/apps/calendar/utils/parseIcal.ts
+++ b/src/apps/calendar/utils/parseIcal.ts
@@ -1,8 +1,13 @@
 import type { CalendarEvent, EventColor } from "@/stores/useCalendarStore";
+import {
+  addDaysToDateString,
+  normalizeAllDayEndDate,
+} from "@/shared/calendarEventDates";
 
 export interface ParsedIcalEvent {
   title: string;
   date: string; // YYYY-MM-DD
+  endDate?: string; // YYYY-MM-DD, inclusive for all-day events
   startTime?: string; // HH:MM
   endTime?: string; // HH:MM
   notes?: string;
@@ -46,7 +51,8 @@ export function toIcalString(events: CalendarEvent[]): string {
       }
     } else {
       lines.push(`DTSTART;VALUE=DATE:${datePart}`);
-      const nextDay = getNextDay(ev.date);
+      const allDayEndDate = normalizeAllDayEndDate(ev.date, ev.endDate) || ev.date;
+      const nextDay = addDaysToDateString(allDayEndDate, 1);
       lines.push(`DTEND;VALUE=DATE:${nextDay.replace(/-/g, "")}`);
     }
 
@@ -66,12 +72,6 @@ export function toIcalString(events: CalendarEvent[]): string {
 function formatIcalDateTime(d: Date): string {
   const p = (n: number) => String(n).padStart(2, "0");
   return `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}T${p(d.getUTCHours())}${p(d.getUTCMinutes())}${p(d.getUTCSeconds())}`;
-}
-
-function getNextDay(dateStr: string): string {
-  const [y, m, d] = dateStr.split("-").map(Number);
-  const next = new Date(y, m - 1, d + 1);
-  return `${next.getFullYear()}-${String(next.getMonth() + 1).padStart(2, "0")}-${String(next.getDate()).padStart(2, "0")}`;
 }
 
 /**
@@ -232,6 +232,11 @@ function buildEvent(
     if (end?.time) {
       event.endTime = end.time;
     }
+  } else if (raw.isAllDay && end?.date) {
+    event.endDate = normalizeAllDayEndDate(
+      start.date,
+      addDaysToDateString(end.date, -1)
+    );
   }
 
   if (raw.description) {

--- a/src/apps/chats/tools/calendarHandler.ts
+++ b/src/apps/chats/tools/calendarHandler.ts
@@ -1,6 +1,7 @@
 import type { ToolHandler } from "./types";
 import { useCalendarStore } from "@/stores/useCalendarStore";
 import type { EventColor } from "@/stores/useCalendarStore";
+import { calendarEventOccursOnDate } from "@/shared/calendarEventDates";
 import i18n from "@/lib/i18n";
 
 export interface CalendarControlInput {
@@ -8,6 +9,7 @@ export interface CalendarControlInput {
   id?: string;
   title?: string;
   date?: string;
+  endDate?: string;
   startTime?: string;
   endTime?: string;
   color?: EventColor;
@@ -31,12 +33,13 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
     case "list": {
       let events = store.events;
       if (input.date) {
-        events = events.filter((ev) => ev.date === input.date);
+        events = events.filter((ev) => calendarEventOccursOnDate(ev, input.date!));
       }
       const formatted = events.map((ev) => ({
         id: ev.id,
         title: ev.title,
         date: ev.date,
+        endDate: ev.endDate,
         startTime: ev.startTime,
         endTime: ev.endTime,
         color: ev.color,
@@ -72,6 +75,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
       const eventId = store.addEvent({
         title: input.title,
         date: input.date,
+        endDate: input.endDate,
         startTime: input.startTime,
         endTime: input.endTime,
         color: input.color || "blue",
@@ -91,6 +95,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
             id: eventId,
             title: input.title,
             date: input.date,
+            endDate: input.endDate,
             startTime: input.startTime,
             endTime: input.endTime,
             color: input.color || "blue",
@@ -126,6 +131,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
       const updates: Record<string, unknown> = {};
       if (input.title !== undefined) updates.title = input.title;
       if (input.date !== undefined) updates.date = input.date;
+      if (input.endDate !== undefined) updates.endDate = input.endDate;
       if (input.startTime !== undefined) updates.startTime = input.startTime;
       if (input.endTime !== undefined) updates.endTime = input.endTime;
       if (input.color !== undefined) updates.color = input.color;

--- a/src/components/layout/dashboard/CalendarWidget.tsx
+++ b/src/components/layout/dashboard/CalendarWidget.tsx
@@ -4,6 +4,7 @@ import { requestAppLaunch } from "@/utils/appEventBus";
 import { useTranslation } from "react-i18next";
 import { useDashboardStore, type CalendarWidgetConfig } from "@/stores/useDashboardStore";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { calendarEventOccursOnDate } from "@/shared/calendarEventDates";
 
 function getLocalizedDayHeaders(locale: string): string[] {
   const fmt = new Intl.DateTimeFormat(locale, { weekday: "narrow" });
@@ -63,13 +64,6 @@ export function CalendarWidget({ widgetId }: CalendarWidgetProps) {
     const daysInMonth = new Date(year, month + 1, 0).getDate();
     const daysInPrev = new Date(year, month, 0).getDate();
 
-    const eventsByDate = new Map<string, CalendarEvent[]>();
-    for (const ev of events) {
-      const existing = eventsByDate.get(ev.date);
-      if (existing) existing.push(ev);
-      else eventsByDate.set(ev.date, [ev]);
-    }
-
     const weeks: Array<
       Array<{
         day: number;
@@ -92,16 +86,16 @@ export function CalendarWidget({ widgetId }: CalendarWidgetProps) {
           const pm = month === 0 ? 11 : month - 1;
           const py = month === 0 ? year - 1 : year;
           const ds = `${py}-${String(pm + 1).padStart(2, "0")}-${String(prevDay).padStart(2, "0")}`;
-          row.push({ day: prevDay, dateStr: ds, isCurrentMonth: false, isToday: ds === todayStr, events: eventsByDate.get(ds) || [] });
+          row.push({ day: prevDay, dateStr: ds, isCurrentMonth: false, isToday: ds === todayStr, events: events.filter((ev) => calendarEventOccursOnDate(ev, ds)) });
         } else if (dayCounter <= daysInMonth) {
           const ds = `${year}-${String(month + 1).padStart(2, "0")}-${String(dayCounter).padStart(2, "0")}`;
-          row.push({ day: dayCounter, dateStr: ds, isCurrentMonth: true, isToday: ds === todayStr, events: eventsByDate.get(ds) || [] });
+          row.push({ day: dayCounter, dateStr: ds, isCurrentMonth: true, isToday: ds === todayStr, events: events.filter((ev) => calendarEventOccursOnDate(ev, ds)) });
           dayCounter++;
         } else {
           const nm = month === 11 ? 0 : month + 1;
           const ny = month === 11 ? year + 1 : year;
           const ds = `${ny}-${String(nm + 1).padStart(2, "0")}-${String(nextCounter).padStart(2, "0")}`;
-          row.push({ day: nextCounter, dateStr: ds, isCurrentMonth: false, isToday: ds === todayStr, events: eventsByDate.get(ds) || [] });
+          row.push({ day: nextCounter, dateStr: ds, isCurrentMonth: false, isToday: ds === todayStr, events: events.filter((ev) => calendarEventOccursOnDate(ev, ds)) });
           nextCounter++;
         }
       }

--- a/src/shared/calendarEventDates.ts
+++ b/src/shared/calendarEventDates.ts
@@ -1,0 +1,41 @@
+export interface CalendarDateRangeLike {
+  date: string;
+  endDate?: string;
+  startTime?: string;
+}
+
+export function addDaysToDateString(dateStr: string, days: number): string {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const date = new Date(year, month - 1, day + days);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+export function normalizeAllDayEndDate(
+  startDate: string,
+  endDate: string | undefined
+): string | undefined {
+  if (!endDate || endDate <= startDate) return undefined;
+  return endDate;
+}
+
+export function getCalendarEventEndDate(event: CalendarDateRangeLike): string {
+  if (event.startTime) return event.date;
+  return normalizeAllDayEndDate(event.date, event.endDate) || event.date;
+}
+
+export function calendarEventOccursOnDate(
+  event: CalendarDateRangeLike,
+  date: string
+): boolean {
+  if (event.startTime) return event.date === date;
+  return event.date <= date && date <= getCalendarEventEndDate(event);
+}
+
+export function calendarEventOverlapsDateRange(
+  event: CalendarDateRangeLike,
+  startDate: string,
+  endDate: string
+): boolean {
+  const eventEndDate = getCalendarEventEndDate(event);
+  return event.date <= endDate && eventEndDate >= startDate;
+}

--- a/src/shared/domains/calendar.ts
+++ b/src/shared/domains/calendar.ts
@@ -15,6 +15,7 @@ export interface CalendarEventDto {
   id: string;
   title: string;
   date: string;
+  endDate?: string;
   startTime?: string;
   endTime?: string;
   color: CalendarColor;
@@ -67,6 +68,7 @@ export function isCalendarEventDto(value: unknown): value is CalendarEventDto {
     typeof event.id === "string" &&
     typeof event.title === "string" &&
     typeof event.date === "string" &&
+    (event.endDate === undefined || typeof event.endDate === "string") &&
     isCalendarColor(event.color) &&
     isFiniteNumber(event.createdAt) &&
     isFiniteNumber(event.updatedAt)

--- a/src/shared/tools/calendar.ts
+++ b/src/shared/tools/calendar.ts
@@ -4,6 +4,10 @@ import type {
   CalendarSnapshotData,
   TodoItemDto,
 } from "../domains/calendar";
+import {
+  calendarEventOccursOnDate,
+  normalizeAllDayEndDate,
+} from "../calendarEventDates";
 
 export const CALENDAR_ACTIONS = [
   "list",
@@ -25,6 +29,7 @@ export interface CalendarControlInput {
   id?: string;
   title?: string;
   date?: string;
+  endDate?: string;
   startTime?: string;
   endTime?: string;
   color?: CalendarColor;
@@ -38,6 +43,7 @@ export interface CalendarEventToolRecord {
   id: string;
   title: string;
   date: string;
+  endDate?: string;
   startTime?: string;
   endTime?: string;
   color: string;
@@ -118,6 +124,7 @@ export function serializeCalendarEvent(
     id: event.id,
     title: event.title,
     date: event.date,
+    endDate: event.endDate,
     startTime: event.startTime,
     endTime: event.endTime,
     color: event.color,
@@ -159,7 +166,9 @@ export function applyCalendarToolAction(
   switch (input.action) {
     case "list": {
       const events = input.date
-        ? state.events.filter((event) => event.date === input.date)
+        ? state.events.filter((event) =>
+            calendarEventOccursOnDate(event, input.date!)
+          )
         : state.events;
       return {
         ok: true,
@@ -178,6 +187,9 @@ export function applyCalendarToolAction(
         id: deps.generateId(),
         title: input.title,
         date: input.date,
+        endDate: input.startTime
+          ? undefined
+          : normalizeAllDayEndDate(input.date, input.endDate),
         startTime: input.startTime,
         endTime: input.endTime,
         color: resolveCalendarColor(input, state.calendars),
@@ -199,10 +211,19 @@ export function applyCalendarToolAction(
       if (!input.id) return { ok: false, error: "missing_id" };
       const index = state.events.findIndex((event) => event.id === input.id);
       if (index === -1) return { ok: false, error: "not_found", id: input.id };
+      const existing = state.events[index];
+      const nextDate = input.date ?? existing.date;
+      const nextStartTime =
+        input.startTime !== undefined ? input.startTime : existing.startTime;
+      const nextEndDate =
+        input.endDate !== undefined ? input.endDate : existing.endDate;
       const event = {
-        ...state.events[index],
+        ...existing,
         ...(input.title !== undefined ? { title: input.title } : {}),
-        ...(input.date !== undefined ? { date: input.date } : {}),
+        ...(input.date !== undefined ? { date: nextDate } : {}),
+        endDate: nextStartTime
+          ? undefined
+          : normalizeAllDayEndDate(nextDate, nextEndDate),
         ...(input.startTime !== undefined ? { startTime: input.startTime } : {}),
         ...(input.endTime !== undefined ? { endTime: input.endTime } : {}),
         ...(input.color !== undefined ? { color: input.color } : {}),

--- a/src/stores/useCalendarStore.ts
+++ b/src/stores/useCalendarStore.ts
@@ -1,6 +1,11 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
+import {
+  calendarEventOccursOnDate,
+  calendarEventOverlapsDateRange,
+  normalizeAllDayEndDate,
+} from "@/shared/calendarEventDates";
 
 export type EventColor = "blue" | "red" | "green" | "orange" | "purple";
 
@@ -15,6 +20,7 @@ export interface CalendarEvent {
   id: string;
   title: string;
   date: string; // YYYY-MM-DD
+  endDate?: string; // YYYY-MM-DD, inclusive for all-day multi-day events
   startTime?: string; // HH:MM (optional — all-day if omitted)
   endTime?: string; // HH:MM
   color: EventColor;
@@ -159,8 +165,12 @@ export const useCalendarStore = create<CalendarStoreState>()(
           const timestamp = Date.now();
           const calendarId = eventData.calendarId || get().calendars[0]?.id || "home";
           const calendar = get().calendars.find((c) => c.id === calendarId);
+          const endDate = eventData.startTime
+            ? undefined
+            : normalizeAllDayEndDate(eventData.date, eventData.endDate);
           const newEvent: CalendarEvent = {
             ...eventData,
+            endDate,
             id,
             calendarId,
             color: calendar?.color || eventData.color,
@@ -175,11 +185,14 @@ export const useCalendarStore = create<CalendarStoreState>()(
 
         updateEvent: (id, updates) => {
           set((state) => ({
-            events: state.events.map((ev) =>
-              ev.id === id
-                ? { ...ev, ...updates, updatedAt: Date.now() }
-                : ev
-            ),
+            events: state.events.map((ev) => {
+              if (ev.id !== id) return ev;
+              const next = { ...ev, ...updates, updatedAt: Date.now() };
+              next.endDate = next.startTime
+                ? undefined
+                : normalizeAllDayEndDate(next.date, next.endDate);
+              return next;
+            }),
           }));
         },
 
@@ -290,13 +303,16 @@ export const useCalendarStore = create<CalendarStoreState>()(
             }, [])
           );
           return state.events.filter(
-            (ev) => ev.date === date && visibleCalendarIds.has(ev.calendarId || "home")
+            (ev) =>
+              calendarEventOccursOnDate(ev, date) &&
+              visibleCalendarIds.has(ev.calendarId || "home")
           );
         },
 
         getEventsForMonth: (year, month) => {
           const state = get();
-          const prefix = `${year}-${String(month + 1).padStart(2, "0")}`;
+          const startDate = `${year}-${String(month + 1).padStart(2, "0")}-01`;
+          const endDate = formatDate(new Date(year, month + 1, 0));
           const visibleCalendarIds = new Set(
             state.calendars.reduce<string[]>((acc, calendar) => {
               if (calendar.visible) {
@@ -306,7 +322,9 @@ export const useCalendarStore = create<CalendarStoreState>()(
             }, [])
           );
           return state.events.filter(
-            (ev) => ev.date.startsWith(prefix) && visibleCalendarIds.has(ev.calendarId || "home")
+            (ev) =>
+              calendarEventOverlapsDateRange(ev, startDate, endDate) &&
+              visibleCalendarIds.has(ev.calendarId || "home")
           );
         },
       };

--- a/tests/test-calendar-event-dates.test.ts
+++ b/tests/test-calendar-event-dates.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import {
+  addDaysToDateString,
+  calendarEventOccursOnDate,
+  calendarEventOverlapsDateRange,
+  normalizeAllDayEndDate,
+} from "../src/shared/calendarEventDates";
+
+describe("calendar event date ranges", () => {
+  test("matches inclusive all-day ranges", () => {
+    const event = { date: "2026-06-07", endDate: "2026-06-09" };
+
+    expect(calendarEventOccursOnDate(event, "2026-06-06")).toBe(false);
+    expect(calendarEventOccursOnDate(event, "2026-06-07")).toBe(true);
+    expect(calendarEventOccursOnDate(event, "2026-06-08")).toBe(true);
+    expect(calendarEventOccursOnDate(event, "2026-06-09")).toBe(true);
+    expect(calendarEventOccursOnDate(event, "2026-06-10")).toBe(false);
+  });
+
+  test("keeps timed events on their start date only", () => {
+    const event = {
+      date: "2026-06-07",
+      endDate: "2026-06-09",
+      startTime: "09:00",
+    };
+
+    expect(calendarEventOccursOnDate(event, "2026-06-07")).toBe(true);
+    expect(calendarEventOccursOnDate(event, "2026-06-08")).toBe(false);
+  });
+
+  test("normalizes single-day ranges and checks month overlap", () => {
+    expect(normalizeAllDayEndDate("2026-06-07", "2026-06-07")).toBeUndefined();
+    expect(addDaysToDateString("2026-06-30", 1)).toBe("2026-07-01");
+    expect(
+      calendarEventOverlapsDateRange(
+        { date: "2026-06-29", endDate: "2026-07-02" },
+        "2026-07-01",
+        "2026-07-31"
+      )
+    ).toBe(true);
+  });
+});

--- a/tests/test-calendar-ical-multiday.test.ts
+++ b/tests/test-calendar-ical-multiday.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseIcalString,
+  toIcalString,
+} from "../src/apps/calendar/utils/parseIcal";
+import type { CalendarEvent } from "../src/stores/useCalendarStore";
+
+describe("calendar iCal multi-day all-day events", () => {
+  test("imports exclusive DTEND as inclusive endDate", () => {
+    const events = parseIcalString(
+      [
+        "BEGIN:VCALENDAR",
+        "BEGIN:VEVENT",
+        "DTSTART;VALUE=DATE:20260607",
+        "DTEND;VALUE=DATE:20260610",
+        "SUMMARY:Conference",
+        "END:VEVENT",
+        "END:VCALENDAR",
+      ].join("\r\n")
+    );
+
+    expect(events).toEqual([
+      {
+        title: "Conference",
+        date: "2026-06-07",
+        endDate: "2026-06-09",
+        color: "blue",
+      },
+    ]);
+  });
+
+  test("exports inclusive endDate as exclusive DTEND", () => {
+    const ics = toIcalString([
+      {
+        id: "event-1",
+        title: "Conference",
+        date: "2026-06-07",
+        endDate: "2026-06-09",
+        color: "blue",
+        createdAt: 1,
+        updatedAt: 2,
+      } as CalendarEvent,
+    ]);
+
+    expect(ics).toContain("DTSTART;VALUE=DATE:20260607");
+    expect(ics).toContain("DTEND;VALUE=DATE:20260610");
+  });
+});

--- a/tests/test-calendar-sync-domain.test.ts
+++ b/tests/test-calendar-sync-domain.test.ts
@@ -12,6 +12,7 @@ function event(id: string, updatedAt: number) {
     id,
     title: `event ${id}`,
     date: "2026-06-07",
+    endDate: "2026-06-09",
     color: "blue" as const,
     calendarId: "home",
     location: "Tokyo",

--- a/tests/test-calendar-tool-reducer.test.ts
+++ b/tests/test-calendar-tool-reducer.test.ts
@@ -53,6 +53,7 @@ describe("calendar tool shared reducer", () => {
         action: "create",
         title: "Dinner",
         date: "2026-06-08",
+        endDate: "2026-06-10",
         calendarId: "home",
         location: "Osaka",
       },
@@ -62,7 +63,35 @@ describe("calendar tool shared reducer", () => {
     if (!result.ok || result.kind !== "create") return;
     expect(result.event.id).toBe("generated-id");
     expect(result.event.color).toBe("green");
+    expect(result.event.endDate).toBe("2026-06-10");
     expect(result.event.location).toBe("Osaka");
+  });
+
+  test("lists multi-day all-day events on covered dates", () => {
+    const current = state();
+    current.events[0] = {
+      ...current.events[0],
+      date: "2026-06-07",
+      endDate: "2026-06-09",
+    };
+
+    const middle = applyCalendarToolAction(
+      current,
+      { action: "list", date: "2026-06-08" },
+      deps
+    );
+    expect(middle.ok).toBe(true);
+    if (!middle.ok || middle.kind !== "list") return;
+    expect(middle.events.map((event) => event.id)).toEqual(["event-1"]);
+
+    const after = applyCalendarToolAction(
+      current,
+      { action: "list", date: "2026-06-10" },
+      deps
+    );
+    expect(after.ok).toBe(true);
+    if (!after.ok || after.kind !== "list") return;
+    expect(after.events).toEqual([]);
   });
 
   test("updates and deletes events with tombstones", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add inclusive `endDate` support for all-day calendar events across storage, month/week/day rendering, assistant tools, and iCal import/export.
- Update the all-day event tray to support editable `From`/`To` dates without overlapping helper text.
- Add focused tests for date-range matching, calendar tool filtering, sync preservation, and iCal conversion.

### Walkthrough
<a href="https://cursor.com/agents/bc-019f01ad-c19c-7518-b087-feba812fcb6d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_multiday_all_day_final_verified.mp4"><img src="https://cursor.com/artifacts/c/art-e7867634-aefc-485a-9997-89e1aa2060fa" alt="calendar_multiday_all_day_final_verified.mp4" /></a>

### Testing
- `bun test tests/test-calendar-event-dates.test.ts tests/test-calendar-tool-reducer.test.ts tests/test-calendar-sync-domain.test.ts tests/test-calendar-ical-multiday.test.ts`
- `bun run build`
- Manual browser verification of creating/editing `Multi-day retreat` from `2026-06-26` to `2026-06-28`, confirming clean date rows and month-grid rendering through June 28.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f01ad-c19c-7518-b087-feba812fcb6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f01ad-c19c-7518-b087-feba812fcb6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

