### PR TITLE
perf(textedit): debounce per-keystroke localStorage persistence

### DIFF
--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { JSONContent } from "@tiptap/core";
 import { AppProps } from "@/apps/base/types";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { TextEditMenuBar } from "./TextEditMenuBar";
@@ -35,6 +36,12 @@ import { useMenuShortcuts } from "@/hooks/useMenuShortcuts";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { getTextAnalytics, TEXTEDIT_ANALYTICS, track } from "@/utils/analytics";
 import { openNativeFile } from "@/utils/nativeFileDialogs";
+
+// Debounce window for mirroring the editor content into the persisted store on
+// each keystroke, plus a max wait so continuous typing still snapshots for
+// crash recovery.
+const CONTENT_PERSIST_DEBOUNCE_MS = 500;
+const CONTENT_PERSIST_MAX_WAIT_MS = 2000;
 
 // Inner component that has access to editor context
 function TextEditContent({
@@ -83,6 +90,57 @@ function TextEditContent({
     setContentJson,
     setHasUnsavedChanges,
   } = useTextEditState({ instanceId: instanceId! });
+
+  // The TextEdit store is `persist`-backed, so every `setContentJson` writes all
+  // open documents to localStorage synchronously. Writing on every keystroke
+  // caused typing jank, so the per-keystroke mirror is debounced (with a max
+  // wait so a long uninterrupted typing burst still snapshots periodically for
+  // crash recovery). `lastWrittenJsonRef` records the exact object we persist so
+  // the external-merge effect can tell our own writes apart from genuinely
+  // external updates (AI edits, cloud/file sync) and not fight the user's edits.
+  const lastWrittenJsonRef = useRef<JSONContent | null>(null);
+  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastPersistAtRef = useRef(0);
+
+  const flushContentJson = useCallback(() => {
+    if (persistTimerRef.current !== null) {
+      clearTimeout(persistTimerRef.current);
+      persistTimerRef.current = null;
+    }
+    if (!editor) return;
+    const json = editor.getJSON();
+    lastWrittenJsonRef.current = json;
+    lastPersistAtRef.current = Date.now();
+    setContentJson(json);
+  }, [editor, setContentJson]);
+
+  const scheduleContentJsonPersist = useCallback(() => {
+    // Snapshot immediately if it has been a while (bounds recovery staleness
+    // during continuous typing); otherwise debounce the trailing write.
+    if (Date.now() - lastPersistAtRef.current >= CONTENT_PERSIST_MAX_WAIT_MS) {
+      flushContentJson();
+      return;
+    }
+    if (persistTimerRef.current !== null) {
+      clearTimeout(persistTimerRef.current);
+    }
+    persistTimerRef.current = setTimeout(
+      flushContentJson,
+      CONTENT_PERSIST_DEBOUNCE_MS
+    );
+  }, [flushContentJson]);
+
+  // Flush any pending content snapshot when the editor goes away / unmounts, or
+  // when the page is being hidden/unloaded (reload, tab close, navigation) so a
+  // debounced edit can't be lost from crash-recovery on a fast reload.
+  useEffect(() => {
+    const handlePageHide = () => flushContentJson();
+    window.addEventListener("pagehide", handlePageHide);
+    return () => {
+      window.removeEventListener("pagehide", handlePageHide);
+      flushContentJson();
+    };
+  }, [flushContentJson]);
 
   const {
     handleSave,
@@ -140,9 +198,11 @@ function TextEditContent({
       // "external" meta. Ignore them here so merging cloud/sync/AI updates does
       // not mark the document dirty or fight the user's edits.
       if (transaction?.getMeta("external")) return;
-      // Only mark changes and store latest content/JSON in onUpdate
-      const currentJson = editor.getJSON();
-      setContentJson(currentJson); // Update store JSON for recovery
+      // Mirror the latest content into the (persisted) store for recovery, but
+      // debounced so we don't serialize every open document to localStorage on
+      // every keystroke. The unsaved flag is still flipped immediately so the
+      // title indicator and close confirmation react without delay.
+      scheduleContentJsonPersist();
       if (!hasUnsavedChanges) {
         setHasUnsavedChanges(true);
         console.log(
@@ -162,7 +222,7 @@ function TextEditContent({
   }, [
     editor,
     hasUnsavedChanges,
-    setContentJson,
+    scheduleContentJsonPersist,
     setHasUnsavedChanges,
     instanceId,
     currentFilePath,
@@ -329,6 +389,10 @@ function TextEditContent({
   // Sync editor when contentJson is externally updated (e.g. AI edit tool)
   useEffect(() => {
     if (!editor || !contentJson) return;
+    // Skip our own debounced user-originated writes (matched by reference) so a
+    // slightly-stale persisted snapshot can never be merged back over newer
+    // keystrokes. Genuinely external updates arrive as different objects.
+    if (contentJson === lastWrittenJsonRef.current) return;
 
     const currentJson = editor.getJSON();
     if (JSON.stringify(currentJson) === JSON.stringify(contentJson)) return;

--- a/src/apps/textedit/hooks/useTextEditState.ts
+++ b/src/apps/textedit/hooks/useTextEditState.ts
@@ -17,7 +17,12 @@ export function useTextEditState({ instanceId }: UseTextEditStateProps) {
   const updateTextEditInstance = useTextEditStore(
     (state) => state.updateInstance
   );
-  const textEditInstances = useTextEditStore((state) => state.instances);
+  // Subscribe only to THIS instance, not the whole instances map. Subscribing to
+  // the entire map re-rendered every open TextEdit window whenever any instance
+  // changed (e.g. another window's per-keystroke content write).
+  const currentInstance = useTextEditStore(
+    (state) => state.instances[instanceId] || null
+  );
 
   // Create instance when component mounts
   useEffect(() => {
@@ -30,9 +35,6 @@ export function useTextEditState({ instanceId }: UseTextEditStateProps) {
       removeTextEditInstance(instanceId);
     };
   }, [instanceId, removeTextEditInstance]);
-
-  // Get current instance data
-  const currentInstance = textEditInstances[instanceId] || null;
 
   // Instance state
   const currentFilePath = currentInstance?.filePath || null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continuing the app performance pass (Tier 1). This targets TextEdit typing, which was the highest-frequency hot path I found.

The TextEdit store is `persist`-backed, so the previous code serialized **every open document to `localStorage` on every keystroke** (via `setContentJson` in the editor `update` handler) and `useTextEditState` subscribed to the **entire** `instances` map (so a keystroke in one window re-rendered every open TextEdit window). Both are addressed here without changing behavior.

## Changes

- **Debounce the per-keystroke store mirror** (`TextEditAppComponent.tsx`): mirror editor content into the persisted store with a 500ms trailing debounce plus a 2s max-wait (so a long uninterrupted typing burst still snapshots periodically for crash recovery), and flush on unmount and `pagehide`. The unsaved-changes flag is still flipped immediately so the title indicator / close-confirm react without delay.
- **Reference-guard the external-merge effect**: the effect that merges externally-updated `contentJson` back into the editor now skips our own debounced user writes (matched by object reference), so a slightly-stale snapshot can never be merged back over newer keystrokes. Genuinely external updates (AI edits, cloud/file sync) arrive as different objects and still apply.
- **Narrow the subscription** (`useTextEditState.ts`): subscribe to `state.instances[instanceId]` instead of the whole `instances` map, so one window's edits no longer re-render every open TextEdit window.

## Profiling (measured in-browser)

| Interaction | Before | After |
|---|---|---|
| Type ~44 characters (`localStorage` persists) | ~44 | **2** |

So a typing burst now does ~2 `localStorage` writes instead of one per keystroke (~95% fewer synchronous storage writes).

## Testing

- ✅ `bunx tsc -b`
- ✅ `bunx eslint` on changed files (clean)
- ✅ `bun run test:unit` (426 pass / 0 fail)
- ✅ Manual browser testing (computer-use):
  - Typed multi-line text at speed — text stays stable, **no reverting/glitching** (verifies the reference-guard prevents merge-back).
  - File > Save works correctly (title updates, unsaved indicator clears).
  - Measured 44 keystrokes → 2 persisted writes.

## Note (pre-existing, out of scope)

While verifying, I found that unsaved content in an `Untitled` document is **not** restored after a very fast page reload. I confirmed this happens on `main` too (with my changes stashed), so it's a **pre-existing** recovery gap unrelated to this change, not a regression. Worth a separate look if recovery-on-reload matters.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f06fc-ea6f-7f02-b961-c3ddbfb9052e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f06fc-ea6f-7f02-b961-c3ddbfb9052e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

