### PR TITLE
Theme timezone map marker with OS accent color

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/InternationalWorldMap.tsx
+++ b/src/apps/control-panels/components/control-panels-app/InternationalWorldMap.tsx
@@ -148,16 +148,6 @@ export function InternationalWorldMap({
         stroke="#fff"
         strokeWidth={1}
       />
-
-      <rect
-        x={0.5}
-        y={0.5}
-        width={MAP_W - 1}
-        height={MAP_H - 1}
-        fill="none"
-        stroke="rgba(0,0,0,0.4)"
-        strokeWidth={1}
-      />
     </svg>
   );
 }

--- a/src/apps/control-panels/components/control-panels-app/InternationalWorldMap.tsx
+++ b/src/apps/control-panels/components/control-panels-app/InternationalWorldMap.tsx
@@ -96,37 +96,36 @@ export function InternationalWorldMap({
       preserveAspectRatio="xMidYMid meet"
       style={{ display: "block", width: "100%", height: "auto" }}
     >
-      <defs>
-        <linearGradient id="cp-ocean" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="#3b6ea5" />
-          <stop offset="100%" stopColor="#244b73" />
-        </linearGradient>
-      </defs>
-
+      {/* Sea: a neutral, semi-transparent tint so the panel surface shows
+          through (works on both light and dark window backgrounds). */}
       <rect
         x={0}
         y={0}
         width={MAP_W}
         height={MAP_H}
-        fill="url(#cp-ocean)"
+        fill="rgba(127,127,127,0.12)"
       />
 
       <path
         d={graticulePath}
         fill="none"
-        stroke="rgba(255,255,255,0.12)"
+        stroke="rgba(127,127,127,0.25)"
         strokeWidth={0.3}
       />
 
+      {/* Land: tinted with the OS accent color. `--os-accent-color` is only set
+          for non-default accents, so fall back to the classic map green for the
+          "System"/default accent. */}
       <path
         d={landPath}
-        fill="#6f9e5a"
-        stroke="rgba(0,0,0,0.35)"
+        style={{ fill: "var(--os-accent-color, #6f9e5a)" }}
+        fillOpacity={0.6}
+        stroke="rgba(0,0,0,0.3)"
         strokeWidth={0.3}
       />
 
       {/* Live day/night shadow. */}
-      <path d={nightPath} fill="rgba(8,16,34,0.42)" stroke="none" />
+      <path d={nightPath} fill="rgba(0,0,0,0.28)" stroke="none" />
 
       {/* Selected timezone meridian + marker, tinted with the OS accent color.
           `--os-accent-color` is only set for non-default accents, so fall back

--- a/src/apps/control-panels/components/control-panels-app/InternationalWorldMap.tsx
+++ b/src/apps/control-panels/components/control-panels-app/InternationalWorldMap.tsx
@@ -128,13 +128,16 @@ export function InternationalWorldMap({
       {/* Live day/night shadow. */}
       <path d={nightPath} fill="rgba(8,16,34,0.42)" stroke="none" />
 
-      {/* Selected timezone meridian + marker. */}
+      {/* Selected timezone meridian + marker, tinted with the OS accent color.
+          `--os-accent-color` is only set for non-default accents, so fall back
+          to the classic Mac OS "Time Zone" red when "System" is selected. */}
       <line
         x1={marker.x}
         y1={0}
         x2={marker.x}
         y2={MAP_H}
-        stroke="rgba(255,90,70,0.55)"
+        style={{ stroke: "var(--os-accent-color, #ff5a46)" }}
+        strokeOpacity={0.7}
         strokeWidth={0.8}
         strokeDasharray="2 2"
       />
@@ -142,7 +145,7 @@ export function InternationalWorldMap({
         cx={marker.x}
         cy={MAP_H / 2}
         r={3}
-        fill="#ff4d4d"
+        style={{ fill: "var(--os-accent-color, #ff4d4d)" }}
         stroke="#fff"
         strokeWidth={1}
       />

--- a/src/apps/control-panels/components/control-panels-app/TimezoneCombobox.tsx
+++ b/src/apps/control-panels/components/control-panels-app/TimezoneCombobox.tsx
@@ -71,6 +71,10 @@ function TimezoneComboboxImpl({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [highlight, setHighlight] = useState(0);
+  // Only paint the highlight when it follows the pointer; keyboard navigation
+  // (and the initial index) moves the selection silently, matching the request
+  // to keep the keyboard-select color out of the menu.
+  const [hovering, setHovering] = useState(false);
   const [rect, setRect] = useState<{
     left: number;
     top: number;
@@ -129,6 +133,7 @@ function TimezoneComboboxImpl({
     updateRect();
     setQuery("");
     setHighlight(0);
+    setHovering(false);
     setOpen(true);
     playOpen();
   }, [updateRect, playOpen]);
@@ -198,9 +203,11 @@ function TimezoneComboboxImpl({
   const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
+      setHovering(false);
       setHighlight((h) => Math.min(h + 1, rows.length - 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
+      setHovering(false);
       setHighlight((h) => Math.max(h - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
@@ -288,6 +295,7 @@ function TimezoneComboboxImpl({
                   onChange={(v) => {
                     setQuery(v);
                     setHighlight(0);
+                    setHovering(false);
                   }}
                   onKeyDown={onInputKeyDown}
                   placeholder={t(
@@ -308,7 +316,7 @@ function TimezoneComboboxImpl({
                     const isAuto = row.kind === "auto";
                     const rowId = isAuto ? AUTO_TIMEZONE : row.zone.id;
                     const selected = rowId === currentId;
-                    const active = index === highlight;
+                    const highlighted = hovering && index === highlight;
                     const label = isAuto
                       ? t("apps.control-panels.timezoneAutomatic")
                       : row.zone.city;
@@ -320,11 +328,18 @@ function TimezoneComboboxImpl({
                         role="option"
                         aria-selected={selected}
                         data-row={index}
-                        onMouseEnter={() => setHighlight(index)}
+                        data-highlighted={highlighted ? "" : undefined}
+                        onMouseEnter={() => {
+                          setHighlight(index);
+                          setHovering(true);
+                        }}
                         onClick={() => selectRow(row)}
                         className={cn(
                           "os-select-item-with-description group relative flex w-full cursor-default select-none items-center pl-4 pr-7 py-1.5 text-sm text-left outline-none",
-                          active && "bg-accent text-accent-foreground"
+                          // Generic fallback for non-mac themes; the macOS themed
+                          // CSS overrides `[role="option"][data-highlighted]` with
+                          // the OS accent selection color.
+                          "data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
                         )}
                       >
                         <span className="absolute right-2 top-2 flex size-3.5 items-center justify-center">
@@ -335,7 +350,7 @@ function TimezoneComboboxImpl({
                           <span
                             className={cn(
                               "text-[11px] font-normal leading-tight truncate",
-                              active ? "text-inherit" : "text-neutral-500"
+                              highlighted ? "text-inherit" : "text-neutral-500"
                             )}
                           >
                             {description}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Themes the Control Panels → International → Date & Time world map (`InternationalWorldMap`) with the active OS accent color, and aligns the timezone combobox highlight behavior with the native `Select`.

## Changes

### World map (`InternationalWorldMap`)
- **Marker + meridian**: the selected-timezone `<line>` and `<circle>` read `var(--os-accent-color, …)` (fallback to classic Mac OS "Time Zone" red for the "System"/default accent).
- **Land**: tinted with `var(--os-accent-color, …)` at 60% opacity (fallback to the classic map green), so continents follow the accent while the full-opacity marker stays distinct.
- **Sea**: replaced the hardcoded blue ocean gradient with a neutral semi-transparent tint (`rgba(127,127,127,0.12)`) so the panel surface shows through on both light and dark window backgrounds; graticule and day/night shadow neutralized to match.
- Removed the SVG's inner border `<rect>` — the wrapping container already draws the border, so this drops a duplicated edge.

SVG presentation attributes don't resolve CSS `var()`, so accent colors are applied via inline `style`. `--os-accent-color` is set inline on `<html>` by the accent system, so the map follows any chosen accent (including the wallpaper-sampled default) automatically.

### Timezone combobox (`TimezoneCombobox`)
- Hover highlight now uses `data-highlighted` so the themed `[role="option"][data-highlighted]` CSS paints the **OS accent selection color** (matching the real `Select`), instead of the generic gray `bg-accent`.
- Keyboard navigation / initial index no longer paints a highlight (a new `hovering` flag gates the visual), so the keyboard-select color stays out of the menu; arrow keys still move + autoscroll and Enter still selects.

## Testing

- `tsc -b` — passes
- `eslint` on changed files — clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f04df-ec74-7aab-a0bf-43b16aed729d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f04df-ec74-7aab-a0bf-43b16aed729d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

