### PR TITLE
feat(calculator): classic Windows 98 six-column keypad layout

### DIFF
--- a/src/apps/calculator/components/CalculatorBody.tsx
+++ b/src/apps/calculator/components/CalculatorBody.tsx
@@ -6,6 +6,7 @@ import { CalculatorConversionPanel } from "./CalculatorConversionPanel";
 import { CalculatorDisplay } from "./CalculatorKey";
 import { CalculatorScientificPanel } from "./CalculatorScientificPanel";
 import { CalculatorSystem7Panel } from "./CalculatorSystem7Panel";
+import { CalculatorWin98Panel } from "./CalculatorWin98Panel";
 import type { CalculatorTheme } from "./types";
 import type { useCalculatorLogic } from "../hooks/useCalculatorLogic";
 
@@ -40,6 +41,7 @@ export function CalculatorBody({ logic }: CalculatorBodyProps) {
     pressMemoryRecall,
     pressMemoryAdd,
     pressMemorySubtract,
+    pressMemoryStore,
     conversionCategory,
     handleCategoryChange,
     fromUnit,
@@ -144,6 +146,51 @@ export function CalculatorBody({ logic }: CalculatorBodyProps) {
           onClearEntry={pressClearEntry}
           onDecimal={pressDecimal}
         />
+      ) : theme === "win98" || theme === "xp" ? (
+        <>
+          <CalculatorDisplay
+            value={calcState.display}
+            secondary={
+              mode === "scientific"
+                ? calcState.angleMode === "deg"
+                  ? t("apps.calculator.angle.deg")
+                  : t("apps.calculator.angle.rad")
+                : null
+            }
+            theme={theme}
+          />
+          {mode === "scientific" ? (
+            <CalculatorScientificPanel
+              theme={theme}
+              angleMode={calcState.angleMode}
+              onUnary={pressUnary}
+              onPi={pressPi}
+              onE={pressE}
+              onFactorial={pressFactorial}
+              onToggleAngle={pressToggleAngle}
+              onPower={() => pressOperator("^")}
+            />
+          ) : null}
+          <CalculatorWin98Panel
+            theme={theme}
+            memoryActive={calcState.memory !== 0}
+            onDigit={pressDigit}
+            onOperator={pressOperator}
+            onEquals={pressEquals}
+            onClear={pressClear}
+            onClearEntry={pressClearEntry}
+            onBackspace={pressBackspace}
+            onDecimal={pressDecimal}
+            onNegate={pressNegate}
+            onPercent={pressPercent}
+            onUnary={pressUnary}
+            onMemoryClear={pressMemoryClear}
+            onMemoryRecall={pressMemoryRecall}
+            onMemoryStore={pressMemoryStore}
+            onMemoryAdd={pressMemoryAdd}
+            onMemorySubtract={pressMemorySubtract}
+          />
+        </>
       ) : (
         <>
           <CalculatorDisplay

--- a/src/apps/calculator/components/CalculatorBody.tsx
+++ b/src/apps/calculator/components/CalculatorBody.tsx
@@ -188,7 +188,6 @@ export function CalculatorBody({ logic }: CalculatorBodyProps) {
             onMemoryRecall={pressMemoryRecall}
             onMemoryStore={pressMemoryStore}
             onMemoryAdd={pressMemoryAdd}
-            onMemorySubtract={pressMemorySubtract}
           />
         </>
       ) : (

--- a/src/apps/calculator/components/CalculatorWin98Panel.tsx
+++ b/src/apps/calculator/components/CalculatorWin98Panel.tsx
@@ -19,7 +19,6 @@ interface CalculatorWin98PanelProps {
   onMemoryRecall: () => void;
   onMemoryStore: () => void;
   onMemoryAdd: () => void;
-  onMemorySubtract: () => void;
 }
 
 /** Classic Windows 98 Calculator — 6-column standard layout. */
@@ -40,7 +39,6 @@ export function CalculatorWin98Panel({
   onMemoryRecall,
   onMemoryStore,
   onMemoryAdd,
-  onMemorySubtract,
 }: CalculatorWin98PanelProps) {
   return (
     <div className="calc-win98-panel flex flex-col gap-1">

--- a/src/apps/calculator/components/CalculatorWin98Panel.tsx
+++ b/src/apps/calculator/components/CalculatorWin98Panel.tsx
@@ -1,0 +1,198 @@
+import { cn } from "@/lib/utils";
+import { CalculatorKey } from "./CalculatorKey";
+import type { CalculatorTheme } from "./types";
+
+interface CalculatorWin98PanelProps {
+  theme: Extract<CalculatorTheme, "win98" | "xp">;
+  memoryActive: boolean;
+  onDigit: (digit: string) => void;
+  onOperator: (op: "+" | "-" | "*" | "/") => void;
+  onEquals: () => void;
+  onClear: () => void;
+  onClearEntry: () => void;
+  onBackspace: () => void;
+  onDecimal: () => void;
+  onNegate: () => void;
+  onPercent: () => void;
+  onUnary: (name: "sqrt" | "reciprocal") => void;
+  onMemoryClear: () => void;
+  onMemoryRecall: () => void;
+  onMemoryStore: () => void;
+  onMemoryAdd: () => void;
+  onMemorySubtract: () => void;
+}
+
+/** Classic Windows 98 Calculator — 6-column standard layout. */
+export function CalculatorWin98Panel({
+  theme,
+  memoryActive,
+  onDigit,
+  onOperator,
+  onEquals,
+  onClear,
+  onClearEntry,
+  onBackspace,
+  onDecimal,
+  onNegate,
+  onPercent,
+  onUnary,
+  onMemoryClear,
+  onMemoryRecall,
+  onMemoryStore,
+  onMemoryAdd,
+  onMemorySubtract,
+}: CalculatorWin98PanelProps) {
+  return (
+    <div className="calc-win98-panel flex flex-col gap-1">
+      <div className="calc-win98-grid">
+        <div
+          className={cn("calc-win98-status", memoryActive && "calc-win98-status-active")}
+          aria-hidden={!memoryActive}
+        >
+          {memoryActive ? "M" : null}
+        </div>
+        <CalculatorKey
+          label="Backspace"
+          onClick={onBackspace}
+          theme={theme}
+          variant="function"
+          className="calc-key-clear text-[10px]"
+          style={{ gridColumn: "2 / span 2", gridRow: 1 }}
+        />
+        <CalculatorKey
+          label="CE"
+          onClick={onClearEntry}
+          theme={theme}
+          variant="function"
+          className="calc-key-clear"
+          style={{ gridColumn: "4 / span 2", gridRow: 1 }}
+        />
+        <CalculatorKey
+          label="C"
+          onClick={onClear}
+          theme={theme}
+          variant="function"
+          className="calc-key-clear"
+          style={{ gridColumn: 6, gridRow: 1 }}
+        />
+
+        <CalculatorKey
+          label="MC"
+          onClick={onMemoryClear}
+          theme={theme}
+          variant="function"
+          className="calc-key-memory"
+          style={{ gridColumn: 1, gridRow: 2 }}
+        />
+        <CalculatorKey label="7" onClick={() => onDigit("7")} theme={theme} style={{ gridColumn: 2, gridRow: 2 }} />
+        <CalculatorKey label="8" onClick={() => onDigit("8")} theme={theme} style={{ gridColumn: 3, gridRow: 2 }} />
+        <CalculatorKey label="9" onClick={() => onDigit("9")} theme={theme} style={{ gridColumn: 4, gridRow: 2 }} />
+        <CalculatorKey
+          label="÷"
+          onClick={() => onOperator("/")}
+          theme={theme}
+          variant="operator"
+          className="calc-key-operator-red"
+          style={{ gridColumn: 5, gridRow: 2 }}
+        />
+        <CalculatorKey
+          label="sqrt"
+          onClick={() => onUnary("sqrt")}
+          theme={theme}
+          variant="function"
+          className="text-[10px]"
+          style={{ gridColumn: 6, gridRow: 2 }}
+        />
+
+        <CalculatorKey
+          label="MR"
+          onClick={onMemoryRecall}
+          theme={theme}
+          variant="function"
+          className="calc-key-memory"
+          style={{ gridColumn: 1, gridRow: 3 }}
+        />
+        <CalculatorKey label="4" onClick={() => onDigit("4")} theme={theme} style={{ gridColumn: 2, gridRow: 3 }} />
+        <CalculatorKey label="5" onClick={() => onDigit("5")} theme={theme} style={{ gridColumn: 3, gridRow: 3 }} />
+        <CalculatorKey label="6" onClick={() => onDigit("6")} theme={theme} style={{ gridColumn: 4, gridRow: 3 }} />
+        <CalculatorKey
+          label="×"
+          onClick={() => onOperator("*")}
+          theme={theme}
+          variant="operator"
+          className="calc-key-operator-red"
+          style={{ gridColumn: 5, gridRow: 3 }}
+        />
+        <CalculatorKey
+          label="%"
+          onClick={onPercent}
+          theme={theme}
+          variant="function"
+          style={{ gridColumn: 6, gridRow: 3 }}
+        />
+
+        <CalculatorKey
+          label="MS"
+          onClick={onMemoryStore}
+          theme={theme}
+          variant="function"
+          className="calc-key-memory"
+          style={{ gridColumn: 1, gridRow: 4 }}
+        />
+        <CalculatorKey label="1" onClick={() => onDigit("1")} theme={theme} style={{ gridColumn: 2, gridRow: 4 }} />
+        <CalculatorKey label="2" onClick={() => onDigit("2")} theme={theme} style={{ gridColumn: 3, gridRow: 4 }} />
+        <CalculatorKey label="3" onClick={() => onDigit("3")} theme={theme} style={{ gridColumn: 4, gridRow: 4 }} />
+        <CalculatorKey
+          label="−"
+          onClick={() => onOperator("-")}
+          theme={theme}
+          variant="operator"
+          className="calc-key-operator-red"
+          style={{ gridColumn: 5, gridRow: 4 }}
+        />
+        <CalculatorKey
+          label="1/x"
+          onClick={() => onUnary("reciprocal")}
+          theme={theme}
+          variant="function"
+          className="text-[10px]"
+          style={{ gridColumn: 6, gridRow: 4 }}
+        />
+
+        <CalculatorKey
+          label="M+"
+          onClick={onMemoryAdd}
+          theme={theme}
+          variant="function"
+          className="calc-key-memory"
+          style={{ gridColumn: 1, gridRow: 5 }}
+        />
+        <CalculatorKey label="0" onClick={() => onDigit("0")} theme={theme} style={{ gridColumn: 2, gridRow: 5 }} />
+        <CalculatorKey
+          label="±"
+          onClick={onNegate}
+          theme={theme}
+          variant="function"
+          style={{ gridColumn: 3, gridRow: 5 }}
+        />
+        <CalculatorKey label="." onClick={onDecimal} theme={theme} style={{ gridColumn: 4, gridRow: 5 }} />
+        <CalculatorKey
+          label="+"
+          onClick={() => onOperator("+")}
+          theme={theme}
+          variant="operator"
+          className="calc-key-operator-red"
+          style={{ gridColumn: 5, gridRow: 5 }}
+        />
+        <CalculatorKey
+          label="="
+          onClick={onEquals}
+          theme={theme}
+          variant="equals"
+          className="calc-key-operator-red"
+          style={{ gridColumn: 6, gridRow: 5 }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/apps/calculator/utils/calculatorStyles.ts
+++ b/src/apps/calculator/utils/calculatorStyles.ts
@@ -155,6 +155,32 @@ export const calculatorStyles = `
   .calc-theme-win98 .calc-key-operator {
     font-weight: 700;
   }
+  .calc-win98-grid {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    grid-template-rows: repeat(5, 28px);
+    gap: 3px;
+  }
+  .calc-win98-status {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 28px;
+    font-family: "MS Sans Serif", Tahoma, sans-serif;
+    font-size: 11px;
+    font-weight: 700;
+    color: #800000;
+    box-shadow: inset -1px -1px #fff, inset 1px 1px #808080, inset -2px -2px #dfdfdf, inset 2px 2px #0a0a0a;
+    background: #c0c0c0;
+  }
+  .calc-theme-win98 .calc-key-memory,
+  .calc-theme-win98 .calc-key-clear,
+  .calc-theme-win98 .calc-key-operator-red {
+    color: #800000;
+  }
+  .calc-theme-win98 .calc-key:not(.calc-key-memory):not(.calc-key-clear):not(.calc-key-operator-red) {
+    color: #000080;
+  }
 
   /* ── Windows XP ── */
   .calc-theme-xp {
@@ -198,6 +224,26 @@ export const calculatorStyles = `
   }
   .calc-theme-xp .calc-key-equals {
     font-weight: 700;
+  }
+  .calc-theme-xp .calc-win98-grid {
+    grid-template-rows: repeat(5, 26px);
+    gap: 2px;
+  }
+  .calc-theme-xp .calc-win98-status {
+    min-height: 26px;
+    font-family: Tahoma, sans-serif;
+    color: #800000;
+    border: 1px solid #888;
+    box-shadow: inset 1px 1px 2px rgba(0, 0, 0, 0.15);
+    background: #fff;
+  }
+  .calc-theme-xp .calc-key-memory,
+  .calc-theme-xp .calc-key-clear,
+  .calc-theme-xp .calc-key-operator-red {
+    color: #800000;
+  }
+  .calc-theme-xp .calc-key:not(.calc-key-memory):not(.calc-key-clear):not(.calc-key-operator-red) {
+    color: #000080;
   }
 
   .calc-conversion-panel {

--- a/src/apps/calculator/utils/windowSizes.ts
+++ b/src/apps/calculator/utils/windowSizes.ts
@@ -19,12 +19,19 @@ const SYSTEM7_SIZES: Record<CalculatorMode, { width: number; height: number }> =
   conversion: { width: 220, height: 300 },
 };
 
+const WINDOWS_SIZES: Record<CalculatorMode, { width: number; height: number }> = {
+  basic: { width: 272, height: 300 },
+  scientific: { width: 320, height: 480 },
+  conversion: { width: 300, height: 420 },
+};
+
 export function getCalculatorWindowSize(
   mode: CalculatorMode,
   theme: CalculatorTheme
 ): { width: number; height: number } {
   if (theme === "aqua") return AQUA_SIZES[mode];
   if (theme === "system7") return SYSTEM7_SIZES[mode];
+  if (theme === "win98" || theme === "xp") return WINDOWS_SIZES[mode];
   return DEFAULT_SIZES[mode];
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the classic **Windows 98 Calculator** six-column keypad layout for Win98 and XP themes, matching the reference screenshot.

## Layout

- **Top row:** memory indicator (inset `M` box), wide Backspace, wide CE, C
- **Main grid (6×4):** MC/MR/MS/M+ in column 1; number pad in columns 2–4; `/ × − +` in column 5; `sqrt`, `%`, `1/x`, `=` in column 6
- Red text for memory/clear/operator keys; blue for digits and unary helpers

## Changes

- New `CalculatorWin98Panel.tsx`
- Route Win98/XP basic + scientific modes through the panel in `CalculatorBody.tsx`
- Theme styles + window sizes for the wider grid

## Testing

- `bun test tests/test-calculator-engine.test.ts`
- Manual UI verification in Windows 98 theme

![Windows 98 Calculator layout](https://cursor.com/artifacts/c/art-1f70fdd9-652f-467b-a845-619b1f025f67)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0771-1f54-7458-a7b0-bc0265b4a635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0771-1f54-7458-a7b0-bc0265b4a635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

