### PR TITLE
Fix boot screen dialog description warning

### DIFF
--- a/src/components/dialogs/BootScreen.tsx
+++ b/src/components/dialogs/BootScreen.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useReducer } from "react";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useSound, Sounds } from "@/hooks/useSound";
@@ -52,6 +57,7 @@ export function BootScreen({
     isWin98,
   } = useThemeFlags();
   const localizedTitle = title ?? t("common.system.systemRestoring");
+  const dialogDescription = localizedTitle;
 
   const handleDone = () => {
     onBootComplete?.();
@@ -153,6 +159,7 @@ export function BootScreen({
           >
             <VisuallyHidden>
               <DialogTitle>{localizedTitle}</DialogTitle>
+              <DialogDescription>{dialogDescription}</DialogDescription>
             </VisuallyHidden>
             <div 
               className="flex flex-col items-center justify-center size-full bg-black"
@@ -205,6 +212,7 @@ export function BootScreen({
           >
             <VisuallyHidden>
               <DialogTitle>{localizedTitle}</DialogTitle>
+              <DialogDescription>{dialogDescription}</DialogDescription>
             </VisuallyHidden>
             <div 
               className="flex flex-col items-center justify-center pt-2 pb-12 px-16 min-h-[280px] w-full"
@@ -270,6 +278,7 @@ export function BootScreen({
         >
           <VisuallyHidden>
             <DialogTitle>{localizedTitle}</DialogTitle>
+            <DialogDescription>{dialogDescription}</DialogDescription>
           </VisuallyHidden>
           <div 
             className="flex flex-col items-center justify-center p-8 min-h-[300px] w-full"

--- a/tests/test-boot-screen-accent.test.ts
+++ b/tests/test-boot-screen-accent.test.ts
@@ -1,13 +1,96 @@
-import { describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { getAccentCssVars } from "../src/themes/accents";
 import { darkAquaThemeCss } from "./theme-css-fixtures";
+import type { OsThemeId } from "../src/themes/types";
+
+beforeAll(() => {
+  if (typeof document === "undefined") {
+    GlobalRegistrator.register();
+  }
+});
+
+afterAll(() => {
+  if (GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.unregister();
+  }
+});
+
+mock.module("@/hooks/useSound", () => ({
+  Sounds: {
+    BOOT: "/sounds/boot.mp3",
+    WINDOW_CLOSE: "/sounds/window-close.mp3",
+    WINDOW_OPEN: "/sounds/window-open.mp3",
+  },
+  useSound: () => ({ play: () => {} }),
+}));
+
+mock.module("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      key === "common.system.systemRestoring" ? "System Restoring..." : key,
+  }),
+}));
+
+const { BootScreen } = await import("../src/components/dialogs/BootScreen");
+const { useThemeStore } = await import("../src/stores/useThemeStore");
 
 const bootScreenSource = readFileSync(
   join(import.meta.dir, "../src/components/dialogs/BootScreen.tsx"),
   "utf8"
 );
+
+async function flushReact(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function renderBootScreen(theme: OsThemeId): Promise<string[]> {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  let root: Root | null = null;
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  useThemeStore.setState({ current: theme });
+
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.join(" "));
+  };
+  console.error = (...args: unknown[]) => {
+    warnings.push(args.join(" "));
+  };
+
+  try {
+    root = createRoot(host);
+    root.render(
+      React.createElement(BootScreen, {
+        isOpen: true,
+        onOpenChange: () => {},
+        debugMode: true,
+      })
+    );
+    await flushReact();
+    return warnings;
+  } finally {
+    console.warn = originalWarn;
+    console.error = originalError;
+    root?.unmount();
+    host.remove();
+    document.body.innerHTML = "";
+  }
+}
 
 function hexToHsl(hex: string): { h: number; s: number; l: number } {
   const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
@@ -87,6 +170,19 @@ describe("macOS boot screen accent tokens", () => {
         /<DialogDescription>\{dialogDescription\}<\/DialogDescription>/g
       )
     ).toHaveLength(3);
+  });
+
+  test("BootScreen renders without Radix missing-description warnings", async () => {
+    for (const theme of ["macosx", "system7", "xp", "win98"] as const) {
+      const warnings = await renderBootScreen(theme);
+      expect(
+        warnings.some(
+          (warning) =>
+            warning.includes("Missing `Description`") ||
+            warning.includes("aria-describedby={undefined}")
+        )
+      ).toBe(false);
+    }
   });
 
   test("dark-aqua.css wires boot apple logo filter with stock fallback", () => {

--- a/tests/test-boot-screen-accent.test.ts
+++ b/tests/test-boot-screen-accent.test.ts
@@ -1,6 +1,5 @@
 import {
   afterAll,
-  afterEach,
   beforeAll,
   describe,
   expect,
@@ -22,7 +21,8 @@ beforeAll(() => {
   }
 });
 
-afterAll(() => {
+afterAll(async () => {
+  await flushReact();
   if (GlobalRegistrator.isRegistered) {
     GlobalRegistrator.unregister();
   }
@@ -87,6 +87,7 @@ async function renderBootScreen(theme: OsThemeId): Promise<string[]> {
     console.warn = originalWarn;
     console.error = originalError;
     root?.unmount();
+    await flushReact();
     host.remove();
     document.body.innerHTML = "";
   }

--- a/tests/test-boot-screen-accent.test.ts
+++ b/tests/test-boot-screen-accent.test.ts
@@ -80,6 +80,15 @@ describe("macOS boot screen accent tokens", () => {
     expect(bootScreenSource).not.toContain('filter: "grayscale(50%) brightness(1.25)"');
   });
 
+  test("BootScreen supplies descriptions for each Radix dialog content", () => {
+    expect(bootScreenSource).toContain("DialogDescription");
+    expect(
+      bootScreenSource.match(
+        /<DialogDescription>\{dialogDescription\}<\/DialogDescription>/g
+      )
+    ).toHaveLength(3);
+  });
+
   test("dark-aqua.css wires boot apple logo filter with stock fallback", () => {
     expect(darkAquaThemeCss).toContain("img.boot-screen-apple-logo");
     expect(darkAquaThemeCss).toContain("--os-accent-boot-apple-filter");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add hidden Radix dialog descriptions to every boot screen dialog branch.
- Add a focused regression check that mounts `BootScreen` across macOS, System 7, XP, and Win98 and asserts the missing-description warning is not emitted.

### Walkthrough
<a href="https://cursor.com/agents/bc-019f0bce-3ef5-700a-8529-61ba8b07b9be/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fboot_screen_no_description_warning.mp4"><img src="https://cursor.com/artifacts/c/art-c87e5538-ee1b-4d39-a9d1-d1406f4ebaf5" alt="boot_screen_no_description_warning.mp4" /></a>

### Testing
- Passed: `bun test tests/test-boot-screen-accent.test.ts`
- Passed: `bun run build`
- Passed: manual browser check with debug boot screen and DevTools console; no `Missing \`Description\`` / `aria-describedby={undefined}` warning observed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0bce-3ef5-700a-8529-61ba8b07b9be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0bce-3ef5-700a-8529-61ba8b07b9be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

