### PR TITLE
Localize timezone and weather city displays

### DIFF
--- a/src/apps/admin/components/dashboard-panel/utils.ts
+++ b/src/apps/admin/components/dashboard-panel/utils.ts
@@ -1,41 +1,8 @@
 export { formatDateLabel } from "@/utils/formatDateLabel";
+export { formatCountryDisplay } from "@/utils/formatCountryDisplay";
 
 export function formatNumber(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
-}
-
-function isLikelyIsoAlpha2(value: string): boolean {
-  return /^[A-Za-z]{2}$/.test(value);
-}
-
-function countryCodeToFlagEmoji(code: string): string {
-  const upper = code.toUpperCase();
-  if (!/^[A-Z]{2}$/.test(upper)) return "";
-  const A = 0x1f1e6;
-  const codePoints = [
-    A + (upper.charCodeAt(0) - "A".charCodeAt(0)),
-    A + (upper.charCodeAt(1) - "A".charCodeAt(0)),
-  ];
-  return String.fromCodePoint(...codePoints);
-}
-
-export function formatCountryDisplay(
-  raw: string,
-  locale: string
-): { flag: string; name: string } {
-  const trimmed = raw.trim();
-  if (isLikelyIsoAlpha2(trimmed)) {
-    const code = trimmed.toUpperCase();
-    let name = code;
-    try {
-      const display = new Intl.DisplayNames([locale], { type: "region" });
-      name = display.of(code) ?? code;
-    } catch {
-      name = code;
-    }
-    return { flag: countryCodeToFlagEmoji(code), name };
-  }
-  return { flag: "", name: trimmed };
 }

--- a/src/apps/control-panels/components/control-panels-app/InternationalPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/InternationalPaneContent.tsx
@@ -11,7 +11,7 @@ import type { LanguageCode } from "@/stores/useLanguageStore";
 import type { TimezonePreference } from "@/lib/timezoneConfig";
 import {
   formatOffsetLabel,
-  formatTimezoneCity,
+  formatTimezoneCityLocalized,
   getTimezoneOffsetMinutes,
   resolveEffectiveTimezone,
 } from "@/lib/timezoneConfig";
@@ -104,7 +104,10 @@ export function InternationalPaneContent({
     }
   }, [currentLanguage, effectiveTimezone, now]);
 
-  const cityLabel = formatTimezoneCity(effectiveTimezone);
+  const cityLabel = useMemo(
+    () => formatTimezoneCityLocalized(effectiveTimezone, currentLanguage, now),
+    [currentLanguage, effectiveTimezone, now]
+  );
 
   const formatSamples = useMemo(
     () => getLocaleFormatSamples(currentLanguage, effectiveTimezone),
@@ -268,6 +271,7 @@ export function InternationalPaneContent({
                   value={timezone}
                   onChange={setTimezone}
                   t={t}
+                  locale={currentLanguage}
                 />
               </ControlPanelsPrefFormRow>
 

--- a/src/apps/control-panels/components/control-panels-app/TimezoneCombobox.tsx
+++ b/src/apps/control-panels/components/control-panels-app/TimezoneCombobox.tsx
@@ -4,7 +4,8 @@ import {
   AUTO_TIMEZONE,
   buildTimezoneSearchText,
   formatOffsetLabel,
-  formatTimezoneCity,
+  formatTimezoneCityLocalized,
+  formatTimezoneRegionLocalized,
   getSupportedTimezones,
   getTimezoneNameVariants,
   getTimezoneOffsetMinutes,
@@ -16,6 +17,7 @@ export type TimezoneComboboxProps = {
   value: TimezonePreference;
   onChange: (value: TimezonePreference) => void;
   t: (key: string, opts?: Record<string, unknown>) => string;
+  locale: string;
   className?: string;
 };
 
@@ -23,12 +25,17 @@ function TimezoneComboboxImpl({
   value,
   onChange,
   t,
+  locale,
   className,
 }: TimezoneComboboxProps) {
   // Computing offsets / abbreviations for every zone is non-trivial; once per mount.
   const autoCity = useMemo(
-    () => formatTimezoneCity(resolveEffectiveTimezone(AUTO_TIMEZONE)),
-    []
+    () =>
+      formatTimezoneCityLocalized(
+        resolveEffectiveTimezone(AUTO_TIMEZONE),
+        locale
+      ),
+    [locale]
   );
 
   const options = useMemo<ComboboxOption[]>(() => {
@@ -44,34 +51,34 @@ function TimezoneComboboxImpl({
     ];
     for (const id of getSupportedTimezones()) {
       const slash = id.indexOf("/");
-      const region = slash === -1 ? "" : id.slice(0, slash).replace(/_/g, " ");
-      const city = formatTimezoneCity(id);
+      const region = slash === -1 ? "" : id.slice(0, slash);
+      const city = formatTimezoneCityLocalized(id, locale, now);
       const offsetLabel = formatOffsetLabel(getTimezoneOffsetMinutes(id, now));
-      const abbrevs = getTimezoneNameVariants(id, now)
+      const abbrevs = getTimezoneNameVariants(id, now, "en-US")
         .filter((n) => /^[A-Za-z]{2,5}$/.test(n))
         .slice(0, 3);
       const abbrevSuffix = abbrevs.length > 0 ? ` · ${abbrevs.join("/")}` : "";
       const description = region
-        ? `${region} · ${offsetLabel}${abbrevSuffix}`
+        ? `${formatTimezoneRegionLocalized(region, t)} · ${offsetLabel}${abbrevSuffix}`
         : `${offsetLabel}${abbrevSuffix}`;
       zones.push({
         value: id,
         label: city,
         description,
-        searchText: buildTimezoneSearchText(id, now),
+        searchText: buildTimezoneSearchText(id, now, locale),
       });
     }
     return zones;
-  }, [t, autoCity]);
+  }, [t, autoCity, locale]);
 
   const displayValue = useMemo(() => {
     if (value === AUTO_TIMEZONE) {
       return t("apps.control-panels.timezoneAutomaticCity", { city: autoCity });
     }
-    const city = formatTimezoneCity(value);
+    const city = formatTimezoneCityLocalized(value, locale);
     const offset = formatOffsetLabel(getTimezoneOffsetMinutes(value));
     return `${city} (${offset})`;
-  }, [value, t, autoCity]);
+  }, [value, t, autoCity, locale]);
 
   return (
     <Combobox

--- a/src/components/layout/dashboard/ClockWidget.tsx
+++ b/src/components/layout/dashboard/ClockWidget.tsx
@@ -7,9 +7,10 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useEffectiveTimezone } from "@/hooks/useEffectiveTimezone";
 import {
   formatInTimeZone,
-  formatTimezoneCity,
+  formatTimezoneCityLocalized,
   getZonedDateTimeParts,
 } from "@/lib/timezoneConfig";
+import { formatCountryDisplay } from "@/utils/formatCountryDisplay";
 
 interface CityResult {
   name: string;
@@ -36,9 +37,9 @@ function getPopularCities(t: TFunction): CityResult[] {
   ];
 }
 
-function getCityFromTimezone(tz: string): string {
+function getCityFromTimezone(tz: string, locale: string): string {
   try {
-    return formatTimezoneCity(tz).toUpperCase();
+    return formatTimezoneCityLocalized(tz, locale).toLocaleUpperCase(locale);
   } catch {
     return "";
   }
@@ -74,7 +75,8 @@ interface ClockWidgetProps {
 }
 
 export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language || "en";
   const [time, setTime] = useState(() => new Date());
   const { isWindowsTheme } = useThemeFlags();
   const effectiveTimezone = useEffectiveTimezone();
@@ -86,10 +88,10 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
   const displayTimezone = config?.timezone || effectiveTimezone;
 
   const cityName = useMemo(() => {
-    if (config?.cityKey) return t(config.cityKey).toUpperCase();
-    if (config?.cityName) return config.cityName.toUpperCase();
-    return getCityFromTimezone(displayTimezone) || t("apps.dashboard.cities.local");
-  }, [config?.cityKey, config?.cityName, displayTimezone, t]);
+    if (config?.cityKey) return t(config.cityKey).toLocaleUpperCase(locale);
+    if (config?.cityName) return config.cityName.toLocaleUpperCase(locale);
+    return getCityFromTimezone(displayTimezone, locale) || t("apps.dashboard.cities.local");
+  }, [config?.cityKey, config?.cityName, displayTimezone, locale, t]);
 
   useEffect(() => {
     if (isFlipped) return;
@@ -111,7 +113,7 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
   const secondAngle = (seconds / 60) * 360;
   const minuteAngle = (minutes / 60) * 360 + (seconds / 60) * 6;
   const hourAngle = ((hours % 12) / 12) * 360 + (minutes / 60) * 30;
-  const digitalTime = formatInTimeZone(time, displayTimezone, undefined, {
+  const digitalTime = formatInTimeZone(time, displayTimezone, locale, {
     hour: "numeric",
     minute: "2-digit",
     hour12: true,
@@ -226,15 +228,17 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
   );
 }
 
-function formatCityLabel(city: CityResult): string {
+function formatCityLabel(city: CityResult, locale: string): string {
   const parts = [city.name];
   if (city.state) parts.push(city.state);
-  parts.push(city.country);
+  const country = formatCountryDisplay(city.country, locale).name;
+  if (country) parts.push(country);
   return parts.join(", ");
 }
 
 export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?: () => void }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language || "en";
   const popularCities = useMemo(() => getPopularCities(t), [t]);
   const { isWindowsTheme } = useThemeFlags();
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
@@ -289,7 +293,10 @@ export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?
     try {
       const res = await fetch(
         `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=6&addressdetails=1&featuretype=city`,
-        { signal: controller.signal }
+        {
+          signal: controller.signal,
+          headers: { "Accept-Language": locale },
+        }
       );
       if (res.ok) {
         const data = await res.json();
@@ -314,7 +321,7 @@ export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?
       // search failed silently
     }
     dispatch({ type: "searchResults", results: [] });
-  }, []);
+  }, [locale]);
 
   useEffect(() => {
     return () => {
@@ -415,7 +422,7 @@ export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?
               onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
             >
               <MapPin size={10} weight="fill" style={{ color: isWindowsTheme ? "#999" : "rgba(255,255,255,0.25)", flexShrink: 0 }} />
-              <span className="text-[11px] truncate" style={{ color: textColor }}>{formatCityLabel(city)}</span>
+              <span className="text-[11px] truncate" style={{ color: textColor }}>{formatCityLabel(city, locale)}</span>
             </button>
           ))
         )}

--- a/src/components/layout/dashboard/WeatherWidget.tsx
+++ b/src/components/layout/dashboard/WeatherWidget.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/weather/openMeteo";
 import { coordKey, SF_LAT, SF_LON } from "@/stores/useWeatherStore";
 import type { CityResult, WeatherLocation } from "@/lib/weather/types";
+import { formatCountryDisplay } from "@/utils/formatCountryDisplay";
 
 function getPopularCities(t: TFunction): CityResult[] {
   return [
@@ -65,10 +66,11 @@ function getSkyGradient(code: number, isDay: boolean): string {
   return "linear-gradient(180deg, #4A90C4 0%, #7AB4D8 40%, #A8CBE0 100%)";
 }
 
-function formatCityLabel(city: CityResult): string {
+function formatCityLabel(city: CityResult, locale: string): string {
   const parts = [city.name];
   if (city.state) parts.push(city.state);
-  parts.push(city.country);
+  const country = formatCountryDisplay(city.country, locale).name;
+  if (country) parts.push(country);
   return parts.join(", ");
 }
 
@@ -89,7 +91,10 @@ export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
       ? { kind: "coords", lat: cityConfig.lat, lon: cityConfig.lon }
       : { kind: "geo" };
 
-  const { snapshot, loading, error } = useWeather(location, { active: true });
+  const { snapshot, loading, error } = useWeather(location, {
+    active: true,
+    locale,
+  });
 
   const forecast = useMemo(
     () => (snapshot ? buildForecast(snapshot.daily, locale) : []),
@@ -322,7 +327,8 @@ export function WeatherEmojiOverflow({ widgetId }: { widgetId: string }) {
 
 // Back panel: city picker for the weather widget settings
 export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDone?: () => void }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language || "en";
   const popularCities = useMemo(() => getPopularCities(t), [t]);
   const { isWindowsTheme } = useThemeFlags();
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
@@ -378,7 +384,7 @@ export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDon
     searchAbortRef.current = controller;
     dispatchSearch({ type: "searchStart" });
     try {
-      const results = await searchCitiesApi(query, controller.signal);
+      const results = await searchCitiesApi(query, controller.signal, locale);
       dispatchSearch({ type: "searchResults", results });
       return;
     } catch (err) {
@@ -387,7 +393,7 @@ export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDon
       // search failed silently
     }
     dispatchSearch({ type: "searchResults", results: [] });
-  }, []);
+  }, [locale]);
 
   useEffect(() => {
     return () => {
@@ -474,7 +480,7 @@ export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDon
               onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
             >
               <MapPin size={10} weight="fill" style={{ color: isWindowsTheme ? "#999" : "rgba(255,255,255,0.25)", flexShrink: 0 }} />
-              <span className="text-[11px] truncate" style={{ color: textColor }}>{formatCityLabel(city)}</span>
+              <span className="text-[11px] truncate" style={{ color: textColor }}>{formatCityLabel(city, locale)}</span>
             </button>
           ))
         )}

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -38,9 +38,10 @@ export function buildForecast(
 
 export function useWeather(
   location: WeatherLocation,
-  opts?: { active?: boolean }
+  opts?: { active?: boolean; locale?: string }
 ): UseWeatherResult {
   const active = opts?.active ?? true;
+  const locale = opts?.locale;
   const locKind = location.kind;
   const locLat = location.kind === "coords" ? location.lat : undefined;
   const locLon = location.kind === "coords" ? location.lon : undefined;
@@ -73,10 +74,13 @@ export function useWeather(
       locKind === "coords"
         ? { kind: "coords", lat: locLat as number, lon: locLon as number }
         : { kind: "geo" };
-    ensureWeather(loc);
-    const id = window.setInterval(() => ensureWeather(loc), WEATHER_TTL_MS);
+    ensureWeather(loc, { locale });
+    const id = window.setInterval(
+      () => ensureWeather(loc, { locale }),
+      WEATHER_TTL_MS
+    );
     return () => window.clearInterval(id);
-  }, [active, locKind, locLat, locLon, ensureWeather]);
+  }, [active, locKind, locLat, locLon, ensureWeather, locale]);
 
   return {
     snapshot,

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1824,6 +1824,19 @@
       "timezoneAutomaticCity": "Auto ({{city}})",
       "timezoneNoResults": "Keine passenden Zeitzonen",
       "timezoneSearchPlaceholder": "Zeitzonen suchen…",
+      "timezoneRegions": {
+        "africa": "Afrika",
+        "america": "Amerika",
+        "antarctica": "Antarktis",
+        "arctic": "Arktis",
+        "asia": "Asien",
+        "atlantic": "Atlantik",
+        "australia": "Australien",
+        "europe": "Europa",
+        "indian": "Indischer Ozean",
+        "pacific": "Pazifik",
+        "other": "Andere"
+      },
       "toolbar": {
         "back": "Zurück",
         "forward": "Vorwärts",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -2916,6 +2916,19 @@
       "timezoneAutomaticCity": "Auto ({{city}})",
       "timezoneSearchPlaceholder": "Search time zones…",
       "timezoneNoResults": "No matching time zones",
+      "timezoneRegions": {
+        "africa": "Africa",
+        "america": "Americas",
+        "antarctica": "Antarctica",
+        "arctic": "Arctic",
+        "asia": "Asia",
+        "atlantic": "Atlantic",
+        "australia": "Australia",
+        "europe": "Europe",
+        "indian": "Indian Ocean",
+        "pacific": "Pacific",
+        "other": "Other"
+      },
       "internationalTabs": {
         "language": "Language",
         "dateTime": "Date & Time"

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1824,6 +1824,19 @@
       "timezoneAutomaticCity": "Auto ({{city}})",
       "timezoneNoResults": "No hay zonas horarias coincidentes",
       "timezoneSearchPlaceholder": "Buscar husos horarios…",
+      "timezoneRegions": {
+        "africa": "África",
+        "america": "Américas",
+        "antarctica": "Antártida",
+        "arctic": "Ártico",
+        "asia": "Asia",
+        "atlantic": "Atlántico",
+        "australia": "Australia",
+        "europe": "Europa",
+        "indian": "Océano Índico",
+        "pacific": "Pacífico",
+        "other": "Otro"
+      },
       "toolbar": {
         "back": "Atrás",
         "forward": "Adelante",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1824,6 +1824,19 @@
       "timezoneAutomaticCity": "Auto ({{city}})",
       "timezoneNoResults": "Aucun fuseau horaire correspondant",
       "timezoneSearchPlaceholder": "Rechercher des fuseaux horaires…",
+      "timezoneRegions": {
+        "africa": "Afrique",
+        "america": "Amériques",
+        "antarctica": "Antarctique",
+        "arctic": "Arctique",
+        "asia": "Asie",
+        "atlantic": "Atlantique",
+        "australia": "Australie",
+        "europe": "Europe",
+        "indian": "Océan Indien",
+        "pacific": "Pacifique",
+        "other": "Autre"
+      },
       "toolbar": {
         "back": "Précédent",
         "forward": "Suivant",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1824,6 +1824,19 @@
       "timezoneAutomaticCity": "Auto ({{city}})",
       "timezoneNoResults": "Nessun fuso orario corrispondente",
       "timezoneSearchPlaceholder": "Cerca fusi orari…",
+      "timezoneRegions": {
+        "africa": "Africa",
+        "america": "Americhe",
+        "antarctica": "Antartide",
+        "arctic": "Artico",
+        "asia": "Asia",
+        "atlantic": "Atlantico",
+        "australia": "Australia",
+        "europe": "Europa",
+        "indian": "Oceano Indiano",
+        "pacific": "Pacifico",
+        "other": "Altro"
+      },
       "toolbar": {
         "back": "Indietro",
         "forward": "Avanti",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1824,6 +1824,19 @@
       "timezoneAutomaticCity": "自動 ({{city}})",
       "timezoneNoResults": "一致するタイムゾーンがありません",
       "timezoneSearchPlaceholder": "タイムゾーンを検索…",
+      "timezoneRegions": {
+        "africa": "アフリカ",
+        "america": "アメリカ大陸",
+        "antarctica": "南極",
+        "arctic": "北極",
+        "asia": "アジア",
+        "atlantic": "大西洋",
+        "australia": "オーストラリア",
+        "europe": "ヨーロッパ",
+        "indian": "インド洋",
+        "pacific": "太平洋",
+        "other": "その他"
+      },
       "toolbar": {
         "back": "戻る",
         "forward": "進む",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1824,6 +1824,19 @@
       "timezoneAutomaticCity": "자동({{city}})",
       "timezoneNoResults": "일치하는 시간대 없음",
       "timezoneSearchPlaceholder": "시간대 검색…",
+      "timezoneRegions": {
+        "africa": "아프리카",
+        "america": "아메리카",
+        "antarctica": "남극",
+        "arctic": "북극",
+        "asia": "아시아",
+        "atlantic": "대서양",
+        "australia": "오스트레일리아",
+        "europe": "유럽",
+        "indian": "인도양",
+        "pacific": "태평양",
+        "other": "기타"
+      },
       "toolbar": {
         "back": "뒤로",
         "forward": "앞으로",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1824,6 +1824,19 @@
       "timezoneAutomaticCity": "Auto ({{city}})",
       "timezoneNoResults": "Nenhum fuso horário correspondente",
       "timezoneSearchPlaceholder": "Pesquisar fusos horários…",
+      "timezoneRegions": {
+        "africa": "África",
+        "america": "Américas",
+        "antarctica": "Antártida",
+        "arctic": "Ártico",
+        "asia": "Ásia",
+        "atlantic": "Atlântico",
+        "australia": "Austrália",
+        "europe": "Europa",
+        "indian": "Oceano Índico",
+        "pacific": "Pacífico",
+        "other": "Outro"
+      },
       "toolbar": {
         "back": "Voltar",
         "forward": "Avançar",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1824,6 +1824,19 @@
       "timezoneAutomaticCity": "Авто ({{city}})",
       "timezoneNoResults": "Нет подходящих часовых поясов",
       "timezoneSearchPlaceholder": "Поиск часовых поясов…",
+      "timezoneRegions": {
+        "africa": "Африка",
+        "america": "Америка",
+        "antarctica": "Антарктика",
+        "arctic": "Арктика",
+        "asia": "Азия",
+        "atlantic": "Атлантика",
+        "australia": "Австралия",
+        "europe": "Европа",
+        "indian": "Индийский океан",
+        "pacific": "Тихий океан",
+        "other": "Другое"
+      },
       "toolbar": {
         "back": "Назад",
         "forward": "Вперед",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1824,6 +1824,19 @@
       "timezoneAutomaticCity": "自動 ({{city}})",
       "timezoneNoResults": "沒有相符的時區",
       "timezoneSearchPlaceholder": "搜尋時區…",
+      "timezoneRegions": {
+        "africa": "非洲",
+        "america": "美洲",
+        "antarctica": "南極洲",
+        "arctic": "北極",
+        "asia": "亞洲",
+        "atlantic": "大西洋",
+        "australia": "澳洲",
+        "europe": "歐洲",
+        "indian": "印度洋",
+        "pacific": "太平洋",
+        "other": "其他"
+      },
       "toolbar": {
         "back": "返回",
         "forward": "前進",

--- a/src/lib/timezoneConfig.ts
+++ b/src/lib/timezoneConfig.ts
@@ -195,9 +195,39 @@ const REGION_SEARCH_ALIASES: Record<string, string> = {
   Pacific: "pacific oceania",
 };
 
+const TIMEZONE_REGION_KEYS: Record<string, string> = {
+  Africa: "africa",
+  America: "america",
+  Antarctica: "antarctica",
+  Arctic: "arctic",
+  Asia: "asia",
+  Atlantic: "atlantic",
+  Australia: "australia",
+  Europe: "europe",
+  Indian: "indian",
+  Pacific: "pacific",
+  Other: "other",
+};
+
+const TIMEZONE_REGION_FALLBACKS: Record<string, string> = {
+  Africa: "Africa",
+  America: "Americas",
+  Antarctica: "Antarctica",
+  Arctic: "Arctic",
+  Asia: "Asia",
+  Atlantic: "Atlantic",
+  Australia: "Australia",
+  Europe: "Europe",
+  Indian: "Indian Ocean",
+  Pacific: "Pacific",
+  Other: "Other",
+};
+
 /** Zones treated as southern-hemisphere for map click tie-breaking. */
 const SOUTHERN_HEMISPHERE_HINT =
   /Argentina|Santiago|Sao_Paulo|Montevideo|Asuncion|La_Paz|Lima|Sydney|Melbourne|Brisbane|Adelaide|Darwin|Perth|Hobart|Auckland|Fiji|Johannesburg|Buenos_Aires|Antarctica|Easter|Rarotonga|Tahiti|Apia|Tongatapu|Norfolk|Lord_Howe|Chatham|Enderbury|Fakaofo|Kiritimati/i;
+
+type TranslationFn = (key: string, opts?: Record<string, unknown>) => string;
 
 /** The browser's resolved IANA timezone, or "UTC" when unavailable. */
 export function getBrowserTimezone(): string {
@@ -274,13 +304,62 @@ export function formatTimezoneCity(tz: string): string {
   return city.replace(/_/g, " ");
 }
 
+function isEnglishLocale(locale: string | undefined): boolean {
+  return !locale || locale.toLowerCase().startsWith("en");
+}
+
+function getLocalizedTimezoneName(
+  tz: string,
+  locale: string | undefined,
+  date = new Date()
+): string | null {
+  if (!locale || isEnglishLocale(locale)) return null;
+  try {
+    const parts = new Intl.DateTimeFormat(locale, {
+      timeZone: tz,
+      timeZoneName: "longGeneric",
+    }).formatToParts(date);
+    const value = parts.find((p) => p.type === "timeZoneName")?.value?.trim();
+    if (!value || /^GMT|^UTC/i.test(value)) return null;
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Locale-aware timezone display label. English keeps the classic principal-city
+ * label, while other locales use CLDR timezone names when available.
+ */
+export function formatTimezoneCityLocalized(
+  tz: string,
+  locale: string | undefined,
+  date = new Date()
+): string {
+  return getLocalizedTimezoneName(tz, locale, date) ?? formatTimezoneCity(tz);
+}
+
+export function formatTimezoneRegionLocalized(
+  region: string,
+  t?: TranslationFn
+): string {
+  const normalized = region || "Other";
+  const key = TIMEZONE_REGION_KEYS[normalized] ?? "other";
+  const fallback = TIMEZONE_REGION_FALLBACKS[normalized] ?? normalized;
+  if (!t) return fallback;
+  const translationKey = `apps.control-panels.timezoneRegions.${key}`;
+  const translated = t(translationKey);
+  return translated && translated !== translationKey ? translated : fallback;
+}
+
 /**
  * Short / long timezone names from Intl (e.g. PDT, PST, Pacific Daylight Time)
  * sampled in winter and summer so DST abbreviations are both searchable.
  */
 export function getTimezoneNameVariants(
   tz: string,
-  date = new Date()
+  date = new Date(),
+  locale = "en-US"
 ): string[] {
   const year = date.getUTCFullYear();
   const samples = [
@@ -298,7 +377,7 @@ export function getTimezoneNameVariants(
   for (const sample of samples) {
     for (const timeZoneName of styles) {
       try {
-        const parts = new Intl.DateTimeFormat("en-US", {
+        const parts = new Intl.DateTimeFormat(locale, {
           timeZone: tz,
           timeZoneName,
         }).formatToParts(sample);
@@ -316,17 +395,27 @@ export function getTimezoneNameVariants(
  * Lowercased search blob for combobox filtering: IANA path, city segments,
  * region, GMT/UTC offsets, Intl abbreviations (PDT/PST…), and country aliases.
  */
-export function buildTimezoneSearchText(tz: string, date = new Date()): string {
+export function buildTimezoneSearchText(
+  tz: string,
+  date = new Date(),
+  locale?: string
+): string {
   const slash = tz.indexOf("/");
   const region = slash === -1 ? "" : tz.slice(0, slash);
   const segments = tz.split("/").map((s) => s.replace(/_/g, " "));
   const city = formatTimezoneCity(tz);
+  const localizedCity = formatTimezoneCityLocalized(tz, locale, date);
   const offset = getTimezoneOffsetMinutes(tz, date);
   const offsetLabel = formatOffsetLabel(offset);
   const hours = offset / 60;
   const hourToken =
     Number.isInteger(hours) ? String(hours) : hours.toFixed(1).replace(/\.0$/, "");
-  const variants = getTimezoneNameVariants(tz, date);
+  const variants = new Set([
+    ...getTimezoneNameVariants(tz, date, "en-US"),
+    ...(locale && !isEnglishLocale(locale)
+      ? getTimezoneNameVariants(tz, date, locale)
+      : []),
+  ]);
   const alias = TIMEZONE_SEARCH_ALIASES[tz] ?? "";
   const regionAlias = region ? (REGION_SEARCH_ALIASES[region] ?? "") : "";
 
@@ -335,6 +424,7 @@ export function buildTimezoneSearchText(tz: string, date = new Date()): string {
     tz.replace(/\//g, " "),
     ...segments,
     city,
+    localizedCity,
     region,
     regionAlias,
     alias,

--- a/src/lib/weather/openMeteo.ts
+++ b/src/lib/weather/openMeteo.ts
@@ -13,7 +13,11 @@ export function getWeatherEmoji(code: number, isDay = true): string {
   return isDay ? "🌤️" : "☁️";
 }
 
-type WeatherPayload = Omit<WeatherSnapshot, "city">;
+type WeatherPayload = Omit<WeatherSnapshot, "city" | "cityLocale">;
+
+function languageHeaders(locale?: string): HeadersInit | undefined {
+  return locale ? { "Accept-Language": locale } : undefined;
+}
 
 export async function fetchWeatherPayload(
   lat: number,
@@ -45,11 +49,13 @@ export async function fetchWeatherPayload(
 
 export async function reverseGeocodeCity(
   lat: number,
-  lon: number
+  lon: number,
+  locale?: string
 ): Promise<string | null> {
   try {
     const res = await fetch(
-      `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=json&zoom=10`
+      `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=json&zoom=10`,
+      { headers: languageHeaders(locale) }
     );
     if (!res.ok) return null;
     const data = await res.json();
@@ -67,14 +73,15 @@ export async function reverseGeocodeCity(
 
 export async function searchCities(
   query: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  locale?: string
 ): Promise<CityResult[]> {
   if (query.length < 2) return [];
   const res = await fetch(
     `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(
       query
     )}&format=json&limit=6&addressdetails=1&featuretype=city`,
-    { signal }
+    { signal, headers: languageHeaders(locale) }
   );
   if (!res.ok) return [];
   const data = await res.json();

--- a/src/lib/weather/types.ts
+++ b/src/lib/weather/types.ts
@@ -37,6 +37,7 @@ export interface WeatherSnapshot {
   isDay: boolean;
   daily: WeatherSnapshotDaily;
   city: string | null;
+  cityLocale?: string | null;
   lat: number;
   lon: number;
   fetchedAt: number;

--- a/src/stores/useWeatherStore.ts
+++ b/src/stores/useWeatherStore.ts
@@ -28,7 +28,7 @@ export interface WeatherStoreState {
   errors: Record<string, string>;
   ensureWeather: (
     location: WeatherLocation,
-    opts?: { force?: boolean }
+    opts?: { force?: boolean; locale?: string }
   ) => void;
 }
 
@@ -55,23 +55,37 @@ function setError(key: string, message: string) {
   }));
 }
 
-function refresh(lat: number, lon: number, force = false) {
+function refresh(
+  lat: number,
+  lon: number,
+  force = false,
+  locale?: string
+) {
   const key = coordKey(lat, lon);
   const existing = useWeatherStore.getState().entries[key];
   const isFresh = existing && Date.now() - existing.fetchedAt <= WEATHER_TTL_MS;
-  if (!force && isFresh) return;
+  const sfFallback = isSfCoords(lat, lon);
+  const cityLocale = locale ?? null;
+  const needsCityLocale =
+    !sfFallback && !!locale && existing?.cityLocale !== cityLocale;
+  if (!force && isFresh && !needsCityLocale) return;
   if (inFlight.has(key)) return;
 
-  const sfFallback = isSfCoords(lat, lon);
   const promise = (async () => {
     const payload = await fetchWeatherPayload(lat, lon);
-    const prevCity = useWeatherStore.getState().entries[key]?.city ?? null;
-    setEntry(key, { ...payload, city: sfFallback ? null : prevCity });
-    if (!sfFallback && !prevCity) {
-      const city = await reverseGeocodeCity(lat, lon);
+    const previous = useWeatherStore.getState().entries[key];
+    const prevCity = previous?.city ?? null;
+    const prevCityLocale = previous?.cityLocale ?? null;
+    setEntry(key, {
+      ...payload,
+      city: sfFallback ? null : prevCity,
+      cityLocale: sfFallback ? null : prevCityLocale,
+    });
+    if (!sfFallback && (!prevCity || prevCityLocale !== cityLocale)) {
+      const city = await reverseGeocodeCity(lat, lon, locale);
       if (city) {
         const cur = useWeatherStore.getState().entries[key];
-        if (cur) setEntry(key, { ...cur, city });
+        if (cur) setEntry(key, { ...cur, city, cityLocale });
       }
     }
   })()
@@ -87,11 +101,11 @@ function refresh(lat: number, lon: number, force = false) {
   inFlight.set(key, promise);
 }
 
-function resolveGeoThenFetch(force: boolean) {
+function resolveGeoThenFetch(force: boolean, locale?: string) {
   if (geoResolving) return;
   if (typeof navigator === "undefined" || !navigator.geolocation) {
     useWeatherStore.setState({ geoFailed: true });
-    refresh(SF_LAT, SF_LON, force);
+    refresh(SF_LAT, SF_LON, force, locale);
     return;
   }
   geoResolving = true;
@@ -103,12 +117,12 @@ function resolveGeoThenFetch(force: boolean) {
         geoCoords: { lat: latitude, lon: longitude },
         geoFailed: false,
       });
-      refresh(latitude, longitude, force);
+      refresh(latitude, longitude, force, locale);
     },
     () => {
       geoResolving = false;
       useWeatherStore.setState({ geoFailed: true });
-      refresh(SF_LAT, SF_LON, force);
+      refresh(SF_LAT, SF_LON, force, locale);
     },
     { timeout: 10000, maximumAge: WEATHER_TTL_MS }
   );
@@ -116,7 +130,7 @@ function resolveGeoThenFetch(force: boolean) {
 
 // Re-resolve the device position in the background (no prompt when permission
 // was already granted) and re-key if it moved materially.
-function refreshDevicePosition() {
+function refreshDevicePosition(locale?: string) {
   if (typeof navigator === "undefined" || !navigator.geolocation) return;
   const now = Date.now();
   if (now - lastGeoRefreshAt < WEATHER_TTL_MS) return;
@@ -129,7 +143,7 @@ function refreshDevicePosition() {
         useWeatherStore.setState({
           geoCoords: { lat: latitude, lon: longitude },
         });
-        refresh(latitude, longitude, false);
+        refresh(latitude, longitude, false, locale);
       }
     },
     () => {},
@@ -146,22 +160,23 @@ export const useWeatherStore = create<WeatherStoreState>()(
       errors: {},
       ensureWeather: (location, opts) => {
         const force = opts?.force ?? false;
+        const locale = opts?.locale;
         if (location.kind === "coords") {
-          refresh(location.lat, location.lon, force);
+          refresh(location.lat, location.lon, force, locale);
           return;
         }
         if (typeof navigator === "undefined") {
           useWeatherStore.setState({ geoFailed: true });
-          refresh(SF_LAT, SF_LON, force);
+          refresh(SF_LAT, SF_LON, force, locale);
           return;
         }
         const persisted = get().geoCoords;
         if (persisted) {
-          refresh(persisted.lat, persisted.lon, force);
-          refreshDevicePosition();
+          refresh(persisted.lat, persisted.lon, force, locale);
+          refreshDevicePosition(locale);
           return;
         }
-        resolveGeoThenFetch(force);
+        resolveGeoThenFetch(force, locale);
       },
     }),
     {

--- a/src/utils/formatCountryDisplay.ts
+++ b/src/utils/formatCountryDisplay.ts
@@ -1,0 +1,33 @@
+function isLikelyIsoAlpha2(value: string): boolean {
+  return /^[A-Za-z]{2}$/.test(value);
+}
+
+function countryCodeToFlagEmoji(code: string): string {
+  const upper = code.toUpperCase();
+  if (!/^[A-Z]{2}$/.test(upper)) return "";
+  const A = 0x1f1e6;
+  const codePoints = [
+    A + (upper.charCodeAt(0) - "A".charCodeAt(0)),
+    A + (upper.charCodeAt(1) - "A".charCodeAt(0)),
+  ];
+  return String.fromCodePoint(...codePoints);
+}
+
+export function formatCountryDisplay(
+  raw: string,
+  locale: string
+): { flag: string; name: string } {
+  const trimmed = raw.trim();
+  if (isLikelyIsoAlpha2(trimmed)) {
+    const code = trimmed.toUpperCase();
+    let name = code;
+    try {
+      const display = new Intl.DisplayNames([locale], { type: "region" });
+      name = display.of(code) ?? code;
+    } catch {
+      name = code;
+    }
+    return { flag: countryCodeToFlagEmoji(code), name };
+  }
+  return { flag: "", name: trimmed };
+}

--- a/tests/test-format-country-display.test.ts
+++ b/tests/test-format-country-display.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { formatCountryDisplay } from "../src/utils/formatCountryDisplay";
+
+describe("formatCountryDisplay", () => {
+  test("localizes ISO alpha-2 country codes", () => {
+    expect(formatCountryDisplay("JP", "en").name).toBe("Japan");
+    expect(formatCountryDisplay("JP", "ja").name).toBe("日本");
+  });
+
+  test("passes through non-ISO country labels", () => {
+    expect(formatCountryDisplay("Atlantis", "en")).toEqual({
+      flag: "",
+      name: "Atlantis",
+    });
+  });
+});

--- a/tests/test-timezone-config.test.ts
+++ b/tests/test-timezone-config.test.ts
@@ -7,6 +7,8 @@ import {
   formatInTimeZone,
   formatOffsetLabel,
   formatTimezoneCity,
+  formatTimezoneCityLocalized,
+  formatTimezoneRegionLocalized,
   formatZonedDateString,
   getSupportedTimezones,
   getTimezoneNameVariants,
@@ -43,6 +45,27 @@ describe("timezoneConfig", () => {
       "Buenos Aires"
     );
     expect(formatTimezoneCity("UTC")).toBe("UTC");
+  });
+
+  test("formatTimezoneCityLocalized uses localized timezone names when available", () => {
+    expect(formatTimezoneCityLocalized("Asia/Tokyo", "en")).toBe("Tokyo");
+    const localized = formatTimezoneCityLocalized(
+      "Asia/Tokyo",
+      "ja",
+      new Date("2023-01-15T12:00:00Z")
+    );
+    expect(localized).toContain("日本");
+  });
+
+  test("formatTimezoneRegionLocalized reads translated region labels", () => {
+    const t = (key: string) =>
+      key === "apps.control-panels.timezoneRegions.america"
+        ? "Americas translated"
+        : key;
+    expect(formatTimezoneRegionLocalized("America", t)).toBe(
+      "Americas translated"
+    );
+    expect(formatTimezoneRegionLocalized("Unknown")).toBe("Unknown");
   });
 
   test("getTimezoneOffsetMinutes computes fixed offsets", () => {
@@ -145,6 +168,17 @@ describe("timezoneConfig", () => {
     );
     expect(text).toContain("usa");
     expect(text).toContain("california");
+  });
+
+  test("buildTimezoneSearchText preserves English aliases and adds localized names", () => {
+    const text = buildTimezoneSearchText(
+      "Asia/Tokyo",
+      new Date("2023-01-15T12:00:00Z"),
+      "ja"
+    );
+    expect(text).toContain("tokyo");
+    expect(text).toContain("japan");
+    expect(text).toContain("日本");
   });
 
   test("getTimezoneCoordinates uses principal city when known", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Localizes timezone display labels/search terms and timezone region descriptions in the International pane.
- Localizes dashboard clock/weather city picker country names and geocoding requests using the active UI language.
- Adds translated timezone region labels across supported locale files.
- Adds coverage for localized timezone search/labels and shared country display formatting.

### Testing
- `bun test tests/test-timezone-config.test.ts`
- `bun run i18n:sync:dry-run`
- `bun run build`
- `bun test tests/test-timezone-config.test.ts tests/test-format-country-display.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f06d6-90ea-75df-b40a-07de6ed05a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f06d6-90ea-75df-b40a-07de6ed05a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

