### PR TITLE
Make appearance preview tabs match the real settings tab group

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/AppearanceMacosxPreviewScene.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AppearanceMacosxPreviewScene.tsx
@@ -10,6 +10,7 @@ import {
   isDynamicWallpaper,
 } from "@/utils/dynamicWallpaper";
 import { cn } from "@/lib/utils";
+import { AppearancePreviewTabGroup } from "./AppearancePreviewTabGroup";
 
 const noopClick = () => {};
 
@@ -175,39 +176,19 @@ export function AppearanceMacosxPreviewScene({
               </div>
 
               <div className="window-body control-panels-theme-preview-window-body-live flex min-h-0 flex-1 flex-col">
-                <div
-                  className="aqua-tab-bar control-panels-theme-preview-tab-bar-live"
-                  role="tablist"
-                >
-                  <button
-                    type="button"
-                    className="aqua-tab"
-                    data-state="active"
-                    tabIndex={-1}
+                <AppearancePreviewTabGroup t={t}>
+                  <div
+                    className="control-panels-theme-preview-list-live"
+                    style={listStyle}
                   >
-                    {t("apps.control-panels.themePreviewTabs.general")}
-                  </button>
-                  <button
-                    type="button"
-                    className="aqua-tab"
-                    data-state="inactive"
-                    tabIndex={-1}
-                  >
-                    {t("apps.control-panels.themePreviewTabs.sharing")}
-                  </button>
-                </div>
-
-                <div
-                  className="control-panels-theme-preview-list-live"
-                  style={listStyle}
-                >
-                  <div className="control-panels-theme-preview-list-row-live">
-                    {t("apps.control-panels.themePreviewFirstItem")}
+                    <div className="control-panels-theme-preview-list-row-live">
+                      {t("apps.control-panels.themePreviewFirstItem")}
+                    </div>
+                    <div className="control-panels-theme-preview-list-row-live control-panels-theme-preview-list-row-live-selected">
+                      {t("apps.control-panels.themePreviewSelectedItem")}
+                    </div>
                   </div>
-                  <div className="control-panels-theme-preview-list-row-live control-panels-theme-preview-list-row-live-selected">
-                    {t("apps.control-panels.themePreviewSelectedItem")}
-                  </div>
-                </div>
+                </AppearancePreviewTabGroup>
               </div>
             </div>
       </div>

--- a/src/apps/control-panels/components/control-panels-app/AppearancePreviewTabGroup.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AppearancePreviewTabGroup.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { useControlPanelsTabClasses } from "./useControlPanelsTabClasses";
+
+export type AppearancePreviewTabGroupProps = {
+  t: (key: string, opts?: Record<string, unknown>) => string;
+  /** Tab-panel content (the preview list). */
+  children: ReactNode;
+};
+
+/**
+ * Renders a faithful, non-interactive copy of the Control Panels preference
+ * tab group (tab strip + content well) inside the Appearance theme preview.
+ *
+ * It reuses the exact same class hooks the real preference panes use
+ * (`control-panels-pref-tab-bar` + `useControlPanelsTabClasses`, and a
+ * `control-panels-pref-well`), so the preview tabs read identically to the
+ * live settings tabs in every theme — centered Aqua tabs with a bordered well,
+ * System 7 framed tabs, Windows XP/98 folder tabs, etc.
+ */
+export function AppearancePreviewTabGroup({
+  t,
+  children,
+}: AppearancePreviewTabGroupProps) {
+  const { barClassName, triggerClassName, triggerStyle } =
+    useControlPanelsTabClasses();
+
+  return (
+    <div className="control-panels-theme-preview-tabbed">
+      <div
+        role="tablist"
+        className={cn("control-panels-pref-tab-bar", barClassName)}
+        aria-hidden="true"
+      >
+        <button
+          type="button"
+          role="tab"
+          className={triggerClassName}
+          style={triggerStyle}
+          data-state="active"
+          tabIndex={-1}
+        >
+          {t("apps.control-panels.themePreviewTabs.general")}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          className={triggerClassName}
+          style={triggerStyle}
+          data-state="inactive"
+          tabIndex={-1}
+        >
+          {t("apps.control-panels.themePreviewTabs.sharing")}
+        </button>
+      </div>
+      <div className="control-panels-pref-well control-panels-theme-preview-tab-well">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/apps/control-panels/components/control-panels-app/AppearanceThemePreview.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AppearanceThemePreview.tsx
@@ -7,6 +7,7 @@ import {
   type AccentId,
 } from "@/themes/accents";
 import { AppearanceMacosxPreviewScene } from "./AppearanceMacosxPreviewScene";
+import { AppearancePreviewTabGroup } from "./AppearancePreviewTabGroup";
 
 function subscribeSystemDark(onStoreChange: () => void) {
   const mq = window.matchMedia("(prefers-color-scheme: dark)");
@@ -128,17 +129,16 @@ function System7ThemePreview({ t }: { t: AppearanceThemePreviewProps["t"] }) {
           </span>
         </div>
         <div className="control-panels-theme-preview-window-body">
-          <div className="control-panels-theme-preview-list">
-            <div className="control-panels-theme-preview-list-row control-panels-theme-preview-list-row-selected">
-              {t("apps.control-panels.themePreviewSelectedItem")}
+          <AppearancePreviewTabGroup t={t}>
+            <div className="control-panels-theme-preview-list">
+              <div className="control-panels-theme-preview-list-row control-panels-theme-preview-list-row-selected">
+                {t("apps.control-panels.themePreviewSelectedItem")}
+              </div>
+              <div className="control-panels-theme-preview-list-row">
+                {t("apps.control-panels.themePreviewOtherItem")}
+              </div>
             </div>
-            <div className="control-panels-theme-preview-list-row">
-              {t("apps.control-panels.themePreviewOtherItem")}
-            </div>
-          </div>
-          <button type="button" className="control-panels-theme-preview-s7-button" tabIndex={-1}>
-            {t("apps.control-panels.themePreviewButton")}
-          </button>
+          </AppearancePreviewTabGroup>
         </div>
       </div>
     </div>
@@ -160,17 +160,16 @@ function XpThemePreview({ t }: { t: AppearanceThemePreviewProps["t"] }) {
           </div>
         </div>
         <div className="control-panels-theme-preview-window-body">
-          <div className="control-panels-theme-preview-list">
-            <div className="control-panels-theme-preview-list-row control-panels-theme-preview-list-row-selected">
-              {t("apps.control-panels.themePreviewSelectedItem")}
+          <AppearancePreviewTabGroup t={t}>
+            <div className="control-panels-theme-preview-list">
+              <div className="control-panels-theme-preview-list-row control-panels-theme-preview-list-row-selected">
+                {t("apps.control-panels.themePreviewSelectedItem")}
+              </div>
+              <div className="control-panels-theme-preview-list-row">
+                {t("apps.control-panels.themePreviewOtherItem")}
+              </div>
             </div>
-            <div className="control-panels-theme-preview-list-row">
-              {t("apps.control-panels.themePreviewOtherItem")}
-            </div>
-          </div>
-          <button type="button" className="control-panels-theme-preview-xp-button" tabIndex={-1}>
-            {t("apps.control-panels.themePreviewButton")}
-          </button>
+          </AppearancePreviewTabGroup>
         </div>
       </div>
     </div>
@@ -192,17 +191,16 @@ function Win98ThemePreview({ t }: { t: AppearanceThemePreviewProps["t"] }) {
           </div>
         </div>
         <div className="control-panels-theme-preview-window-body">
-          <div className="control-panels-theme-preview-list">
-            <div className="control-panels-theme-preview-list-row control-panels-theme-preview-list-row-selected">
-              {t("apps.control-panels.themePreviewSelectedItem")}
+          <AppearancePreviewTabGroup t={t}>
+            <div className="control-panels-theme-preview-list">
+              <div className="control-panels-theme-preview-list-row control-panels-theme-preview-list-row-selected">
+                {t("apps.control-panels.themePreviewSelectedItem")}
+              </div>
+              <div className="control-panels-theme-preview-list-row">
+                {t("apps.control-panels.themePreviewOtherItem")}
+              </div>
             </div>
-            <div className="control-panels-theme-preview-list-row">
-              {t("apps.control-panels.themePreviewOtherItem")}
-            </div>
-          </div>
-          <button type="button" className="control-panels-theme-preview-98-button" tabIndex={-1}>
-            {t("apps.control-panels.themePreviewButton")}
-          </button>
+          </AppearancePreviewTabGroup>
         </div>
       </div>
     </div>

--- a/src/styles/themes/control-panels-mac.css
+++ b/src/styles/themes/control-panels-mac.css
@@ -1122,18 +1122,6 @@
   color: var(--os-color-selection-text, #fff);
 }
 
-:root[data-os-theme="macosx"] .control-panels-theme-preview-s7-button {
-  margin-top: 6px;
-  padding: 2px 10px;
-  border: 1px solid #000;
-  background: #fff;
-  box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080;
-  font-family: "Geneva-12", monospace;
-  font-size: 9px;
-  color: #000;
-  pointer-events: none;
-}
-
 /* --- Windows XP preview --- */
 :root[data-os-theme="macosx"]
   .control-panels-pref-theme-preview[data-preview-theme="xp"]
@@ -1191,18 +1179,6 @@
   color: #fff;
 }
 
-:root[data-os-theme="macosx"] .control-panels-theme-preview-xp-button {
-  margin-top: 6px;
-  padding: 2px 12px;
-  border: 1px solid #aca899;
-  border-radius: 3px;
-  background: linear-gradient(to bottom, #fff, #ece9d8);
-  box-shadow: inset 0 1px 0 #fff;
-  font-family: Tahoma, sans-serif;
-  font-size: 9px;
-  pointer-events: none;
-}
-
 /* --- Windows 98 preview --- */
 :root[data-os-theme="macosx"]
   .control-panels-pref-theme-preview[data-preview-theme="win98"]
@@ -1251,17 +1227,6 @@
   .control-panels-theme-preview-list-row-selected {
   background: #000080;
   color: #fff;
-}
-
-:root[data-os-theme="macosx"] .control-panels-theme-preview-98-button {
-  margin-top: 6px;
-  padding: 2px 12px;
-  border: 2px solid #000;
-  background: #c0c0c0;
-  box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080;
-  font-family: "MS Sans Serif", Tahoma, sans-serif;
-  font-size: 9px;
-  pointer-events: none;
 }
 
 /* Tabbed preference pane (Desktop | Screen Saver) — tabs on pinstripe, well below.

--- a/src/styles/themes/control-panels-mac.css
+++ b/src/styles/themes/control-panels-mac.css
@@ -825,13 +825,22 @@
   padding: 6px 8px 8px;
 }
 
-:root[data-os-theme="macosx"] .control-panels-theme-preview-tab-bar-live {
-  margin-bottom: 6px;
+/* Faithful preview tab group: reuses the real preference tab strip + well so
+   the tabs read identically to the live settings (centered Aqua tabs, bordered
+   well connected to the strip). */
+:root[data-os-theme="macosx"] .control-panels-theme-preview-tabbed {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
 }
 
-:root[data-os-theme="macosx"] .control-panels-theme-preview-tab-bar-live .aqua-tab {
-  font-size: 11px;
-  padding: 3px 10px 4px;
+/* Connect the well to the tab bar: square top corners sit flush under tabs. */
+:root[data-os-theme="macosx"]
+  .control-panels-mac-pane-inner
+  .control-panels-pref-well.control-panels-theme-preview-tab-well {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 :root[data-os-theme="macosx"] .control-panels-theme-preview-list-live {
@@ -1029,35 +1038,6 @@
   .control-panels-pref-theme-preview[data-preview-theme="macosx"][data-preview-dark="true"][data-preview-aqua-material="glass"]
   .control-panels-theme-preview-window-body {
   background: rgba(0, 0, 0, 0.28);
-}
-
-:root[data-os-theme="macosx"] .control-panels-theme-preview-tab-bar {
-  display: flex;
-  gap: 2px;
-  align-items: flex-end;
-  margin-bottom: 6px;
-  padding-bottom: 1px;
-  border-bottom: 2px solid #8ab4f0;
-}
-
-:root[data-os-theme="macosx"] .control-panels-theme-preview-tab {
-  padding: 3px 10px 4px;
-  border-radius: 4px 4px 0 0;
-  border: 1px solid rgba(0, 0, 0, 0.18);
-  border-bottom: none;
-  background: linear-gradient(to bottom, #f0f0f0, #d8d8d8);
-  color: #333;
-  font-size: 9px;
-}
-
-:root[data-os-theme="macosx"] .control-panels-theme-preview-tab-active {
-  background: linear-gradient(#2765ca, #4a85d9, #8ab4f0);
-  border-color: #8ab4f0;
-  color: #fff;
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.35);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.35),
-    0 1px 2px rgba(39, 101, 202, 0.35);
 }
 
 :root[data-os-theme="macosx"] .control-panels-theme-preview-list-row {

--- a/src/styles/themes/control-panels-themed.css
+++ b/src/styles/themes/control-panels-themed.css
@@ -969,20 +969,6 @@
 }
 
 /* System 7 default push button — rounded rect with a bold default ring. */
-:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-s7-button {
-  align-self: flex-start;
-  margin-top: 6px;
-  padding: 1px 12px;
-  border: 1px solid #000;
-  border-radius: 8px;
-  background: #fff;
-  box-shadow: 0 0 0 1px #fff, 0 0 0 2px #000;
-  font-family: "Geneva-12", monospace;
-  font-size: 9px;
-  color: #000;
-  pointer-events: none;
-}
-
 /* --- Windows XP mock --- Luna: rounded blue title bar with a glossy top
    highlight, real caption buttons, ECE9D8 body, a sunken white listbox. --- */
 :root:not([data-os-theme="macosx"])
@@ -1070,25 +1056,6 @@
   .control-panels-theme-preview-list-row-selected {
   background: #316ac5;
   color: #fff;
-}
-
-:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-xp-button {
-  align-self: flex-start;
-  margin-top: 6px;
-  padding: 2px 12px;
-  border: 1px solid #003c74;
-  border-radius: 3px;
-  background: linear-gradient(
-    to bottom,
-    #fff 0%,
-    #f3f3ee 48%,
-    #e3e1d2 52%,
-    #eceae0 100%
-  );
-  box-shadow: inset 0 0 0 1px #fff;
-  font-family: Tahoma, sans-serif;
-  font-size: 9px;
-  pointer-events: none;
 }
 
 /* --- Windows 98 mock --- raised silver window bevel, navy gradient title bar,
@@ -1189,15 +1156,3 @@
   color: #fff;
 }
 
-:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-98-button {
-  align-self: flex-start;
-  margin-top: 6px;
-  padding: 2px 12px;
-  border: 1px solid #000;
-  background: #c0c0c0;
-  box-shadow: inset 1px 1px 0 #fff, inset -1px -1px 0 #808080,
-    inset 2px 2px 0 #dfdfdf, inset -2px -2px 0 #000;
-  font-family: "MS Sans Serif", Tahoma, sans-serif;
-  font-size: 9px;
-  pointer-events: none;
-}

--- a/src/styles/themes/control-panels-themed.css
+++ b/src/styles/themes/control-panels-themed.css
@@ -830,6 +830,46 @@
   border-radius: 3px;
 }
 
+/* Faithful preview tab group (classic themes): reuse the real preference tab
+   strip + well so the preview tabs read identically to the live settings —
+   System 7 framed tabs over a panel-bg well, Windows XP/98 folder tabs over a
+   connected content field. */
+:root:not([data-os-theme="macosx"]) .control-panels-theme-preview-tabbed {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+}
+
+/* Connect the well to the tab strip (square top corners), mirroring the real
+   `.control-panels-pref-tabbed > .control-panels-pref-well` look per theme. */
+:root[data-os-theme="system7"]
+  .control-panels-mac-pane-inner
+  .control-panels-pref-well.control-panels-theme-preview-tab-well {
+  background: var(--os-color-panel-bg, #e3e3e3);
+  border: 1px solid var(--os-color-separator);
+  border-top: none;
+  box-shadow: none;
+}
+
+:root[data-os-theme="xp"]
+  .control-panels-mac-pane-inner
+  .control-panels-pref-well.control-panels-theme-preview-tab-well {
+  background: #fff;
+  border: 1px solid #919b9c;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+:root[data-os-theme="win98"]
+  .control-panels-mac-pane-inner
+  .control-panels-pref-well.control-panels-theme-preview-tab-well {
+  background: var(--os-color-window-bg, #c0c0c0);
+  border: none;
+  box-shadow: inset 1px 1px 0 #fff, inset 2px 2px 0 #dfdfdf,
+    inset -1px -1px 0 #000, inset -2px -2px 0 #808080;
+}
+
 /* --- System 7 mock --- the menu bar / striped title bar are the real System 7
    window chrome (Chicago menu bar, racing-stripe active title bar with the
    title in a white notch and a square close box). --- */

--- a/tests/test-control-panels-mac-layout.test.ts
+++ b/tests/test-control-panels-mac-layout.test.ts
@@ -747,7 +747,22 @@ describe("Control Panels macOS 10.3 layout", () => {
     );
     expect(macosxSceneSource.includes("useWallpaper")).toBe(true);
     expect(macosxSceneSource.includes("TrafficLightButton")).toBe(true);
-    expect(macosxSceneSource.includes("aqua-tab-bar")).toBe(true);
+    // Tabs are now rendered through the shared preview tab group, which reuses
+    // the real settings tab strip + well so the preview reads identically to
+    // live settings in every theme (centered Aqua tabs with a bordered well).
+    expect(macosxSceneSource.includes("AppearancePreviewTabGroup")).toBe(true);
+    const previewTabGroupSource = readSource(
+      "src/apps/control-panels/components/control-panels-app/AppearancePreviewTabGroup.tsx"
+    );
+    expect(previewTabGroupSource.includes("useControlPanelsTabClasses")).toBe(
+      true
+    );
+    expect(previewTabGroupSource.includes("control-panels-pref-tab-bar")).toBe(
+      true
+    );
+    expect(
+      previewTabGroupSource.includes("control-panels-theme-preview-tab-well")
+    ).toBe(true);
     expect(macosxSceneSource.includes("desktop-background")).toBe(true);
     expect(macosxSceneSource.includes("mac-top-menubar")).toBe(false);
     expect(macosxSceneSource.includes("control-panels-theme-preview-menubar-live")).toBe(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the Control Panels → Appearance theme preview more truthful by rendering its tabs with the **exact same styling as a real settings tab group**, for every theme.

Previously the preview's tab strip used bespoke `-live` styling (left-aligned, no surrounding well), so it didn't match how settings panes actually look. Now the preview reuses the same class hooks the real preference panes use, so:

- **Aqua / Aqua Glass**: tabs are centered and sit on a bordered content well (matching System Preferences).
- **System 7**: framed tabs over a panel-bg well.
- **Windows XP / 98**: folder tabs connected to the content field.

The classic-theme mock previews (System 7 / XP / 98) previously had no tabs at all; they now render the faithful tab group too.

## Changes

- Add `AppearancePreviewTabGroup` — a shared, non-interactive tab group that reuses `control-panels-pref-tab-bar` + `useControlPanelsTabClasses()` and a `control-panels-pref-well`, so it inherits each theme's real tab styling automatically.
- Wire it into the macOS live preview scene and the System 7 / XP / Win98 mock scenes.
- Add preview-scoped CSS to connect the well to the tab strip (square top corners) per theme, mirroring the real `control-panels-pref-tabbed > control-panels-pref-well` look without pulling in pane-level scroll/layout rules.
- Remove obsolete `-live` tab CSS and now-unused mock push-button CSS.
- Update the Appearance-preview wiring test to assert the new shared tab group.

## Verification

Verified the Appearance preview across all themes with a browser (Playwright) capture of the preview element:

![Aqua preview – centered tabs + bordered well](https://cursor.com/artifacts/c/art-f8923e5b-9b7a-4768-ab1a-b418cd5d808f)
![Aqua Glass preview – centered tabs + translucent well](https://cursor.com/artifacts/c/art-c09ef9f2-68fd-48b8-a7de-76a1b2fb08f2)
![System 7 preview – framed tabs over panel well](https://cursor.com/artifacts/c/art-f68227ac-43e3-456f-b154-fd2267c451d4)
![Windows XP preview – folder tabs connected to content](https://cursor.com/artifacts/c/art-ed4559ac-fa81-4ca7-98b2-babf90e4c983)
![Windows 98 preview – silver folder tabs connected to content](https://cursor.com/artifacts/c/art-30f6eb18-40f6-4e45-b1be-71b087c50df4)

Full Appearance pane (Aqua) showing the preview in context:

![Appearance pane with preview](https://cursor.com/artifacts/c/art-ba0f3694-9cc4-4f0d-84fd-5438fd3bd28a)

- `bun test tests/test-control-panels-mac-layout.test.ts` → 25 pass
- `bun run test:unit` → 431 pass
- `tsc --noEmit` → clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f06e8-0aa1-75ef-98a9-c433610d2cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f06e8-0aa1-75ef-98a9-c433610d2cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

