### PR TITLE
Fix iPod Apple Music startup hydration

### DIFF
--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -1055,10 +1055,10 @@ export async function refreshAppleMusicPlaylists(
 const inFlightPlaylistTracksRefresh = new Set<string>();
 
 /**
- * Refresh stale tracks for every playlist that currently has a cached
- * copy in memory or IndexedDB. Iterates with bounded concurrency so a
- * user with 50 cached playlists doesn't fire 50 simultaneous Apple Music
- * requests on iPod open.
+ * Refresh stale tracks for playlists that are already present in memory.
+ * This deliberately does not scan IndexedDB or enumerate the playlist list:
+ * opening the iPod should not touch per-playlist track caches until the user
+ * drills into a playlist.
  *
  * Playback safety: each refresh uses
  * `setAppleMusicPlaylistTracks(playlistId, ...)`, which only mutates the
@@ -1074,14 +1074,6 @@ export async function refreshStaleAppleMusicPlaylistTracks(
   options: {
     force?: boolean;
     concurrency?: number;
-    /**
-     * Also include playlists that exist in `appleMusicPlaylists` but have
-     * never been viewed (no `loadedAt` entry). This makes the function
-     * pre-fetch every playlist's tracks during the initial library sync
-     * so the Playlists menu row subtitles ("N songs") render correctly
-     * without requiring the user to click into each playlist first.
-     */
-    includeUncached?: boolean;
   } = {}
 ): Promise<void> {
   const instance = getMusicKitInstance();
@@ -1090,11 +1082,6 @@ export async function refreshStaleAppleMusicPlaylistTracks(
   const state = useIpodStore.getState();
   const loadedAtMap = state.appleMusicPlaylistTracksLoadedAt;
   const knownIds = new Set<string>(Object.keys(loadedAtMap));
-  if (options.includeUncached) {
-    for (const playlist of state.appleMusicPlaylists) {
-      knownIds.add(playlist.id);
-    }
-  }
   const playlistIds = Array.from(knownIds);
   if (playlistIds.length === 0) return;
 
@@ -1415,27 +1402,6 @@ export async function fetchAppleMusicLibrary(
     } catch (err) {
       warnAppleMusic("[apple music] playlist sync failed (songs kept)", err);
     }
-
-    // After the playlist list is fresh, kick off a background pre-fetch
-    // of EVERY playlist's tracks (including playlists the user has never
-    // opened). This populates `appleMusicPlaylistTracks[playlistId]`, so
-    // the Playlists menu can show accurate "N songs" subtitles for every
-    // row without the user having to click into each playlist first.
-    //
-    // Fire-and-forget on purpose:
-    //   - We don't want the library-load promise to wait for potentially
-    //     dozens of per-playlist round-trips before resolving.
-    //   - `refreshStaleAppleMusicPlaylistTracks` already runs with bounded
-    //     concurrency and swallows per-playlist errors, so it can't take
-    //     down the library sync if a single playlist fetch fails.
-    void refreshStaleAppleMusicPlaylistTracks({ includeUncached: true }).catch(
-      (err) => {
-        warnAppleMusic(
-          "[apple music] background pre-fetch of playlist tracks failed",
-          err
-        );
-      }
-    );
 
     return aggregated.length || existingTracks.length;
   } catch (err) {
@@ -1913,18 +1879,10 @@ export function useAppleMusicLibrary({
         // hit separate Apple Music endpoints and don't share the same
         // in-flight guard.
         //
-        // `refreshStaleAppleMusicPlaylistTracks` is included with
-        // `includeUncached: true` so the per-playlist track caches get
-        // populated for every playlist (not just those the user has
-        // already opened). This is what backs the Playlists menu's
-        // "N songs" subtitles, so without this they'd stay at 0 for any
-        // playlist the user hasn't drilled into yet. The helper has its
-        // own per-playlist in-flight guard + bounded concurrency, so
-        // running it here in parallel with the other refreshes is safe.
         await Promise.allSettled([
           refreshAppleMusicRecentlyAdded(),
           refreshAppleMusicFavorites(),
-          refreshStaleAppleMusicPlaylistTracks({ includeUncached: true }),
+          refreshStaleAppleMusicPlaylistTracks(),
         ]);
       } catch (err) {
         // Each helper handles its own per-call errors; a top-level

--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -392,6 +392,34 @@ const FAVORITE_SONGS_COLLECTION_KEY: AppleMusicTrackCollectionKey =
 const RADIO_STATIONS_COLLECTION_KEY: AppleMusicTrackCollectionKey =
   "radio-stations";
 
+function describeAppleMusicError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "object" && err !== null) {
+    const errorLike = err as {
+      message?: unknown;
+      status?: unknown;
+      statusCode?: unknown;
+      response?: { status?: unknown };
+    };
+    const message =
+      typeof errorLike.message === "string" ? errorLike.message : undefined;
+    const status =
+      errorLike.status ?? errorLike.statusCode ?? errorLike.response?.status;
+    if (message && status) return `${message} (status ${String(status)})`;
+    if (message) return message;
+    if (status) return `status ${String(status)}`;
+  }
+  return String(err);
+}
+
+function warnAppleMusic(message: string, err?: unknown): void {
+  if (err === undefined) {
+    console.warn(message);
+    return;
+  }
+  console.warn(`${message}: ${describeAppleMusicError(err)}`);
+}
+
 function getAppleMusicInstanceForUser() {
   const instance = getMusicKitInstance();
   if (!instance) throw new Error("MusicKit instance is not configured");
@@ -505,7 +533,7 @@ export async function fetchAppleMusicRadioStations(
 
     const recommendations = await fetchAppleMusicRecommendations().catch(
       (err) => {
-        console.warn("[apple music] failed to load recommendation stations", err);
+        warnAppleMusic("[apple music] failed to load recommendation stations", err);
         return [] as AppleMusicRecommendationResource[];
       }
     );
@@ -542,7 +570,7 @@ export async function fetchAppleMusicRadioStations(
     return stations;
   } catch (err) {
     if (cached) {
-      console.warn(
+      warnAppleMusic(
         "[apple music] radio refresh failed (using cached stations)",
         err
       );
@@ -638,7 +666,7 @@ async function fetchAppleMusicRecentlyAddedTracksFromApi(): Promise<Track[]> {
           addTrack(track);
         }
       } catch (err) {
-        console.warn(
+        warnAppleMusic(
           `[apple music] failed to load recently added album ${resource.id}`,
           err
         );
@@ -679,7 +707,7 @@ export async function fetchAppleMusicRecentlyAddedTracks(
     return tracks;
   } catch (err) {
     if (cached?.tracks.length) {
-      console.warn(
+      warnAppleMusic(
         "[apple music] recently added refresh failed (using cached collection)",
         err
       );
@@ -761,7 +789,7 @@ export async function fetchAppleMusicFavoriteSongTracks(
     return tracks;
   } catch (err) {
     if (cached?.tracks.length) {
-      console.warn(
+      warnAppleMusic(
         "[apple music] favorite songs refresh failed (using cached collection)",
         err
       );
@@ -1099,7 +1127,7 @@ export async function refreshStaleAppleMusicPlaylistTracks(
           try {
             await fetchAppleMusicPlaylistTracks(id, { force: true });
           } catch (err) {
-            console.warn(
+            warnAppleMusic(
               `[apple music] background refresh of playlist ${id} failed`,
               err
             );
@@ -1385,7 +1413,7 @@ export async function fetchAppleMusicLibrary(
       // background path.
       await refreshAppleMusicPlaylists({ force: true });
     } catch (err) {
-      console.warn("[apple music] playlist sync failed (songs kept)", err);
+      warnAppleMusic("[apple music] playlist sync failed (songs kept)", err);
     }
 
     // After the playlist list is fresh, kick off a background pre-fetch
@@ -1402,7 +1430,7 @@ export async function fetchAppleMusicLibrary(
     //     down the library sync if a single playlist fetch fails.
     void refreshStaleAppleMusicPlaylistTracks({ includeUncached: true }).catch(
       (err) => {
-        console.warn(
+        warnAppleMusic(
           "[apple music] background pre-fetch of playlist tracks failed",
           err
         );
@@ -1816,7 +1844,7 @@ export function useAppleMusicLibrary({
         // refresh quietly in the background. Don't show the progress
         // toast — the user already has a working library.
         fetchAppleMusicLibrary({ force: true }).catch((err) => {
-          console.warn(
+          warnAppleMusic(
             "[apple music] background library refresh failed (using cached copy)",
             err
           );
@@ -1828,7 +1856,9 @@ export function useAppleMusicLibrary({
       // toast since the user has nothing to look at until this
       // finishes.
       runWithProgressToast(false).catch((err) => {
-        console.error("[apple music] initial library load failed", err);
+        console.error(
+          `[apple music] initial library load failed: ${describeAppleMusicError(err)}`
+        );
       });
     };
 
@@ -1901,7 +1931,7 @@ export function useAppleMusicLibrary({
         // failure here would be unexpected (e.g. MusicKit instance went
         // away mid-refresh). Log + swallow so opportunistic background
         // work never bubbles into the UI.
-        console.warn(
+        warnAppleMusic(
           "[apple music] opportunistic playlist refresh failed",
           err
         );

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -24,7 +24,6 @@ import {
   fetchAppleMusicGeniusTrack,
   addAppleMusicTrackToFavorites,
   cacheAppleMusicFavoriteSongTrack,
-  refreshStaleAppleMusicPlaylistTracks,
   type AppleMusicSearchScope,
 } from "./useAppleMusicLibrary";
 import { useMusicKit } from "@/hooks/useMusicKit";
@@ -1056,21 +1055,6 @@ export function useIpodLogic({
       await syncAppleMusicResource({
         kind: "playlists",
         allowEmpty: true,
-      });
-      // Kick off a background pre-fetch of tracks for every cached
-      // playlist (including ones the user has never opened) so the
-      // "N songs" subtitles render correctly on first paint instead of
-      // showing 0 until the user clicks into each row. Fire-and-forget:
-      // the helper runs with bounded concurrency and dedupes against
-      // any in-flight per-playlist fetches, so this is safe to call
-      // every time the Playlists menu opens.
-      void refreshStaleAppleMusicPlaylistTracks({
-        includeUncached: true,
-      }).catch((err) => {
-        console.warn(
-          "[apple music] background pre-fetch of playlist tracks failed",
-          err
-        );
       });
     } catch (err) {
       const hasCached = useIpodStore.getState().appleMusicPlaylists.length > 0;

--- a/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
+++ b/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
@@ -8,6 +8,7 @@ import { hasLibraryTrackMetadataChanges } from "@/stores/ipodTrackMetadataSync";
 import { mapCatalogSongToTrack } from "@/stores/ipodCatalogTrackMapping";
 import { fetchSongsVersion, type SongsVersionInfo } from "@/api/songs";
 import { createVisibilityGatedInterval } from "@/utils/backgroundTask";
+import { debug } from "@/utils/debug";
 
 const CHECK_INTERVAL = 5 * 60 * 1000; // Check every 5 minutes
 
@@ -65,7 +66,9 @@ export function useLibraryUpdateChecker(isActive: boolean) {
           versionInfo.version === lastInSync.version &&
           versionInfo.count === lastInSync.count
         ) {
-          console.log("[iPod] Catalog version unchanged, skipping full check", versionInfo);
+          debug(
+            `[iPod] Catalog version unchanged, skipping full check (version=${versionInfo.version}, count=${versionInfo.count})`
+          );
           return;
         }
 
@@ -75,7 +78,7 @@ export function useLibraryUpdateChecker(isActive: boolean) {
         const cachedSongs = await listAllCachedSongMetadata("ryo");
         
         if (cachedSongs.length === 0) {
-          console.log("[iPod] No songs found in Redis cache, skipping update check");
+          debug("[iPod] No songs found in Redis cache, skipping update check");
           return;
         }
         
@@ -102,14 +105,9 @@ export function useLibraryUpdateChecker(isActive: boolean) {
           }
         });
 
-        console.log("[iPod] Auto update check:", {
-          newTracksCount,
-          tracksUpdated,
-          currentTracksCount: currentTracks.length,
-          serverTracksCount: serverTracks.length,
-          serverVersion,
-          currentLastKnownVersion: useIpodStore.getState().lastKnownVersion,
-        });
+        debug(
+          `[iPod] Auto update check: new=${newTracksCount}, updated=${tracksUpdated}, current=${currentTracks.length}, server=${serverTracks.length}, version=${serverVersion}, known=${useIpodStore.getState().lastKnownVersion}`
+        );
 
         if (newTracksCount === 0 && tracksUpdated === 0) {
           // Fully in sync — remember the server version so the next polls
@@ -129,7 +127,7 @@ export function useLibraryUpdateChecker(isActive: boolean) {
               lastInSyncVersionRef.current = versionInfo;
             }
             if (result.newTracksAdded === 0 && result.tracksUpdated === 0) {
-              console.log("[iPod] Auto update check resolved with no applied changes");
+              debug("[iPod] Auto update check resolved with no applied changes");
               return;
             }
             const message =
@@ -159,7 +157,7 @@ export function useLibraryUpdateChecker(isActive: boolean) {
               duration: 4000,
             });
 
-            console.log(
+            debug(
               `[iPod] Auto-updated: ${result.newTracksAdded} new tracks, ${result.tracksUpdated} updated tracks`
             );
           } catch (error) {
@@ -181,7 +179,7 @@ export function useLibraryUpdateChecker(isActive: boolean) {
     
     const immediateCheckTimeout = shouldCheckImmediately
       ? setTimeout(() => {
-          console.log(
+          debug(
             "[iPod] Running immediate library update check on app activation"
           );
           checkForUpdates();
@@ -190,7 +188,7 @@ export function useLibraryUpdateChecker(isActive: boolean) {
       : null;
     
     if (!shouldCheckImmediately) {
-      console.log(
+      debug(
         `[iPod] Skipping immediate check - last checked ${Math.round(timeSinceLastCheck / 1000)}s ago (< ${CHECK_INTERVAL / 1000}s)`
       );
     }

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -42,6 +42,7 @@ import {
   saveAppleMusicPlaylistTracks,
   saveAppleMusicTrackCollection,
 } from "@/utils/appleMusicLibraryCache";
+import type { IpodMenuKind } from "@/apps/ipod/types";
 
 /** Special value for lyricsTranslationLanguage that means "use ryOS locale" */
 export const LYRICS_TRANSLATION_AUTO = "auto";
@@ -807,6 +808,26 @@ const INDEXED_DB_BACKED_APPLE_MUSIC_KEYS = [
   "appleMusicKitNowPlaying",
 ] as const;
 
+const VALID_IPOD_MENU_KINDS = new Set<IpodMenuKind>([
+  "root",
+  "music",
+  "settings",
+  "extras",
+  "artists",
+  "albums",
+  "songs",
+  "playlists",
+  "recentlyAdded",
+  "favorites",
+  "radio",
+  "artist",
+  "album",
+  "artistAllSongs",
+  "artistAlbum",
+  "appleMusicPlaylist",
+  "nowPlayingSong",
+]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -830,7 +851,10 @@ function sanitizePersistedIpodMenuBreadcrumb(
         : 0;
     return [
       {
-        ...(typeof entry.kind === "string" && { kind: entry.kind }),
+        ...(typeof entry.kind === "string" &&
+          VALID_IPOD_MENU_KINDS.has(entry.kind as IpodMenuKind) && {
+            kind: entry.kind as IpodMenuKind,
+          }),
         ...(typeof entry.id === "string" && { id: entry.id }),
         title: entry.title,
         ...(typeof entry.displayTitle === "string" && {

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -781,7 +781,119 @@ export function navigateActiveIpodTrack(
   }
 }
 
-const CURRENT_IPOD_STORE_VERSION = 40; // Default fullscreen/Karaoke lyrics style is Gold Glow
+const CURRENT_IPOD_STORE_VERSION = 41; // Drop legacy Apple Music cache payloads from localStorage
+
+type PersistedIpodData = Partial<IpodData> & Record<string, unknown>;
+
+const INDEXED_DB_BACKED_APPLE_MUSIC_KEYS = [
+  "appleMusicTracks",
+  "appleMusicPlaylists",
+  "appleMusicPlaylistsLoadedAt",
+  "appleMusicPlaylistsLoading",
+  "appleMusicPlaylistTracks",
+  "appleMusicPlaylistTracksLoadedAt",
+  "appleMusicPlaylistTracksLoading",
+  "appleMusicRecentlyAddedTracks",
+  "appleMusicRecentlyAddedLoadedAt",
+  "appleMusicRecentlyAddedLoading",
+  "appleMusicFavoriteTracks",
+  "appleMusicFavoriteTracksLoadedAt",
+  "appleMusicFavoritesLoading",
+  "appleMusicPlaybackHistory",
+  "appleMusicLibraryLoadedAt",
+  "appleMusicLibraryLoading",
+  "appleMusicLibraryError",
+  "appleMusicStorefrontId",
+  "appleMusicKitNowPlaying",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sanitizePersistedString(value: unknown): string | null | undefined {
+  if (typeof value === "string") return value;
+  if (value === null) return null;
+  return undefined;
+}
+
+function sanitizePersistedIpodMenuBreadcrumb(
+  value: unknown
+): IpodData["ipodMenuBreadcrumb"] {
+  if (!Array.isArray(value)) return null;
+  const breadcrumb = value.flatMap((entry) => {
+    if (!isRecord(entry) || typeof entry.title !== "string") return [];
+    const selectedIndex =
+      typeof entry.selectedIndex === "number" &&
+      Number.isFinite(entry.selectedIndex)
+        ? Math.max(0, Math.floor(entry.selectedIndex))
+        : 0;
+    return [
+      {
+        ...(typeof entry.kind === "string" && { kind: entry.kind }),
+        ...(typeof entry.id === "string" && { id: entry.id }),
+        title: entry.title,
+        ...(typeof entry.displayTitle === "string" && {
+          displayTitle: entry.displayTitle,
+        }),
+        selectedIndex,
+        ...(typeof entry.modernMediaList === "boolean" && {
+          modernMediaList: entry.modernMediaList,
+        }),
+        ...(typeof entry.alphabetic === "boolean" && {
+          alphabetic: entry.alphabetic,
+        }),
+      },
+    ];
+  });
+  return breadcrumb.length > 0 ? breadcrumb : null;
+}
+
+export function sanitizePersistedIpodStateForRehydrate(
+  persistedState: unknown
+): Partial<IpodData> {
+  if (!isRecord(persistedState)) return {};
+
+  const state = { ...persistedState } as PersistedIpodData;
+  for (const key of INDEXED_DB_BACKED_APPLE_MUSIC_KEYS) {
+    delete state[key];
+  }
+
+  if (state.librarySource !== "youtube" && state.librarySource !== "appleMusic") {
+    delete state.librarySource;
+  }
+
+  const currentSongId = sanitizePersistedString(state.currentSongId);
+  if (currentSongId === undefined) delete state.currentSongId;
+  else state.currentSongId = currentSongId;
+
+  const appleMusicCurrentSongId = sanitizePersistedString(
+    state.appleMusicCurrentSongId
+  );
+  if (appleMusicCurrentSongId === undefined) {
+    delete state.appleMusicCurrentSongId;
+  } else {
+    state.appleMusicCurrentSongId = appleMusicCurrentSongId;
+  }
+
+  if (Array.isArray(state.appleMusicPlaybackQueue)) {
+    state.appleMusicPlaybackQueue = normalizeAppleMusicPlaybackQueue(
+      state.appleMusicPlaybackQueue.filter(
+        (id): id is string => typeof id === "string"
+      )
+    );
+  } else if (state.appleMusicPlaybackQueue !== null) {
+    state.appleMusicPlaybackQueue = null;
+  }
+
+  if ("ipodMenuBreadcrumb" in state) {
+    state.ipodMenuBreadcrumb = sanitizePersistedIpodMenuBreadcrumb(
+      state.ipodMenuBreadcrumb
+    );
+  }
+
+  return state;
+}
 
 // Helper function to get unplayed track IDs from history
 function getUnplayedTrackIds(
@@ -2387,6 +2499,12 @@ export const useIpodStore = create<IpodState>()(
       // JSON.stringify'd and written synchronously on every persisted
       // mutation. Serialization now happens once per quiet window.
       storage: createDebouncedPersistStorage(),
+      migrate: (persistedState) =>
+        sanitizePersistedIpodStateForRehydrate(persistedState),
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        ...sanitizePersistedIpodStateForRehydrate(persistedState),
+      }),
       partialize: (state) => ({
         tracks: state.tracks,
         currentSongId: state.currentSongId,

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -1048,6 +1048,30 @@ describe("Apple Music opportunistic playlist refresh", () => {
     expect(state.appleMusicPlaylistTracksLoading).toEqual({});
   });
 
+  test("refreshStaleAppleMusicPlaylistTracks ignores playlist-list rows that were never opened", async () => {
+    useIpodStore.setState({
+      appleMusicPlaylists: [
+        {
+          id: "p:never-opened",
+          name: "Never Opened",
+          artworkUrl: undefined,
+          trackCount: 42,
+          canEdit: false,
+        },
+      ],
+      appleMusicPlaylistTracks: {},
+      appleMusicPlaylistTracksLoadedAt: {},
+      appleMusicPlaylistTracksLoading: {},
+    });
+
+    await refreshStaleAppleMusicPlaylistTracks();
+
+    const state = useIpodStore.getState();
+    expect(state.appleMusicPlaylistTracks).toEqual({});
+    expect(state.appleMusicPlaylistTracksLoadedAt).toEqual({});
+    expect(state.appleMusicPlaylistTracksLoading).toEqual({});
+  });
+
   test("refreshStaleAppleMusicPlaylistTracks no-ops silently when MusicKit isn't available even with stale entries", async () => {
     useIpodStore.setState({
       appleMusicPlaylistTracks: { "p:1": [] },

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -58,6 +58,7 @@ const {
   getActiveIpodTracks,
   getIpodTracksForLibrary,
   getIpodChatContextTrack,
+  sanitizePersistedIpodStateForRehydrate,
 } = await import("../src/stores/useIpodStore");
 const { handleIpodControl } = await import("../src/apps/chats/tools/ipodHandler");
 const { handleKaraokeControl } = await import("../src/apps/chats/tools/karaokeHandler");
@@ -480,6 +481,57 @@ describe("useIpodStore Apple Music slice", () => {
       },
     ]);
     expect(useIpodStore.getState().appleMusicCurrentSongId).toBe("am:1");
+  });
+
+  test("rehydrate sanitizer drops legacy Apple Music cache payloads from localStorage", () => {
+    const staleTrack = {
+      id: "am:legacy",
+      url: "applemusic:legacy",
+      title: "Legacy Track",
+      source: "appleMusic",
+      rawMusicKitResource: {
+        attributes: { name: "Legacy Track" },
+        relationships: { catalog: { data: Array.from({ length: 20 }) } },
+      },
+    };
+
+    const sanitized = sanitizePersistedIpodStateForRehydrate({
+      librarySource: "appleMusic",
+      appleMusicCurrentSongId: "am:legacy",
+      appleMusicPlaybackQueue: [staleTrack, "am:legacy", "", "am:next"],
+      appleMusicTracks: [staleTrack],
+      appleMusicPlaylists: [{ id: "p.1", name: "Playlist" }],
+      appleMusicPlaylistTracks: { "p.1": [staleTrack] },
+      appleMusicRecentlyAddedTracks: [staleTrack],
+      appleMusicFavoriteTracks: [staleTrack],
+      appleMusicLibraryLoading: true,
+      appleMusicKitNowPlaying: { title: "Live Song", id: "123" },
+      ipodMenuBreadcrumb: [
+        {
+          title: "Songs",
+          selectedIndex: 3,
+          items: [staleTrack],
+          action: { giant: staleTrack },
+        },
+      ],
+    });
+
+    expect(sanitized.librarySource).toBe("appleMusic");
+    expect(sanitized.appleMusicCurrentSongId).toBe("am:legacy");
+    expect(sanitized.appleMusicPlaybackQueue).toEqual([
+      "am:legacy",
+      "am:next",
+    ]);
+    expect(sanitized.appleMusicTracks).toBeUndefined();
+    expect(sanitized.appleMusicPlaylists).toBeUndefined();
+    expect(sanitized.appleMusicPlaylistTracks).toBeUndefined();
+    expect(sanitized.appleMusicRecentlyAddedTracks).toBeUndefined();
+    expect(sanitized.appleMusicFavoriteTracks).toBeUndefined();
+    expect(sanitized.appleMusicLibraryLoading).toBeUndefined();
+    expect(sanitized.appleMusicKitNowPlaying).toBeUndefined();
+    expect(sanitized.ipodMenuBreadcrumb).toEqual([
+      { title: "Songs", selectedIndex: 3 },
+    ]);
   });
 
   test("appleMusicNextTrack walks the library forward without touching the YouTube slice", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Sanitize legacy iPod Apple Music persistence on rehydrate so IndexedDB-backed library payloads, playlist caches, transient MusicKit snapshots, and old menu item objects do not enter the live store on startup.
- Keep compact startup state (`librarySource`, current Apple Music id, and string-only queue ids) so Apple Music mode can still restore after cache hydration.
- Replace noisy Apple Music background error object logging and routine iPod update logs with concise messages/debug logs.
- Stop eager Apple Music per-playlist track refreshes on iPod load, library sync, opportunistic refresh, and Playlists menu open; playlist tracks now stay lazy until a specific playlist is opened.

### Testing
- `bun test tests/test-ipod-apple-music.test.ts` — passed (74 tests).
- `bun run build` — passed; build emits existing CSS/chunking warnings unrelated to this change.
- Search confirmed no remaining `includeUncached` / all-playlist prefetch call sites.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0b6d-234b-7556-9bdd-ea97fcf95016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0b6d-234b-7556-9bdd-ea97fcf95016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

