### PR TITLE
Fix Finder list column wrapping

### DIFF
--- a/src/apps/finder/components/file-list/FileListListView.tsx
+++ b/src/apps/finder/components/file-list/FileListListView.tsx
@@ -41,19 +41,25 @@ export function FileListListView(vm: FileListViewModel) {
       className="relative font-geneva-12"
       {...containerDragHandlers}
     >
-      <Table key={listTableKey} className="min-w-[480px]">
+      <Table key={listTableKey} className="min-w-[480px] table-fixed">
+        <colgroup>
+          <col />
+          <col className="w-[80px]" />
+          <col className="w-[76px]" />
+          <col className="w-[112px]" />
+        </colgroup>
         <TableHeader>
           <TableRow className={`${listHeaderTextClass} border-none font-normal`}>
-            <TableHead className="font-normal h-[24px]">
+            <TableHead className="h-[24px] truncate whitespace-nowrap font-normal">
               {t("apps.finder.tableHeaders.name")}
             </TableHead>
-            <TableHead className="font-normal h-[24px]">
+            <TableHead className="h-[24px] truncate whitespace-nowrap font-normal">
               {t("apps.finder.tableHeaders.type")}
             </TableHead>
-            <TableHead className="font-normal h-[24px] whitespace-nowrap">
+            <TableHead className="h-[24px] truncate whitespace-nowrap font-normal">
               {t("apps.finder.tableHeaders.size")}
             </TableHead>
-            <TableHead className="font-normal h-[24px] whitespace-nowrap">
+            <TableHead className="h-[24px] truncate whitespace-nowrap font-normal">
               {t("apps.finder.tableHeaders.modified")}
             </TableHead>
           </TableRow>

--- a/src/apps/finder/components/file-list/ListRowItem.tsx
+++ b/src/apps/finder/components/file-list/ListRowItem.tsx
@@ -70,6 +70,8 @@ export const ListRowItem = memo(function ListRowItem({
   };
 
   const isSelected = selectedFiles.includes(file.path);
+  const displayName = getDisplayName(file);
+  const fileType = getFileType(file);
 
   const handleDoubleClick = (e: React.MouseEvent<HTMLTableRowElement>) => {
     const now = Date.now();
@@ -130,39 +132,45 @@ export const ListRowItem = memo(function ListRowItem({
       data-file-item="true"
       data-file-path={file.path}
     >
-      <TableCell className="flex items-center gap-2">
-        {file.icon &&
-        !(file.icon.startsWith("/") || file.icon.startsWith("http")) ? (
-          <span
-            className="inline-flex items-center justify-center leading-none"
-            style={{ fontSize: 14, lineHeight: 1, width: 16, height: 16 }}
-            aria-hidden
-          >
-            {file.icon}
+      <TableCell className="min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
+          {file.icon &&
+          !(file.icon.startsWith("/") || file.icon.startsWith("http")) ? (
+            <span
+              className="inline-flex size-4 shrink-0 items-center justify-center leading-none"
+              style={{ fontSize: 14, lineHeight: 1 }}
+              aria-hidden
+            >
+              {file.icon}
+            </span>
+          ) : file.contentUrl && shouldShowThumbnail(file) ? (
+            <img
+              src={file.contentUrl}
+              alt={file.name}
+              className="size-4 shrink-0 rounded-sm object-cover"
+              style={{ imageRendering: isImageFile(file) ? "pixelated" : "auto" }}
+              onError={(e) => {
+                console.error(`Error loading thumbnail for ${file.name}`);
+                (e.target as HTMLImageElement).style.display = "none";
+              }}
+            />
+          ) : (
+            <ThemedIcon
+              name={getIconPath(file)}
+              alt={getListIconAlt(file)}
+              className="size-4 shrink-0"
+              style={{ imageRendering: "pixelated" }}
+              data-legacy-aware="true"
+            />
+          )}
+          <span className="truncate" title={displayName}>
+            {displayName}
           </span>
-        ) : file.contentUrl && shouldShowThumbnail(file) ? (
-          <img
-            src={file.contentUrl}
-            alt={file.name}
-            className="size-4 object-cover rounded-sm"
-            style={{ imageRendering: isImageFile(file) ? "pixelated" : "auto" }}
-            onError={(e) => {
-              console.error(`Error loading thumbnail for ${file.name}`);
-              (e.target as HTMLImageElement).style.display = "none";
-            }}
-          />
-        ) : (
-          <ThemedIcon
-            name={getIconPath(file)}
-            alt={getListIconAlt(file)}
-            className="size-4"
-            style={{ imageRendering: "pixelated" }}
-            data-legacy-aware="true"
-          />
-        )}
-        {getDisplayName(file)}
+        </div>
       </TableCell>
-      <TableCell>{getFileType(file)}</TableCell>
+      <TableCell className="truncate whitespace-nowrap" title={fileType}>
+        {fileType}
+      </TableCell>
       <TableCell className="whitespace-nowrap">
         {file.size
           ? file.size < 1024


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Use fixed Finder list columns so localized headers and metadata stay on one line.
- Truncate long filenames and file types while preserving full values in tooltips.

## Walkthrough
<a href="https://cursor.com/agents/bc-aaf0b81d-2859-41bd-a1d8-107c42c4de8a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffinder_table_single_line_proof_trimmed.mp4"><img src="https://cursor.com/artifacts/c/art-1689ed87-4a47-410c-b14c-cd31bc5d819b" alt="finder_table_single_line_proof_trimmed.mp4" /></a>

The narrow Finder list keeps headers and rows single-line and truncates constrained text with ellipses.

## Testing
- `bunx eslint src/apps/finder/components/file-list/FileListListView.tsx src/apps/finder/components/file-list/ListRowItem.tsx` — passed.
- `bun run build` — blocked by pre-existing TypeScript errors in `src/apps/chats/hooks/useChatRoom.ts` and `src/utils/dynamicWallpaper.ts`.
- Browser verification in Chrome — passed at narrow Finder widths; headers and rows remain single-line and constrained text truncates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aaf0b81d-2859-41bd-a1d8-107c42c4de8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aaf0b81d-2859-41bd-a1d8-107c42c4de8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

