### PR TITLE
fix(calculator): make equals the tall key in Aqua compact layout

### DIFF
--- a/src/apps/calculator/components/CalculatorAquaCompactPanel.tsx
+++ b/src/apps/calculator/components/CalculatorAquaCompactPanel.tsx
@@ -55,21 +55,21 @@ export function CalculatorAquaCompactPanel({
         <CalculatorKey label="4" onClick={() => onDigit("4")} theme={theme} style={{ gridColumn: 1, gridRow: 4 }} />
         <CalculatorKey label="5" onClick={() => onDigit("5")} theme={theme} style={{ gridColumn: 2, gridRow: 4 }} />
         <CalculatorKey label="6" onClick={() => onDigit("6")} theme={theme} style={{ gridColumn: 3, gridRow: 4 }} />
-        <CalculatorKey
-          label="+"
-          onClick={() => onOperator("+")}
-          theme={theme}
-          variant="operator"
-          style={{ gridColumn: 4, gridRow: "4 / span 2" }}
-        />
+        <CalculatorKey label="+" onClick={() => onOperator("+")} theme={theme} variant="operator" style={{ gridColumn: 4, gridRow: 4 }} />
 
         <CalculatorKey label="1" onClick={() => onDigit("1")} theme={theme} style={{ gridColumn: 1, gridRow: 5 }} />
         <CalculatorKey label="2" onClick={() => onDigit("2")} theme={theme} style={{ gridColumn: 2, gridRow: 5 }} />
         <CalculatorKey label="3" onClick={() => onDigit("3")} theme={theme} style={{ gridColumn: 3, gridRow: 5 }} />
+        <CalculatorKey
+          label="="
+          onClick={onEquals}
+          theme={theme}
+          variant="equals"
+          style={{ gridColumn: 4, gridRow: "5 / span 2" }}
+        />
 
         <CalculatorKey label="0" onClick={() => onDigit("0")} theme={theme} variant="wide" style={{ gridColumn: "1 / span 2", gridRow: 6 }} />
         <CalculatorKey label="." onClick={onDecimal} theme={theme} style={{ gridColumn: 3, gridRow: 6 }} />
-        <CalculatorKey label="=" onClick={onEquals} theme={theme} variant="equals" style={{ gridColumn: 4, gridRow: 6 }} />
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Aqua compact (Tiger-style) calculator keypad so **`=`** spans rows 5–6 in the right column, matching the classic Mac OS X Calculator reference. **`+`** is now a single-height key in row 4.

## Changes

- `CalculatorAquaCompactPanel.tsx`: swap tall-key placement from `+` to `=`

## Testing

- `bun test tests/test-calculator-engine.test.ts`
- Manual UI verification in Aqua basic mode
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0771-1f54-7458-a7b0-bc0265b4a635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0771-1f54-7458-a7b0-bc0265b4a635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

