### PR TITLE
Bound cloud sync changes catch-up reads

### DIFF
--- a/api/sync/v2/_core.ts
+++ b/api/sync/v2/_core.ts
@@ -42,6 +42,7 @@ import { redisKeys } from "../../../src/shared/redisKeys.js";
 
 export const MAX_OPS_PER_REQUEST = 1000;
 export const MAX_OP_VALUE_BYTES = 512 * 1024;
+export const MAX_CHANGES_OPS_PER_RESPONSE = 512;
 const JOURNAL_MAX_LENGTH = 4096;
 const LOCK_TTL_SECONDS = 10;
 const LOCK_RETRY_DELAYS_MS = [150, 300, 600, 1200, 2400];
@@ -431,6 +432,11 @@ export async function readSyncChanges(
   const count = await redis.zcard(journalKey);
   const missing = seq - since;
   if (missing > count) {
+    return { seq, snapshotRequired: true };
+  }
+  // Keep the latency-sensitive changes endpoint bounded; large catch-ups use
+  // the already-supported snapshot path instead of replaying the full journal.
+  if (missing > MAX_CHANGES_OPS_PER_RESPONSE) {
     return { seq, snapshotRequired: true };
   }
 

--- a/tests/test-sync-v2-api.test.ts
+++ b/tests/test-sync-v2-api.test.ts
@@ -5,6 +5,7 @@ import {
   fetchWithAuth,
   fetchWithOrigin,
 } from "./test-utils";
+import { MAX_CHANGES_OPS_PER_RESPONSE } from "../api/sync/v2/_core";
 import { formatHlc } from "../src/shared/sync2/hlc";
 
 /**
@@ -94,6 +95,44 @@ describe("sync v2 API", () => {
     );
     const body = (await changes.json()) as { ops: unknown[] };
     expect(body.ops).toEqual([]);
+  });
+
+  test("large cursor gaps fall back to snapshot without streaming the journal", async () => {
+    const username = `sync2large${Date.now().toString(36)}`;
+    const authToken = await ensureUserAuth(username, PASSWORD);
+    const ops = Array.from(
+      { length: MAX_CHANGES_OPS_PER_RESPONSE + 1 },
+      (_, index) => ({
+        k: `settings/large-gap-${index}`,
+        v: { value: index },
+        t: t(20_000 + index, "large-gap-client"),
+      })
+    );
+
+    const upload = await fetchWithAuth(
+      `${BASE_URL}/api/sync/v2/ops`,
+      username,
+      authToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ clientId: "large-gap-client", ops }),
+      }
+    );
+    expect(upload.status).toBe(200);
+
+    const changes = await fetchWithAuth(
+      `${BASE_URL}/api/sync/v2/changes?since=0`,
+      username,
+      authToken
+    );
+    expect(changes.status).toBe(200);
+    const body = (await changes.json()) as {
+      snapshotRequired?: boolean;
+      ops?: unknown[];
+    };
+    expect(body.snapshotRequired).toBe(true);
+    expect(body.ops).toBeUndefined();
   });
 
   test("LWW: an older write loses and receives the winner inline", async () => {

--- a/tests/test-sync-v2-core.test.ts
+++ b/tests/test-sync-v2-core.test.ts
@@ -3,6 +3,7 @@ import type { Redis } from "../api/_utils/redis";
 import {
   applySyncOps,
   ensureSync2Initialized,
+  MAX_CHANGES_OPS_PER_RESPONSE,
   readSyncChanges,
   readSyncDocsByPrefix,
   readSyncSnapshot,
@@ -35,6 +36,7 @@ function redis(): Redis {
 class TrackingRedis extends FakeRedis {
   directZaddCount = 0;
   pipelineZaddCount = 0;
+  zrangeCalls: Array<{ key: string; start: number; stop: number }> = [];
 
   async zadd(
     key: string,
@@ -52,6 +54,11 @@ class TrackingRedis extends FakeRedis {
       return originalZadd(key, entry);
     }) as typeof pipeline.zadd;
     return pipeline;
+  }
+
+  async zrange(key: string, start: number, stop: number): Promise<string[]> {
+    this.zrangeCalls.push({ key, start, stop });
+    return super.zrange(key, start, stop);
   }
 }
 
@@ -271,6 +278,26 @@ describe("sync v2 changes feed", () => {
     (r as unknown as FakeRedis).zsets.clear();
     const result = await readSyncChanges(r, "user1", 0);
     expect(result.snapshotRequired).toBe(true);
+  });
+
+  test("requires a snapshot instead of reading an oversized journal catch-up", async () => {
+    const r = new TrackingRedis();
+    const username = "farbehind";
+    const ops = Array.from(
+      { length: MAX_CHANGES_OPS_PER_RESPONSE + 1 },
+      (_, index) => ({
+        k: `settings/far-behind-${index}`,
+        v: { value: index },
+        t: t(index),
+      })
+    );
+
+    await applySyncOps(r as unknown as Redis, username, ops, "client-a");
+    const result = await readSyncChanges(r as unknown as Redis, username, 0);
+
+    expect(result.snapshotRequired).toBe(true);
+    expect(result.ops).toBeUndefined();
+    expect(r.zrangeCalls).toEqual([]);
   });
 
   test("coalesces repeated writes to the same key to the latest op", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bound `/api/sync/v2/changes` incremental catch-up reads to 512 ops and return the existing `snapshotRequired` fallback for larger cursor gaps.
- Add unit coverage that oversized catch-ups do not call `zrange`.
- Add HTTP integration coverage that a 513-op gap returns `snapshotRequired` instead of streaming the journal.

## Testing
- `bun test tests/test-sync-v2-core.test.ts`
- `bun test tests/test-sync-v2-core.test.ts && bun test tests/test-sync-v2-api.test.ts`
- `bun test tests/test-sync-v2-engine-e2e.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0bd0-8b2a-78f3-830d-417ca2748786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0bd0-8b2a-78f3-830d-417ca2748786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

