### PR TITLE
Improve lyrics and Apple Music error handling

### DIFF
--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -658,12 +658,13 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           });
         }
         if (isStale()) return;
-        if (currentTrack.durationMs && currentTrack.durationMs > 0) {
+        const durationMs = currentTrack.durationMs;
+        if (durationMs && durationMs > 0) {
           callBridgeCallback(
             "queue:onDuration",
-            () => onDurationRef.current?.(currentTrack.durationMs / 1000),
+            () => onDurationRef.current?.(durationMs / 1000),
             {
-              durationMs: currentTrack.durationMs,
+              durationMs,
               snapshot: getBridgeSnapshot(),
             }
           );

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -1,14 +1,25 @@
-import { useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { Track } from "@/stores/useIpodStore";
 import { getMusicKitInstance, onMusicKitReady } from "@/hooks/useMusicKit";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
 import {
   getMusicKitEventItemId,
+  isLikelyMusicKitUnhandledRejection,
   isStaleQueueLoad,
   isWithinEndedFanoutDedupWindow,
   shouldFireEndedForPlaybackState,
   shouldSuppressPlaybackStateFanoutWhileQueueLoading,
 } from "./appleMusicPlayerBridgeUtils";
+import { createClientLogger } from "@/utils/logger";
+
+const appleMusicLog = createClientLogger("AppleMusic");
 
 /**
  * Apple Music playback bridge.
@@ -114,6 +125,41 @@ function mediaItemToNowPlayingMetadata(
   };
 }
 
+function summarizeTrackForLog(track: Track | null): Record<string, unknown> | null {
+  if (!track) return null;
+  return {
+    id: track.id,
+    title: track.title,
+    artist: track.artist,
+    source: track.source,
+    hasPlayParams: Boolean(track.appleMusicPlayParams),
+    playParams: track.appleMusicPlayParams
+      ? {
+          kind: track.appleMusicPlayParams.kind,
+          hasCatalogId: Boolean(track.appleMusicPlayParams.catalogId),
+          hasLibraryId: Boolean(track.appleMusicPlayParams.libraryId),
+          hasStationId: Boolean(track.appleMusicPlayParams.stationId),
+          hasPlaylistId: Boolean(track.appleMusicPlayParams.playlistId),
+        }
+      : null,
+  };
+}
+
+function callBridgeCallback(
+  name: string,
+  callback: (() => unknown) | undefined,
+  context: Record<string, unknown>
+): void {
+  try {
+    const result = callback?.();
+    void Promise.resolve(result).catch((error) => {
+      appleMusicLog.error(`callback:${name}:rejected`, { error, context });
+    });
+  } catch (error) {
+    appleMusicLog.error(`callback:${name}:threw`, { error, context });
+  }
+}
+
 export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   {
     ref,
@@ -180,7 +226,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         } catch {
           /* ignore — unmount is best-effort */
         }
-        console.warn("[apple music] stop() on unmount failed", err);
+        appleMusicLog.warn("stop:onUnmount:failed", { error: err });
       }
     };
   }, []);
@@ -205,6 +251,24 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   // without resubscribing on every render.
   const currentTrackRef = useRef(currentTrack);
   currentTrackRef.current = currentTrack;
+
+  const getBridgeSnapshot = useCallback(() => {
+    const inst = instanceRef.current;
+    return {
+      currentTrack: summarizeTrackForLog(currentTrackRef.current),
+      queuedTrackId: lastQueuedTrackIdRef.current,
+      queueGeneration: queueGenerationRef.current,
+      hasPendingQueueLoad: queueLoadingRef.current !== null,
+      instance: inst
+        ? {
+            isAuthorized: inst.isAuthorized,
+            playbackState: inst.playbackState,
+            currentPlaybackTime: inst.currentPlaybackTime,
+            storefrontId: inst.storefrontId,
+          }
+        : null,
+    };
+  }, []);
 
   // Dedup state for `onEnded` fan-out. MusicKit JS fires both `ended`
   // (5) and `completed` (10) when a single-song queue's only item
@@ -250,11 +314,17 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         return;
       }
       if (state === 2) {
-        onPlayRef.current?.();
+        callBridgeCallback("playbackStateDidChange:onPlay", onPlayRef.current, {
+          state,
+          snapshot: getBridgeSnapshot(),
+        });
         return;
       }
       if (state === 3 || state === 4) {
-        onPauseRef.current?.();
+        callBridgeCallback("playbackStateDidChange:onPause", onPauseRef.current, {
+          state,
+          snapshot: getBridgeSnapshot(),
+        });
         return;
       }
       if (
@@ -284,7 +354,11 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           lastEndedFiredForItemIdRef.current = eventItemId;
         }
         lastEndedFiredAtRef.current = now;
-        onEndedRef.current?.();
+        callBridgeCallback("playbackStateDidChange:onEnded", onEndedRef.current, {
+          state,
+          eventItemId,
+          snapshot: getBridgeSnapshot(),
+        });
         return;
       }
       // loading/seeking/waiting/stalled and the suppressed mid-queue
@@ -298,10 +372,22 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         event.item?.playbackDuration ??
         0;
       if (durationMs > 0) {
-        onDurationRef.current?.(durationMs / 1000);
+        callBridgeCallback(
+          "mediaItemDidChange:onDuration",
+          () => onDurationRef.current?.(durationMs / 1000),
+          { durationMs, snapshot: getBridgeSnapshot() }
+        );
       }
-      onNowPlayingItemChangeRef.current?.(
-        mediaItemToNowPlayingMetadata(event.item)
+      callBridgeCallback(
+        "mediaItemDidChange:onNowPlayingItemChange",
+        () =>
+          onNowPlayingItemChangeRef.current?.(
+            mediaItemToNowPlayingMetadata(event.item)
+          ),
+        {
+          itemId: getMusicKitEventItemId(event.item),
+          snapshot: getBridgeSnapshot(),
+        }
       );
     };
 
@@ -336,7 +422,27 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         );
       }
     };
-  }, []);
+  }, [getBridgeSnapshot]);
+
+  // MusicKit JS can reject inside its own event dispatcher, outside any promise
+  // we directly await. Convert those known MusicKit-owned unhandled rejections
+  // into scoped logs with playback context, but let unrelated app rejections
+  // keep bubbling to the global console capture.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      if (!isLikelyMusicKitUnhandledRejection(event.reason)) return;
+      event.preventDefault();
+      appleMusicLog.error("musickit:unhandledrejection", {
+        error: event.reason,
+        snapshot: getBridgeSnapshot(),
+      });
+    };
+    window.addEventListener("unhandledrejection", onUnhandledRejection);
+    return () => {
+      window.removeEventListener("unhandledrejection", onUnhandledRejection);
+    };
+  }, [getBridgeSnapshot]);
 
   // Steady-cadence progress polling with wall-clock interpolation.
   //
@@ -439,9 +545,13 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         Math.min(1, volume)
       );
     } catch (err) {
-      console.warn("[apple music] failed to set volume", err);
+      appleMusicLog.warn("volume:set:failed", {
+        error: err,
+        volume,
+        snapshot: getBridgeSnapshot(),
+      });
     }
-  }, [volume]);
+  }, [getBridgeSnapshot, volume]);
 
   // Stable representation of the queue so we only call setQueue when the
   // *track* (not unrelated prop changes) actually flips.
@@ -474,10 +584,10 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
 
     const queueOptions = getQueueOptions(currentTrack);
     if (!queueOptions) {
-      console.warn(
-        "[apple music] track is missing playParams, skipping",
-        currentTrack
-      );
+      appleMusicLog.warn("queue:missingPlayParams", {
+        currentTrack: summarizeTrackForLog(currentTrack),
+        snapshot: getBridgeSnapshot(),
+      });
       return;
     }
 
@@ -540,30 +650,47 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         if (isStale()) return;
         if (resumeSeconds != null) {
           await inst.seekToTime(resumeSeconds).catch((err) => {
-            console.warn("[apple music] resume seek failed", err);
+            appleMusicLog.warn("queue:resumeSeek:failed", {
+              error: err,
+              resumeSeconds,
+              snapshot: getBridgeSnapshot(),
+            });
           });
         }
         if (isStale()) return;
         if (currentTrack.durationMs && currentTrack.durationMs > 0) {
-          onDurationRef.current?.(currentTrack.durationMs / 1000);
+          callBridgeCallback(
+            "queue:onDuration",
+            () => onDurationRef.current?.(currentTrack.durationMs / 1000),
+            {
+              durationMs: currentTrack.durationMs,
+              snapshot: getBridgeSnapshot(),
+            }
+          );
         }
         lastQueuedTrackIdRef.current = localQueueKey;
         if (shouldPlayAfterQueue) {
           await inst.play().catch((err) => {
             // Browsers block autoplay until the user interacts; surface as
             // a paused state so the iPod's play button shows the right icon.
-            console.warn(
-              "[apple music] play() blocked, awaiting user gesture",
-              err
-            );
-            onPauseRef.current?.();
+            appleMusicLog.warn("queue:play:blocked", {
+              error: err,
+              snapshot: getBridgeSnapshot(),
+            });
+            callBridgeCallback("queue:onPauseAfterBlockedPlay", onPauseRef.current, {
+              snapshot: getBridgeSnapshot(),
+            });
           });
         }
       } catch (err) {
         if (!isStale()) {
           lastQueuedTrackIdRef.current = null;
         }
-        console.error("[apple music] setQueue failed", err);
+        appleMusicLog.error("queue:setQueue:failed", {
+          error: err,
+          queueOptions,
+          snapshot: getBridgeSnapshot(),
+        });
       } finally {
         // Only clear the shared ref when *we* are still the most recent
         // load. A newer track change already replaced `queueLoadingRef`
@@ -606,7 +733,11 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           );
           if (startSeconds != null) {
             await inst.seekToTime(startSeconds).catch((err) => {
-              console.warn("[apple music] play seek failed", err);
+              appleMusicLog.warn("playback:playSeek:failed", {
+                error: err,
+                startSeconds,
+                snapshot: getBridgeSnapshot(),
+              });
             });
           }
           await inst.play();
@@ -614,11 +745,15 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           inst.pause();
         }
       } catch (err) {
-        console.warn("[apple music] play/pause failed", err);
+        appleMusicLog.warn("playback:playPause:failed", {
+          error: err,
+          playing,
+          snapshot: getBridgeSnapshot(),
+        });
       }
     };
     void apply();
-  }, [playing, instanceReadyTick]);
+  }, [getBridgeSnapshot, playing, instanceReadyTick]);
 
   useImperativeHandle(
     ref,
@@ -632,7 +767,11 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           await inst.seekToTime(seconds);
         };
         apply().catch((err) => {
-          console.warn("[apple music] seekToTime failed", err);
+          appleMusicLog.warn("imperativeSeek:failed", {
+            error: err,
+            seconds,
+            snapshot: getBridgeSnapshot(),
+          });
         });
       },
       getCurrentTime() {
@@ -642,7 +781,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         return instanceRef.current;
       },
     }),
-    []
+    [getBridgeSnapshot]
   );
 
   return null;

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -114,6 +114,34 @@ export function isStaleQueueLoad(
   return cancelled || loadGeneration !== currentGeneration;
 }
 
+function getErrorLikeText(value: unknown): string {
+  if (value instanceof Error) {
+    return [value.name, value.message, value.stack].filter(Boolean).join("\n");
+  }
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object") {
+    const record = value as {
+      name?: unknown;
+      message?: unknown;
+      stack?: unknown;
+    };
+    return [record.name, record.message, record.stack]
+      .filter((part): part is string => typeof part === "string")
+      .join("\n");
+  }
+  return String(value);
+}
+
+/**
+ * MusicKit JS v3 sometimes rejects internally from its event dispatcher. Those
+ * rejections otherwise surface as bare `Unhandled rejection: @...musickit.js`
+ * logs with no iPod context. Detect only MusicKit-owned stacks so app errors
+ * still bubble normally.
+ */
+export function isLikelyMusicKitUnhandledRejection(reason: unknown): boolean {
+  return /(?:musickit|music\.apple\.com)/i.test(getErrorLikeText(reason));
+}
+
 export function getMusicKitEventItemId(
   item:
     | {

--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -18,6 +18,9 @@ import {
   saveAppleMusicTrackCollection,
   type AppleMusicTrackCollectionKey,
 } from "@/utils/appleMusicLibraryCache";
+import { createClientLogger } from "@/utils/logger";
+
+const appleMusicLog = createClientLogger("AppleMusic");
 
 /**
  * Apple Music library fetcher.
@@ -392,7 +395,7 @@ const FAVORITE_SONGS_COLLECTION_KEY: AppleMusicTrackCollectionKey =
 const RADIO_STATIONS_COLLECTION_KEY: AppleMusicTrackCollectionKey =
   "radio-stations";
 
-function describeAppleMusicError(err: unknown): string {
+export function describeAppleMusicError(err: unknown): string {
   if (err instanceof Error) return err.message;
   if (typeof err === "object" && err !== null) {
     const errorLike = err as {
@@ -412,12 +415,20 @@ function describeAppleMusicError(err: unknown): string {
   return String(err);
 }
 
-function warnAppleMusic(message: string, err?: unknown): void {
+function warnAppleMusic(
+  message: string,
+  err?: unknown,
+  context?: Record<string, unknown>
+): void {
   if (err === undefined) {
-    console.warn(message);
+    appleMusicLog.warn(message, context);
     return;
   }
-  console.warn(`${message}: ${describeAppleMusicError(err)}`);
+  appleMusicLog.warn(message, {
+    ...context,
+    summary: describeAppleMusicError(err),
+    error: err,
+  });
 }
 
 function getAppleMusicInstanceForUser() {
@@ -694,8 +705,10 @@ export async function fetchAppleMusicRecentlyAddedTracks(
   try {
     const tracks = await fetchAppleMusicRecentlyAddedTracksFromApi();
     if (tracks.length === 0 && cached?.tracks.length) {
-      console.warn(
-        "[apple music] recently added refresh returned 0 songs; keeping cached collection"
+      warnAppleMusic(
+        "[apple music] recently added refresh returned 0 songs; keeping cached collection",
+        undefined,
+        { cachedCount: cached.tracks.length }
       );
       return cached.tracks;
     }
@@ -776,8 +789,10 @@ export async function fetchAppleMusicFavoriteSongTracks(
       force: options.force,
     });
     if (tracks.length === 0 && cached?.tracks.length) {
-      console.warn(
-        "[apple music] favorite songs refresh returned 0 songs; keeping cached collection"
+      warnAppleMusic(
+        "[apple music] favorite songs refresh returned 0 songs; keeping cached collection",
+        undefined,
+        { cachedCount: cached.tracks.length }
       );
       return cached.tracks;
     }
@@ -1033,8 +1048,10 @@ export async function refreshAppleMusicPlaylists(
         existing.length > 0 &&
         !options.allowEmpty
       ) {
-        console.warn(
-          "[apple music] playlist refresh returned 0; keeping cached list"
+        warnAppleMusic(
+          "[apple music] playlist refresh returned 0; keeping cached list",
+          undefined,
+          { cachedCount: existing.length }
         );
         return existing;
       }
@@ -1386,8 +1403,10 @@ export async function fetchAppleMusicLibrary(
     const existingTracks = useIpodStore.getState().appleMusicTracks;
     if (aggregated.length === 0 && existingTracks.length > 0) {
       store.setAppleMusicLibraryLoading(false);
-      console.warn(
-        "[apple music] refresh returned 0 songs; keeping cached library"
+      warnAppleMusic(
+        "[apple music] refresh returned 0 songs; keeping cached library",
+        undefined,
+        { cachedCount: existingTracks.length }
       );
     } else {
       store.setAppleMusicTracks(aggregated);
@@ -1489,14 +1508,15 @@ export async function fetchAppleMusicPlaylistTracks(
               offset,
             }
           );
-        } else {
-        if (offset > 0 && isAppleMusicNotFoundError(err)) {
-          console.warn(
-            `[apple music] playlist ${playlistId} returned 404 after ${aggregated.length} tracks; treating as end of pagination`
+        } else if (offset > 0 && isAppleMusicNotFoundError(err)) {
+          warnAppleMusic(
+            "[apple music] playlist page returned 404; treating as end of pagination",
+            err,
+            { playlistId, offset, aggregatedCount: aggregated.length }
           );
           break;
-        }
-        throw err;
+        } else {
+          throw err;
         }
       }
       const data = response?.data as LibraryPlaylistTracksResponse | undefined;
@@ -1822,9 +1842,10 @@ export function useAppleMusicLibrary({
       // toast since the user has nothing to look at until this
       // finishes.
       runWithProgressToast(false).catch((err) => {
-        console.error(
-          `[apple music] initial library load failed: ${describeAppleMusicError(err)}`
-        );
+        appleMusicLog.error("[apple music] initial library load failed", {
+          summary: describeAppleMusicError(err),
+          error: err,
+        });
       });
     };
 

--- a/src/components/dialogs/LyricsSearchDialog.tsx
+++ b/src/components/dialogs/LyricsSearchDialog.tsx
@@ -15,6 +15,9 @@ import { useTranslation } from "react-i18next";
 import { getApiUrl } from "@/utils/platform";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { formatKugouImageUrl } from "@/utils/coverArt";
+import { createClientLogger } from "@/utils/logger";
+
+const lyricsSearchLog = createClientLogger("LyricsSearch");
 
 const lyricsSearchListStyle: CSSProperties = {
   border: "1px solid var(--os-color-input-border)",
@@ -201,7 +204,12 @@ export function LyricsSearchDialog({
         throw new Error(t("apps.ipod.dialogs.lyricsSearchInvalidResponse"));
       }
     } catch (err) {
-      console.error("Lyrics search error:", err);
+      lyricsSearchLog.error("search:failed", {
+        error: err,
+        query: query.trim(),
+        trackTitle,
+        trackArtist,
+      });
       dispatch({
         type: "searchError",
         error:

--- a/src/components/dialogs/song-search-dialog/hooks/useSongSearchDialog.ts
+++ b/src/components/dialogs/song-search-dialog/hooks/useSongSearchDialog.ts
@@ -9,6 +9,9 @@ import {
 } from "../songSearchReducer";
 import type { SongSearchDialogProps } from "../types";
 import { isYouTubeUrl } from "../utils";
+import { createClientLogger } from "@/utils/logger";
+
+const songSearchLog = createClientLogger("SongSearch");
 
 export function useSongSearchDialog({
   isOpen,
@@ -60,7 +63,7 @@ export function useSongSearchDialog({
       await onAddUrl(query.trim());
       onOpenChange(false);
     } catch (err) {
-      console.error("Add URL error:", err);
+      songSearchLog.error("addUrl:failed", { error: err, query: query.trim() });
       dispatch({
         type: "setError",
         error:
@@ -168,7 +171,12 @@ export function useSongSearchDialog({
         throw new Error(t("apps.ipod.dialogs.songSearchInvalidResponse"));
       }
     } catch (err) {
-      console.error("Song search error:", err);
+      songSearchLog.error("search:failed", {
+        error: err,
+        mode,
+        appleMusicScope: isAppleMusicMode ? activeAppleMusicTab : undefined,
+        query: query.trim(),
+      });
       dispatch({
         type: "searchError",
         error:
@@ -191,6 +199,11 @@ export function useSongSearchDialog({
           await onAppleMusicSelect(appleMusicResults[selectedIndex]);
           onOpenChange(false);
         } catch (err) {
+          songSearchLog.error("appleMusicSelect:failed", {
+            error: err,
+            trackId: appleMusicResults[selectedIndex]?.id,
+            title: appleMusicResults[selectedIndex]?.title,
+          });
           dispatch({
             type: "setError",
             error:
@@ -234,6 +247,11 @@ export function useSongSearchDialog({
             await onAppleMusicSelect(appleMusicResults[index]);
             onOpenChange(false);
           } catch (err) {
+            songSearchLog.error("appleMusicSelect:failed", {
+              error: err,
+              trackId: appleMusicResults[index]?.id,
+              title: appleMusicResults[index]?.title,
+            });
             dispatch({
               type: "setError",
               error:

--- a/src/hooks/useLyrics.ts
+++ b/src/hooks/useLyrics.ts
@@ -3,8 +3,12 @@ import type { LyricLine } from "@/types/lyrics";
 import { useIpodStore } from "@/stores/useIpodStore";
 import { useCacheBustTrigger, useRefetchTrigger } from "@/hooks/useCacheBustTrigger";
 import { isOffline } from "@/utils/offline";
-import { ApiRequestError } from "@/api/core";
 import { fetchSongLyrics } from "@/api/songs";
+import { createClientLogger } from "@/utils/logger";
+import {
+  getLyricsErrorMessage,
+  normalizeLyricsFetchError,
+} from "@/utils/lyricsError";
 import {
   processTranslationSSE,
   parseLrcToTranslations,
@@ -14,6 +18,8 @@ import {
   type TranslationResult,
 } from "@/utils/chunkedStream";
 import { parseLyricTimestamps, findCurrentLineIndex } from "@/utils/lyricsSearch";
+
+const lyricsLog = createClientLogger("Lyrics");
 
 // Stable empty-lines sentinel used while no lyrics are loaded for the current
 // song. Reusing the same reference across renders is critical: it keeps the
@@ -88,6 +94,23 @@ interface UnifiedLyricsResponse {
   translation?: TranslationStreamInfo;
   furigana?: FuriganaStreamInfo;
   soramimi?: SoramimiStreamInfo;
+}
+
+interface LyricsLogContext {
+  songId: string;
+  title?: string;
+  artist?: string;
+  translateTo?: string | null;
+  includeFurigana?: boolean;
+  includeSoramimi?: boolean;
+  soramimiTargetLanguage?: "zh-TW" | "en";
+  selectedMatch?: {
+    hasHash: boolean;
+    albumId?: string | number;
+    title?: string;
+    artist?: string;
+    album?: string;
+  };
 }
 
 // =============================================================================
@@ -265,6 +288,36 @@ export function useLyrics({
         : undefined,
     [auth?.username, auth?.isAuthenticated]
   );
+  const logContext = useMemo<LyricsLogContext>(
+    () => ({
+      songId,
+      title: title || undefined,
+      artist: artist || undefined,
+      translateTo,
+      includeFurigana: Boolean(includeFurigana),
+      includeSoramimi: Boolean(includeSoramimi),
+      soramimiTargetLanguage,
+      selectedMatch: selectedMatch
+        ? {
+            hasHash: Boolean(selectedMatch.hash),
+            albumId: selectedMatch.albumId,
+            title: selectedMatch.title,
+            artist: selectedMatch.artist,
+            album: selectedMatch.album,
+          }
+        : undefined,
+    }),
+    [
+      songId,
+      title,
+      artist,
+      translateTo,
+      includeFurigana,
+      includeSoramimi,
+      soramimiTargetLanguage,
+      selectedMatch,
+    ]
+  );
 
   // Clear cached translation/furigana/soramimi info when cache bust trigger changes (force refresh)
   useEffect(() => {
@@ -441,12 +494,13 @@ export function useLyrics({
       .catch((err: unknown) => {
         if (controller.signal.aborted) return;
         if (effectSongId !== currentSongIdRef.current) return;
-        if (err instanceof ApiRequestError && err.status === 404) {
-          err = new Error("No lyrics found");
-        } else if (err instanceof ApiRequestError) {
-          err = new Error(`Failed to fetch lyrics (status ${err.status})`);
-        }
-        handleLyricsError(err, setError, setOriginalLines, setCurrentLine);
+        handleLyricsError(
+          normalizeLyricsFetchError(err),
+          logContext,
+          setError,
+          setOriginalLines,
+          setCurrentLine
+        );
         dispatch({
           type: "patch",
           payload: {
@@ -469,7 +523,7 @@ export function useLyrics({
       // Reset loading state on cleanup to prevent stuck indicators
       setIsFetchingOriginal(false);
     };
-  }, [songId, title, artist, isRefetchRequest, markRefetchHandled, selectedMatch, translateTo, includeFurigana, includeSoramimi, soramimiTargetLanguage, authCredentials]);
+  }, [songId, title, artist, isRefetchRequest, markRefetchHandled, selectedMatch, translateTo, includeFurigana, includeSoramimi, soramimiTargetLanguage, authCredentials, logContext]);
 
   // ==========================================================================
   // Effect: Translate lyrics
@@ -574,7 +628,7 @@ export function useLyrics({
       .catch((err: unknown) => {
         if (controller.signal.aborted) return;
         if (effectSongId !== currentSongIdRef.current) return;
-        handleTranslationError(err, setError, setTranslatedLines);
+        handleTranslationError(err, logContext, setError, setTranslatedLines);
       })
       .finally(() => {
         if (!controller.signal.aborted && effectSongId === currentSongIdRef.current) {
@@ -600,7 +654,7 @@ export function useLyrics({
         },
       });
     };
-  }, [songId, originalLines, translateTo, isFetchingOriginal, isCacheBustRequest, markCacheBustHandled, authCredentials]);
+  }, [songId, originalLines, translateTo, isFetchingOriginal, isCacheBustRequest, markCacheBustHandled, authCredentials, logContext]);
 
   // ==========================================================================
   // Current line tracking
@@ -666,22 +720,14 @@ export function useLyrics({
 
 function handleLyricsError(
   err: unknown,
+  context: LyricsLogContext,
   setError: (e: string | undefined) => void,
   setOriginalLines: (lines: LyricLine[]) => void,
   setCurrentLine: (line: number) => void
 ) {
-  console.error("[useLyrics] Error:", err);
-  if (err instanceof DOMException && err.name === "AbortError") {
-    setError("Lyrics search timed out.");
-  } else {
-    const msg = err instanceof Error ? err.message : "Unknown error";
-    const isNoLyricsError =
-      msg.includes("500") ||
-      msg.includes("404") ||
-      msg.includes("No lyrics") ||
-      msg.includes("not found");
-    setError(isNoLyricsError ? "No lyrics available" : msg);
-  }
+  const displayError = getLyricsErrorMessage(err);
+  lyricsLog.error("fetch:failed", { error: err, displayError, context });
+  setError(displayError);
   setOriginalLines([]);
   setCurrentLine(-1);
   useIpodStore.setState({ currentLyrics: null });
@@ -689,10 +735,11 @@ function handleLyricsError(
 
 function handleTranslationError(
   err: unknown,
+  context: LyricsLogContext,
   setError: (e: string | undefined) => void,
   setTranslatedLines: (lines: LyricLine[] | null) => void
 ) {
-  console.error("[useLyrics] Translation error:", err);
+  lyricsLog.error("translation:failed", { error: err, context });
   if (err instanceof DOMException && err.name === "AbortError") {
     setError("Translation timed out.");
   } else {

--- a/src/hooks/useMusicKit.ts
+++ b/src/hooks/useMusicKit.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
+import { createClientLogger } from "@/utils/logger";
 
 /**
  * Apple MusicKit JS v3 lazy loader / configurer.
@@ -20,6 +21,7 @@ const MUSICKIT_SCRIPT_ID = "ryos-musickit-js-v3";
 const MUSICKIT_TOKEN_ENDPOINT = "/api/musickit-token";
 const TOKEN_REFRESH_BUFFER_MS = 60 * 60 * 1000; // refresh if <1h left
 export const APPLE_MUSIC_STREAMING_BITRATE_KBPS = 256;
+const musicKitLog = createClientLogger("MusicKit");
 
 export function buildMusicKitConfigureOptions(
   developerToken: string,
@@ -60,7 +62,7 @@ function notifyReady(instance: MusicKit.MusicKitInstance) {
     try {
       listener(instance);
     } catch (err) {
-      console.error("[musickit] ready listener threw", err);
+      musicKitLog.error("readyListener:threw", { error: err });
     }
   }
 }
@@ -118,10 +120,7 @@ async function resolveDeveloperToken(): Promise<string> {
   } catch (err) {
     const fallback = getEnvFallbackToken();
     if (fallback) {
-      console.warn(
-        "[musickit] server token fetch failed, using VITE_MUSICKIT_DEVELOPER_TOKEN",
-        err
-      );
+      musicKitLog.warn("tokenFetch:failedUsingEnvFallback", { error: err });
       return fallback;
     }
     throw err;
@@ -452,7 +451,7 @@ export function useMusicKit(
       });
       return token ?? null;
     } catch (err) {
-      console.error("[musickit] authorize failed", err);
+      musicKitLog.error("authorize:failed", { error: err });
       dispatch({
         type: "patch",
         payload: { error: err instanceof Error ? err.message : String(err) },
@@ -468,7 +467,7 @@ export function useMusicKit(
       await inst.unauthorize();
       dispatch({ type: "patch", payload: { isAuthorized: false } });
     } catch (err) {
-      console.error("[musickit] unauthorize failed", err);
+      musicKitLog.error("unauthorize:failed", { error: err });
     }
   }, [instance]);
 

--- a/src/utils/lyricsError.ts
+++ b/src/utils/lyricsError.ts
@@ -1,0 +1,33 @@
+import { ApiRequestError } from "@/api/core";
+
+function errorWithCause(message: string, cause: unknown): Error {
+  const error = new Error(message);
+  Object.defineProperty(error, "cause", {
+    configurable: true,
+    value: cause,
+  });
+  return error;
+}
+
+export function normalizeLyricsFetchError(err: unknown): unknown {
+  if (err instanceof ApiRequestError && err.status === 404) {
+    return errorWithCause("No lyrics found", err);
+  }
+  if (err instanceof ApiRequestError) {
+    return errorWithCause(`Failed to fetch lyrics (status ${err.status})`, err);
+  }
+  return err;
+}
+
+export function getLyricsErrorMessage(err: unknown): string {
+  if (err instanceof DOMException && err.name === "AbortError") {
+    return "Lyrics search timed out.";
+  }
+  const msg = err instanceof Error ? err.message : "Unknown error";
+  const isNoLyricsError =
+    msg.includes("500") ||
+    msg.includes("404") ||
+    msg.includes("No lyrics") ||
+    msg.includes("not found");
+  return isNoLyricsError ? "No lyrics available" : msg;
+}

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -50,6 +50,7 @@ const {
   refreshAppleMusicFavorites,
   APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS,
   APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS,
+  describeAppleMusicError,
 } = await import("../src/apps/ipod/hooks/useAppleMusicLibrary");
 const {
   useIpodStore,
@@ -70,6 +71,7 @@ const {
   getMusicKitEventItemId,
   shouldSuppressPlaybackStateFanoutWhileQueueLoading,
   isStaleQueueLoad,
+  isLikelyMusicKitUnhandledRejection,
 } = await import(
   "../src/apps/ipod/components/appleMusicPlayerBridgeUtils"
 );
@@ -102,6 +104,34 @@ describe("MusicKit configuration", () => {
       bitrate: 256,
     });
     expect(APPLE_MUSIC_STREAMING_BITRATE_KBPS).toBe(256);
+  });
+});
+
+describe("Apple Music error logging helpers", () => {
+  test("summarizes MusicKit API errors with status details", () => {
+    expect(
+      describeAppleMusicError({
+        message: "Forbidden",
+        response: { status: 403 },
+      })
+    ).toBe("Forbidden (status 403)");
+    expect(describeAppleMusicError({ statusCode: 429 })).toBe("status 429");
+  });
+
+  test("detects MusicKit-owned unhandled rejections without catching app errors", () => {
+    const musicKitError = new Error("");
+    musicKitError.stack =
+      "@https://js-cdn.music.apple.com/musickit/v3/musickit.js:28:48338";
+
+    expect(isLikelyMusicKitUnhandledRejection(musicKitError)).toBe(true);
+    expect(
+      isLikelyMusicKitUnhandledRejection({
+        message: "MusicKit authorization failed",
+      })
+    ).toBe(true);
+    expect(isLikelyMusicKitUnhandledRejection(new Error("No lyrics found"))).toBe(
+      false
+    );
   });
 });
 

--- a/tests/test-lyrics-parsing.test.ts
+++ b/tests/test-lyrics-parsing.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import { parseLrcToLines } from "../api/songs/_lyrics";
+import { ApiRequestError } from "../src/api/core";
+import {
+  getLyricsErrorMessage,
+  normalizeLyricsFetchError,
+} from "../src/utils/lyricsError";
 
 describe("lyrics prefix filtering", () => {
   test("skips additional metadata prefixes in LRC content", () => {
@@ -67,5 +72,32 @@ describe("lyrics prefix filtering", () => {
         words: "Plain lyric",
       },
     ]);
+  });
+});
+
+describe("lyrics error handling", () => {
+  test("normalizes lyrics API errors while preserving the original cause", () => {
+    const original = new ApiRequestError(503, "upstream failed", {
+      code: "LYRICS_UPSTREAM",
+    });
+    const normalized = normalizeLyricsFetchError(original);
+
+    expect(normalized).toBeInstanceOf(Error);
+    if (!(normalized instanceof Error)) {
+      throw new Error("Expected lyrics error to normalize to Error");
+    }
+    expect(normalized.message).toBe("Failed to fetch lyrics (status 503)");
+    expect(Object.getOwnPropertyDescriptor(normalized, "cause")?.value).toBe(
+      original
+    );
+  });
+
+  test("maps not-found and abort errors to user-facing lyrics messages", () => {
+    expect(getLyricsErrorMessage(new Error("No lyrics found"))).toBe(
+      "No lyrics available"
+    );
+    expect(
+      getLyricsErrorMessage(new DOMException("cancelled", "AbortError"))
+    ).toBe("Lyrics search timed out.");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Log lyrics fetch/search/translation failures through scoped client loggers with song/request context.
- Preserve Apple Music and MusicKit error objects in logs, including playback snapshots around bridge failures.
- Catch known MusicKit-owned unhandled rejections while the Apple Music bridge is mounted.
- Cover lyrics error normalization and MusicKit rejection detection with Bun tests.

### Testing
- Passed: `bun test tests/test-lyrics-parsing.test.ts tests/test-ipod-apple-music.test.ts` (82 tests)
- Passed with existing warnings: `./node_modules/.bin/eslint src/hooks/useLyrics.ts src/utils/lyricsError.ts src/apps/ipod/components/AppleMusicPlayerBridge.tsx src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts src/apps/ipod/hooks/useAppleMusicLibrary.ts src/hooks/useMusicKit.ts src/components/dialogs/LyricsSearchDialog.tsx src/components/dialogs/song-search-dialog/hooks/useSongSearchDialog.ts tests/test-lyrics-parsing.test.ts tests/test-ipod-apple-music.test.ts`
  - Existing `react-hooks/exhaustive-deps` warnings remain in `src/hooks/useLyrics.ts`.
- Passed with existing Vite/CSS warnings: `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0c9b-345c-7c11-9921-96334671bb96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0c9b-345c-7c11-9921-96334671bb96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

