### PR TITLE
perf: isolate TV/Videos playback clock from the app tree

### DIFF
--- a/src/apps/tv/components/MtvLyricsOverlay.tsx
+++ b/src/apps/tv/components/MtvLyricsOverlay.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { useShallow } from "zustand/react/shallow";
 import { useLyrics } from "@/hooks/useLyrics";
 import { useIpodStore } from "@/stores/useIpodStore";
+import { useTvPlayedSeconds } from "@/apps/tv/hooks/useTvPlayedSeconds";
 import { cn } from "@/lib/utils";
 import type { LyricLine } from "@/types/lyrics";
 
@@ -17,8 +18,6 @@ interface MtvLyricsOverlayProps {
   title?: string;
   /** Optional artist used as a fallback for the same reason. */
   artist?: string;
-  /** Current playback time, in seconds, from ReactPlayer's onProgress. */
-  playedSeconds: number;
   /** When false, no overlay is rendered. */
   visible: boolean;
   /**
@@ -109,10 +108,14 @@ export function MtvLyricsOverlay({
   songId,
   title,
   artist,
-  playedSeconds,
   visible,
   variant = "windowed",
 }: MtvLyricsOverlayProps) {
+  // Subscribe to the playback clock directly here (the lone leaf that needs
+  // it) so the ~1Hz tick re-renders only this overlay, never the TV tree.
+  // Gating on `visible` opts out of tick re-renders while the caption is
+  // hidden (wrong channel, screen off, buffering, etc.).
+  const playedSeconds = useTvPlayedSeconds(visible);
   // Pull the matching iPod track so we can apply its `lyricOffset`. Using
   // a shallow selector keeps this overlay from re-rendering on unrelated
   // ipod store changes.

--- a/src/apps/tv/components/tv-app/TvAppComponent.tsx
+++ b/src/apps/tv/components/tv-app/TvAppComponent.tsx
@@ -191,7 +191,6 @@ export function TvAppComponent(props: AppProps) {
                       songId={c.currentVideo?.id}
                       title={c.currentVideo?.title}
                       artist={c.currentVideo?.artist}
-                      playedSeconds={c.playedSeconds}
                       visible={
                         !c.screenOff &&
                         !c.poweringOff &&
@@ -289,7 +288,6 @@ export function TvAppComponent(props: AppProps) {
                   songId={c.currentVideo?.id}
                   title={c.currentVideo?.title}
                   artist={c.currentVideo?.artist}
-                  playedSeconds={c.playedSeconds}
                   visible={
                     !c.screenOff &&
                     !c.poweringOff &&

--- a/src/apps/tv/components/tv-app/useTvAppController.tsx
+++ b/src/apps/tv/components/tv-app/useTvAppController.tsx
@@ -62,7 +62,6 @@ export function useTvAppController({
     animationDirection,
     scheduleNowTitle,
     scheduleNextTitle,
-    playedSeconds,
     videoIndex,
   } = useTvLogic({ isWindowOpen, isForeground });
 
@@ -295,7 +294,6 @@ export function useTvAppController({
     animationDirection,
     scheduleNowTitle,
     scheduleNextTitle,
-    playedSeconds,
     videoIndex,
     lcdSlot,
     scheduleAnimDirection,

--- a/src/apps/tv/hooks/useTvLogic.ts
+++ b/src/apps/tv/hooks/useTvLogic.ts
@@ -75,7 +75,6 @@ export function useTvLogic({ isWindowOpen, isForeground }: UseTvLogicOptions) {
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [duration, setDuration] = useState(0);
-  const [playedSeconds, setPlayedSeconds] = useState(0);
   const [isVideoHovered, setIsVideoHovered] = useState(false);
   const [animationDirection, setAnimationDirection] = useState<"next" | "prev">(
     "next"
@@ -371,7 +370,9 @@ export function useTvLogic({ isWindowOpen, isForeground }: UseTvLogicOptions) {
 
   const handleProgress = useCallback(
     (state: { playedSeconds: number }) => {
-      setPlayedSeconds(state.playedSeconds);
+      // Write straight to the store (not React state) so the ~1Hz tick only
+      // re-renders the MTV caption overlay, not the whole TV tree.
+      useTvStore.getState().setPlayedSeconds(state.playedSeconds);
     },
     []
   );
@@ -579,7 +580,6 @@ export function useTvLogic({ isWindowOpen, isForeground }: UseTvLogicOptions) {
     handleProgress,
     handleDuration,
     handleSeek,
-    playedSeconds,
     duration,
     isVideoHovered,
     setIsVideoHovered,

--- a/src/apps/tv/hooks/useTvPlayedSeconds.ts
+++ b/src/apps/tv/hooks/useTvPlayedSeconds.ts
@@ -1,0 +1,16 @@
+import { useTvStore } from "@/stores/useTvStore";
+
+/**
+ * Narrow subscription to the TV playback clock.
+ *
+ * `playedSeconds` updates ~1x/sec while a video plays. Reading it from
+ * `useTvLogic` (or threading it through the controller) re-renders the entire
+ * TV tree on every tick, so only the leaf that actually displays time-aligned
+ * content — the MTV closed-caption overlay — should call this hook.
+ *
+ * Pass `enabled: false` while the consuming UI is hidden so the selector
+ * returns a constant `0` and the leaf opts out of tick re-renders entirely.
+ */
+export function useTvPlayedSeconds(enabled: boolean = true): number {
+  return useTvStore((s) => (enabled ? s.playedSeconds : 0));
+}

--- a/src/apps/videos/components/videos-app/VideosCdPlayerControls.tsx
+++ b/src/apps/videos/components/videos-app/VideosCdPlayerControls.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { SkipBack, SkipForward, Play, Pause } from "@phosphor-icons/react";
 import { AnimatedNumber } from "@/components/shared/lcd/AnimatedNumber";
 import { LcdAnimatedTitle } from "@/components/shared/lcd/LcdAnimatedTitle";
+import { VideosLcdTime } from "./VideosLcdTime";
 import type { VideosAppController } from "./useVideosAppController";
 
 type VideosCdPlayerControlsProps = {
@@ -19,7 +20,6 @@ export function VideosCdPlayerControls({ c }: VideosCdPlayerControlsProps) {
     formatTime,
     isDraggingSeek,
     dragSeekTime,
-    elapsedTime,
     getCurrentVideo,
     animationDirection,
     previousVideo,
@@ -69,9 +69,11 @@ export function VideosCdPlayerControls({ c }: VideosCdPlayerControlsProps) {
           >
             <div>{t("apps.videos.status.time")}</div>
             <div className="text-xl">
-              {formatTime(
-                isDraggingSeek ? Math.floor(dragSeekTime) : elapsedTime
-              )}
+              <VideosLcdTime
+                formatTime={formatTime}
+                isDraggingSeek={isDraggingSeek}
+                dragSeekTime={dragSeekTime}
+              />
             </div>
           </div>
         </div>

--- a/src/apps/videos/components/videos-app/VideosLcdTime.tsx
+++ b/src/apps/videos/components/videos-app/VideosLcdTime.tsx
@@ -1,0 +1,24 @@
+import { useVideosElapsedTime } from "../../hooks/useVideosPlaybackTime";
+
+type VideosLcdTimeProps = {
+  formatTime: (seconds: number) => string;
+  isDraggingSeek: boolean;
+  dragSeekTime: number;
+};
+
+/**
+ * Leaf wrapper that subscribes to the floored playback clock so only the LCD
+ * time readout — not the whole `VideosCdPlayerControls` bar — re-renders as
+ * the elapsed second ticks over (~1x/sec). While the user is scrubbing it
+ * shows the drag target instead.
+ */
+export function VideosLcdTime({
+  formatTime,
+  isDraggingSeek,
+  dragSeekTime,
+}: VideosLcdTimeProps) {
+  const elapsedTime = useVideosElapsedTime();
+  return (
+    <>{formatTime(isDraggingSeek ? Math.floor(dragSeekTime) : elapsedTime)}</>
+  );
+}

--- a/src/apps/videos/components/videos-app/VideosSeekBar.tsx
+++ b/src/apps/videos/components/videos-app/VideosSeekBar.tsx
@@ -1,0 +1,35 @@
+import { SeekBar } from "../SeekBar";
+import { useVideosPlayedSeconds } from "../../hooks/useVideosPlaybackTime";
+
+type VideosSeekBarProps = {
+  duration: number;
+  onSeek: (time: number) => void;
+  isPlaying: boolean;
+  isHovered?: boolean;
+  onDragChange?: (isDragging: boolean, seekTime?: number) => void;
+};
+
+/**
+ * Leaf wrapper that subscribes to the playback clock so only the seek bar —
+ * not its parent (`VideosVideoPane`, which renders the YouTube player) —
+ * re-renders on every ~1Hz progress tick.
+ */
+export function VideosSeekBar({
+  duration,
+  onSeek,
+  isPlaying,
+  isHovered,
+  onDragChange,
+}: VideosSeekBarProps) {
+  const playedSeconds = useVideosPlayedSeconds();
+  return (
+    <SeekBar
+      duration={duration}
+      currentTime={playedSeconds}
+      onSeek={onSeek}
+      isPlaying={isPlaying}
+      isHovered={isHovered}
+      onDragChange={onDragChange}
+    />
+  );
+}

--- a/src/apps/videos/components/videos-app/VideosVideoPane.tsx
+++ b/src/apps/videos/components/videos-app/VideosVideoPane.tsx
@@ -1,6 +1,6 @@
 import { motion, AnimatePresence } from "motion/react";
 import { YouTubePlayer } from "@/components/shared/YouTubePlayer";
-import { SeekBar } from "../SeekBar";
+import { VideosSeekBar } from "./VideosSeekBar";
 import { LcdStatusDisplay } from "@/components/shared/lcd/LcdStatusDisplay";
 import { VideosWhiteNoiseOverlay } from "./VideosWhiteNoise";
 import { STATUS_FADE_TRANSITION } from "@/components/shared/lcd/lcdMotionConstants";
@@ -32,7 +32,6 @@ export function VideosVideoPane({
     loopCurrent,
     setIsVideoHovered,
     duration,
-    playedSeconds,
     handleSeek,
     isVideoHovered,
     setIsDraggingSeek,
@@ -126,9 +125,8 @@ export function VideosVideoPane({
         />
       </div>
       <div className="absolute bottom-0 left-0 right-0 z-30">
-        <SeekBar
+        <VideosSeekBar
           duration={duration}
-          currentTime={playedSeconds}
           onSeek={handleSeek}
           isPlaying={isPlaying}
           isHovered={isVideoHovered}

--- a/src/apps/videos/hooks/useVideosLogic.ts
+++ b/src/apps/videos/hooks/useVideosLogic.ts
@@ -119,11 +119,9 @@ export function useVideosLogic({
     isConfirmResetOpen: boolean;
     isAddingVideo: boolean;
     isFullScreen: boolean;
-    elapsedTime: number;
     statusMessage: string | null;
     isShareDialogOpen: boolean;
     duration: number;
-    playedSeconds: number;
     isVideoHovered: boolean;
     isDraggingSeek: boolean;
     dragSeekTime: number;
@@ -138,11 +136,9 @@ export function useVideosLogic({
     isConfirmResetOpen: false,
     isAddingVideo: false,
     isFullScreen: false,
-    elapsedTime: 0,
     statusMessage: null,
     isShareDialogOpen: false,
     duration: 0,
-    playedSeconds: 0,
     isVideoHovered: false,
     isDraggingSeek: false,
     dragSeekTime: 0,
@@ -169,11 +165,9 @@ export function useVideosLogic({
     isConfirmResetOpen,
     isAddingVideo,
     isFullScreen,
-    elapsedTime,
     statusMessage,
     isShareDialogOpen,
     duration,
-    playedSeconds,
     isVideoHovered,
     isDraggingSeek,
     dragSeekTime,
@@ -207,9 +201,6 @@ export function useVideosLogic({
   }, []);
   const setIsFullScreen = useCallback((value: boolean) => {
     dispatchUi({ type: "patch", payload: { isFullScreen: value } });
-  }, []);
-  const setElapsedTime = useCallback((value: number) => {
-    dispatchUi({ type: "patch", payload: { elapsedTime: value } });
   }, []);
   const setStatusMessage = useCallback((value: string | null) => {
     dispatchUi({ type: "patch", payload: { statusMessage: value } });
@@ -606,13 +597,10 @@ export function useVideosLogic({
   }, [loopCurrent, setIsPlaying, nextVideo]);
 
   const handleProgress = useCallback((state: { playedSeconds: number }) => {
-    dispatchUi({
-      type: "patch",
-      payload: {
-        playedSeconds: state.playedSeconds,
-        elapsedTime: Math.floor(state.playedSeconds),
-      },
-    });
+    // Write straight to the store (not reducer state) so the ~1Hz tick only
+    // re-renders the seek-bar + LCD-time leaf subscribers, not the whole
+    // Videos tree.
+    useVideoStore.getState().setPlaybackTime(state.playedSeconds);
   }, []);
 
   const handleDuration = useCallback((duration: number) => {
@@ -823,9 +811,10 @@ export function useVideosLogic({
     }
   }, [videos, currentVideoId, safeSetCurrentVideoId]);
 
-  // Reset elapsed time when changing tracks
+  // Reset the playback clock when changing tracks so the LCD readout and
+  // seek-bar fill don't briefly show the previous track's position.
   useEffect(() => {
-    setElapsedTime(0);
+    useVideoStore.getState().resetPlaybackTime();
   }, [currentVideoId]);
 
   // Shuffle initialization: when shuffle was persisted as enabled, re-shuffle
@@ -983,7 +972,9 @@ export function useVideosLogic({
 
     if (isFullScreen && !prevFullScreenRef.current) {
       // Just entered fullscreen - sync position from main player to fullscreen player
-      const currentTime = playerRef.current?.getCurrentTime() || playedSeconds;
+      const currentTime =
+        playerRef.current?.getCurrentTime() ||
+        useVideoStore.getState().playedSeconds;
       const wasPlaying = isPlaying;
 
       // Wait for fullscreen player to be ready before seeking
@@ -1021,7 +1012,7 @@ export function useVideosLogic({
       timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
       timeoutIds.clear();
     };
-  }, [isFullScreen, playedSeconds, isPlaying]);
+  }, [isFullScreen, isPlaying]);
 
   // Listen for App Menu fullscreen toggle
   useCustomEventListener<{ appId: string; instanceId: string }>(
@@ -1073,12 +1064,10 @@ export function useVideosLogic({
     setIsConfirmResetOpen,
     isAddingVideo,
     isFullScreen,
-    elapsedTime,
     statusMessage,
     isShareDialogOpen,
     setIsShareDialogOpen,
     duration,
-    playedSeconds,
     isVideoHovered,
     setIsVideoHovered,
     isDraggingSeek,

--- a/src/apps/videos/hooks/useVideosPlaybackTime.ts
+++ b/src/apps/videos/hooks/useVideosPlaybackTime.ts
@@ -1,0 +1,21 @@
+import { useVideoStore } from "@/stores/useVideoStore";
+
+/**
+ * Narrow subscriptions to the Videos playback clock.
+ *
+ * The clock updates ~1x/sec while a video plays. Reading it from
+ * `useVideosLogic` (whose state the top-level component subscribes to) would
+ * re-render the entire Videos tree on every tick, so only the leaf components
+ * that display time — the seek bar fill and the LCD time readout — call these
+ * hooks.
+ *
+ * `playedSeconds` is fine-grained (smooth seek-bar fill); `elapsedTime` is the
+ * floored-second value that flips at most ~1x/sec (LCD readout).
+ */
+export function useVideosPlayedSeconds(): number {
+  return useVideoStore((s) => s.playedSeconds);
+}
+
+export function useVideosElapsedTime(): number {
+  return useVideoStore((s) => s.elapsedTime);
+}

--- a/src/stores/useTvStore.ts
+++ b/src/stores/useTvStore.ts
@@ -7,6 +7,7 @@ import {
   type Channel,
 } from "@/apps/tv/data/channels";
 import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
+import { shouldUpdatePlaybackTime } from "@/stores/playbackTime";
 import type { Video } from "@/stores/useVideoStore";
 
 /** Persisted custom channel; `number` is assigned at runtime from lineup order. */
@@ -44,6 +45,14 @@ interface TvStoreState {
   lcdFilterOn: boolean;
   /** MTV (and similar) word-timed lyric captions over the picture. */
   closedCaptionsOn: boolean;
+  /**
+   * Transient playback clock (seconds) reported by ReactPlayer's `onProgress`.
+   * NOT persisted. Lives here — rather than in `useTvLogic` React state — so
+   * the ~1Hz tick only re-renders the lone leaf subscriber
+   * (`MtvLyricsOverlay`) instead of the whole TV tree. Mirrors the iPod
+   * `elapsedTime` pattern.
+   */
+  playedSeconds: number;
   setCurrentChannelId: (id: string) => void;
   setVideoIndex: (channelId: string, index: number) => void;
   setIsPlaying: (playing: boolean) => void;
@@ -52,6 +61,7 @@ interface TvStoreState {
   setLcdFilterOn: (on: boolean) => void;
   toggleClosedCaptions: () => void;
   setClosedCaptionsOn: (on: boolean) => void;
+  setPlayedSeconds: (seconds: number) => void;
   addCustomChannel: (
     channel: Omit<CustomChannel, "id" | "createdAt"> & { id?: string }
   ) => CustomChannel;
@@ -103,6 +113,7 @@ export const useTvStore = create<TvStoreState>()(
       hiddenDefaultChannelIdsResetAt: null,
       lcdFilterOn: true,
       closedCaptionsOn: true,
+      playedSeconds: 0,
       setCurrentChannelId: (id) => set({ currentChannelId: id }),
       setVideoIndex: (channelId, index) =>
         set((s) => ({
@@ -119,6 +130,12 @@ export const useTvStore = create<TvStoreState>()(
       toggleClosedCaptions: () =>
         set((s) => ({ closedCaptionsOn: !s.closedCaptionsOn })),
       setClosedCaptionsOn: (on) => set({ closedCaptionsOn: on }),
+      setPlayedSeconds: (seconds) =>
+        set((s) =>
+          shouldUpdatePlaybackTime(s.playedSeconds, seconds)
+            ? { playedSeconds: seconds }
+            : {}
+        ),
       addCustomChannel: (channel) => {
         const existing = get().customChannels;
         const created: CustomChannel = {

--- a/src/stores/useVideoStore.ts
+++ b/src/stores/useVideoStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { useStoreShallow } from "./helpers";
 import { persist } from "zustand/middleware";
+import { shouldUpdatePlaybackTime } from "./playbackTime";
 
 export interface Video {
   id: string;
@@ -133,6 +134,16 @@ interface VideoStoreState {
   loopCurrent: boolean;
   isShuffled: boolean;
   isPlaying: boolean;
+  /**
+   * Transient playback clock reported by ReactPlayer's `onProgress`. NOT
+   * persisted. `playedSeconds` is the fine-grained value (drives the seek
+   * bar); `elapsedTime` is the floored-second value (drives the LCD readout)
+   * and only changes ~1x/sec. Living here — rather than in `useVideosLogic`
+   * reducer state — keeps the ~1Hz tick from re-rendering the whole Videos
+   * tree; only the leaf subscribers re-render. Mirrors the iPod pattern.
+   */
+  playedSeconds: number;
+  elapsedTime: number;
   // actions
   setVideos: (videos: Video[] | ((prev: Video[]) => Video[])) => void;
   setCurrentVideoId: (videoId: string | null) => void;
@@ -141,6 +152,10 @@ interface VideoStoreState {
   setIsShuffled: (val: boolean) => void;
   togglePlay: () => void;
   setIsPlaying: (val: boolean) => void;
+  /** Update the playback clock from a progress tick (fine + floored). */
+  setPlaybackTime: (seconds: number) => void;
+  /** Reset the playback clock to zero (e.g. on track change). */
+  resetPlaybackTime: () => void;
   // derived state helpers
   getCurrentIndex: () => number;
   getCurrentVideo: () => Video | null;
@@ -155,6 +170,8 @@ const getInitialState = () => ({
   loopCurrent: false,
   isShuffled: false,
   isPlaying: false,
+  playedSeconds: 0,
+  elapsedTime: 0,
 });
 
 export const useVideoStore = create<VideoStoreState>()(
@@ -198,6 +215,26 @@ export const useVideoStore = create<VideoStoreState>()(
       setIsShuffled: (val) => set({ isShuffled: val }),
       togglePlay: () => set((state) => ({ isPlaying: !state.isPlaying })),
       setIsPlaying: (val) => set({ isPlaying: val }),
+      setPlaybackTime: (seconds) =>
+        set((state) => {
+          const flooredSeconds = Math.floor(seconds);
+          const nextPlayed = shouldUpdatePlaybackTime(
+            state.playedSeconds,
+            seconds
+          )
+            ? seconds
+            : state.playedSeconds;
+          // `elapsedTime` only flips on whole-second boundaries, so it
+          // re-renders the LCD readout subscriber at most ~1x/sec.
+          if (
+            nextPlayed === state.playedSeconds &&
+            flooredSeconds === state.elapsedTime
+          ) {
+            return {};
+          }
+          return { playedSeconds: nextPlayed, elapsedTime: flooredSeconds };
+        }),
+      resetPlaybackTime: () => set({ playedSeconds: 0, elapsedTime: 0 }),
 
       // Derived state helpers
       getCurrentIndex: () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

TV and Videos report playback progress via ReactPlayer's `onProgress` (~10Hz for these players). That value lived in `useTvLogic` React state / the `useVideosLogic` reducer, so every tick re-rendered the **entire** app tree (player wrapper, control bar, dialogs, CRT effects) even though only one or two leaf components actually display time.

This PR moves the playback clock into the app stores (transient, **not** persisted) and has the leaf consumers subscribe narrowly — mirroring the existing iPod `elapsedTime` / `useIpodElapsedTime` pattern.

### TV
- `useTvStore` gains a transient `playedSeconds` + `setPlayedSeconds` (guarded by `shouldUpdatePlaybackTime`, excluded from `partialize`).
- `useTvLogic.handleProgress` writes straight to the store instead of holding React state; `playedSeconds` is dropped from the hook/controller return chain.
- `MtvLyricsOverlay` (the lone consumer — only mounts on the MTV channel with captions on) subscribes via the new `useTvPlayedSeconds(visible)` hook, gated by `visible` so it opts out of ticks while hidden.

### Videos
- `useVideoStore` gains transient `playedSeconds` (fine-grained, seek bar) + `elapsedTime` (floored, LCD readout) with `setPlaybackTime` / `resetPlaybackTime`. `elapsedTime` only flips on whole-second boundaries.
- `useVideosLogic` writes progress to the store; the two fields leave the reducer so the top-level `VideosAppComponent` no longer re-renders on tick.
- New leaf subscribers `VideosSeekBar` and `VideosLcdTime` read the clock directly; `VideosVideoPane` and `VideosCdPlayerControls` no longer thread it.
- Track-change now resets both values (previously only the floored readout reset), avoiding a brief flash of the previous track's position.

## Profiling (dev build, in-browser; React.StrictMode doubles raw counts)

Drove the playback-clock store directly (10 deterministic ticks ≈ 2s) and counted component renders via a temporary `window.__perfRenders` counter (removed before commit).

**Videos — clean win:** during 10 ticks, `VideosAppComponent` rendered **0×** (absent from counter); only the leaves ticked (`VideosSeekBar` 20, `VideosLcdTime` 20). The app tree is fully decoupled from the playback clock.

**TV:** the clock store fires ~11×/sec while playing, but `TvAppComponent` is **not subscribed** to `playedSeconds`, so those fires no longer re-render the tree (off the MTV channel the clock has zero subscribers).

### Follow-up (separate, pre-existing — not addressed here)
Profiling surfaced that `TvAppComponent` re-renders **~18×/sec during playback from a non-`playedSeconds`, non-store source** (idle 3s windows: ~112–116 renders; store fires only ~33). This is the dominant TV render cost and a strong candidate for the next perf pass; it is independent of this change.

## Testing
- `bunx tsc -b` — passes.
- `bun run test:unit` — 426 pass / 0 fail (includes TV store + playback-throttle suites).
- In-browser render profiling (above).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f06fc-ea6f-7f02-b961-c3ddbfb9052e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f06fc-ea6f-7f02-b961-c3ddbfb9052e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

