### PR TITLE
Fix clipped Calculator height on phone

### DIFF
--- a/src/apps/calculator/utils/windowSizes.ts
+++ b/src/apps/calculator/utils/windowSizes.ts
@@ -25,14 +25,38 @@ const WINDOWS_SIZES: Record<CalculatorMode, { width: number; height: number }> =
   conversion: { width: 300, height: 420 },
 };
 
+// On mobile (< 768px) the outer WindowFrame container has `p-2` padding
+// (8px top + 8px bottom = 16px) which, with border-box sizing, is subtracted
+// from the fixed window height and clips the calculator keypad. Add it back so
+// the usable body height matches desktop.
+const MOBILE_FRAME_BREAKPOINT = 768;
+const MOBILE_FRAME_VERTICAL_PADDING = 16;
+
 export function getCalculatorWindowSize(
   mode: CalculatorMode,
   theme: CalculatorTheme
 ): { width: number; height: number } {
-  if (theme === "aqua") return AQUA_SIZES[mode];
-  if (theme === "system7") return SYSTEM7_SIZES[mode];
-  if (theme === "win98" || theme === "xp") return WINDOWS_SIZES[mode];
-  return DEFAULT_SIZES[mode];
+  const base =
+    theme === "aqua"
+      ? AQUA_SIZES[mode]
+      : theme === "system7"
+        ? SYSTEM7_SIZES[mode]
+        : theme === "win98" || theme === "xp"
+          ? WINDOWS_SIZES[mode]
+          : DEFAULT_SIZES[mode];
+
+  const isMobile =
+    typeof window !== "undefined" &&
+    window.innerWidth < MOBILE_FRAME_BREAKPOINT;
+
+  if (isMobile) {
+    return {
+      width: base.width,
+      height: base.height + MOBILE_FRAME_VERTICAL_PADDING,
+    };
+  }
+
+  return base;
 }
 
 /** @deprecated use getCalculatorWindowSize */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On phone (`< 768px`), the Calculator keypad is clipped at the bottom — it uses a smaller usable height than on desktop.

## Root cause

The outer `WindowFrame` container has `p-2 md:p-0`, i.e. 8px top + 8px bottom (16px total) padding on mobile only. With the global `box-sizing: border-box`, that padding is subtracted from the window's fixed `height`. Calculator windows are fixed-size (`minHeight === maxHeight`) and the keypad grid is tuned to exactly fill the desktop frame, so on mobile the body loses 16px and the `overflow-hidden` `.window` clips the bottom row of keys.

## Fix

`getCalculatorWindowSize` now adds the 16px mobile frame padding back to the window height when `window.innerWidth < 768`, so the usable body height matches desktop across all calculator themes/modes. Both the window constraints and the instance window-state sync use this helper, so they stay aligned.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0a4c-ffc6-7bc6-9d7b-040c60d0f69e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0a4c-ffc6-7bc6-9d7b-040c60d0f69e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

