### PR TITLE
Remove Books debug overlay

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -4,7 +4,6 @@ import {
   useEffect,
   useImperativeHandle,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -81,13 +80,6 @@ interface FlipState {
 
 type BooksDebugLevel = "info" | "warn" | "error";
 
-interface BooksDebugEvent {
-  at: string;
-  level: BooksDebugLevel;
-  step: string;
-  data?: unknown;
-}
-
 // Extra top clearance so the page never sits under the hover-revealed window
 // titlebar (the window uses the full-bleed "notitlebar" material).
 const TOP_CLEARANCE = 36;
@@ -107,7 +99,6 @@ const SPREAD_MIN_WIDTH = 560;
 export const ZOOM_DURATION = 0.45;
 export const ZOOM_EASE = [0.32, 0.72, 0, 1] as const;
 const REVEAL_DELAY_MS = 480;
-const MAX_DEBUG_EVENTS = 80;
 const DEFAULT_BOOK_ASSET_BY_PATH: Record<string, string> = {
   "/Books/Meditations - Marcus Aurelius.epub":
     "/assets/books/meditations-marcus-aurelius.epub",
@@ -163,19 +154,6 @@ function flattenBookChapters(
       ...flattenBookChapters(item.subitems, depth + 1, key),
     ];
   });
-}
-
-function isRuntimeBooksDebugEnabled(): boolean {
-  try {
-    if (typeof window === "undefined") return false;
-    const url = new URL(window.location.href);
-    return (
-      url.searchParams.get("booksDebug") === "1" ||
-      window.localStorage.getItem("ryos:debug") === "1"
-    );
-  } catch {
-    return false;
-  }
 }
 
 function serializeDebugValue(
@@ -284,10 +262,6 @@ export const BooksReaderPane = forwardRef<
   // Set when the EPUB can't be opened (missing blob or display failure) so the
   // user sees a message instead of being stuck on the loading shim / cover.
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [debugEvents, setDebugEvents] = useState<BooksDebugEvent[]>([]);
-  const [debugCopyStatus, setDebugCopyStatus] = useState<
-    "idle" | "copied" | "failed"
-  >("idle");
   // Zoom-in geometry for the cover overlay: animates from the clicked shelf
   // cover (`from`) to full-bleed (`to`), both in viewport-local coordinates.
   const [zoom, setZoom] = useState<{ from: ZoomRect; to: ZoomRect } | null>(
@@ -318,9 +292,8 @@ export const BooksReaderPane = forwardRef<
   );
 
   const displayDebugMode = useDisplaySettingsStore((s) => s.debugMode);
-  const booksDebugEnabled = displayDebugMode || isRuntimeBooksDebugEnabled();
-  const booksDebugEnabledRef = useRef(booksDebugEnabled);
-  booksDebugEnabledRef.current = booksDebugEnabled;
+  const displayDebugModeRef = useRef(displayDebugMode);
+  displayDebugModeRef.current = displayDebugMode;
 
   useEffect(() => {
     onNavigationStateChange?.(navigationState);
@@ -333,18 +306,15 @@ export const BooksReaderPane = forwardRef<
 
   const appendDebugEvent = useCallback(
     (step: string, data?: unknown, level: BooksDebugLevel = "info") => {
-      if (!booksDebugEnabledRef.current) return;
-      const event: BooksDebugEvent = {
-        at: new Date().toISOString(),
-        level,
-        step,
-        data: serializeDebugValue(data),
-      };
-      setDebugEvents((events) =>
-        [...events, event].slice(-MAX_DEBUG_EVENTS)
-      );
-      const log = level === "error" ? console.error : level === "warn" ? console.warn : console.log;
-      log("[BooksReader]", step, event.data);
+      if (!displayDebugModeRef.current) return;
+      const debugData = serializeDebugValue(data);
+      const log =
+        level === "error"
+          ? console.error
+          : level === "warn"
+            ? console.warn
+            : console.log;
+      log("[BooksReader]", step, debugData);
     },
     []
   );
@@ -408,7 +378,7 @@ export const BooksReaderPane = forwardRef<
   }, []);
 
   useEffect(() => {
-    if (!booksDebugEnabled) return;
+    if (!displayDebugMode) return;
     const onError = (event: ErrorEvent) => {
       appendDebugEvent(
         "window.error",
@@ -435,7 +405,7 @@ export const BooksReaderPane = forwardRef<
       window.removeEventListener("error", onError);
       window.removeEventListener("unhandledrejection", onUnhandledRejection);
     };
-  }, [appendDebugEvent, booksDebugEnabled]);
+  }, [appendDebugEvent, displayDebugMode]);
 
   // Create the book + rendition for the active EPUB.
   useEffect(() => {
@@ -445,8 +415,6 @@ export const BooksReaderPane = forwardRef<
     setIsReady(false);
     setCoverVisible(true);
     setLoadError(null);
-    setDebugCopyStatus("idle");
-    setDebugEvents([]);
     activeSectionHrefRef.current = undefined;
     setNavigationState(createInitialBooksNavigationState());
     appendDebugEvent("open:start", {
@@ -931,61 +899,6 @@ export const BooksReaderPane = forwardRef<
     return () => host.removeEventListener("keydown", onKeyDown);
   }, [handleKey]);
 
-  const debugSnapshot = useMemo(
-    () =>
-      JSON.stringify(
-        {
-          book: {
-            path: entry.path,
-            fileName: entry.fileName,
-            name: entry.name,
-            modifiedAt: entry.modifiedAt,
-          },
-          state: {
-            isReady,
-            coverVisible,
-            loadError,
-            progressPct,
-            atStart,
-            atEnd,
-            initialCfi,
-            initialPercentage,
-            settings,
-          },
-          environment: getBooksDebugEnvironment(),
-          events: debugEvents,
-        },
-        null,
-        2
-      ),
-    [
-      atEnd,
-      atStart,
-      coverVisible,
-      debugEvents,
-      entry.fileName,
-      entry.modifiedAt,
-      entry.name,
-      entry.path,
-      initialCfi,
-      initialPercentage,
-      isReady,
-      loadError,
-      progressPct,
-      settings,
-    ]
-  );
-
-  const copyDebugSnapshot = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(debugSnapshot);
-      setDebugCopyStatus("copied");
-    } catch (error) {
-      setDebugCopyStatus("failed");
-      appendDebugEvent("debug:copy:failed", error, "warn");
-    }
-  }, [appendDebugEvent, debugSnapshot]);
-
   return (
     <div
       ref={viewportRef}
@@ -1112,50 +1025,6 @@ export const BooksReaderPane = forwardRef<
           >
             {loadError}
           </span>
-        </div>
-      )}
-
-      {booksDebugEnabled && (
-        <div
-          className={cn(
-            "absolute bottom-8 left-3 right-3 z-[70] max-h-[42%] overflow-hidden rounded border p-2 text-left shadow-xl",
-            palette.isDark
-              ? "border-white/20 bg-black/85 text-white"
-              : "border-black/20 bg-white/90 text-black"
-          )}
-        >
-          <div className="mb-1 flex items-center justify-between gap-2">
-            <span className="font-os-ui text-[10px] font-bold uppercase tracking-wide">
-              {t("apps.books.reader.debugTitle", {
-                defaultValue: "EPUB debug log",
-              })}
-            </span>
-            <button
-              type="button"
-              onClick={copyDebugSnapshot}
-              className={cn(
-                "rounded px-2 py-1 font-os-ui text-[10px]",
-                palette.isDark
-                  ? "bg-white/15 text-white hover:bg-white/25"
-                  : "bg-black/10 text-black hover:bg-black/15"
-              )}
-            >
-              {debugCopyStatus === "copied"
-                ? t("apps.books.reader.debugCopied", {
-                    defaultValue: "Copied",
-                  })
-                : debugCopyStatus === "failed"
-                  ? t("apps.books.reader.debugCopyFailed", {
-                      defaultValue: "Copy failed",
-                    })
-                  : t("apps.books.reader.debugCopy", {
-                      defaultValue: "Copy logs",
-                    })}
-            </button>
-          </div>
-          <pre className="max-h-[calc(42vh-48px)] overflow-auto whitespace-pre-wrap break-words rounded bg-black/80 p-2 font-mono text-[10px] leading-snug text-lime-100">
-            {debugSnapshot}
-          </pre>
         </div>
       )}
 

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -618,10 +618,6 @@
       "name": "Bücher",
       "reader": {
         "backToShelf": "Regal",
-        "debugCopied": "Kopiert",
-        "debugCopy": "Logs kopieren",
-        "debugCopyFailed": "Kopieren fehlgeschlagen",
-        "debugTitle": "EPUB-Debug-Log",
         "error": "Dieses Buch konnte nicht geöffnet werden."
       },
       "shelf": {

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -4466,11 +4466,7 @@
       },
       "reader": {
         "backToShelf": "Shelf",
-        "error": "Couldn’t open this book.",
-        "debugTitle": "EPUB debug log",
-        "debugCopy": "Copy logs",
-        "debugCopied": "Copied",
-        "debugCopyFailed": "Copy failed"
+        "error": "Couldn’t open this book."
       },
       "import": {
         "title": "Import EPUB"

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -618,10 +618,6 @@
       "name": "Libros",
       "reader": {
         "backToShelf": "Estantería",
-        "debugCopied": "Copiado",
-        "debugCopy": "Copiar registros",
-        "debugCopyFailed": "Error al copiar",
-        "debugTitle": "Registro de depuración EPUB",
         "error": "No se pudo abrir este libro."
       },
       "shelf": {

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -618,10 +618,6 @@
       "name": "Livres",
       "reader": {
         "backToShelf": "Bibliothèque",
-        "debugCopied": "Copié",
-        "debugCopy": "Copier les journaux",
-        "debugCopyFailed": "Échec de la copie",
-        "debugTitle": "Journal de débogage EPUB",
         "error": "Impossible d’ouvrir ce livre."
       },
       "shelf": {

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -618,10 +618,6 @@
       "name": "Libri",
       "reader": {
         "backToShelf": "Libreria",
-        "debugCopied": "Copiato",
-        "debugCopy": "Copia log",
-        "debugCopyFailed": "Copia non riuscita",
-        "debugTitle": "Log di debug EPUB",
         "error": "Impossibile aprire questo libro."
       },
       "shelf": {

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -618,10 +618,6 @@
       "name": "ブック",
       "reader": {
         "backToShelf": "本棚",
-        "debugCopied": "コピーしました",
-        "debugCopy": "ログをコピー",
-        "debugCopyFailed": "コピーに失敗しました",
-        "debugTitle": "EPUBデバッグログ",
         "error": "この本を開けませんでした。"
       },
       "shelf": {

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -618,10 +618,6 @@
       "name": "도서",
       "reader": {
         "backToShelf": "책장",
-        "debugCopied": "복사됨",
-        "debugCopy": "로그 복사",
-        "debugCopyFailed": "복사 실패",
-        "debugTitle": "EPUB 디버그 로그",
         "error": "이 책을 열 수 없습니다."
       },
       "shelf": {

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -618,10 +618,6 @@
       "name": "Livros",
       "reader": {
         "backToShelf": "Estante",
-        "debugCopied": "Copiado",
-        "debugCopy": "Copiar logs",
-        "debugCopyFailed": "Falha ao copiar",
-        "debugTitle": "Log de depuração EPUB",
         "error": "Não foi possível abrir este livro."
       },
       "shelf": {

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -618,10 +618,6 @@
       "name": "Книги",
       "reader": {
         "backToShelf": "Полка",
-        "debugCopied": "Скопировано",
-        "debugCopy": "Копировать логи",
-        "debugCopyFailed": "Ошибка копирования",
-        "debugTitle": "Журнал отладки EPUB",
         "error": "Не удалось открыть эту книгу."
       },
       "shelf": {

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -618,10 +618,6 @@
       "name": "書籍",
       "reader": {
         "backToShelf": "書架",
-        "debugCopied": "已複製",
-        "debugCopy": "複製記錄",
-        "debugCopyFailed": "複製失敗",
-        "debugTitle": "EPUB 除錯記錄",
         "error": "無法開啟此書。"
       },
       "shelf": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Remove the custom Books EPUB debug overlay and copy-log snapshot UI.
- Remove the now-unused Books reader debug UI translation keys.

### Walkthrough
<a href="https://cursor.com/agents/bc-019f0b83-3fbd-71ff-9867-01ad89ae3bde/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbooks_reader_without_debug_overlay.mp4"><img src="https://cursor.com/artifacts/c/art-9cec29b1-1f2f-4821-a81c-d66f69d87ef9" alt="books_reader_without_debug_overlay.mp4" /></a>
![Books reader without debug overlay](https://cursor.com/artifacts/c/art-f61ba149-de78-4ccd-9000-88615f71f029)

### Testing
- `bun test tests/test-books-default-epub.test.ts tests/test-books-cover-load-queue.test.ts`
- `bun run build`
- Manual browser verification with global debug mode enabled: opened Books and the default EPUB; no Books-specific EPUB debug panel or Copy logs button was visible.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0b83-3fbd-71ff-9867-01ad89ae3bde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0b83-3fbd-71ff-9867-01ad89ae3bde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

