### PR TITLE
perf: pause always-on rAF/WebGL loops while the tab is hidden

### DIFF
--- a/src/apps/paint/components/paint-canvas/usePaintCanvas.ts
+++ b/src/apps/paint/components/paint-canvas/usePaintCanvas.ts
@@ -181,12 +181,31 @@ export function usePaintCanvas({
 
       // Update dash offset
       dashOffsetRef.current = (dashOffsetRef.current + 1) % 10;
+      // Pause the marching-ants loop while the tab is hidden; `onVisibility`
+      // resumes it. Mirrors the visibility gating in `TvCrtEffects`.
+      if (document.hidden) {
+        animationFrameRef.current = null;
+        return;
+      }
       animationFrameRef.current = requestAnimationFrame(animate);
     };
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        if (animationFrameRef.current !== null) {
+          cancelAnimationFrame(animationFrameRef.current);
+          animationFrameRef.current = null;
+        }
+      } else if (animationFrameRef.current === null) {
+        animate();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
 
     animate();
 
     return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
       if (animationFrameRef.current !== null) {
         cancelAnimationFrame(animationFrameRef.current);
         animationFrameRef.current = null;

--- a/src/apps/synth/components/Waveform3D.tsx
+++ b/src/apps/synth/components/Waveform3D.tsx
@@ -219,9 +219,31 @@ export const Waveform3D: React.FC<Waveform3DProps> = ({ analyzer }) => {
       }
 
       renderer.render(scene, camera);
+      // Pause the loop while the tab is hidden so a backgrounded window
+      // doesn't keep the GPU busy rendering an invisible visualizer.
+      // `onVisibility` resumes it. Mirrors the gating in `TvCrtEffects`.
+      if (document.hidden) {
+        animationFrameRef.current = null;
+        return;
+      }
       animationFrameRef.current = requestAnimationFrame(animate);
     };
-    animate();
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        if (animationFrameRef.current !== null) {
+          cancelAnimationFrame(animationFrameRef.current);
+          animationFrameRef.current = null;
+        }
+      } else if (animationFrameRef.current === null) {
+        animate();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    if (!document.hidden) {
+      animate();
+    }
 
     // Handle resize with ResizeObserver
     const handleResize = () => {
@@ -242,6 +264,7 @@ export const Waveform3D: React.FC<Waveform3DProps> = ({ analyzer }) => {
     handleResize();
 
     return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
       resizeObserver.disconnect();
       if (animationFrameRef.current !== null) {
         cancelAnimationFrame(animationFrameRef.current);

--- a/src/apps/videos/components/videos-app/VideosWhiteNoise.tsx
+++ b/src/apps/videos/components/videos-app/VideosWhiteNoise.tsx
@@ -62,16 +62,37 @@ function WhiteNoiseEffect({ active }: { active: boolean }) {
       }
 
       ctx.putImageData(imageData, 0, 0);
+      // Pause while the tab is hidden so a backgrounded window doesn't keep
+      // painting static; `onVisibility` resumes it. Mirrors `TvCrtEffects`.
+      if (document.hidden) {
+        animationFrameRef.current = null;
+        return;
+      }
       animationFrameRef.current = requestAnimationFrame(drawNoise);
     };
 
-    resizeCanvas();
-    drawNoise();
+    const onVisibility = () => {
+      if (document.hidden) {
+        if (animationFrameRef.current !== null) {
+          cancelAnimationFrame(animationFrameRef.current);
+          animationFrameRef.current = null;
+        }
+      } else if (animationFrameRef.current === null) {
+        drawNoise();
+      }
+    };
 
+    resizeCanvas();
     window.addEventListener("resize", resizeCanvas);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    if (!document.hidden) {
+      drawNoise();
+    }
 
     return () => {
       window.removeEventListener("resize", resizeCanvas);
+      document.removeEventListener("visibilitychange", onVisibility);
       if (animationFrameRef.current !== null) {
         cancelAnimationFrame(animationFrameRef.current);
         animationFrameRef.current = null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three animation loops kept running at ~60fps even when the browser tab/window was hidden, burning CPU/GPU on output nobody can see. This gates each on `document.hidden` and resumes on `visibilitychange` — the same pattern `TvCrtEffects` already uses. No visual or behavioral change while visible.

- `Waveform3D` (Synth) — a continuous Three.js/WebGL render loop that ran whenever the Synth was open, regardless of tab visibility. Biggest win (GPU shader work every frame). `src/apps/synth/components/Waveform3D.tsx`.
- `VideosWhiteNoise` (Videos) — the static-noise canvas loop shown on the idle/paused overlay; gated on `active` but not visibility. `src/apps/videos/components/videos-app/VideosWhiteNoise.tsx`.
- Paint marching-ants — the selection-outline redraw loop; gated on an active `selection` but not visibility. `src/apps/paint/components/paint-canvas/usePaintCanvas.ts`.

Each loop now self-stops at the end of a frame when `document.hidden` is true (`animationFrameRef = null; return;`) and a `visibilitychange` listener restarts it when the tab becomes visible again. Listeners are removed in effect cleanup.

## Testing
- `bunx tsc -b` — passes.
- `bun run test:unit` — 426 pass / 0 fail.
- In-browser, drove a simulated `visibilitychange` and counted per-frame ticks over 1s windows. Videos white-noise loop: **13 ticks visible → 0 hidden → 15 resumed**, confirming the loop fully pauses while hidden and resumes on focus. (The Synth WebGL renderer is unavailable in the test VM so its loop wasn't running to begin with; it uses the identical gating code path.)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f06fc-ea6f-7f02-b961-c3ddbfb9052e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f06fc-ea6f-7f02-b961-c3ddbfb9052e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

