### PR TITLE
Virtualize debug console logs

### DIFF
--- a/src/components/debug/DebugLogOverlay.tsx
+++ b/src/components/debug/DebugLogOverlay.tsx
@@ -7,7 +7,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { Bug, Check, Copy, Trash, X } from "@phosphor-icons/react";
+import { ArrowDown, Bug, Check, Copy, Trash, X } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
@@ -31,12 +31,40 @@ const LEVEL_TEXT_CLASS: Record<ConsoleLogLevel, string> = {
   error: "text-red-500",
 };
 
+const ESTIMATED_LOG_ROW_HEIGHT = 22;
+const VIRTUAL_OVERSCAN = 8;
+const STICK_TO_BOTTOM_THRESHOLD = 24;
+
 function formatTime(timestamp: number): string {
   const d = new Date(timestamp);
   const pad = (n: number, len = 2) => String(n).padStart(len, "0");
   return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(
     d.getSeconds()
   )}.${pad(d.getMilliseconds(), 3)}`;
+}
+
+function findFirstVisibleIndex(
+  offsets: number[],
+  totalHeight: number,
+  scrollTop: number
+): number {
+  let low = 0;
+  let high = offsets.length - 1;
+  let result = offsets.length;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const rowBottom = mid === offsets.length - 1 ? totalHeight : offsets[mid + 1];
+
+    if (rowBottom > scrollTop) {
+      result = mid;
+      high = mid - 1;
+    } else {
+      low = mid + 1;
+    }
+  }
+
+  return Math.min(result, Math.max(0, offsets.length - 1));
 }
 
 /**
@@ -66,22 +94,134 @@ export function DebugLogOverlay() {
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const stickToBottomRef = useRef(true);
+  const rowHeightsRef = useRef<Map<number, number>>(new Map());
+  const [heightRevision, setHeightRevision] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(0);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [isAtBottom, setIsAtBottom] = useState(true);
 
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
     const distanceFromBottom =
       el.scrollHeight - el.scrollTop - el.clientHeight;
-    stickToBottomRef.current = distanceFromBottom < 24;
+    const atBottom = distanceFromBottom < STICK_TO_BOTTOM_THRESHOLD;
+    stickToBottomRef.current = atBottom;
+    setIsAtBottom((previous) => (previous === atBottom ? previous : atBottom));
+    setScrollTop(el.scrollTop);
   }, []);
+
+  const { offsets, totalHeight } = useMemo(() => {
+    let height = 0;
+    const nextOffsets = entries.map((entry) => {
+      const offset = height;
+      height += rowHeightsRef.current.get(entry.id) ?? ESTIMATED_LOG_ROW_HEIGHT;
+      return offset;
+    });
+
+    return { offsets: nextOffsets, totalHeight: height };
+  }, [entries, heightRevision]);
+
+  const virtualItems = useMemo(() => {
+    if (entries.length === 0) return [];
+
+    const visibleHeight = viewportHeight || ESTIMATED_LOG_ROW_HEIGHT;
+    const firstVisibleIndex = findFirstVisibleIndex(
+      offsets,
+      totalHeight,
+      scrollTop
+    );
+    const lastVisibleIndex = findFirstVisibleIndex(
+      offsets,
+      totalHeight,
+      scrollTop + visibleHeight
+    );
+    const startIndex = Math.max(0, firstVisibleIndex - VIRTUAL_OVERSCAN);
+    const endIndex = Math.min(
+      entries.length - 1,
+      lastVisibleIndex + VIRTUAL_OVERSCAN
+    );
+    const items: Array<{
+      entry: ConsoleLogEntry;
+      index: number;
+      start: number;
+    }> = [];
+
+    for (let index = startIndex; index <= endIndex; index += 1) {
+      items.push({ entry: entries[index], index, start: offsets[index] });
+    }
+
+    return items;
+  }, [entries, offsets, scrollTop, totalHeight, viewportHeight]);
+
+  const measureRow = useCallback(
+    (entryId: number, node: HTMLDivElement | null) => {
+      if (!node) return;
+      const height = node.getBoundingClientRect().height;
+      if (height <= 0) return;
+
+      const previous = rowHeightsRef.current.get(entryId);
+      if (previous === undefined || Math.abs(previous - height) > 0.5) {
+        rowHeightsRef.current.set(entryId, height);
+        setHeightRevision((revision) => revision + 1);
+      }
+    },
+    []
+  );
+
+  const scrollToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight });
+    stickToBottomRef.current = true;
+    setIsAtBottom(true);
+    setScrollTop(el.scrollTop);
+  }, []);
+
+  const handleClear = useCallback(() => {
+    clearConsoleCapture();
+    rowHeightsRef.current.clear();
+    stickToBottomRef.current = true;
+    setIsAtBottom(true);
+    setScrollTop(0);
+  }, []);
+
+  useEffect(() => {
+    const ids = new Set(entries.map((entry) => entry.id));
+    for (const id of rowHeightsRef.current.keys()) {
+      if (!ids.has(id)) rowHeightsRef.current.delete(id);
+    }
+    if (entries.length === 0) {
+      stickToBottomRef.current = true;
+      setIsAtBottom(true);
+      setScrollTop(0);
+    }
+  }, [entries]);
 
   useLayoutEffect(() => {
     if (!open) return;
     const el = scrollRef.current;
-    if (el && stickToBottomRef.current) {
-      el.scrollTop = el.scrollHeight;
+    if (!el) return;
+
+    const updateViewportHeight = () => {
+      setViewportHeight(el.clientHeight);
+    };
+
+    updateViewportHeight();
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", updateViewportHeight);
+      return () => window.removeEventListener("resize", updateViewportHeight);
     }
-  }, [open, entries]);
+
+    const observer = new ResizeObserver(updateViewportHeight);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [open]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    if (stickToBottomRef.current) scrollToBottom();
+  }, [open, scrollToBottom, totalHeight]);
 
   const copyText = useMemo(
     () => formatConsoleEntriesForCopy(entries),
@@ -185,7 +325,7 @@ export function DebugLogOverlay() {
               </button>
               <button
                 type="button"
-                onClick={() => clearConsoleCapture()}
+                onClick={handleClear}
                 title={t("debug.clearLogs")}
                 aria-label={t("debug.clearLogs")}
                 className="flex items-center rounded p-1 hover:bg-black/10 os-mac-aqua-dark:hover:bg-white/15"
@@ -205,34 +345,61 @@ export function DebugLogOverlay() {
           </div>
 
           {/* Log list */}
-          <div
-            ref={scrollRef}
-            onScroll={handleScroll}
-            className="flex-1 min-h-0 overflow-auto px-2 py-1 font-os-mono text-[10px] leading-[1.45]"
-          >
-            {entries.length === 0 ? (
-              <div className="py-4 text-center text-[11px] opacity-50">
-                {t("debug.noLogsYet")}
-              </div>
-            ) : (
-              entries.map((entry: ConsoleLogEntry) => (
-                <div
-                  key={entry.id}
-                  className="flex gap-1.5 border-b border-black/5 py-0.5 os-mac-aqua-dark:border-white/5"
-                >
-                  <span className="shrink-0 tabular-nums opacity-40">
-                    {formatTime(entry.timestamp)}
-                  </span>
-                  <span
-                    className={cn(
-                      "whitespace-pre-wrap break-words",
-                      LEVEL_TEXT_CLASS[entry.level]
-                    )}
-                  >
-                    {entry.text}
-                  </span>
+          <div className="relative flex-1 min-h-0">
+            <div
+              ref={scrollRef}
+              onScroll={handleScroll}
+              className="h-full overflow-auto px-2 py-1 font-os-mono text-[10px] leading-[1.45]"
+            >
+              {entries.length === 0 ? (
+                <div className="py-4 text-center text-[11px] opacity-50">
+                  {t("debug.noLogsYet")}
                 </div>
-              ))
+              ) : (
+                <div
+                  className="relative w-full"
+                  style={{ height: `${totalHeight}px` }}
+                >
+                  {virtualItems.map(({ entry, index, start }) => (
+                    <div
+                      key={entry.id}
+                      ref={(node) => measureRow(entry.id, node)}
+                      className="absolute left-0 right-0 flex gap-1.5 border-b border-black/5 py-0.5 os-mac-aqua-dark:border-white/5"
+                      style={{ transform: `translateY(${start}px)` }}
+                      data-console-row-index={index}
+                    >
+                      <span className="shrink-0 tabular-nums opacity-40">
+                        {formatTime(entry.timestamp)}
+                      </span>
+                      <span
+                        className={cn(
+                          "min-w-0 whitespace-pre-wrap break-words",
+                          LEVEL_TEXT_CLASS[entry.level]
+                        )}
+                      >
+                        {entry.text}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+            {entries.length > 0 && !isAtBottom && (
+              <button
+                type="button"
+                onClick={scrollToBottom}
+                title={t("debug.scrollToBottom")}
+                aria-label={t("debug.scrollToBottom")}
+                className={cn(
+                  "absolute bottom-2 right-3 flex items-center gap-1 rounded-full px-2 py-1",
+                  "border-[length:var(--os-metrics-border-width)] border-os-window",
+                  "bg-os-window-bg text-os-text-primary shadow-os-window",
+                  "font-os-ui text-[11px] hover:brightness-105 active:brightness-95"
+                )}
+              >
+                <ArrowDown weight="bold" className="size-3" />
+                <span>{t("debug.scrollToBottom")}</span>
+              </button>
             )}
           </div>
         </div>

--- a/src/components/debug/DebugLogOverlay.tsx
+++ b/src/components/debug/DebugLogOverlay.tsx
@@ -94,6 +94,7 @@ export function DebugLogOverlay() {
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const stickToBottomRef = useRef(true);
+  const pendingStickToBottomRef = useRef(false);
   const rowHeightsRef = useRef<Map<number, number>>(new Map());
   const [heightRevision, setHeightRevision] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(0);
@@ -162,6 +163,7 @@ export function DebugLogOverlay() {
 
       const previous = rowHeightsRef.current.get(entryId);
       if (previous === undefined || Math.abs(previous - height) > 0.5) {
+        if (stickToBottomRef.current) pendingStickToBottomRef.current = true;
         rowHeightsRef.current.set(entryId, height);
         setHeightRevision((revision) => revision + 1);
       }
@@ -174,6 +176,7 @@ export function DebugLogOverlay() {
     if (!el) return;
     el.scrollTo({ top: el.scrollHeight });
     stickToBottomRef.current = true;
+    pendingStickToBottomRef.current = false;
     setIsAtBottom(true);
     setScrollTop(el.scrollTop);
   }, []);
@@ -182,6 +185,7 @@ export function DebugLogOverlay() {
     clearConsoleCapture();
     rowHeightsRef.current.clear();
     stickToBottomRef.current = true;
+    pendingStickToBottomRef.current = false;
     setIsAtBottom(true);
     setScrollTop(0);
   }, []);
@@ -193,6 +197,7 @@ export function DebugLogOverlay() {
     }
     if (entries.length === 0) {
       stickToBottomRef.current = true;
+      pendingStickToBottomRef.current = false;
       setIsAtBottom(true);
       setScrollTop(0);
     }
@@ -220,7 +225,9 @@ export function DebugLogOverlay() {
 
   useLayoutEffect(() => {
     if (!open) return;
-    if (stickToBottomRef.current) scrollToBottom();
+    if (stickToBottomRef.current || pendingStickToBottomRef.current) {
+      scrollToBottom();
+    }
   }, [open, scrollToBottom, totalHeight]);
 
   const copyText = useMemo(

--- a/src/components/debug/DebugLogOverlay.tsx
+++ b/src/components/debug/DebugLogOverlay.tsx
@@ -349,6 +349,7 @@ export function DebugLogOverlay() {
             <div
               ref={scrollRef}
               onScroll={handleScroll}
+              data-debug-console-scroll
               className="h-full overflow-auto px-2 py-1 font-os-mono text-[10px] leading-[1.45]"
             >
               {entries.length === 0 ? (
@@ -388,6 +389,7 @@ export function DebugLogOverlay() {
               <button
                 type="button"
                 onClick={scrollToBottom}
+                data-debug-console-scroll-bottom
                 title={t("debug.scrollToBottom")}
                 aria-label={t("debug.scrollToBottom")}
                 className={cn(

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -4695,6 +4695,7 @@
     "hideConsole": "Konsole ausblenden",
     "noLogsYet": "Noch keine Logs erfasst.",
     "showConsole": "Konsole anzeigen",
+    "scrollToBottom": "Nach unten scrollen",
     "toggleLabel": "Debug",
     "warnCount": "{{count}} Warn."
   },

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -4711,6 +4711,7 @@
     "closeConsole": "Close console",
     "hideConsole": "Hide console",
     "showConsole": "Show console",
+    "scrollToBottom": "Scroll to bottom",
     "noLogsYet": "No logs captured yet.",
     "toggleLabel": "Debug"
   },

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -4680,6 +4680,7 @@
     "hideConsole": "Ocultar consola",
     "noLogsYet": "No hay registros capturados aún.",
     "showConsole": "Mostrar consola",
+    "scrollToBottom": "Desplazarse al final",
     "toggleLabel": "Depuración",
     "warnCount": "{{count}} warn"
   },

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -4695,6 +4695,7 @@
     "hideConsole": "Masquer la console",
     "noLogsYet": "Aucun log capturé pour le moment.",
     "showConsole": "Afficher la console",
+    "scrollToBottom": "Faire défiler vers le bas",
     "toggleLabel": "Debug",
     "warnCount": "{{count}} avert"
   },

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -4680,6 +4680,7 @@
     "hideConsole": "Nascondi console",
     "noLogsYet": "Nessun log ancora acquisito.",
     "showConsole": "Mostra console",
+    "scrollToBottom": "Scorri in fondo",
     "toggleLabel": "Debug",
     "warnCount": "{{count}} warn"
   },

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -4695,6 +4695,7 @@
     "hideConsole": "コンソールを非表示",
     "noLogsYet": "ログはまだ記録されていません。",
     "showConsole": "コンソールを表示",
+    "scrollToBottom": "一番下へスクロール",
     "toggleLabel": "デバッグ",
     "warnCount": "{{count}} 警告"
   },

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -4695,6 +4695,7 @@
     "hideConsole": "콘솔 숨기기",
     "noLogsYet": "아직 캡처된 로그가 없습니다.",
     "showConsole": "콘솔 표시",
+    "scrollToBottom": "맨 아래로 스크롤",
     "toggleLabel": "디버그",
     "warnCount": "{{count}} 경고"
   },

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -4680,6 +4680,7 @@
     "hideConsole": "Ocultar console",
     "noLogsYet": "Nenhum log capturado ainda.",
     "showConsole": "Mostrar console",
+    "scrollToBottom": "Rolar até o fim",
     "toggleLabel": "Debug",
     "warnCount": "{{count}} warn"
   },

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -4680,6 +4680,7 @@
     "hideConsole": "Скрыть консоль",
     "noLogsYet": "Логи пока не собраны.",
     "showConsole": "Показать консоль",
+    "scrollToBottom": "Прокрутить вниз",
     "toggleLabel": "Отладка",
     "warnCount": "{{count}} предупр."
   },

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -4695,6 +4695,7 @@
     "hideConsole": "隱藏主控台",
     "noLogsYet": "尚未擷取到任何記錄。",
     "showConsole": "顯示主控台",
+    "scrollToBottom": "捲動到底部",
     "toggleLabel": "除錯",
     "warnCount": "{{count}} 個警告"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Virtualize the debug console log panel with measured rows so large captured logs render only visible entries.
- Add a localized scroll-to-bottom button when the panel is not at the bottom.
- Keep sticky-bottom behavior pinned while multiline virtual rows are measured.

### Walkthrough
<a href="https://cursor.com/agents/bc-019f0c46-c4f1-7c9b-844d-b2ddcfdd4c14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdebug_console_scroll_to_bottom.mp4"><img src="https://cursor.com/artifacts/c/art-331370b6-d36b-4684-a21f-3764d310254c" alt="debug_console_scroll_to_bottom.mp4" /></a>

### Testing
- `bun test tests/test-console-capture.test.ts`
- `bun run i18n:sync:dry-run`
- `bun run build`
- Browser assertion against local dev app with 500 generated logs: latest log visible, 16 virtual rows mounted, scroll-to-bottom final distance 0.
- Manual browser walkthrough recorded and reviewed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0c46-c4f1-7c9b-844d-b2ddcfdd4c14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0c46-c4f1-7c9b-844d-b2ddcfdd4c14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

