### PR TITLE
Fix MusicKit redundant play() errors and lyrics 404 log noise

### DIFF
--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -12,6 +12,8 @@ import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
 import {
   getMusicKitEventItemId,
   isLikelyMusicKitUnhandledRejection,
+  isMusicKitPlaying,
+  isMusicKitRedundantPlayError,
   isStaleQueueLoad,
   isWithinEndedFanoutDedupWindow,
   shouldFireEndedForPlaybackState,
@@ -433,10 +435,15 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     const onUnhandledRejection = (event: PromiseRejectionEvent) => {
       if (!isLikelyMusicKitUnhandledRejection(event.reason)) return;
       event.preventDefault();
-      appleMusicLog.error("musickit:unhandledrejection", {
+      const payload = {
         error: event.reason,
         snapshot: getBridgeSnapshot(),
-      });
+      };
+      if (isMusicKitRedundantPlayError(event.reason)) {
+        appleMusicLog.warn("musickit:redundantPlay", payload);
+        return;
+      }
+      appleMusicLog.error("musickit:unhandledrejection", payload);
     };
     window.addEventListener("unhandledrejection", onUnhandledRejection);
     return () => {
@@ -670,8 +677,9 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           );
         }
         lastQueuedTrackIdRef.current = localQueueKey;
-        if (shouldPlayAfterQueue) {
+        if (shouldPlayAfterQueue && !isMusicKitPlaying(inst.playbackState)) {
           await inst.play().catch((err) => {
+            if (isMusicKitRedundantPlayError(err)) return;
             // Browsers block autoplay until the user interacts; surface as
             // a paused state so the iPod's play button shows the right icon.
             appleMusicLog.warn("queue:play:blocked", {
@@ -728,6 +736,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         const queuedTrackId = lastQueuedTrackIdRef.current;
         if (queuedTrackId !== track.id) return;
         if (playing) {
+          if (isMusicKitPlaying(inst.playbackState)) return;
           const startSeconds = getSafeStartSeconds(
             track,
             resumeAtSecondsRef.current
@@ -746,6 +755,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           inst.pause();
         }
       } catch (err) {
+        if (isMusicKitRedundantPlayError(err)) return;
         appleMusicLog.warn("playback:playPause:failed", {
           error: err,
           playing,

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -142,6 +142,27 @@ export function isLikelyMusicKitUnhandledRejection(reason: unknown): boolean {
   return /(?:musickit|music\.apple\.com)/i.test(getErrorLikeText(reason));
 }
 
+/** MusicKit `playbackState` value for actively playing audio. */
+export const MUSICKIT_PLAYBACK_STATE_PLAYING = 2;
+
+export function isMusicKitPlaying(
+  playbackState: number | undefined
+): boolean {
+  return playbackState === MUSICKIT_PLAYBACK_STATE_PLAYING;
+}
+
+/**
+ * MusicKit JS v3 rejects when `play()` is called while already playing:
+ * "The play() method was called without a previous stop() or pause() call."
+ * Detect that known rejection so callers can skip redundant play() calls or
+ * downgrade the log level.
+ */
+export function isMusicKitRedundantPlayError(reason: unknown): boolean {
+  return /play\(\) method was called without a previous stop\(\) or pause\(\) call/i.test(
+    getErrorLikeText(reason)
+  );
+}
+
 export function getMusicKitEventItemId(
   item:
     | {

--- a/src/hooks/useLyrics.ts
+++ b/src/hooks/useLyrics.ts
@@ -7,6 +7,7 @@ import { fetchSongLyrics } from "@/api/songs";
 import { createClientLogger } from "@/utils/logger";
 import {
   getLyricsErrorMessage,
+  isExpectedLyricsMissError,
   normalizeLyricsFetchError,
 } from "@/utils/lyricsError";
 import {
@@ -726,7 +727,12 @@ function handleLyricsError(
   setCurrentLine: (line: number) => void
 ) {
   const displayError = getLyricsErrorMessage(err);
-  lyricsLog.error("fetch:failed", { error: err, displayError, context });
+  const logPayload = { error: err, displayError, context };
+  if (isExpectedLyricsMissError(err)) {
+    lyricsLog.warn("fetch:notFound", logPayload);
+  } else {
+    lyricsLog.error("fetch:failed", logPayload);
+  }
   setError(displayError);
   setOriginalLines([]);
   setCurrentLine(-1);

--- a/src/utils/lyricsError.ts
+++ b/src/utils/lyricsError.ts
@@ -19,6 +19,18 @@ export function normalizeLyricsFetchError(err: unknown): unknown {
   return err;
 }
 
+export function isExpectedLyricsMissError(err: unknown): boolean {
+  if (err instanceof ApiRequestError && err.status === 404) {
+    return true;
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    msg.includes("No lyrics") ||
+    msg.includes("404") ||
+    msg.includes("not found")
+  );
+}
+
 export function getLyricsErrorMessage(err: unknown): string {
   if (err instanceof DOMException && err.name === "AbortError") {
     return "Lyrics search timed out.";

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -72,6 +72,9 @@ const {
   shouldSuppressPlaybackStateFanoutWhileQueueLoading,
   isStaleQueueLoad,
   isLikelyMusicKitUnhandledRejection,
+  isMusicKitPlaying,
+  isMusicKitRedundantPlayError,
+  MUSICKIT_PLAYBACK_STATE_PLAYING,
 } = await import(
   "../src/apps/ipod/components/appleMusicPlayerBridgeUtils"
 );
@@ -132,6 +135,25 @@ describe("Apple Music error logging helpers", () => {
     expect(isLikelyMusicKitUnhandledRejection(new Error("No lyrics found"))).toBe(
       false
     );
+  });
+
+  test("detects redundant MusicKit play() rejections", () => {
+    expect(
+      isMusicKitRedundantPlayError(
+        new Error(
+          "The play() method was called without a previous stop() or pause() call."
+        )
+      )
+    ).toBe(true);
+    expect(isMusicKitRedundantPlayError(new Error("Autoplay blocked"))).toBe(
+      false
+    );
+  });
+
+  test("recognizes MusicKit playing playback state", () => {
+    expect(isMusicKitPlaying(MUSICKIT_PLAYBACK_STATE_PLAYING)).toBe(true);
+    expect(isMusicKitPlaying(3)).toBe(false);
+    expect(isMusicKitPlaying(undefined)).toBe(false);
   });
 });
 

--- a/tests/test-lyrics-parsing.test.ts
+++ b/tests/test-lyrics-parsing.test.ts
@@ -4,6 +4,7 @@ import { parseLrcToLines } from "../api/songs/_lyrics";
 import { ApiRequestError } from "../src/api/core";
 import {
   getLyricsErrorMessage,
+  isExpectedLyricsMissError,
   normalizeLyricsFetchError,
 } from "../src/utils/lyricsError";
 
@@ -99,5 +100,19 @@ describe("lyrics error handling", () => {
     expect(
       getLyricsErrorMessage(new DOMException("cancelled", "AbortError"))
     ).toBe("Lyrics search timed out.");
+  });
+
+  test("treats 404 and no-lyrics errors as expected misses", () => {
+    expect(
+      isExpectedLyricsMissError(
+        normalizeLyricsFetchError(new ApiRequestError(404, "missing", {}))
+      )
+    ).toBe(true);
+    expect(isExpectedLyricsMissError(new Error("No lyrics found"))).toBe(true);
+    expect(
+      isExpectedLyricsMissError(
+        normalizeLyricsFetchError(new ApiRequestError(503, "upstream", {}))
+      )
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated debug console logs from a production iPod/Apple Music session and fixed the two actionable errors:

1. **MusicKit unhandled rejection** — `The play() method was called without a previous stop() or pause() call.` This occurred when the Apple Music bridge called `play()` while MusicKit was already in the playing state (e.g. after queue load + play/pause sync race).

2. **Lyrics fetch logged as ERROR** — Missing lyrics (404 / "No lyrics found") is an expected outcome for many tracks; it now logs at `warn` instead of `error`.

## Changes

- **`AppleMusicPlayerBridge`**: Skip redundant `play()` calls when `playbackState === 2`; ignore redundant-play rejections in the play/pause sync path; downgrade any remaining MusicKit redundant-play unhandled rejections to `warn`.
- **`appleMusicPlayerBridgeUtils`**: Add `isMusicKitPlaying`, `isMusicKitRedundantPlayError`, and `MUSICKIT_PLAYBACK_STATE_PLAYING` helpers.
- **`lyricsError` / `useLyrics`**: Add `isExpectedLyricsMissError()` and log expected misses as `[Lyrics] fetch:notFound` at warn level.

## Testing

- `bun test tests/test-ipod-apple-music.test.ts tests/test-lyrics-parsing.test.ts` — 85 pass

## Notes

Other log lines in the report (CloudSync, IndexedDB, Pusher reconnects) are normal operational logs, not errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66281099-7841-4d66-b6eb-9409e87ef2b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66281099-7841-4d66-b6eb-9409e87ef2b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

