### PR TITLE
fix(calendar): restore calendarControl tool access (Telegram heartbeat + chat)

### DIFF
--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -714,20 +714,13 @@ export const calendarControlSchema = z.object({
       path: ["date"],
     });
   }
-  if (data.endDate && data.date && data.endDate < data.date) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "The 'endDate' parameter must be on or after 'date'.",
-      path: ["endDate"],
-    });
-  }
-  if (data.endDate && (data.startTime || data.endTime)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Use 'endDate' only for all-day events; omit startTime/endTime for multi-day all-day events.",
-      path: ["endDate"],
-    });
-  }
+  // NOTE: Intentionally no cross-field validation between `endDate` and
+  // `date`/`startTime`/`endTime`. Tool-calling models (e.g. gpt-5.5) tend to
+  // emit *every* schema field, so any "omit X when Y" refinement here would
+  // reject otherwise-valid calls (e.g. `list`) and make the whole tool
+  // unusable. `endDate` is normalized server-side in `applyCalendarToolAction`
+  // (and client-side in the calendar store) via `normalizeAllDayEndDate`,
+  // which drops `endDate` for timed events or when it is on/before `date`.
   if ((data.action === "update" || data.action === "delete") && !data.id) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,

--- a/tests/test-calendar-tool-reducer.test.ts
+++ b/tests/test-calendar-tool-reducer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { applyCalendarToolAction } from "../src/shared/tools/calendar";
+import { calendarControlSchema } from "../api/chat/tools/schemas";
 import type { CalendarSnapshotData } from "../src/shared/domains/calendar";
 
 function state(): CalendarSnapshotData {
@@ -146,5 +147,50 @@ describe("calendar tool shared reducer", () => {
     expect(deleted.state.deletedTodoIds).toEqual({
       "todo-1": "2026-06-07T22:00:00.000Z",
     });
+  });
+});
+
+describe("calendarControlSchema accepts over-filled tool-model input", () => {
+  // Regression: tool-calling models (e.g. gpt-5.5) emit EVERY schema field, so
+  // the schema must not reject calls that include endDate alongside
+  // startTime/endTime. A blocking cross-field refinement here previously made
+  // calendarControl unusable (every call failed validation before executing).
+  test("a 'list' call with all fields populated still validates", () => {
+    const parsed = calendarControlSchema.safeParse({
+      action: "list",
+      id: "",
+      title: "",
+      date: "2026-06-27",
+      endDate: "2026-06-27",
+      startTime: "00:00",
+      endTime: "23:59",
+      color: "blue",
+      notes: "",
+      completed: false,
+      calendarId: "",
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  test("a timed 'create' with endDate present still validates", () => {
+    const parsed = calendarControlSchema.safeParse({
+      action: "create",
+      title: "Standup",
+      date: "2026-06-27",
+      endDate: "2026-06-27",
+      startTime: "09:00",
+      endTime: "09:30",
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  test("a multi-day all-day 'create' validates", () => {
+    const parsed = calendarControlSchema.safeParse({
+      action: "create",
+      title: "Trip",
+      date: "2026-06-27",
+      endDate: "2026-06-29",
+    });
+    expect(parsed.success).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Telegram heartbeat and AI tool calls could no longer use the calendar (and, by knock-on effect, produced broken/empty heartbeat output). This was a regression from **"Allow multi-day all-day calendar events" (#1587)**, exactly as suspected (timezone / full-day events).

## Root cause

#1587 added two cross-field `superRefine` rules to `calendarControlSchema`:

- `endDate` must be on/after `date`
- omit `startTime`/`endTime` when `endDate` is set

Tool-calling models (e.g. `gpt-5.5`) emit **every** field in a tool schema. For any `calendarControl` call they fill in `date`, `endDate`, `startTime` (`00:00`), and `endTime` (`23:59`), which trips the `endDate && (startTime || endTime)` rule. The input then **fails Zod validation before `execute` runs**, so the tool never returns a result — for a plain `list` too. In the heartbeat tool loop the model retries until it runs out of steps and gives up, so calendar *and* notes appear inaccessible.

### Reproduced (gpt-5.5, telegram tool profile)

Before:
```
TOOL_CALL: calendarControl {"action":"list","date":"2026-06-27","endDate":"2026-06-27","startTime":"00:00","endTime":"23:59",...}
(no calendarControl tool result — rejected by validation)
FINAL: "the tool call kept rejecting the extra endDate/time fields ... i couldn't get a valid calendar result"
```

After:
```
TOOL_CALL: calendarControl {"action":"list","date":"2026-06-27","endDate":"2026-06-27","startTime":"00:00","endTime":"23:59",...}
TOOL_RESULT: calendarControl {"success":true,"message":"Found 0 events for 2026-06-27.","events":[]}
```

## Fix

Remove the two `endDate` cross-field refinements. They are redundant: `endDate` is already normalized safely server-side in `applyCalendarToolAction` and client-side in the calendar store via `normalizeAllDayEndDate` (drops `endDate` for timed events or when it is on/before `date`). Verified normalization still produces correct timed, single-day, and multi-day all-day events.

## Tests

- Added regression tests asserting `calendarControlSchema` accepts over-filled tool-model input (`list`, timed `create`, multi-day all-day `create`).
- Existing calendar reducer / event-dates / server-app-state / telegram-heartbeat suites still pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0a4c-0d40-760d-8ce2-c5b11dec36b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0a4c-0d40-760d-8ce2-c5b11dec36b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

