### PR TITLE
Stabilize Books startup cover loading

### DIFF
--- a/src/apps/books/hooks/useBooksLogic.ts
+++ b/src/apps/books/hooks/useBooksLogic.ts
@@ -17,7 +17,6 @@ import { useBooksStore } from "@/stores/useBooksStore";
 import { useVfsFileOperations } from "@/services/vfs/useVfsFileOperations";
 import { openNativeFile } from "@/utils/nativeFileDialogs";
 import { emitFileSaved, onFileRenamed } from "@/utils/appEventBus";
-import { requestCloudSyncDomainCheck } from "@/utils/cloudSyncEvents";
 import { helpItems } from "../metadata";
 import { useBookCover } from "../utils/useBookCover";
 import type { BooksInitialData } from "@/apps/base/types";
@@ -214,15 +213,6 @@ export function useBooksLogic({
     },
     [moveToTrash, removeBook, t]
   );
-
-  // On open, reconcile Books cloud-sync state (reading progress, shelf
-  // ordering, last-opened) so the shelf reflects the latest synced data from
-  // other devices. This pulls via the shared cursor; the `bookshelf` namespace
-  // applies independently of the (large) file blobs.
-  useEffect(() => {
-    if (!isWindowOpen) return;
-    requestCloudSyncDomainCheck("bookshelf");
-  }, [isWindowOpen]);
 
   // Handle being launched / re-targeted with a specific book path.
   useEffect(() => {

--- a/src/apps/books/utils/useBookCover.ts
+++ b/src/apps/books/utils/useBookCover.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import ePub from "epubjs";
 import { readBookBlobContent } from "@/services/vfs/FileContentRepository";
 import { STORES, dbOperations } from "@/utils/indexedDB";
+import { isLikelyEpubBuffer } from "./booksReader";
 
 export interface BookCoverInfo {
   coverUrl: string | null;
@@ -14,7 +15,7 @@ export interface BookCoverInfo {
 // for the session.
 const coverCache = new Map<string, BookCoverInfo>();
 const inflight = new Map<string, Promise<BookCoverInfo>>();
-const MAX_CONCURRENT_COVER_LOADS = 3;
+const MAX_CONCURRENT_COVER_LOADS = 1;
 const THUMBNAIL_CACHE_VERSION = 1;
 let activeCoverLoads = 0;
 const pendingCoverLoadSlots: Array<() => void> = [];
@@ -136,6 +137,11 @@ async function loadCover(
         const blob = await readBookBlobContent(path);
         if (blob) {
           const buffer = await blob.arrayBuffer();
+          if (!isLikelyEpubBuffer(buffer)) {
+            await writeStoredThumbnail(key, result, coverBlob);
+            coverCache.set(key, result);
+            return result;
+          }
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const book = ePub(buffer as any);
           try {

--- a/src/apps/books/utils/useBookCover.ts
+++ b/src/apps/books/utils/useBookCover.ts
@@ -15,6 +15,8 @@ export interface BookCoverInfo {
 // for the session.
 const coverCache = new Map<string, BookCoverInfo>();
 const inflight = new Map<string, Promise<BookCoverInfo>>();
+// Cover extraction reads and parses full EPUB archives; keep this serial so an
+// online sync burst cannot stack multiple book-sized ArrayBuffers at startup.
 const MAX_CONCURRENT_COVER_LOADS = 1;
 const THUMBNAIL_CACHE_VERSION = 1;
 let activeCoverLoads = 0;

--- a/tests/test-books-cover-load-queue.test.ts
+++ b/tests/test-books-cover-load-queue.test.ts
@@ -13,31 +13,25 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import React from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { dbOperations, STORES } from "../src/utils/indexedDB";
+import type { FileSystemItem } from "../src/stores/useFilesStore";
 
-let activeReads = 0;
-let maxActiveReads = 0;
-let readCalls = 0;
+let activeParses = 0;
+let maxActiveParses = 0;
 let epubCreates = 0;
-let readBlobBytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04]);
-
-mock.module("@/services/vfs/FileContentRepository", () => ({
-  readBookBlobContent: mock(async () => {
-    readCalls += 1;
-    activeReads += 1;
-    maxActiveReads = Math.max(maxActiveReads, activeReads);
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    activeReads -= 1;
-    return new Blob([readBlobBytes], {
-      type: "application/epub+zip",
-    });
-  }),
-}));
 
 mock.module("epubjs", () => ({
   default: mock(() => {
     epubCreates += 1;
+    activeParses += 1;
+    maxActiveParses = Math.max(maxActiveParses, activeParses);
+    const ready = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        activeParses -= 1;
+        resolve();
+      }, 20);
+    });
     return {
-      ready: Promise.resolve(),
+      ready,
       loaded: { metadata: Promise.resolve({ title: "T", creator: "A" }) },
       coverUrl: async () => null,
       destroy: () => {},
@@ -46,6 +40,55 @@ mock.module("epubjs", () => ({
 }));
 
 const { useBookCover } = await import("../src/apps/books/utils/useBookCover");
+const { useFilesStore } = await import("../src/stores/useFilesStore");
+
+const EPUB_BYTES = new Uint8Array([0x50, 0x4b, 0x03, 0x04]);
+
+function arrayBufferFromBytes(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  );
+}
+
+async function deleteRyOsDatabase(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase("ryOS");
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => resolve();
+  });
+}
+
+async function seedBookContent(
+  path: string,
+  bytes: Uint8Array = EPUB_BYTES
+): Promise<void> {
+  const name = path.split("/").pop() ?? "book.epub";
+  const uuid = `uuid:${path}`;
+  const item: FileSystemItem = {
+    path,
+    name,
+    isDirectory: false,
+    type: "epub",
+    uuid,
+    size: bytes.byteLength,
+    status: "active",
+    createdAt: 1,
+    modifiedAt: 1,
+  };
+  useFilesStore.setState((state) => ({
+    items: {
+      ...state.items,
+      [path]: item,
+    },
+  }));
+  await dbOperations.put(
+    STORES.BOOKS,
+    { name, content: arrayBufferFromBytes(bytes) },
+    uuid
+  );
+}
 
 function CoverProbe({
   path,
@@ -62,7 +105,7 @@ function CoverProbe({
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {
-  for (let i = 0; i < 30; i += 1) {
+  for (let i = 0; i < 80; i += 1) {
     if (predicate()) return;
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
@@ -78,12 +121,12 @@ describe("Books cover loading queue", () => {
     }
   });
 
-  beforeEach(() => {
-    activeReads = 0;
-    maxActiveReads = 0;
-    readCalls = 0;
+  beforeEach(async () => {
+    activeParses = 0;
+    maxActiveParses = 0;
     epubCreates = 0;
-    readBlobBytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04]);
+    await deleteRyOsDatabase();
+    useFilesStore.setState({ items: {}, libraryState: "loaded" });
   });
 
   afterEach(async () => {
@@ -102,6 +145,12 @@ describe("Books cover loading queue", () => {
   });
 
   test("serializes shelf EPUB cover reads to limit startup memory", async () => {
+    const paths = Array.from(
+      { length: 12 },
+      (_, index) => `/Books/queued-book-${index}.epub`
+    );
+    await Promise.all(paths.map((path) => seedBookContent(path)));
+
     const host = document.createElement("div");
     document.body.appendChild(host);
     root = createRoot(host);
@@ -110,10 +159,10 @@ describe("Books cover loading queue", () => {
       React.createElement(
         React.Fragment,
         null,
-        Array.from({ length: 12 }, (_, index) =>
+        paths.map((path) =>
           React.createElement(CoverProbe, {
-            key: index,
-            path: `/Books/queued-book-${index}.epub`,
+            key: path,
+            path,
           })
         )
       )
@@ -121,8 +170,7 @@ describe("Books cover loading queue", () => {
 
     await waitFor(() => epubCreates === 12);
 
-    expect(readCalls).toBe(12);
-    expect(maxActiveReads).toBeLessThanOrEqual(1);
+    expect(maxActiveParses).toBeLessThanOrEqual(1);
 
     const cached = await dbOperations.get<{ title?: string; author?: string }>(
       STORES.BOOK_THUMBNAILS,
@@ -166,13 +214,15 @@ describe("Books cover loading queue", () => {
       title: "Cached title",
       author: "Cached author",
     });
-    expect(readCalls).toBe(0);
     expect(epubCreates).toBe(0);
   });
 
   test("does not parse invalid synced blobs as EPUB covers", async () => {
-    readBlobBytes = new TextEncoder().encode('{"error":"Not found"}');
     const path = "/Books/invalid-synced-payload.epub";
+    await seedBookContent(
+      path,
+      new TextEncoder().encode('{"error":"Not found"}')
+    );
 
     const host = document.createElement("div");
     document.body.appendChild(host);
@@ -190,7 +240,6 @@ describe("Books cover loading queue", () => {
 
     await waitFor(() => latest?.loading === false);
 
-    expect(readCalls).toBe(1);
     expect(epubCreates).toBe(0);
     expect(latest?.info).toMatchObject({
       coverUrl: null,

--- a/tests/test-books-cover-load-queue.test.ts
+++ b/tests/test-books-cover-load-queue.test.ts
@@ -17,6 +17,7 @@ let activeReads = 0;
 let maxActiveReads = 0;
 let readCalls = 0;
 let epubCreates = 0;
+let readBlobBytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04]);
 
 mock.module("@/services/vfs/FileContentRepository", () => ({
   readBookBlobContent: mock(async () => {
@@ -25,7 +26,7 @@ mock.module("@/services/vfs/FileContentRepository", () => ({
     maxActiveReads = Math.max(maxActiveReads, activeReads);
     await new Promise((resolve) => setTimeout(resolve, 20));
     activeReads -= 1;
-    return new Blob([new Uint8Array([0x50, 0x4b, 0x03, 0x04])], {
+    return new Blob([readBlobBytes], {
       type: "application/epub+zip",
     });
   }),
@@ -81,6 +82,7 @@ describe("Books cover loading queue", () => {
     maxActiveReads = 0;
     readCalls = 0;
     epubCreates = 0;
+    readBlobBytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04]);
   });
 
   afterEach(async () => {
@@ -98,7 +100,7 @@ describe("Books cover loading queue", () => {
     }
   });
 
-  test("limits concurrent shelf EPUB cover reads", async () => {
+  test("serializes shelf EPUB cover reads to limit startup memory", async () => {
     const host = document.createElement("div");
     document.body.appendChild(host);
     root = createRoot(host);
@@ -119,7 +121,7 @@ describe("Books cover loading queue", () => {
     await waitFor(() => epubCreates === 12);
 
     expect(readCalls).toBe(12);
-    expect(maxActiveReads).toBeLessThanOrEqual(3);
+    expect(maxActiveReads).toBeLessThanOrEqual(1);
 
     const cached = await dbOperations.get<{ title?: string; author?: string }>(
       STORES.BOOK_THUMBNAILS,
@@ -165,5 +167,34 @@ describe("Books cover loading queue", () => {
     });
     expect(readCalls).toBe(0);
     expect(epubCreates).toBe(0);
+  });
+
+  test("does not parse invalid synced blobs as EPUB covers", async () => {
+    readBlobBytes = new TextEncoder().encode('{"error":"Not found"}');
+    const path = "/Books/invalid-synced-payload.epub";
+
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+    let latest: ReturnType<typeof useBookCover> | null = null;
+
+    root.render(
+      React.createElement(CoverProbe, {
+        path,
+        onSnapshot: (snapshot) => {
+          latest = snapshot;
+        },
+      })
+    );
+
+    await waitFor(() => latest?.loading === false);
+
+    expect(readCalls).toBe(1);
+    expect(epubCreates).toBe(0);
+    expect(latest?.info).toMatchObject({
+      coverUrl: null,
+      title: null,
+      author: null,
+    });
   });
 });

--- a/tests/test-books-cover-load-queue.test.ts
+++ b/tests/test-books-cover-load-queue.test.ts
@@ -8,6 +8,7 @@ import {
   mock,
   test,
 } from "bun:test";
+import "fake-indexeddb/auto";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import React from "react";
 import { createRoot, type Root } from "react-dom/client";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Stop the Books app from forcing a global cloud-sync pull/flush every time the window opens.
- Serialize shelf EPUB cover extraction to reduce peak startup memory while online sync may also be active.
- Skip epub.js parsing for invalid synced book payloads and fall back to placeholder covers.
- Update Books cover-loading tests to use real VFS/IndexedDB content and cover invalid synced blobs.

## Testing
- `bun test tests/test-books-cover-load-queue.test.ts tests/test-books-default-epub.test.ts tests/test-books-cloud-blob-sync.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f01c5-5295-73f8-929a-e7e40c8f8873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f01c5-5295-73f8-929a-e7e40c8f8873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

