### PR TITLE
Make currency the default calculator conversion

### DIFF
--- a/src/apps/calculator/components/CalculatorConversionPanel.tsx
+++ b/src/apps/calculator/components/CalculatorConversionPanel.tsx
@@ -14,7 +14,7 @@ import {
   type ConversionUnit,
 } from "../utils/conversionData";
 import { formatCalculatorDisplay } from "../utils/formatCalculatorDisplay";
-import { CalculatorKey } from "./CalculatorKey";
+import { CalculatorDisplayValue, CalculatorKey } from "./CalculatorKey";
 import type { CalculatorTheme } from "./types";
 
 interface CalculatorConversionPanelProps {
@@ -233,9 +233,9 @@ export function CalculatorConversionPanel({
     <div className="calc-conversion-panel flex min-h-0 flex-1 flex-col">
       <div className="calc-display calc-conversion-lcd">
         <div className="calc-conversion-value-row">
-          <div className="calc-display-value truncate">
-            {formatCalculatorDisplay(amount, locale)}
-          </div>
+          <CalculatorDisplayValue
+            value={formatCalculatorDisplay(amount, locale)}
+          />
           <ConversionUnitCombobox
             value={fromUnit}
             category={category}
@@ -260,9 +260,7 @@ export function CalculatorConversionPanel({
         </div>
 
         <div className="calc-conversion-value-row">
-          <div className="calc-display-value truncate">
-            {loading ? "–" : result}
-          </div>
+          <CalculatorDisplayValue value={loading ? "–" : result} />
           <ConversionUnitCombobox
             value={toUnit}
             category={category}

--- a/src/apps/calculator/components/CalculatorKey.tsx
+++ b/src/apps/calculator/components/CalculatorKey.tsx
@@ -115,7 +115,7 @@ export function CalculatorDisplayValue({ value }: { value: string }) {
   }, [value]);
 
   return (
-    <div ref={valueRef} className="calc-display-value truncate">
+    <div ref={valueRef} className="calc-display-value whitespace-nowrap">
       {value}
     </div>
   );

--- a/src/apps/calculator/components/CalculatorKey.tsx
+++ b/src/apps/calculator/components/CalculatorKey.tsx
@@ -1,8 +1,11 @@
 import { cn } from "@/lib/utils";
 import { ToolbarButton, ToolbarButtonGroup } from "@/components/ui/toolbar-button";
 import { useLanguageStore } from "@/stores/useLanguageStore";
-import type { CSSProperties } from "react";
-import { formatCalculatorDisplay } from "../utils/formatCalculatorDisplay";
+import { useLayoutEffect, useRef, type CSSProperties } from "react";
+import {
+  calculateFittedCalculatorFontSize,
+  formatCalculatorDisplay,
+} from "../utils/formatCalculatorDisplay";
 import type { CalculatorTheme } from "./types";
 
 export interface CalculatorKeyProps {
@@ -80,6 +83,44 @@ export interface CalculatorDisplayProps {
   theme: CalculatorTheme;
 }
 
+export function CalculatorDisplayValue({ value }: { value: string }) {
+  const valueRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const valueElement = valueRef.current;
+    const container = valueElement?.parentElement;
+    if (!valueElement || !container) return;
+
+    const fitValue = () => {
+      valueElement.style.fontSize = "";
+      const baseFontSize = Number.parseFloat(
+        window.getComputedStyle(valueElement).fontSize
+      );
+      const fittedFontSize = calculateFittedCalculatorFontSize({
+        baseFontSize,
+        availableWidth: valueElement.clientWidth,
+        contentWidth: valueElement.scrollWidth,
+      });
+      if (fittedFontSize < baseFontSize) {
+        valueElement.style.fontSize = `${fittedFontSize}px`;
+      }
+    };
+
+    fitValue();
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(fitValue);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [value]);
+
+  return (
+    <div ref={valueRef} className="calc-display-value truncate">
+      {value}
+    </div>
+  );
+}
+
 export function CalculatorDisplay({
   value,
   secondary,
@@ -103,7 +144,7 @@ export function CalculatorDisplay({
         </div>
       ) : null}
       <div className="calc-display" title={value}>
-        <div className="calc-display-value truncate">{formattedValue}</div>
+        <CalculatorDisplayValue value={formattedValue} />
         {theme === "aqua" ? (
           <div className="calc-display-status" aria-live="polite">
             <span>{memoryActive ? "M" : "\u00a0"}</span>

--- a/src/apps/calculator/hooks/useCalculatorLogic.ts
+++ b/src/apps/calculator/hooks/useCalculatorLogic.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_CONVERSION_TO_UNIT,
   formatSwappedConversionValue,
   getCategoryById,
+  resolveConversionAmount,
   type ConversionCategoryId,
 } from "../utils/conversionData";
 import {
@@ -148,6 +149,9 @@ export function useCalculatorLogic({
   calcStateRef.current = calcState;
   const conversionCalcStateRef = useRef(conversionCalcState);
   conversionCalcStateRef.current = conversionCalcState;
+  const [conversionExactAmount, setConversionExactAmount] = useState<
+    number | null
+  >(null);
   const [currencyRate, setCurrencyRate] = useState(1);
   const [currencyLoading, setCurrencyLoading] = useState(false);
   const [currencyError, setCurrencyError] = useState<string | null>(null);
@@ -256,7 +260,10 @@ export function useCalculatorLogic({
   }, [category, fromUnit, toUnit]);
 
   const conversionRawResult = useMemo(() => {
-    const amount = Number(conversionAmount.replace(/,/g, ""));
+    const amount = resolveConversionAmount(
+      conversionAmount,
+      conversionExactAmount
+    );
     if (!Number.isFinite(amount)) return NaN;
     return convertValue(
       amount,
@@ -267,6 +274,7 @@ export function useCalculatorLogic({
     );
   }, [
     conversionAmount,
+    conversionExactAmount,
     conversionCategory,
     fromUnit,
     toUnit,
@@ -291,6 +299,7 @@ export function useCalculatorLogic({
     (next: CalculatorMode) => {
       if (next === mode) return;
       if (next === "conversion") {
+        setConversionExactAmount(null);
         dispatchConversionCalc({
           type: "set",
           payload: {
@@ -299,6 +308,7 @@ export function useCalculatorLogic({
           },
         });
       } else if (mode === "conversion") {
+        setConversionExactAmount(null);
         dispatchCalc({
           type: "set",
           payload: {
@@ -339,6 +349,7 @@ export function useCalculatorLogic({
       reducer: (state: CalcState) => CalcState,
       options?: { speakResult?: boolean }
     ) => {
+      setConversionExactAmount(null);
       const prev = conversionCalcStateRef.current;
       const next = reducer(prev);
       conversionCalcStateRef.current = next;
@@ -502,6 +513,7 @@ export function useCalculatorLogic({
   }, [runCalc, speech]);
 
   const handleCategoryChange = useCallback((id: ConversionCategoryId) => {
+    setConversionExactAmount(null);
     setConversionCategory(id);
     const nextCategory = getCategoryById(id);
     setFromUnit(nextCategory.units[0]?.id ?? "m");
@@ -510,6 +522,7 @@ export function useCalculatorLogic({
 
   const swapConversionUnits = useCallback(() => {
     if (Number.isFinite(conversionRawResult)) {
+      setConversionExactAmount(conversionRawResult);
       dispatchConversionCalc({
         type: "set",
         payload: {

--- a/src/apps/calculator/hooks/useCalculatorLogic.ts
+++ b/src/apps/calculator/hooks/useCalculatorLogic.ts
@@ -41,6 +41,7 @@ import {
   type Operator,
 } from "../utils/calculatorEngine";
 import { getCalculatorWindowSize } from "../utils/windowSizes";
+import { formatCalculatorConversionResult } from "../utils/formatCalculatorDisplay";
 import type { CalculatorTheme } from "../components/types";
 import { helpItems } from "..";
 import {
@@ -273,16 +274,11 @@ export function useCalculatorLogic({
   ]);
 
   const conversionResult = useMemo(() => {
-    if (!Number.isFinite(conversionRawResult)) return "—";
     const locale = i18n.resolvedLanguage || i18n.language;
-    if (conversionCategory === "currency") {
-      return new Intl.NumberFormat(locale, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      }).format(conversionRawResult);
-    }
-    return new Intl.NumberFormat(locale, { maximumFractionDigits: 8 }).format(
-      conversionRawResult
+    return formatCalculatorConversionResult(
+      conversionRawResult,
+      locale,
+      conversionCategory === "currency"
     );
   }, [
     conversionRawResult,

--- a/src/apps/calculator/hooks/useCalculatorLogic.ts
+++ b/src/apps/calculator/hooks/useCalculatorLogic.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_CONVERSION_CATEGORY,
   DEFAULT_CONVERSION_FROM_UNIT,
   DEFAULT_CONVERSION_TO_UNIT,
+  formatSwappedConversionValue,
   getCategoryById,
   type ConversionCategoryId,
 } from "../utils/conversionData";
@@ -518,7 +519,10 @@ export function useCalculatorLogic({
         type: "set",
         payload: {
           ...createInitialCalcState(),
-          display: formatNumber(conversionRawResult),
+          display: formatSwappedConversionValue(
+            conversionRawResult,
+            conversionAmount
+          ),
         },
       });
     }
@@ -529,6 +533,7 @@ export function useCalculatorLogic({
     setToUnit(fromUnit);
   }, [
     conversionRawResult,
+    conversionAmount,
     conversionCategory,
     currencyRate,
     fromUnit,

--- a/src/apps/calculator/hooks/useCalculatorLogic.ts
+++ b/src/apps/calculator/hooks/useCalculatorLogic.ts
@@ -7,6 +7,9 @@ import { useAppStore } from "@/stores/useAppStore";
 import { fetchCurrencyRateForWidget } from "@/lib/currency/frankfurter";
 import {
   convertValue,
+  DEFAULT_CONVERSION_CATEGORY,
+  DEFAULT_CONVERSION_FROM_UNIT,
+  DEFAULT_CONVERSION_TO_UNIT,
   getCategoryById,
   type ConversionCategoryId,
 } from "../utils/conversionData";
@@ -124,10 +127,14 @@ export function useCalculatorLogic({
     createInitialCalcState()
   );
   const [conversionCategory, setConversionCategory] = useStateWithDefault<ConversionCategoryId>(
-    persisted.conversionCategory ?? "length"
+    persisted.conversionCategory ?? DEFAULT_CONVERSION_CATEGORY
   );
-  const [fromUnit, setFromUnit] = useStateWithDefault(persisted.fromUnit ?? "m");
-  const [toUnit, setToUnit] = useStateWithDefault(persisted.toUnit ?? "ft");
+  const [fromUnit, setFromUnit] = useStateWithDefault(
+    persisted.fromUnit ?? DEFAULT_CONVERSION_FROM_UNIT
+  );
+  const [toUnit, setToUnit] = useStateWithDefault(
+    persisted.toUnit ?? DEFAULT_CONVERSION_TO_UNIT
+  );
   const [conversionCalcState, dispatchConversionCalc] = useReducer(
     calcReducer,
     {

--- a/src/apps/calculator/hooks/useCalculatorLogic.ts
+++ b/src/apps/calculator/hooks/useCalculatorLogic.ts
@@ -22,7 +22,6 @@ import {
   clearEntry,
   createInitialCalcState,
   factorial,
-  formatNumber,
   inputDecimal,
   inputDigit,
   inputOperator,

--- a/src/apps/calculator/utils/conversionData.ts
+++ b/src/apps/calculator/utils/conversionData.ts
@@ -1,3 +1,5 @@
+import { formatNumber } from "./calculatorEngine";
+
 export type ConversionCategoryId =
   | "length"
   | "area"
@@ -26,6 +28,25 @@ export interface ConversionCategory {
 export const DEFAULT_CONVERSION_CATEGORY: ConversionCategoryId = "currency";
 export const DEFAULT_CONVERSION_FROM_UNIT = "USD";
 export const DEFAULT_CONVERSION_TO_UNIT = "EUR";
+
+export function formatSwappedConversionValue(
+  value: number,
+  sourceDisplay: string
+): string {
+  const normalizedSource = sourceDisplay.replace(/,/g, "");
+  const sourceMantissa = normalizedSource.split(/[eE]/, 1)[0] ?? "";
+  const decimalIndex = sourceMantissa.lastIndexOf(".");
+  if (decimalIndex === -1) {
+    return formatNumber(value);
+  }
+
+  const decimalPlaces = sourceMantissa.length - decimalIndex - 1;
+  if (decimalPlaces === 0) {
+    return formatNumber(value);
+  }
+
+  return value.toFixed(decimalPlaces);
+}
 
 export const CONVERSION_CATEGORIES: ConversionCategory[] = [
   {

--- a/src/apps/calculator/utils/conversionData.ts
+++ b/src/apps/calculator/utils/conversionData.ts
@@ -23,7 +23,29 @@ export interface ConversionCategory {
   units: ConversionUnit[];
 }
 
+export const DEFAULT_CONVERSION_CATEGORY: ConversionCategoryId = "currency";
+export const DEFAULT_CONVERSION_FROM_UNIT = "USD";
+export const DEFAULT_CONVERSION_TO_UNIT = "EUR";
+
 export const CONVERSION_CATEGORIES: ConversionCategory[] = [
+  {
+    id: "currency",
+    labelKey: "apps.calculator.conversion.categories.currency",
+    units: [
+      { id: "USD", labelKey: "USD" },
+      { id: "EUR", labelKey: "EUR" },
+      { id: "GBP", labelKey: "GBP" },
+      { id: "JPY", labelKey: "JPY" },
+      { id: "CHF", labelKey: "CHF" },
+      { id: "CAD", labelKey: "CAD" },
+      { id: "AUD", labelKey: "AUD" },
+      { id: "CNY", labelKey: "CNY" },
+      { id: "INR", labelKey: "INR" },
+      { id: "TWD", labelKey: "TWD" },
+      { id: "SGD", labelKey: "SGD" },
+      { id: "KRW", labelKey: "KRW" },
+    ],
+  },
   {
     id: "length",
     labelKey: "apps.calculator.conversion.categories.length",
@@ -126,22 +148,6 @@ export const CONVERSION_CATEGORIES: ConversionCategory[] = [
       { id: "kcal", labelKey: "apps.calculator.conversion.units.kcal", factor: 4184 },
       { id: "wh", labelKey: "apps.calculator.conversion.units.wh", factor: 3600 },
       { id: "kwh", labelKey: "apps.calculator.conversion.units.kwh", factor: 3_600_000 },
-    ],
-  },
-  {
-    id: "currency",
-    labelKey: "apps.calculator.conversion.categories.currency",
-    units: [
-      { id: "USD", labelKey: "USD" },
-      { id: "EUR", labelKey: "EUR" },
-      { id: "GBP", labelKey: "GBP" },
-      { id: "JPY", labelKey: "JPY" },
-      { id: "CHF", labelKey: "CHF" },
-      { id: "CAD", labelKey: "CAD" },
-      { id: "AUD", labelKey: "AUD" },
-      { id: "CNY", labelKey: "CNY" },
-      { id: "INR", labelKey: "INR" },
-      { id: "KRW", labelKey: "KRW" },
     ],
   },
 ];

--- a/src/apps/calculator/utils/conversionData.ts
+++ b/src/apps/calculator/utils/conversionData.ts
@@ -29,6 +29,16 @@ export const DEFAULT_CONVERSION_CATEGORY: ConversionCategoryId = "currency";
 export const DEFAULT_CONVERSION_FROM_UNIT = "USD";
 export const DEFAULT_CONVERSION_TO_UNIT = "EUR";
 
+export function resolveConversionAmount(
+  displayValue: string,
+  exactAmount: number | null
+): number {
+  if (exactAmount != null && Number.isFinite(exactAmount)) {
+    return exactAmount;
+  }
+  return Number(displayValue.replace(/,/g, ""));
+}
+
 export function formatSwappedConversionValue(
   value: number,
   sourceDisplay: string

--- a/src/apps/calculator/utils/formatCalculatorDisplay.ts
+++ b/src/apps/calculator/utils/formatCalculatorDisplay.ts
@@ -106,7 +106,7 @@ export function formatCalculatorConversionResult(
 
   if (isCurrency) {
     return new Intl.NumberFormat(locale, {
-      minimumFractionDigits: 2,
+      minimumFractionDigits: 0,
       maximumFractionDigits: 2,
     }).format(value);
   }

--- a/src/apps/calculator/utils/formatCalculatorDisplay.ts
+++ b/src/apps/calculator/utils/formatCalculatorDisplay.ts
@@ -1,6 +1,8 @@
 const DECIMAL_PATTERN = /^-?\d+(?:\.\d*)?$/;
 const SCIENTIFIC_PATTERN = /^(-?\d+)(?:\.(\d+))?([eE][+-]?\d+)$/;
 const MAX_CONVERSION_SIGNIFICANT_DIGITS = 12;
+const MAX_STANDARD_DISPLAY_DIGITS = 12;
+const SCIENTIFIC_FRACTION_DIGITS = 8;
 
 interface FittedFontSizeInput {
   baseFontSize: number;
@@ -37,6 +39,18 @@ function getDecimalSeparator(locale: string): string {
   );
 }
 
+function formatScientificNumber(value: number, locale: string): string {
+  const scientific = value
+    .toExponential(SCIENTIFIC_FRACTION_DIGITS)
+    .replace(/(\.\d*?[1-9])0+e/u, "$1e")
+    .replace(/\.0+e/u, "e");
+  return scientific.replace(".", getDecimalSeparator(locale));
+}
+
+function countDisplayDigits(value: string): number {
+  return (value.match(/\d/g) ?? []).length;
+}
+
 /**
  * Localize the calculator's presentation without changing its canonical
  * machine-readable display value.
@@ -55,6 +69,12 @@ export function formatCalculatorDisplay(
   }
 
   if (!DECIMAL_PATTERN.test(value)) return value;
+  if (countDisplayDigits(value) > MAX_STANDARD_DISPLAY_DIGITS) {
+    const numericValue = Number(value);
+    if (Number.isFinite(numericValue)) {
+      return formatScientificNumber(numericValue, locale);
+    }
+  }
   const decimalIndex = value.indexOf(".");
   const integerPart =
     decimalIndex === -1 ? value : value.slice(0, decimalIndex);
@@ -79,6 +99,10 @@ export function formatCalculatorConversionResult(
   isCurrency: boolean
 ): string {
   if (!Number.isFinite(value)) return "—";
+
+  if (Math.abs(value) >= 10 ** MAX_STANDARD_DISPLAY_DIGITS) {
+    return formatScientificNumber(value, locale);
+  }
 
   if (isCurrency) {
     return new Intl.NumberFormat(locale, {

--- a/src/apps/calculator/utils/formatCalculatorDisplay.ts
+++ b/src/apps/calculator/utils/formatCalculatorDisplay.ts
@@ -1,5 +1,6 @@
 const DECIMAL_PATTERN = /^-?\d+(?:\.\d*)?$/;
 const SCIENTIFIC_PATTERN = /^(-?\d+)(?:\.(\d+))?([eE][+-]?\d+)$/;
+const MAX_CONVERSION_SIGNIFICANT_DIGITS = 12;
 
 function getDecimalSeparator(locale: string): string {
   return (
@@ -43,4 +44,26 @@ export function formatCalculatorDisplay(
   } catch {
     return value;
   }
+}
+
+export function formatCalculatorConversionResult(
+  value: number,
+  locale: string,
+  isCurrency: boolean
+): string {
+  if (!Number.isFinite(value)) return "—";
+
+  if (isCurrency) {
+    return new Intl.NumberFormat(locale, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value);
+  }
+
+  const rounded = Number(
+    value.toPrecision(MAX_CONVERSION_SIGNIFICANT_DIGITS)
+  );
+  return new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 8,
+  }).format(rounded);
 }

--- a/src/apps/calculator/utils/formatCalculatorDisplay.ts
+++ b/src/apps/calculator/utils/formatCalculatorDisplay.ts
@@ -3,6 +3,7 @@ const SCIENTIFIC_PATTERN = /^(-?\d+)(?:\.(\d+))?([eE][+-]?\d+)$/;
 const MAX_CONVERSION_SIGNIFICANT_DIGITS = 12;
 const MAX_STANDARD_DISPLAY_DIGITS = 12;
 const SCIENTIFIC_FRACTION_DIGITS = 8;
+const SCIENTIFIC_LOWER_MAGNITUDE = 1e-9;
 
 interface FittedFontSizeInput {
   baseFontSize: number;
@@ -100,7 +101,11 @@ export function formatCalculatorConversionResult(
 ): string {
   if (!Number.isFinite(value)) return "—";
 
-  if (Math.abs(value) >= 10 ** MAX_STANDARD_DISPLAY_DIGITS) {
+  const magnitude = Math.abs(value);
+  if (
+    magnitude >= 10 ** MAX_STANDARD_DISPLAY_DIGITS ||
+    (magnitude > 0 && magnitude < SCIENTIFIC_LOWER_MAGNITUDE)
+  ) {
     return formatScientificNumber(value, locale);
   }
 
@@ -111,10 +116,7 @@ export function formatCalculatorConversionResult(
     }).format(value);
   }
 
-  const rounded = Number(
-    value.toPrecision(MAX_CONVERSION_SIGNIFICANT_DIGITS)
-  );
   return new Intl.NumberFormat(locale, {
-    maximumFractionDigits: 8,
-  }).format(rounded);
+    maximumSignificantDigits: MAX_CONVERSION_SIGNIFICANT_DIGITS,
+  }).format(value);
 }

--- a/src/apps/calculator/utils/formatCalculatorDisplay.ts
+++ b/src/apps/calculator/utils/formatCalculatorDisplay.ts
@@ -2,6 +2,33 @@ const DECIMAL_PATTERN = /^-?\d+(?:\.\d*)?$/;
 const SCIENTIFIC_PATTERN = /^(-?\d+)(?:\.(\d+))?([eE][+-]?\d+)$/;
 const MAX_CONVERSION_SIGNIFICANT_DIGITS = 12;
 
+interface FittedFontSizeInput {
+  baseFontSize: number;
+  availableWidth: number;
+  contentWidth: number;
+  minFontSize?: number;
+}
+
+export function calculateFittedCalculatorFontSize({
+  baseFontSize,
+  availableWidth,
+  contentWidth,
+  minFontSize = 12,
+}: FittedFontSizeInput): number {
+  if (
+    baseFontSize <= 0 ||
+    availableWidth <= 0 ||
+    contentWidth <= availableWidth
+  ) {
+    return baseFontSize;
+  }
+
+  return Math.max(
+    minFontSize,
+    Math.floor(baseFontSize * (availableWidth / contentWidth) * 100) / 100
+  );
+}
+
 function getDecimalSeparator(locale: string): string {
   return (
     new Intl.NumberFormat(locale)

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -379,7 +379,7 @@ function ComboboxImpl({
                 {filters && filters.length > 0 ? (
                   <div
                     ref={filterListRef}
-                    className="flex gap-1 overflow-x-auto border-b border-os-separator px-2 pb-1.5"
+                    className="flex gap-px overflow-x-auto border-b border-os-separator px-2 pb-1.5"
                   >
                     {filters.map((filter) => {
                       const selected = filter.value === filterValue;

--- a/tests/test-calculator-engine.test.ts
+++ b/tests/test-calculator-engine.test.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_CONVERSION_FROM_UNIT,
   DEFAULT_CONVERSION_TO_UNIT,
   formatSwappedConversionValue,
+  resolveConversionAmount,
 } from "../src/apps/calculator/utils/conversionData";
 import {
   calculateFittedCalculatorFontSize,
@@ -173,6 +174,32 @@ describe("conversionData", () => {
     expect(formatSwappedConversionValue(12.3, "1.00e+3")).toBe("12.30");
     expect(formatSwappedConversionValue(12.3, "1")).toBe("12.3");
     expect(formatSwappedConversionValue(12.3, "1.")).toBe("12.3");
+  });
+
+  test("uses the unrounded amount for conversion swap round trips", () => {
+    const originalAmount = 1.23;
+    const rate = 0.9134567;
+    const exactSwappedAmount = convertValue(
+      originalAmount,
+      "currency",
+      "USD",
+      "EUR",
+      rate
+    );
+    const displayedSwappedAmount = formatSwappedConversionValue(
+      exactSwappedAmount,
+      "1.00"
+    );
+    const resolvedAmount = resolveConversionAmount(
+      displayedSwappedAmount,
+      exactSwappedAmount
+    );
+
+    expect(displayedSwappedAmount).toBe("1.12");
+    expect(
+      convertValue(resolvedAmount, "currency", "EUR", "USD", 1 / rate)
+    ).toBeCloseTo(originalAmount, 12);
+    expect(resolveConversionAmount("1.12", null)).toBe(1.12);
   });
 
   test("length feet to meters", () => {

--- a/tests/test-calculator-engine.test.ts
+++ b/tests/test-calculator-engine.test.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_CONVERSION_CATEGORY,
   DEFAULT_CONVERSION_FROM_UNIT,
   DEFAULT_CONVERSION_TO_UNIT,
+  formatSwappedConversionValue,
 } from "../src/apps/calculator/utils/conversionData";
 import { formatCalculatorDisplay } from "../src/apps/calculator/utils/formatCalculatorDisplay";
 
@@ -113,6 +114,14 @@ describe("conversionData", () => {
     expect(currencyIds).toContain("TWD");
     expect(currencyIds).toContain("SGD");
     expect(currencyIds).toContain("KRW");
+  });
+
+  test("preserves entered decimal places when swapping units", () => {
+    expect(formatSwappedConversionValue(12.3, "1.00")).toBe("12.30");
+    expect(formatSwappedConversionValue(12.3, "1.000")).toBe("12.300");
+    expect(formatSwappedConversionValue(12.3, "1.00e+3")).toBe("12.30");
+    expect(formatSwappedConversionValue(12.3, "1")).toBe("12.3");
+    expect(formatSwappedConversionValue(12.3, "1.")).toBe("12.3");
   });
 
   test("length feet to meters", () => {

--- a/tests/test-calculator-engine.test.ts
+++ b/tests/test-calculator-engine.test.ts
@@ -94,9 +94,12 @@ describe("formatCalculatorDisplay", () => {
     expect(formatCalculatorDisplay("1234.", "de")).toBe("1.234,");
   });
 
-  test("groups integers beyond Number safe precision", () => {
+  test("uses scientific notation when a grouped value would overflow", () => {
     expect(formatCalculatorDisplay("1234567890123456", "en")).toBe(
-      "1,234,567,890,123,456"
+      "1.23456789e+15"
+    );
+    expect(formatCalculatorDisplay("8888888888888", "en")).toBe(
+      "8.88888889e+12"
     );
   });
 
@@ -113,6 +116,9 @@ describe("formatCalculatorDisplay", () => {
 
   test("keeps currency results at two decimal places", () => {
     expect(formatCalculatorConversionResult(12.3, "en", true)).toBe("12.30");
+    expect(
+      formatCalculatorConversionResult(6709799999999999, "en", true)
+    ).toBe("6.7098e+15");
   });
 
   test("scales display text to its measured width", () => {

--- a/tests/test-calculator-engine.test.ts
+++ b/tests/test-calculator-engine.test.ts
@@ -11,7 +11,14 @@ import {
   memoryRecall,
   unaryFunctions,
 } from "../src/apps/calculator/utils/calculatorEngine";
-import { convertTemperature, convertValue } from "../src/apps/calculator/utils/conversionData";
+import {
+  CONVERSION_CATEGORIES,
+  convertTemperature,
+  convertValue,
+  DEFAULT_CONVERSION_CATEGORY,
+  DEFAULT_CONVERSION_FROM_UNIT,
+  DEFAULT_CONVERSION_TO_UNIT,
+} from "../src/apps/calculator/utils/conversionData";
 import { formatCalculatorDisplay } from "../src/apps/calculator/utils/formatCalculatorDisplay";
 
 describe("calculatorEngine", () => {
@@ -90,6 +97,24 @@ describe("formatCalculatorDisplay", () => {
 });
 
 describe("conversionData", () => {
+  test("currency is the default and first conversion category", () => {
+    expect(DEFAULT_CONVERSION_CATEGORY).toBe("currency");
+    expect(DEFAULT_CONVERSION_FROM_UNIT).toBe("USD");
+    expect(DEFAULT_CONVERSION_TO_UNIT).toBe("EUR");
+    expect(CONVERSION_CATEGORIES[0]?.id).toBe("currency");
+  });
+
+  test("includes Taiwan, Singapore, and Korean currencies", () => {
+    const currency = CONVERSION_CATEGORIES.find(
+      (category) => category.id === "currency"
+    );
+    const currencyIds = currency?.units.map((unit) => unit.id);
+
+    expect(currencyIds).toContain("TWD");
+    expect(currencyIds).toContain("SGD");
+    expect(currencyIds).toContain("KRW");
+  });
+
   test("length feet to meters", () => {
     const result = convertValue(3, "length", "ft", "m");
     expect(result).toBeCloseTo(0.9144, 4);

--- a/tests/test-calculator-engine.test.ts
+++ b/tests/test-calculator-engine.test.ts
@@ -114,8 +114,10 @@ describe("formatCalculatorDisplay", () => {
     expect(result.replace(/\D/g, "")).toHaveLength(12);
   });
 
-  test("keeps currency results at two decimal places", () => {
-    expect(formatCalculatorConversionResult(12.3, "en", true)).toBe("12.30");
+  test("shows at most two decimal places for currency results", () => {
+    expect(formatCalculatorConversionResult(12, "en", true)).toBe("12");
+    expect(formatCalculatorConversionResult(12.3, "en", true)).toBe("12.3");
+    expect(formatCalculatorConversionResult(12.345, "en", true)).toBe("12.35");
     expect(
       formatCalculatorConversionResult(6709799999999999, "en", true)
     ).toBe("6.7098e+15");

--- a/tests/test-calculator-engine.test.ts
+++ b/tests/test-calculator-engine.test.ts
@@ -20,7 +20,10 @@ import {
   DEFAULT_CONVERSION_TO_UNIT,
   formatSwappedConversionValue,
 } from "../src/apps/calculator/utils/conversionData";
-import { formatCalculatorDisplay } from "../src/apps/calculator/utils/formatCalculatorDisplay";
+import {
+  formatCalculatorConversionResult,
+  formatCalculatorDisplay,
+} from "../src/apps/calculator/utils/formatCalculatorDisplay";
 
 describe("calculatorEngine", () => {
   test("basic addition chain", () => {
@@ -94,6 +97,21 @@ describe("formatCalculatorDisplay", () => {
     expect(formatCalculatorDisplay("1234567890123456", "en")).toBe(
       "1,234,567,890,123,456"
     );
+  });
+
+  test("limits conversion results to 12 significant digits", () => {
+    const result = formatCalculatorConversionResult(
+      2238385.82677165,
+      "en",
+      false
+    );
+
+    expect(result).toBe("2,238,385.82677");
+    expect(result.replace(/\D/g, "")).toHaveLength(12);
+  });
+
+  test("keeps currency results at two decimal places", () => {
+    expect(formatCalculatorConversionResult(12.3, "en", true)).toBe("12.30");
   });
 });
 

--- a/tests/test-calculator-engine.test.ts
+++ b/tests/test-calculator-engine.test.ts
@@ -21,6 +21,7 @@ import {
   formatSwappedConversionValue,
 } from "../src/apps/calculator/utils/conversionData";
 import {
+  calculateFittedCalculatorFontSize,
   formatCalculatorConversionResult,
   formatCalculatorDisplay,
 } from "../src/apps/calculator/utils/formatCalculatorDisplay";
@@ -112,6 +113,30 @@ describe("formatCalculatorDisplay", () => {
 
   test("keeps currency results at two decimal places", () => {
     expect(formatCalculatorConversionResult(12.3, "en", true)).toBe("12.30");
+  });
+
+  test("scales display text to its measured width", () => {
+    expect(
+      calculateFittedCalculatorFontSize({
+        baseFontSize: 22,
+        availableWidth: 200,
+        contentWidth: 220,
+      })
+    ).toBe(20);
+    expect(
+      calculateFittedCalculatorFontSize({
+        baseFontSize: 22,
+        availableWidth: 220,
+        contentWidth: 200,
+      })
+    ).toBe(22);
+    expect(
+      calculateFittedCalculatorFontSize({
+        baseFontSize: 22,
+        availableWidth: 60,
+        contentWidth: 220,
+      })
+    ).toBe(12);
   });
 });
 

--- a/tests/test-currency-cross-rate.test.ts
+++ b/tests/test-currency-cross-rate.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, test } from "bun:test";
 import { crossRateFromUsdRates } from "../api/_utils/currency-cross-rate.js";
 
 describe("crossRateFromUsdRates", () => {
-  const rates = { EUR: 0.9, GBP: 0.8, JPY: 150 };
+  const rates = {
+    EUR: 0.9,
+    GBP: 0.8,
+    JPY: 150,
+    TWD: 32,
+    SGD: 1.35,
+    KRW: 1380,
+  };
 
   test("USD to other", () => {
     expect(crossRateFromUsdRates(rates, "USD", "EUR")).toBe(0.9);
@@ -14,6 +21,13 @@ describe("crossRateFromUsdRates", () => {
 
   test("cross via USD", () => {
     expect(crossRateFromUsdRates(rates, "EUR", "GBP")).toBeCloseTo(0.8 / 0.9);
+  });
+
+  test("supports Taiwan, Singapore, and Korean cross rates", () => {
+    expect(crossRateFromUsdRates(rates, "TWD", "SGD")).toBeCloseTo(1.35 / 32);
+    expect(crossRateFromUsdRates(rates, "SGD", "KRW")).toBeCloseTo(
+      1380 / 1.35
+    );
   });
 
   test("identity", () => {


### PR DESCRIPTION
## Summary
- move Currency to the first/default conversion category and add TWD/SGD while retaining KRW
- preserve user-entered decimal precision while keeping an unrounded internal amount for stable swap round trips
- format non-currency conversions with up to 12 significant digits: more decimal places for small values, fewer for large values, scientific notation at extreme magnitudes
- show currency results with up to two decimal places without forced trailing zeros
- auto-fit values to measured display width and remove CSS ellipsis truncation
- reduce conversion-filter spacing to 1px

## Verification
- `bun test tests/test-calculator-engine.test.ts tests/test-currency-cross-rate.test.ts tests/test-currency-frankfurter.test.ts` — 44 passed
- `bun run test:unit` — 1,489 passed
- `bunx tsc -b --pretty false`
- `bun run build`

## Notes
- Targeted ESLint completed with three pre-existing `react-hooks/exhaustive-deps` warnings in `useCalculatorLogic.ts`; no errors.