### PR TITLE
Improve client error logging detail

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -82,6 +82,7 @@ interface FlipState {
 }
 
 type BooksDebugLevel = "info" | "warn" | "error";
+type BooksDebugSnapshot = Record<string, unknown>;
 
 // Extra top clearance so the page never sits under the hover-revealed window
 // titlebar (the window uses the full-bleed "notitlebar" material).
@@ -164,14 +165,22 @@ function serializeDebugValue(
   seen = new WeakSet<object>()
 ): unknown {
   if (value instanceof Error) {
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+    const cause = "cause" in value ? value.cause : undefined;
     return {
+      kind: "Error",
       name: value.name,
       message: value.message,
       stack: value.stack,
+      cause: cause === undefined ? undefined : serializeDebugValue(cause, seen),
     };
   }
-  if (value instanceof DOMException) {
+  if (typeof DOMException !== "undefined" && value instanceof DOMException) {
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
     return {
+      kind: "DOMException",
       name: value.name,
       message: value.message,
       code: value.code,
@@ -230,6 +239,25 @@ function getBooksDebugEnvironment() {
       "standalone" in window.navigator
         ? Boolean((window.navigator as Navigator & { standalone?: boolean }).standalone)
         : undefined,
+  };
+}
+
+function getElementSnapshot(element: HTMLElement | null): BooksDebugSnapshot | null {
+  if (!element) return null;
+  const rect = element.getBoundingClientRect();
+  return {
+    clientWidth: element.clientWidth,
+    clientHeight: element.clientHeight,
+    offsetWidth: element.offsetWidth,
+    offsetHeight: element.offsetHeight,
+    rect: {
+      width: rect.width,
+      height: rect.height,
+      top: rect.top,
+      left: rect.left,
+    },
+    isConnected: element.isConnected,
+    childElementCount: element.childElementCount,
   };
 }
 
@@ -435,9 +463,72 @@ export const BooksReaderPane = forwardRef<
         requestAnimationFrame(() => resolve())
       );
 
+    const getReaderDebugSnapshot = (
+      step: string,
+      startedAt?: number
+    ): BooksDebugSnapshot => {
+      const debugBook = book as unknown as
+        | {
+            archived?: boolean;
+            container?: { packagePath?: string };
+            package?: { metadata?: unknown };
+            settings?: unknown;
+          }
+        | null;
+      const debugRendition = rendition as unknown as
+        | {
+            location?: unknown;
+            manager?: { constructor?: { name?: string } };
+            settings?: unknown;
+            views?: () => unknown;
+          }
+        | null;
+      let viewCount: number | undefined;
+      try {
+        const views = debugRendition?.views?.();
+        viewCount = Array.isArray(views) ? views.length : undefined;
+      } catch {
+        viewCount = undefined;
+      }
+      return {
+        step,
+        elapsedMs: startedAt ? Date.now() - startedAt : undefined,
+        entry: {
+          path: entry.path,
+          fileName: entry.fileName,
+          name: entry.name,
+          modifiedAt: entry.modifiedAt,
+        },
+        initialCfi: initialCfiRef.current,
+        activeSectionHref: activeSectionHrefRef.current,
+        host: getElementSnapshot(renderHostRef.current),
+        book: book
+          ? {
+              archived: debugBook?.archived,
+              packagePath: debugBook?.container?.packagePath,
+              metadata: debugBook?.package?.metadata,
+              settings: debugBook?.settings,
+            }
+          : null,
+        rendition: rendition
+          ? {
+              location: debugRendition?.location,
+              managerName: debugRendition?.manager?.constructor?.name,
+              settings: debugRendition?.settings,
+              viewCount,
+            }
+          : null,
+      };
+    };
+
     const watch = async <T,>(step: string, promise: Promise<T>): Promise<T> => {
+      const startedAt = Date.now();
       const timeout = window.setTimeout(() => {
-        appendDebugEvent(`${step}:stillPending`, undefined, "warn");
+        appendDebugEvent(
+          `${step}:stillPending`,
+          getReaderDebugSnapshot(step, startedAt),
+          "warn"
+        );
       }, 8000);
       try {
         return await promise;
@@ -553,7 +644,14 @@ export const BooksReaderPane = forwardRef<
           on?: (eventName: string, handler: (...args: unknown[]) => void) => void;
         };
         bookEvents.on?.("openFailed", (error) => {
-          appendDebugEvent("epubjs:book:openFailed", error, "error");
+          appendDebugEvent(
+            "epubjs:book:openFailed",
+            {
+              error,
+              snapshot: getReaderDebugSnapshot("epubjs:book:openFailed"),
+            },
+            "error"
+          );
           if (!cancelled) {
             setLoadError(t("apps.books.reader.error"));
             setCoverVisible(false);
@@ -623,7 +721,14 @@ export const BooksReaderPane = forwardRef<
           })
         );
         rendition.on("displayError", (error: unknown) =>
-          appendDebugEvent("epubjs:rendition:displayError", error, "error")
+          appendDebugEvent(
+            "epubjs:rendition:displayError",
+            {
+              error,
+              snapshot: getReaderDebugSnapshot("epubjs:rendition:displayError"),
+            },
+            "error"
+          )
         );
         rendition.on(
           "layout",
@@ -744,8 +849,13 @@ export const BooksReaderPane = forwardRef<
           // Corrupt / incompatible EPUB — show an error instead of revealing an
           // empty reader shell. Do not proceed to setIsReady / cover hide.
           if (!cancelled) {
-            console.error("[Books] Failed to display book", err);
-            appendDebugEvent("epubjs:display:failed", err, "error");
+            const snapshot = getReaderDebugSnapshot("epubjs:display:failed");
+            booksLog.error("epubjs:display:failed", { error: err, snapshot });
+            appendDebugEvent(
+              "epubjs:display:failed",
+              { error: err, snapshot },
+              "error"
+            );
             setLoadError(t("apps.books.reader.error"));
             setCoverVisible(false);
             setIsReady(true);
@@ -774,8 +884,13 @@ export const BooksReaderPane = forwardRef<
           );
       } catch (err) {
         if (!cancelled) {
-          console.error("[Books] Failed to open book", err);
-          appendDebugEvent("reader:open:failed", err, "error");
+          const snapshot = getReaderDebugSnapshot("reader:open:failed");
+          booksLog.error("reader:open:failed", { error: err, snapshot });
+          appendDebugEvent(
+            "reader:open:failed",
+            { error: err, snapshot },
+            "error"
+          );
           setLoadError(t("apps.books.reader.error"));
           setCoverVisible(false);
           setIsReady(true);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -4,25 +4,71 @@ export type LogContext = Record<string, unknown>;
 
 const REDACTED = "[redacted]";
 const MAX_STRING_LENGTH = 160;
+const MAX_STACK_LENGTH = 4000;
 const MAX_ARRAY_ITEMS = 8;
 const MAX_DEPTH = 3;
 
 const SENSITIVE_KEY_RE =
   /(password|token|secret|authorization|cookie|message|prompt|content|html|markdown|base64|blob|dataurl|transcript|body|text|lyrics|deviceid|useragent)$/i;
 
-function truncateString(value: string): string {
-  if (value.length <= MAX_STRING_LENGTH) return value;
-  return `${value.slice(0, MAX_STRING_LENGTH)}... (truncated, length=${value.length})`;
+function truncateString(value: string, maxLength = MAX_STRING_LENGTH): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}... (truncated, length=${value.length})`;
+}
+
+function isSerializedErrorRecord(record: Record<string, unknown>): boolean {
+  if (
+    record.kind === "Error" ||
+    record.kind === "DOMException" ||
+    record.kind === "ErrorEvent" ||
+    record.kind === "PromiseRejectionEvent"
+  ) {
+    return true;
+  }
+  return (
+    typeof record.name === "string" &&
+    typeof record.message === "string" &&
+    typeof record.stack === "string"
+  );
+}
+
+function shouldRedactKey(
+  key: string,
+  record: Record<string, unknown>
+): boolean {
+  if (!SENSITIVE_KEY_RE.test(key)) return false;
+  if (isSerializedErrorRecord(record) && key === "message") return false;
+  return true;
+}
+
+function ownErrorProperties(
+  error: Error,
+  depth: number,
+  seen: WeakSet<object>
+): Record<string, unknown> | undefined {
+  const props: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(error)) {
+    if (key === "name" || key === "message" || key === "stack" || key === "cause") {
+      continue;
+    }
+    props[key] = shouldRedactKey(key, error as unknown as Record<string, unknown>)
+      ? REDACTED
+      : summarizeForLog(item, depth + 1, seen, key);
+  }
+  return Object.keys(props).length ? props : undefined;
 }
 
 export function summarizeForLog(
   value: unknown,
   depth = 0,
-  seen = new WeakSet<object>()
+  seen = new WeakSet<object>(),
+  key?: string
 ): unknown {
   if (value === null || value === undefined) return value;
 
-  if (typeof value === "string") return truncateString(value);
+  if (typeof value === "string") {
+    return truncateString(value, key === "stack" ? MAX_STACK_LENGTH : MAX_STRING_LENGTH);
+  }
   if (typeof value === "number" || typeof value === "boolean") return value;
   if (typeof value === "bigint") return `${value}n`;
   if (typeof value === "function") {
@@ -30,9 +76,53 @@ export function summarizeForLog(
   }
 
   if (value instanceof Error) {
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+    const cause = "cause" in value ? value.cause : undefined;
+    const props = ownErrorProperties(value, depth, seen);
     return {
+      kind: "Error",
       name: value.name,
       message: truncateString(value.message),
+      stack: value.stack ? truncateString(value.stack, MAX_STACK_LENGTH) : undefined,
+      cause:
+        cause === undefined
+          ? undefined
+          : summarizeForLog(cause, depth + 1, seen, "cause"),
+      props,
+    };
+  }
+
+  if (typeof DOMException !== "undefined" && value instanceof DOMException) {
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+    return {
+      kind: "DOMException",
+      name: value.name,
+      message: truncateString(value.message),
+      code: value.code,
+      stack: value.stack ? truncateString(value.stack, MAX_STACK_LENGTH) : undefined,
+    };
+  }
+
+  if (typeof ErrorEvent !== "undefined" && value instanceof ErrorEvent) {
+    return {
+      kind: "ErrorEvent",
+      message: truncateString(value.message),
+      filename: value.filename,
+      lineno: value.lineno,
+      colno: value.colno,
+      error: summarizeForLog(value.error, depth + 1, seen, "error"),
+    };
+  }
+
+  if (
+    typeof PromiseRejectionEvent !== "undefined" &&
+    value instanceof PromiseRejectionEvent
+  ) {
+    return {
+      kind: "PromiseRejectionEvent",
+      reason: summarizeForLog(value.reason, depth + 1, seen, "reason"),
     };
   }
 
@@ -71,9 +161,9 @@ export function summarizeForLog(
   const record = value as Record<string, unknown>;
   const safe: Record<string, unknown> = {};
   for (const [key, item] of Object.entries(record)) {
-    safe[key] = SENSITIVE_KEY_RE.test(key)
+    safe[key] = shouldRedactKey(key, record)
       ? REDACTED
-      : summarizeForLog(item, depth + 1, seen);
+      : summarizeForLog(item, depth + 1, seen, key);
   }
   return safe;
 }

--- a/tests/test-client-logger.test.ts
+++ b/tests/test-client-logger.test.ts
@@ -126,6 +126,7 @@ describe("client logger", () => {
   test("redacts sensitive fields and summarizes large values", () => {
     const summarized = summarizeForLog({
       prompt: "please keep this private",
+      message: "private chat text",
       contentMarkdown: "# secret note",
       nested: {
         deviceId: "camera-123",
@@ -135,6 +136,7 @@ describe("client logger", () => {
     }) as Record<string, unknown>;
 
     expect(summarized.prompt).toBe("[redacted]");
+    expect(summarized.message).toBe("[redacted]");
     expect(summarized.contentMarkdown).toBe("[redacted]");
     expect((summarized.nested as Record<string, unknown>).deviceId).toBe(
       "[redacted]"
@@ -143,6 +145,49 @@ describe("client logger", () => {
       "truncated"
     );
     expect(summarized.list).toEqual([0, 1, 2, 3, 4, 5, 6, 7, "... (4 more)"]);
+  });
+
+  test("keeps error message, stack, cause, and safe custom fields", () => {
+    const cause = new Error("zip container missing package document");
+    cause.stack = `Error: zip container missing package document\n${"at epub.js loader\n".repeat(20)}`;
+    const error = new Error("failed to display EPUB") as Error & {
+      cause?: unknown;
+      requestToken?: string;
+      sectionHref?: string;
+    };
+    error.stack = "Error: failed to display EPUB\nat Rendition.display (epubjs.js:1:2)";
+    error.cause = cause;
+    error.requestToken = "secret-token";
+    error.sectionHref = "chapter-1.xhtml";
+
+    const summarized = summarizeForLog(error) as Record<string, unknown>;
+    const summarizedCause = summarized.cause as Record<string, unknown>;
+    const props = summarized.props as Record<string, unknown>;
+
+    expect(summarized.kind).toBe("Error");
+    expect(summarized.message).toBe("failed to display EPUB");
+    expect(summarized.stack).toContain("Rendition.display");
+    expect(summarizedCause.message).toBe("zip container missing package document");
+    expect(summarizedCause.stack).toContain("epub.js loader");
+    expect(props.requestToken).toBe("[redacted]");
+    expect(props.sectionHref).toBe("chapter-1.xhtml");
+  });
+
+  test("preserves serialized error messages without unredacting normal messages", () => {
+    const summarized = summarizeForLog({
+      message: "user-authored chat message",
+      error: {
+        kind: "Error",
+        name: "Error",
+        message: "Cannot read properties of undefined",
+        stack: "TypeError: Cannot read properties of undefined\nat book.js:1:2",
+      },
+    }) as Record<string, unknown>;
+    const error = summarized.error as Record<string, unknown>;
+
+    expect(summarized.message).toBe("[redacted]");
+    expect(error.message).toBe("Cannot read properties of undefined");
+    expect(error.stack).toContain("book.js");
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Preserve error message, stack, cause, and safe custom fields in client logger output.
- Add Books reader debug snapshots to epub.js pending and failure logs.
- Cover error serialization and redaction behavior with focused Bun tests.

### Testing
- `bun test tests/test-client-logger.test.ts` passed.
- `bun run build` passed with existing CSS/chunk warnings.
- `./node_modules/.bin/eslint src/utils/logger.ts src/apps/books/components/BooksReaderPane.tsx tests/test-client-logger.test.ts` passed with an existing Fast Refresh warning in `BooksReaderPane.tsx`. 
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0c9b-345c-7c11-9921-96334671bb96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0c9b-345c-7c11-9921-96334671bb96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

