### PR TITLE
Fix manual restore Sync v2 promotion

### DIFF
--- a/src/apps/control-panels/hooks/useControlPanelsLogic.ts
+++ b/src/apps/control-panels/hooks/useControlPanelsLogic.ts
@@ -44,6 +44,11 @@ import { useTelegramLink } from "@/hooks/useTelegramLink";
 import { useRecoveryEmail } from "@/hooks/useRecoveryEmail";
 import { useAccountJoinDate } from "@/hooks/useAccountJoinDate";
 import { getActiveCloudSyncEngine } from "@/sync/engine";
+import { shouldIncludeManualBackupLocalStorageKey } from "@/sync/manualBackup";
+import {
+  createManualRestoreIntent,
+  setManualRestoreIntent,
+} from "@/sync/manualRestoreIntent";
 import { SYNC_CATEGORIES } from "@/shared/sync2/namespaces";
 import {
   readStoreItems,
@@ -627,7 +632,7 @@ export function useControlPanelsLogic({
       flushDebouncedPersistWrites();
       for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
-        if (key) {
+        if (key && shouldIncludeManualBackupLocalStorageKey(key)) {
           backup.localStorage[key] = localStorage.getItem(key);
         }
       }
@@ -933,7 +938,10 @@ export function useControlPanelsLogic({
 
       // Restore localStorage
       Object.entries(backup.localStorage).forEach(([key, value]) => {
-        if (value !== null) {
+        if (
+          value !== null &&
+          shouldIncludeManualBackupLocalStorageKey(key)
+        ) {
           localStorage.setItem(key, value as string);
         }
       });
@@ -999,6 +1007,9 @@ export function useControlPanelsLogic({
       setCloudProgress({ phase: t("apps.control-panels.cloudSync.progress.finishing"), percent: 100 });
 
       setNextBootMessage(t("common.system.restoringSystem"));
+      setManualRestoreIntent(
+        createManualRestoreIntent(username, backup.timestamp)
+      );
 
       // Reload the page to apply changes
       window.location.reload();

--- a/src/hooks/useAutoCloudSync.ts
+++ b/src/hooks/useAutoCloudSync.ts
@@ -22,6 +22,10 @@ import {
 } from "@/shared/sync2/types";
 import { createCloudSyncEngine, destroyCloudSyncEngine } from "@/sync/engine";
 import { cloudSyncLog, summarizeSyncOps } from "@/sync/logging";
+import {
+  clearManualRestoreIntent,
+  getManualRestoreIntent,
+} from "@/sync/manualRestoreIntent";
 
 // Realtime delivers changes; polling is only a safety net for missed events.
 const POLL_INTERVAL_CONNECTED_MS = 30 * 60 * 1000;
@@ -42,9 +46,14 @@ export function useAutoCloudSync() {
   const isAuthenticated = useChatsStore((state) => state.isAuthenticated);
   const autoSyncEnabled = useCloudSyncStore((state) => state.autoSyncEnabled);
   const [syncApiAvailable, setSyncApiAvailable] = useState(false);
+  const [restoreIntentVersion, setRestoreIntentVersion] = useState(0);
 
   const lastVisibilityCheckRef = useRef(0);
   const lastExplicitCheckRef = useRef(0);
+  const pendingRestoreIntent = username
+    ? getManualRestoreIntent(username)
+    : null;
+  const pendingRestoreIntentKey = pendingRestoreIntent?.createdAt ?? null;
 
   // Adopt the cross-device Auto Sync preference on login.
   useEffect(() => {
@@ -113,7 +122,10 @@ export function useAutoCloudSync() {
   }, [username, isAuthenticated]);
 
   const syncRequested = Boolean(
-    username && isAuthenticated && autoSyncEnabled && syncApiAvailable
+    username &&
+      isAuthenticated &&
+      syncApiAvailable &&
+      (autoSyncEnabled || pendingRestoreIntent)
   );
   const isSyncActive = syncRequested;
 
@@ -131,10 +143,43 @@ export function useAutoCloudSync() {
     const engine = createCloudSyncEngine(username, {
       onError: (error) => useCloudSyncStore.getState().setLastError(error),
     });
-    void engine.start();
+    let engineReady = false;
+    let cancelled = false;
+    const restoreIntent = getManualRestoreIntent(username);
+
+    const startEngine = async () => {
+      try {
+        if (restoreIntent) {
+          cloudSyncLog.debug("Promoting restored manual backup to Sync v2", {
+            username,
+            backupTimestamp: restoreIntent.backupTimestamp,
+          });
+          await engine.restoreLocalStateToCloud();
+          clearManualRestoreIntent(username);
+          if (!useCloudSyncStore.getState().autoSyncEnabled) {
+            if (!cancelled) {
+              setRestoreIntentVersion((version) => version + 1);
+            }
+            return;
+          }
+        }
+        if (cancelled) return;
+        await engine.start();
+        engineReady = true;
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Manual restore sync promotion failed";
+        cloudSyncLog.error("Cloud Sync startup failed", { error });
+        useCloudSyncStore.getState().setLastError(message);
+      }
+    };
+    void startEngine();
 
     const unsubscribeChanges = subscribeToCloudSyncDomainChanges(
       (namespace, keys) => {
+        if (!engineReady) return;
         if (engine.isApplyingNamespace(namespace)) return;
         cloudSyncLog.debug("Domain change marked dirty", {
           namespace,
@@ -145,6 +190,7 @@ export function useAutoCloudSync() {
     );
 
     const unsubscribeChecks = subscribeToCloudSyncCheckRequests(() => {
+      if (!engineReady) return;
       const now = Date.now();
       if (now - lastExplicitCheckRef.current < EXPLICIT_CHECK_COOLDOWN_MS) {
         cloudSyncLog.debug("Explicit sync check skipped by cooldown", {
@@ -162,6 +208,7 @@ export function useAutoCloudSync() {
     const channelName = getSyncChannelName(username);
     const channel = subscribePusherChannel(channelName);
     const realtimeHandler = (payload: SyncOpsRealtimeEvent) => {
+      if (!engineReady) return;
       cloudSyncLog.debug("Realtime sync event received", {
         seq: payload.seq,
         clientId: payload.c,
@@ -173,6 +220,7 @@ export function useAutoCloudSync() {
 
     // Visibility / focus / online: one cheap cursor check (with cooldown).
     const checkOnWake = () => {
+      if (!engineReady) return;
       const now = Date.now();
       if (now - lastVisibilityCheckRef.current < VISIBILITY_CHECK_COOLDOWN_MS) {
         cloudSyncLog.debug("Wake sync check skipped by cooldown", {
@@ -186,6 +234,7 @@ export function useAutoCloudSync() {
       engine.schedulePendingFlush();
     };
     const onVisibilityChange = () => {
+      if (!engineReady) return;
       if (document.visibilityState === "visible") {
         cloudSyncLog.debug("Document visible; checking sync");
         checkOnWake();
@@ -209,6 +258,7 @@ export function useAutoCloudSync() {
           ? POLL_INTERVAL_CONNECTED_MS
           : POLL_INTERVAL_DISCONNECTED_MS;
       pollTimer = setInterval(() => {
+        if (!engineReady) return;
         cloudSyncLog.debug("Periodic sync poll triggered", { pollMs });
         void engine.pull();
         engine.schedulePendingFlush();
@@ -223,6 +273,7 @@ export function useAutoCloudSync() {
         if (reconnectTimer) clearTimeout(reconnectTimer);
         reconnectTimer = setTimeout(() => {
           reconnectTimer = null;
+          if (!engineReady) return;
           cloudSyncLog.debug("Realtime reconnect catch-up triggered");
           void engine.pull();
           engine.schedulePendingFlush();
@@ -235,6 +286,7 @@ export function useAutoCloudSync() {
 
     return () => {
       cloudSyncLog.debug("Stopping Cloud Sync engine", { username });
+      cancelled = true;
       unsubscribeChanges();
       unsubscribeChecks();
       unsubscribeConnection();
@@ -247,5 +299,5 @@ export function useAutoCloudSync() {
       if (pollTimer) clearInterval(pollTimer);
       destroyCloudSyncEngine();
     };
-  }, [isSyncActive, username]);
+  }, [isSyncActive, pendingRestoreIntentKey, restoreIntentVersion, username]);
 }

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -89,6 +89,17 @@ interface EngineStatusCallbacks {
   onError?: (error: string | null) => void;
 }
 
+export interface RestoreLocalStateToCloudOptions {
+  /** Test seam / targeted repair path; production restore uses every namespace. */
+  namespaces?: readonly SyncNamespace[];
+}
+
+export interface RestoreLocalStateToCloudResult {
+  seq: number;
+  uploaded: number;
+  deleted: number;
+}
+
 export class CloudSyncEngine {
   private readonly state: SyncClientState;
   private readonly callbacks: EngineStatusCallbacks;
@@ -1104,6 +1115,160 @@ export class CloudSyncEngine {
       this.reportError(null);
     } finally {
       syncStore.setCheckingRemote(false);
+    }
+  }
+
+  /**
+   * Manual backup restore is a local-state restore first. Promote the restored
+   * local snapshot to Sync v2 before normal bootstrap can pull the server over it.
+   */
+  async restoreLocalStateToCloud(
+    options: RestoreLocalStateToCloudOptions = {}
+  ): Promise<RestoreLocalStateToCloudResult> {
+    if (this.stopped) {
+      throw new DOMException("Cloud sync stopped", "AbortError");
+    }
+
+    const requested = options.namespaces
+      ? new Set(options.namespaces)
+      : new Set<SyncNamespace>(SYNC_NAMESPACES);
+    const namespaces = NAMESPACE_APPLY_ORDER.filter((namespace) =>
+      requested.has(namespace)
+    );
+    if (namespaces.length === 0) {
+      return { seq: this.state.cursor ?? 0, uploaded: 0, deleted: 0 };
+    }
+
+    for (const namespace of namespaces) {
+      const codec = SYNC_CODECS[namespace];
+      if (codec.isReady && !codec.isReady()) {
+        throw new Error(`Sync namespace ${namespace} is not ready for restore`);
+      }
+    }
+
+    const syncStore = useCloudSyncStore.getState();
+    const categories = new Set(namespaces.map(getSyncNamespaceCategory));
+    for (const category of categories) {
+      syncStore.markCategorySyncing(category, "upload", true);
+    }
+
+    const needsDb = namespaces.some((ns) => SYNC_CODECS[ns].usesIndexedDb);
+    const db = needsDb ? await ensureIndexedDBInitialized() : undefined;
+    const ctx: CodecContext = { db };
+    let uploaded = 0;
+    let deleted = 0;
+
+    try {
+      cloudSyncLog.debug("Manual restore promotion started", { namespaces });
+      const snapshot = await getSyncSnapshot(this.abortController.signal);
+      if (this.stopped) {
+        throw new DOMException("Cloud sync stopped", "AbortError");
+      }
+
+      // Drop stale cursor/shadow restored from a backup. The server snapshot is
+      // only used as the deletion baseline; it must not be applied locally.
+      this.state.reset();
+      for (const entry of Object.values(snapshot.entries)) {
+        this.state.observeTimestamp(entry.t);
+      }
+      this.state.setCursor(snapshot.seq);
+
+      const ops: SyncOp[] = [];
+      const shadowUpdates = new Map<string, { t: string; h: string }>();
+      const localKeys = new Set<string>();
+
+      for (const namespace of namespaces) {
+        const codec = SYNC_CODECS[namespace];
+        const collected = await codec.collect(ctx);
+        for (const key of collected.keys()) {
+          localKeys.add(key);
+        }
+
+        if (isSyncBlobNamespace(namespace)) {
+          const pendingUploads: BlobUploadItem[] = [];
+          const pendingTimestamps = new Map<string, string>();
+          let itemIndex = 0;
+          for (const [key, item] of collected) {
+            if (itemIndex > 0 && itemIndex % BLOB_HASH_YIELD_INTERVAL === 0) {
+              await yieldToMainThread();
+              if (this.stopped) {
+                throw new DOMException("Cloud sync stopped", "AbortError");
+              }
+            }
+            itemIndex += 1;
+            const sha256 = await sha256Json(item);
+            pendingUploads.push({ key, sha256, item });
+            pendingTimestamps.set(key, this.state.nextTimestamp());
+          }
+
+          if (pendingUploads.length > 0) {
+            const category = getSyncNamespaceCategory(namespace);
+            syncStore.markCategoryUploadProgress(category, 0);
+            const refs = await uploadBlobItems(pendingUploads, {
+              signal: this.abortController.signal,
+              onProgress: (progress) => {
+                syncStore.markCategoryUploadProgress(
+                  category,
+                  progress.percentage
+                );
+              },
+            });
+            for (const upload of pendingUploads) {
+              const ref = refs.get(upload.key);
+              if (!ref) continue;
+              const t = pendingTimestamps.get(upload.key)!;
+              ops.push({ k: upload.key, v: { blob: ref }, t });
+              shadowUpdates.set(upload.key, { t, h: upload.sha256 });
+              uploaded += 1;
+            }
+          }
+        } else {
+          for (const [key, doc] of collected) {
+            const h = hashDoc(doc);
+            const t = this.state.nextTimestamp();
+            ops.push({ k: key, v: doc, t });
+            shadowUpdates.set(key, { t, h });
+            uploaded += 1;
+          }
+        }
+      }
+
+      for (const [key, entry] of Object.entries(snapshot.entries)) {
+        const namespace = getSyncKeyNamespace(key);
+        if (!namespace || !requested.has(namespace)) continue;
+        if (localKeys.has(key) || entry.del) continue;
+        const t = this.state.nextTimestamp();
+        ops.push({ k: key, del: true, t });
+        shadowUpdates.set(key, { t, h: "__del__" });
+        deleted += 1;
+      }
+
+      if (ops.length > 0) {
+        cloudSyncLog.debug("Manual restore promotion uploading ops", {
+          uploaded,
+          deleted,
+          ops: summarizeSyncOps(ops),
+        });
+        await this.sendOps(ops, shadowUpdates);
+      }
+
+      const completedAt = new Date().toISOString();
+      for (const category of categories) {
+        syncStore.markCategoryUploaded(category, completedAt);
+      }
+      this.reportError(null);
+      cloudSyncLog.debug("Manual restore promotion complete", {
+        seq: this.state.cursor,
+        uploaded,
+        deleted,
+      });
+      return { seq: this.state.cursor ?? snapshot.seq, uploaded, deleted };
+    } finally {
+      db?.close();
+      for (const category of categories) {
+        syncStore.markCategorySyncing(category, "upload", false);
+        syncStore.markCategoryUploadProgress(category, null);
+      }
     }
   }
 

--- a/src/sync/manualBackup.ts
+++ b/src/sync/manualBackup.ts
@@ -1,0 +1,5 @@
+const SYNC_V2_LOCAL_STORAGE_PREFIX = "ryos:sync2:";
+
+export function shouldIncludeManualBackupLocalStorageKey(key: string): boolean {
+  return !key.startsWith(SYNC_V2_LOCAL_STORAGE_PREFIX);
+}

--- a/src/sync/manualRestoreIntent.ts
+++ b/src/sync/manualRestoreIntent.ts
@@ -1,0 +1,65 @@
+const MANUAL_RESTORE_INTENT_KEY = "ryos:sync2:manual-restore-intent";
+const MAX_INTENT_AGE_MS = 30 * 60 * 1000;
+
+export interface ManualRestoreIntent {
+  username: string;
+  createdAt: string;
+  backupTimestamp?: string;
+}
+
+function normalizeUsername(username: string): string {
+  return username.trim().toLowerCase();
+}
+
+export function createManualRestoreIntent(
+  username: string,
+  backupTimestamp?: string
+): ManualRestoreIntent {
+  return {
+    username: normalizeUsername(username),
+    createdAt: new Date().toISOString(),
+    ...(backupTimestamp ? { backupTimestamp } : {}),
+  };
+}
+
+export function setManualRestoreIntent(intent: ManualRestoreIntent): void {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(MANUAL_RESTORE_INTENT_KEY, JSON.stringify(intent));
+}
+
+export function getManualRestoreIntent(
+  username: string
+): ManualRestoreIntent | null {
+  if (typeof localStorage === "undefined") return null;
+  const raw = localStorage.getItem(MANUAL_RESTORE_INTENT_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<ManualRestoreIntent>;
+    if (normalizeUsername(parsed.username || "") !== normalizeUsername(username)) {
+      return null;
+    }
+    const createdAt = typeof parsed.createdAt === "string" ? parsed.createdAt : "";
+    const createdMs = Date.parse(createdAt);
+    if (!Number.isFinite(createdMs) || Date.now() - createdMs > MAX_INTENT_AGE_MS) {
+      localStorage.removeItem(MANUAL_RESTORE_INTENT_KEY);
+      return null;
+    }
+    return {
+      username: normalizeUsername(username),
+      createdAt,
+      ...(typeof parsed.backupTimestamp === "string"
+        ? { backupTimestamp: parsed.backupTimestamp }
+        : {}),
+    };
+  } catch {
+    localStorage.removeItem(MANUAL_RESTORE_INTENT_KEY);
+    return null;
+  }
+}
+
+export function clearManualRestoreIntent(username?: string): void {
+  if (typeof localStorage === "undefined") return;
+  if (username && !getManualRestoreIntent(username)) return;
+  localStorage.removeItem(MANUAL_RESTORE_INTENT_KEY);
+}

--- a/tests/test-sync-v2-engine-e2e.test.ts
+++ b/tests/test-sync-v2-engine-e2e.test.ts
@@ -218,4 +218,59 @@ describe("sync v2 engine end-to-end", () => {
     expect(ids).toContain("e2e-rt");
     expect(ids).not.toContain("e2e-1"); // tombstoned
   });
+
+  test("manual restore promotes restored local state before bootstrap", async () => {
+    engine.stop();
+    localStorage.removeItem(`ryos:sync2:state:${USERNAME.toLowerCase()}`);
+
+    const remoteT = formatHlc(Date.now() + 2000, 0, "foreign-restore");
+    await fetchWithAuth(`${BASE_URL}/api/sync/v2/ops`, USERNAME, token, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        clientId: "foreign-restore",
+        ops: [
+          {
+            k: "stickies/note:restore-keep",
+            v: { id: "restore-keep", content: "newer cloud value" },
+            t: remoteT,
+          },
+          {
+            k: "stickies/note:restore-delete",
+            v: { id: "restore-delete", content: "cloud-only value" },
+            t: remoteT,
+          },
+        ],
+      }),
+    });
+
+    // Simulate stores after a restored backup reload: local should win, and
+    // cloud-only keys missing from the backup should become tombstones.
+    useStickiesStore.setState({
+      notes: [{ id: "restore-keep", content: "restored backup value" }] as never,
+    });
+
+    engine = new CloudSyncEngine(USERNAME);
+    const result = await engine.restoreLocalStateToCloud({
+      namespaces: ["stickies"],
+    });
+    expect(result.uploaded).toBe(1);
+    expect(result.deleted).toBeGreaterThanOrEqual(1);
+
+    const snapshot = await readServerSnapshot();
+    expect(snapshot.entries["stickies/note:restore-keep"]?.v).toMatchObject({
+      id: "restore-keep",
+      content: "restored backup value",
+    });
+    expect(snapshot.entries["stickies/note:restore-delete"]?.del).toBe(true);
+
+    engine.stop();
+    engine = new CloudSyncEngine(USERNAME);
+    await engine.start();
+    expect(
+      useStickiesStore
+        .getState()
+        .notes.find((note) => note.id === "restore-keep")?.content
+    ).toBe("restored backup value");
+  });
 });

--- a/tests/test-sync-v2-manual-restore.test.ts
+++ b/tests/test-sync-v2-manual-restore.test.ts
@@ -1,0 +1,49 @@
+import "./local-storage-stub";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { shouldIncludeManualBackupLocalStorageKey } from "../src/sync/manualBackup";
+import {
+  clearManualRestoreIntent,
+  createManualRestoreIntent,
+  getManualRestoreIntent,
+  setManualRestoreIntent,
+} from "../src/sync/manualRestoreIntent";
+
+describe("manual backup Sync v2 metadata filtering", () => {
+  test("excludes Sync v2 cursor, shadow, and restore intent metadata", () => {
+    expect(shouldIncludeManualBackupLocalStorageKey("ryos:files")).toBe(true);
+    expect(
+      shouldIncludeManualBackupLocalStorageKey("ryos:sync2:client-id")
+    ).toBe(false);
+    expect(
+      shouldIncludeManualBackupLocalStorageKey("ryos:sync2:state:alice")
+    ).toBe(false);
+    expect(
+      shouldIncludeManualBackupLocalStorageKey(
+        "ryos:sync2:manual-restore-intent"
+      )
+    ).toBe(false);
+  });
+});
+
+describe("manual restore intent", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("round-trips only for the matching user", () => {
+    const intent = createManualRestoreIntent(
+      "Alice",
+      "2026-06-28T04:00:00.000Z"
+    );
+    setManualRestoreIntent(intent);
+
+    expect(getManualRestoreIntent("alice")).toMatchObject({
+      username: "alice",
+      backupTimestamp: "2026-06-28T04:00:00.000Z",
+    });
+    expect(getManualRestoreIntent("bob")).toBeNull();
+
+    clearManualRestoreIntent("alice");
+    expect(getManualRestoreIntent("alice")).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Exclude Sync v2 cursor/shadow metadata from manual backup payloads.
- Add a one-shot manual restore intent so restored local state is promoted to Sync v2 before normal bootstrap.
- Add `CloudSyncEngine.restoreLocalStateToCloud()` to upload restored docs and tombstone cloud-only keys.
- Add unit and Sync v2 engine regression coverage.

## Testing
- `bun test tests/test-sync-v2-manual-restore.test.ts tests/test-sync-v2-codecs.test.ts`
- `bun test tests/test-sync-v2-engine-e2e.test.ts`
- `bun run test:registration`
- `bun run test:sync-v2:unit`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0c82-b684-7c92-9162-cbbd5363b3a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0c82-b684-7c92-9162-cbbd5363b3a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

