### PR TITLE
Fix Finder stale selection update loop

### DIFF
--- a/src/apps/finder/hooks/useFileSystem.ts
+++ b/src/apps/finder/hooks/useFileSystem.ts
@@ -39,6 +39,7 @@ import {
   getFileTypeFromExtension,
   BOOK_FILE_ICON_PATH,
   isEpubFile,
+  resolveFinderSelectionSnapshot,
 } from "../utils/fileSystemHelpers";
 
 const log = createClientLogger("FileSystem");
@@ -228,10 +229,15 @@ export function useFileSystem(
   const currentPath = finderInstance?.currentPath || localCurrentPath;
   const history = finderInstance?.navigationHistory || localHistory;
   const historyIndex = finderInstance?.navigationIndex || localHistoryIndex;
-  const selectedFilePath = finderInstance?.selectedFile || localSelectedFilePath;
-  const selectedFiles = finderInstance?.selectedFiles || localSelectedFiles;
-  const selectionAnchorPath =
-    finderInstance?.selectionAnchorPath || localSelectionAnchorPath;
+  const {
+    selectedFile: selectedFilePath,
+    selectedFiles,
+    selectionAnchorPath,
+  } = resolveFinderSelectionSnapshot(finderInstance, {
+    selectedFile: localSelectedFilePath,
+    selectedFiles: localSelectedFiles,
+    selectionAnchorPath: localSelectionAnchorPath,
+  });
 
   // State setters that work with both instance and local mode
   const setCurrentPath = useCallback(

--- a/src/apps/finder/utils/fileSystemHelpers.ts
+++ b/src/apps/finder/utils/fileSystemHelpers.ts
@@ -48,6 +48,17 @@ export const arePathArraysEqual = (
   first.length === second.length &&
   first.every((path, index) => path === second[index]);
 
+export interface FinderSelectionSnapshot {
+  selectedFile: string | null;
+  selectedFiles: string[];
+  selectionAnchorPath: string | null;
+}
+
+export const resolveFinderSelectionSnapshot = (
+  instanceSelection: FinderSelectionSnapshot | null | undefined,
+  localSelection: FinderSelectionSnapshot
+): FinderSelectionSnapshot => instanceSelection ?? localSelection;
+
 export const DEFAULT_FILE_PATHS = new Set([
   "/Documents/README.md",
   "/Documents/Quick Tips.md",

--- a/tests/test-finder-selection-snapshot.test.ts
+++ b/tests/test-finder-selection-snapshot.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { resolveFinderSelectionSnapshot } from "../src/apps/finder/utils/fileSystemHelpers";
+
+const staleLocalSelection = {
+  selectedFile: "/Applets/Removed.app",
+  selectedFiles: ["/Applets/Removed.app"],
+  selectionAnchorPath: "/Applets/Removed.app",
+};
+
+describe("resolveFinderSelectionSnapshot", () => {
+  test("preserves cleared instance selection instead of reviving stale local state", () => {
+    const clearedInstanceSelection = {
+      selectedFile: null,
+      selectedFiles: [],
+      selectionAnchorPath: null,
+    };
+
+    expect(
+      resolveFinderSelectionSnapshot(
+        clearedInstanceSelection,
+        staleLocalSelection
+      )
+    ).toBe(clearedInstanceSelection);
+  });
+
+  test("uses local selection before a Finder instance exists", () => {
+    expect(
+      resolveFinderSelectionSnapshot(undefined, staleLocalSelection)
+    ).toBe(staleLocalSelection);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve cleared Finder instance selections instead of falling back to stale local state
- prevent the selection synchronization effect from repeatedly writing the same cleared selection
- add regression coverage for persisted Finder instances with removed files

## Verification
- `bun test tests/test-finder-selection-snapshot.test.ts` — 2 passed
- `bun run test:unit` — 1,479 passed
- `bunx tsc -b --pretty false`
- `bun run test:registration` — 206 unit tests registered
- `bun run build`

## Notes
- Targeted ESLint completed with one pre-existing `react-hooks/exhaustive-deps` warning in `useFileSystem.ts`; no errors.