### PR TITLE
fix: serve version.json in dev to prevent Prefetch JSON parse errors

### DIFF
--- a/scripts/build-version.ts
+++ b/scripts/build-version.ts
@@ -1,0 +1,112 @@
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ============================================================================
+// WEB VERSION CONSTANTS - Manually increment these for web releases
+// ============================================================================
+export const MAJOR_VERSION = 10;
+export const MINOR_VERSION = 3;
+// ============================================================================
+
+export interface BuildVersionJson {
+  version: string;
+  buildNumber: string;
+  commitSha: string;
+  buildTime: string;
+  majorVersion: number;
+  minorVersion: number;
+  desktopVersion: string;
+}
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const versionPath = join(repoRoot, ".version");
+const publicVersionPath = join(repoRoot, "public/version.json");
+const packageJsonPath = join(repoRoot, "package.json");
+
+function readStoredVersion(): { major: number; minor: number } {
+  let majorVersion = MAJOR_VERSION;
+  let minorVersion = MINOR_VERSION;
+
+  if (existsSync(versionPath)) {
+    try {
+      const versionData = JSON.parse(readFileSync(versionPath, "utf-8")) as {
+        major?: number;
+        minor?: number;
+      };
+      majorVersion = versionData.major ?? MAJOR_VERSION;
+      minorVersion = versionData.minor ?? MINOR_VERSION;
+    } catch {
+      // Use defaults
+    }
+  }
+
+  return { major: majorVersion, minor: minorVersion };
+}
+
+function resolveCommitSha(): string {
+  return (
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.SOURCE_COMMIT ||
+    process.env.GIT_COMMIT_SHA ||
+    (() => {
+      try {
+        return execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim();
+      } catch {
+        return "dev";
+      }
+    })()
+  );
+}
+
+function readDesktopVersion(): string {
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as {
+    version?: unknown;
+  };
+
+  if (typeof packageJson.version !== "string" || !packageJson.version.trim()) {
+    throw new Error("package.json must contain a version for desktop releases");
+  }
+
+  return packageJson.version.trim();
+}
+
+export function generateBuildVersion(options?: {
+  bumpMinor?: boolean;
+}): BuildVersionJson {
+  let { major: majorVersion, minor: minorVersion } = readStoredVersion();
+
+  if (options?.bumpMinor) {
+    minorVersion += 1;
+    writeFileSync(
+      versionPath,
+      JSON.stringify({ major: majorVersion, minor: minorVersion }, null, 2)
+    );
+  }
+
+  const commitSha = resolveCommitSha();
+  const shortSha = commitSha === "dev" ? "dev" : commitSha.substring(0, 7);
+  const buildTime = new Date().toISOString();
+
+  return {
+    version: `${majorVersion}.${minorVersion}`,
+    buildNumber: shortSha,
+    commitSha,
+    buildTime,
+    majorVersion,
+    minorVersion,
+    desktopVersion: readDesktopVersion(),
+  };
+}
+
+export function getPublicVersionPath(): string {
+  return publicVersionPath;
+}
+
+export function writeBuildVersionFile(
+  versionJson: BuildVersionJson = generateBuildVersion()
+): BuildVersionJson {
+  writeFileSync(publicVersionPath, JSON.stringify(versionJson, null, 2));
+  return versionJson;
+}

--- a/scripts/dev-with-api.ts
+++ b/scripts/dev-with-api.ts
@@ -7,6 +7,15 @@
  * Exits both processes on Ctrl+C.
  */
 
+import { writeBuildVersionFile } from "./build-version";
+
+// Vite only indexes public/ files at startup; generate version.json first so
+// /version.json is served as JSON instead of falling through to index.html.
+const versionJson = writeBuildVersionFile();
+console.log(
+  `[dev] Generated version.json (${versionJson.version}, ${versionJson.buildNumber})`
+);
+
 const API_PORT = process.env.API_PORT ?? "3000";
 // Bun auto-loads .env.local which may set PORT=3000 (used by the API).
 // The Vite dev server needs a separate port to avoid conflicts.

--- a/scripts/generate-build-version.ts
+++ b/scripts/generate-build-version.ts
@@ -1,100 +1,27 @@
 /**
  * Generates a version.json file with build information
  * Format: MAJOR.MINOR (e.g., 10.1) + commit SHA
- * 
+ *
  * Commit SHA from: VERCEL_GIT_COMMIT_SHA (Vercel), SOURCE_COMMIT (Coolify), GIT_COMMIT_SHA (generic CI), or git rev-parse; falls back to 'dev' if none available.
  * Run manually with `bun run version:bump` to increment MAJOR/MINOR.
  * Desktop app version is read from package.json so generated download links
  * match electron-builder artifact names.
  */
 
-import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { execSync } from 'child_process';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import {
+  generateBuildVersion,
+  writeBuildVersionFile,
+} from "./build-version";
 
-// ============================================================================
-// WEB VERSION CONSTANTS - Manually increment these for web releases
-// ============================================================================
-const MAJOR_VERSION = 10;
-const MINOR_VERSION = 3;
-// ============================================================================
+const isManualBump = process.argv.includes("--bump");
+const versionJson = writeBuildVersionFile(
+  generateBuildVersion({ bumpMinor: isManualBump })
+);
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const versionPath = join(__dirname, '../.version');
-const publicVersionPath = join(__dirname, '../public/version.json');
-const packageJsonPath = join(__dirname, '../package.json');
-
-// Check if this is a manual version bump (called directly via version:bump)
-const isManualBump = process.argv.includes('--bump');
-
-// Read current version or use defaults
-let majorVersion = MAJOR_VERSION;
-let minorVersion = MINOR_VERSION;
-
-if (existsSync(versionPath)) {
-  try {
-    const versionData = JSON.parse(readFileSync(versionPath, 'utf-8'));
-    majorVersion = versionData.major ?? MAJOR_VERSION;
-    minorVersion = versionData.minor ?? MINOR_VERSION;
-  } catch {
-    // Use defaults
-  }
-}
-
-// If manual bump, increment minor version (or handle major bump via editing constants)
 if (isManualBump) {
-  minorVersion++;
-  writeFileSync(versionPath, JSON.stringify({ major: majorVersion, minor: minorVersion }, null, 2));
-  console.log(`[Version] Bumped to ${majorVersion}.${minorVersion}`);
+  console.log(`[Version] Bumped to ${versionJson.version}`);
 }
 
-// Get commit SHA from environment or git
-// VERCEL_GIT_COMMIT_SHA: Vercel | SOURCE_COMMIT: Coolify | GIT_COMMIT_SHA: generic CI
-const commitSha =
-  process.env.VERCEL_GIT_COMMIT_SHA ||
-  process.env.SOURCE_COMMIT ||
-  process.env.GIT_COMMIT_SHA ||
-  (() => {
-    try {
-      return execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
-    } catch {
-      return 'dev';
-    }
-  })();
-
-const shortSha = commitSha === 'dev' ? 'dev' : commitSha.substring(0, 7);
-const buildTime = new Date().toISOString();
-
-// Version format: MAJOR.MINOR
-const version = `${majorVersion}.${minorVersion}`;
-
-function readDesktopVersion(): string {
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
-    version?: unknown;
-  };
-
-  if (typeof packageJson.version !== 'string' || !packageJson.version.trim()) {
-    throw new Error('package.json must contain a version for desktop releases');
-  }
-
-  return packageJson.version.trim();
-}
-
-// Desktop version follows package.json, which electron-builder also uses.
-const desktopVersion = readDesktopVersion();
-
-// Write version.json to public folder for runtime version fetching
-const versionJson = {
-  version,
-  buildNumber: shortSha,
-  commitSha,
-  buildTime,
-  majorVersion,
-  minorVersion,
-  desktopVersion,
-};
-
-writeFileSync(publicVersionPath, JSON.stringify(versionJson, null, 2));
-
-console.log(`[Build] Generated version: ${version} (${shortSha}), desktop: ${desktopVersion} at ${buildTime}`);
+console.log(
+  `[Build] Generated version: ${versionJson.version} (${versionJson.buildNumber}), desktop: ${versionJson.desktopVersion} at ${versionJson.buildTime}`
+);

--- a/src/stores/useChatsStore.ts
+++ b/src/stores/useChatsStore.ts
@@ -196,7 +196,7 @@ const clearApiUnavailable = (key: string): void => {
 function forceLogoutOnUnauthorized() {
   const store = useChatsStore.getState();
   if (!store.username) return;
-  debug("[ChatsStore] Unauthorized — clearing auth state for", store.username);
+  debug("Unauthorized — clearing auth state for", store.username);
   localStorage.removeItem(USERNAME_RECOVERY_KEY);
   useChatsStore.setState({
     username: null,
@@ -519,7 +519,7 @@ export const useChatsStore = create<ChatsStoreState>()(
             return; // Skip update if rooms haven't actually changed
           }
 
-          debug("[ChatsStore] setRooms called. Updating rooms.");
+          debug("setRooms called. Updating rooms.");
           set({ rooms: sortedNewRooms });
         },
         setCurrentRoomId: (roomId) => set({ currentRoomId: roomId }),
@@ -717,7 +717,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           set(getInitialState());
         },
         logout: async () => {
-          debug("[ChatsStore] Logging out user...");
+          debug("Logging out user...");
 
           const currentUsername = get().username;
 
@@ -760,7 +760,7 @@ export const useChatsStore = create<ChatsStoreState>()(
             );
           }
 
-          debug("[ChatsStore] User logged out successfully");
+          debug("User logged out successfully");
         },
         deleteAccount: async ({ confirmUsername, currentPassword }) => {
           const currentUsername = get().username;
@@ -816,16 +816,16 @@ export const useChatsStore = create<ChatsStoreState>()(
         },
         fetchRooms: async (options = {}) => {
           if (roomsFetchPromise) {
-            debug("[ChatsStore] Reusing in-flight rooms fetch...");
+            debug("Reusing in-flight rooms fetch...");
             return roomsFetchPromise;
           }
 
           if (!options.force && Date.now() < roomsFetchFreshUntil) {
-            debug("[ChatsStore] Skipping rooms fetch; cache is fresh.");
+            debug("Skipping rooms fetch; cache is fresh.");
             return { ok: true };
           }
 
-          debug("[ChatsStore] Fetching rooms...");
+          debug("Fetching rooms...");
           if (isApiTemporarilyUnavailable("rooms")) {
             return { ok: false, error: "Rooms API temporarily unavailable" };
           }
@@ -862,7 +862,7 @@ export const useChatsStore = create<ChatsStoreState>()(
         fetchMessagesForRoom: async (roomId: string) => {
           if (!roomId) return { ok: false, error: "Room ID required" };
 
-          debug(`[ChatsStore] Fetching messages for room ${roomId}...`);
+          debug(`Fetching messages for room ${roomId}...`);
           if (isApiTemporarilyUnavailable("room-messages")) {
             return { ok: false, error: "Messages API temporarily unavailable" };
           }
@@ -957,7 +957,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           const username = get().username;
 
           debug(
-            `[ChatsStore] Switching from ${currentRoomId} to ${newRoomId}`
+            `Switching from ${currentRoomId} to ${newRoomId}`
           );
 
           set({ currentRoomId: newRoomId });
@@ -1051,7 +1051,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           } catch (error) {
             if (error instanceof ApiRequestError) {
               if (error.status === 401) {
-                debug("[ChatsStore] Received 401 — forcing logout");
+                debug("Received 401 — forcing logout");
                 forceLogoutOnUnauthorized();
               }
               return { ok: false, error: error.message || "Failed to create room" };
@@ -1081,7 +1081,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           } catch (error) {
             if (error instanceof ApiRequestError) {
               if (error.status === 401) {
-                debug("[ChatsStore] Received 401 — forcing logout");
+                debug("Received 401 — forcing logout");
                 forceLogoutOnUnauthorized();
               }
               return { ok: false, error: error.message || "Failed to delete room" };
@@ -1124,7 +1124,7 @@ export const useChatsStore = create<ChatsStoreState>()(
             get().removeMessageFromRoom(roomId, tempId);
             if (error instanceof ApiRequestError) {
               if (error.status === 401) {
-                debug("[ChatsStore] Received 401 — forcing logout");
+                debug("Received 401 — forcing logout");
                 forceLogoutOnUnauthorized();
               }
               return { ok: false, error: error.message || "Failed to send message" };
@@ -1235,7 +1235,7 @@ export const useChatsStore = create<ChatsStoreState>()(
         hasEverUsedChats: state.hasEverUsedChats,
       }),
       onRehydrateStorage: () => {
-        debug("[ChatsStore] Rehydrating storage...");
+        debug("Rehydrating storage...");
         return (state, error) => {
           if (error) {
             console.error("[ChatsStore] Error during rehydration:", error);
@@ -1279,7 +1279,7 @@ async function restoreSessionFromCookie(expectedUsername: string) {
     const session = await getAuthSession();
 
     if (!session.ok) {
-      debug("[ChatsStore] Session restore failed:", session.status);
+      debug("Session restore failed:", session.status);
       if (session.status === 401 || session.status === 403) {
         forceLogoutOnUnauthorized();
       }
@@ -1288,7 +1288,7 @@ async function restoreSessionFromCookie(expectedUsername: string) {
 
     const data = session.data;
     if (data.authenticated && data.username) {
-      debug("[ChatsStore] Session restored", {
+      debug("Session restored", {
         username: data.username,
         source: "cookie",
       });
@@ -1299,7 +1299,7 @@ async function restoreSessionFromCookie(expectedUsername: string) {
         store.checkHasPassword();
       }
     } else {
-      debug("[ChatsStore] No valid session — logging out.");
+      debug("No valid session — logging out.");
       forceLogoutOnUnauthorized();
     }
   } catch (err) {

--- a/src/utils/prefetch.ts
+++ b/src/utils/prefetch.ts
@@ -181,6 +181,14 @@ async function fetchServerVersion(forceRemote: boolean = false): Promise<ServerV
       console.warn('[Prefetch] Could not fetch version.json');
       return null;
     }
+
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!contentType.includes('application/json')) {
+      console.warn('[Prefetch] version.json returned non-JSON content', {
+        contentType,
+      });
+      return null;
+    }
     
     const data = await response.json();
     if (data.version && data.buildNumber) {

--- a/tests/test-build-version.test.ts
+++ b/tests/test-build-version.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { generateBuildVersion } from "../scripts/build-version";
+
+describe("build-version", () => {
+  test("generateBuildVersion returns required prefetch fields", () => {
+    const version = generateBuildVersion();
+
+    expect(typeof version.version).toBe("string");
+    expect(version.version.length).toBeGreaterThan(0);
+    expect(typeof version.buildNumber).toBe("string");
+    expect(version.buildNumber.length).toBeGreaterThan(0);
+    expect(typeof version.desktopVersion).toBe("string");
+    expect(typeof version.buildTime).toBe("string");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFileSync, existsSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { generateBuildVersion } from "./scripts/build-version";
 
 // Polyfill __dirname in ESM context (Node >=16)
 const __filename = fileURLToPath(import.meta.url);
@@ -331,6 +332,38 @@ export default defineConfig({
                 );
                 res.setHeader("Cache-Control", "no-store, max-age=0");
                 res.end(devServiceWorkerResetScript);
+              });
+            },
+          },
+          {
+            name: "serve-dev-version-json",
+            configureServer(server: ViteDevServer) {
+              server.middlewares.use((
+                req: IncomingMessage,
+                res: ServerResponse,
+                next: () => void
+              ) => {
+                const pathPart = (req.url || "").split("?")[0];
+                if (pathPart !== "/version.json") {
+                  next();
+                  return;
+                }
+
+                try {
+                  const versionJson = generateBuildVersion();
+                  res.statusCode = 200;
+                  res.setHeader(
+                    "Content-Type",
+                    "application/json; charset=utf-8"
+                  );
+                  res.setHeader(
+                    "Cache-Control",
+                    "no-cache, no-store, must-revalidate"
+                  );
+                  res.end(JSON.stringify(versionJson));
+                } catch (error) {
+                  next(error as Error);
+                }
               });
             },
           },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated the provided debug console logs. All entries were `[LOG]` level (normal startup telemetry from CloudSync, ChatsStore, FileSystem, etc.) — no `[ERROR]` or `[WARN]` entries in the paste itself.

Runtime investigation found one real warning during startup:

```
[Prefetch] Failed to fetch server version: SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

**Root cause:** `public/version.json` is gitignored and only generated during `prebuild`. In dev, if the file is missing (or added after Vite starts), `/version.json` falls through to the SPA `index.html` fallback. Prefetch then tries to `response.json()` HTML and throws.

## Changes

- **Shared build version helper** (`scripts/build-version.ts`) used by prebuild and dev tooling
- **`bun run dev`** now writes `public/version.json` before starting API + Vite so Vite indexes it at startup
- **Vite dev middleware** serves `/version.json` dynamically (covers `dev:vite` and files missing from Vite's public-file cache)
- **Prefetch guard** checks `Content-Type` before parsing JSON (avoids noisy SyntaxError if misconfigured)
- **ChatsStore logging cleanup** removes duplicate `[ChatsStore]` prefix from debug messages (logger already scopes output)

## Testing

- `bun test tests/test-build-version.test.ts` — pass
- `bun run test:unit` — 1422 pass
- Playwright headless load before fix: 1 warning (Prefetch JSON parse)
- Playwright headless load after fix (with middleware, no `version.json` on disk): **0 warnings**
- Verified `/version.json` returns `Content-Type: application/json`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e18ebd7b-9a70-43ed-b3c4-d0486ff76969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e18ebd7b-9a70-43ed-b3c4-d0486ff76969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

