### PR TITLE
Improve Internet Explorer proxy robustness

### DIFF
--- a/api/_utils/iframe-proxy-helpers.ts
+++ b/api/_utils/iframe-proxy-helpers.ts
@@ -197,6 +197,13 @@ export function createProxyUrl(
     if (absoluteUrl.protocol !== "http:" && absoluteUrl.protocol !== "https:") {
       return null;
     }
+    const proxyOrigin = new URL(options.proxyOrigin);
+    if (
+      absoluteUrl.origin === proxyOrigin.origin &&
+      absoluteUrl.pathname === "/api/iframe-check"
+    ) {
+      return null;
+    }
 
     const proxyUrl = new URL("/api/iframe-check", options.proxyOrigin);
     proxyUrl.searchParams.set("url", absoluteUrl.toString());
@@ -331,19 +338,6 @@ export function rewriteCssForProxy(
   };
 
   let rewritten = css.replace(
-    /url\(\s*(["']?)(.*?)\1\s*\)/gi,
-    (match, quote, rawUrl) => {
-      const proxied = createProxyUrl(rawUrl, {
-        ...proxyOptions,
-        resourceType: "image",
-      });
-      if (!proxied) return match;
-      count += 1;
-      return `url(${quote || '"'}${proxied}${quote || '"'})`;
-    }
-  );
-
-  rewritten = rewritten.replace(
     /@import\s+(?:url\(\s*)?(["'])(.*?)\1\s*\)?/gi,
     (match, quote, rawUrl) => {
       const proxied = createProxyUrl(rawUrl, {
@@ -353,6 +347,19 @@ export function rewriteCssForProxy(
       if (!proxied) return match;
       count += 1;
       return `@import ${quote}${proxied}${quote}`;
+    }
+  );
+
+  rewritten = rewritten.replace(
+    /url\(\s*(["']?)(.*?)\1\s*\)/gi,
+    (match, quote, rawUrl) => {
+      const proxied = createProxyUrl(rawUrl, {
+        ...proxyOptions,
+        resourceType: "image",
+      });
+      if (!proxied) return match;
+      count += 1;
+      return `url(${quote || '"'}${proxied}${quote || '"'})`;
     }
   );
 
@@ -465,6 +472,7 @@ function domainMatches(hostname: string, domain: string, hostOnly: boolean): boo
 }
 
 function pathMatches(requestPath: string, cookiePath: string): boolean {
+  if (cookiePath === "/") return true;
   return requestPath === cookiePath || requestPath.startsWith(`${cookiePath}/`);
 }
 

--- a/api/_utils/iframe-proxy-helpers.ts
+++ b/api/_utils/iframe-proxy-helpers.ts
@@ -1,0 +1,593 @@
+export type ProxyResourceType =
+  | "document"
+  | "style"
+  | "script"
+  | "image"
+  | "media"
+  | "font"
+  | "xhr"
+  | "iframe"
+  | "other";
+
+export interface RewriteStats {
+  htmlAttributes: number;
+  srcset: number;
+  cssUrls: number;
+  forms: number;
+}
+
+export interface RewriteResult {
+  html: string;
+  stats: RewriteStats;
+}
+
+export interface StoredProxyCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  expiresAt: number | null;
+  secure: boolean;
+  hostOnly: boolean;
+  createdAt: number;
+}
+
+const BROWSER_PROFILES = [
+  {
+    ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    secChUa: '"Not_A Brand";v="8", "Chromium";v="122", "Google Chrome";v="122"',
+    platform: '"Windows"',
+    language: "en-US,en;q=0.9",
+  },
+  {
+    ua: "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_6_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15",
+    secChUa: "",
+    platform: '"macOS"',
+    language: "en-US,en;q=0.9",
+  },
+  {
+    ua: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    secChUa: '"Not_A Brand";v="8", "Chromium";v="121", "Google Chrome";v="121"',
+    platform: '"Linux"',
+    language: "en-GB,en;q=0.8",
+  },
+  {
+    ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0",
+    secChUa: "",
+    platform: '"Windows"',
+    language: "en-US,en;q=0.8",
+  },
+];
+
+const RESOURCE_ACCEPT: Record<ProxyResourceType, string> = {
+  document:
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+  style: "text/css,*/*;q=0.1",
+  script: "*/*",
+  image: "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
+  media: "video/*,audio/*,*/*;q=0.8",
+  font: "font/woff2,font/woff,application/font-woff,*/*;q=0.8",
+  xhr: "application/json,text/plain,*/*",
+  iframe:
+    "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+  other: "*/*",
+};
+
+const RESOURCE_DEST: Record<ProxyResourceType, string> = {
+  document: "document",
+  style: "style",
+  script: "script",
+  image: "image",
+  media: "video",
+  font: "font",
+  xhr: "empty",
+  iframe: "iframe",
+  other: "empty",
+};
+
+const SAFE_RESOURCE_TYPES = new Set<ProxyResourceType>([
+  "document",
+  "style",
+  "script",
+  "image",
+  "media",
+  "font",
+  "xhr",
+  "iframe",
+  "other",
+]);
+
+export function normalizeProxyResourceType(
+  raw: string | string[] | undefined
+): ProxyResourceType {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return SAFE_RESOURCE_TYPES.has(value as ProxyResourceType)
+    ? (value as ProxyResourceType)
+    : "document";
+}
+
+function stableHash(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash;
+}
+
+function profileForUrl(targetUrl: string) {
+  try {
+    const hostname = new URL(targetUrl).hostname.toLowerCase();
+    return BROWSER_PROFILES[stableHash(hostname) % BROWSER_PROFILES.length];
+  } catch {
+    return BROWSER_PROFILES[0];
+  }
+}
+
+export function buildBrowserHeaders(options: {
+  targetUrl: string;
+  resourceType: ProxyResourceType;
+  referrerUrl?: string | null;
+  method?: string;
+  contentType?: string | null;
+  cookieHeader?: string | null;
+}): Record<string, string> {
+  const profile = profileForUrl(options.targetUrl);
+  const method = (options.method || "GET").toUpperCase();
+  const headers: Record<string, string> = {
+    "User-Agent": profile.ua,
+    Accept: RESOURCE_ACCEPT[options.resourceType],
+    "Accept-Language": profile.language,
+    "Sec-Fetch-Dest": RESOURCE_DEST[options.resourceType],
+    "Sec-Fetch-Mode": options.resourceType === "document" ? "navigate" : "no-cors",
+    "Sec-Fetch-Site": options.referrerUrl ? "same-origin" : "none",
+  };
+
+  if (options.resourceType === "document" && method === "GET") {
+    headers["Sec-Fetch-User"] = "?1";
+    headers["Upgrade-Insecure-Requests"] = "1";
+  }
+
+  if (profile.secChUa) {
+    headers["Sec-Ch-Ua"] = profile.secChUa;
+    headers["Sec-Ch-Ua-Mobile"] = "?0";
+    headers["Sec-Ch-Ua-Platform"] = profile.platform;
+  }
+
+  if (options.contentType && method !== "GET" && method !== "HEAD") {
+    headers["Content-Type"] = options.contentType;
+  }
+
+  if (options.cookieHeader) {
+    headers.Cookie = options.cookieHeader;
+  }
+
+  try {
+    const referrer = options.referrerUrl
+      ? new URL(options.referrerUrl).toString()
+      : `${new URL(options.targetUrl).origin}/`;
+    headers.Referer = referrer;
+  } catch {
+    // Ignore invalid referrers; the target URL has already been validated elsewhere.
+  }
+
+  return headers;
+}
+
+function shouldProxyUrl(rawUrl: string): boolean {
+  const trimmed = rawUrl.trim();
+  if (!trimmed || trimmed.startsWith("#")) return false;
+  return !/^(?:javascript|data|mailto|tel|blob|about):/i.test(trimmed);
+}
+
+export function createProxyUrl(
+  rawUrl: string,
+  options: {
+    baseUrl: string;
+    proxyOrigin: string;
+    resourceType: ProxyResourceType;
+    referrerUrl?: string;
+    sessionId?: string | null;
+    form?: boolean;
+    theme?: string | null;
+  }
+): string | null {
+  if (!shouldProxyUrl(rawUrl)) return null;
+  try {
+    const absoluteUrl = new URL(rawUrl, options.baseUrl);
+    if (absoluteUrl.protocol !== "http:" && absoluteUrl.protocol !== "https:") {
+      return null;
+    }
+
+    const proxyUrl = new URL("/api/iframe-check", options.proxyOrigin);
+    proxyUrl.searchParams.set("url", absoluteUrl.toString());
+    proxyUrl.searchParams.set("resource", options.resourceType);
+    if (options.referrerUrl) proxyUrl.searchParams.set("ref", options.referrerUrl);
+    if (options.sessionId) proxyUrl.searchParams.set("session", options.sessionId);
+    if (options.form) proxyUrl.searchParams.set("form", "1");
+    if (options.theme && options.resourceType === "document") {
+      proxyUrl.searchParams.set("theme", options.theme);
+    }
+    return proxyUrl.toString();
+  } catch {
+    return null;
+  }
+}
+
+function rewriteQuotedAttribute(
+  tag: string,
+  attr: string,
+  rewrite: (value: string) => string | null
+): { tag: string; changed: number } {
+  let changed = 0;
+  const quoted = new RegExp(`(\\s${attr}\\s*=\\s*)(["'])([\\s\\S]*?)(\\2)`, "i");
+  let next = tag.replace(quoted, (match, prefix, quote, value, suffix) => {
+    const rewritten = rewrite(value);
+    if (!rewritten || rewritten === value) return match;
+    changed += 1;
+    return `${prefix}${quote}${rewritten}${suffix}`;
+  });
+
+  if (changed > 0) return { tag: next, changed };
+
+  const unquoted = new RegExp(`(\\s${attr}\\s*=\\s*)([^\\s"'=<>` + "`" + `]+)`, "i");
+  next = tag.replace(unquoted, (match, prefix, value) => {
+    const rewritten = rewrite(value);
+    if (!rewritten || rewritten === value) return match;
+    changed += 1;
+    return `${prefix}"${rewritten}"`;
+  });
+
+  return { tag: next, changed };
+}
+
+function rewriteSrcset(
+  value: string,
+  options: Parameters<typeof createProxyUrl>[1]
+): string | null {
+  let changed = false;
+  const rewritten = value
+    .split(",")
+    .map((candidate) => {
+      const trimmed = candidate.trim();
+      if (!trimmed) return candidate;
+      const match = trimmed.match(/^(\S+)(\s+.+)?$/);
+      if (!match) return candidate;
+      const proxied = createProxyUrl(match[1], options);
+      if (!proxied) return candidate;
+      changed = true;
+      return `${proxied}${match[2] ?? ""}`;
+    })
+    .join(", ");
+  return changed ? rewritten : null;
+}
+
+function rewriteTagAttributes(
+  tag: string,
+  options: Parameters<typeof createProxyUrl>[1],
+  attrs: Array<{ name: string; resourceType: ProxyResourceType; srcset?: boolean }>
+): { tag: string; stats: RewriteStats } {
+  let next = tag;
+  const stats = createEmptyRewriteStats();
+
+  for (const attr of attrs) {
+    const attrOptions = { ...options, resourceType: attr.resourceType };
+    const result = rewriteQuotedAttribute(next, attr.name, (value) =>
+      attr.srcset
+        ? rewriteSrcset(value, attrOptions)
+        : createProxyUrl(value, attrOptions)
+    );
+    next = result.tag;
+    if (result.changed > 0) {
+      if (attr.srcset) stats.srcset += result.changed;
+      else stats.htmlAttributes += result.changed;
+    }
+  }
+
+  return { tag: next, stats };
+}
+
+function createEmptyRewriteStats(): RewriteStats {
+  return { htmlAttributes: 0, srcset: 0, cssUrls: 0, forms: 0 };
+}
+
+function addStats(target: RewriteStats, source: RewriteStats): void {
+  target.htmlAttributes += source.htmlAttributes;
+  target.srcset += source.srcset;
+  target.cssUrls += source.cssUrls;
+  target.forms += source.forms;
+}
+
+function resourceTypeForLinkTag(tag: string): ProxyResourceType | null {
+  const relMatch = tag.match(/\srel\s*=\s*(["'])(.*?)\1/i);
+  const rel = relMatch?.[2]?.toLowerCase() ?? "";
+  if (/\bstylesheet\b/.test(rel)) return "style";
+  if (/\b(?:preload|modulepreload|prefetch)\b/.test(rel)) {
+    const asMatch = tag.match(/\sas\s*=\s*(["'])(.*?)\1/i);
+    const asValue = asMatch?.[2]?.toLowerCase() ?? "";
+    if (asValue === "script") return "script";
+    if (asValue === "style") return "style";
+    if (asValue === "image") return "image";
+    if (asValue === "font") return "font";
+    if (asValue === "video" || asValue === "audio") return "media";
+    return "other";
+  }
+  if (/\b(?:icon|apple-touch-icon|manifest)\b/.test(rel)) return "image";
+  return null;
+}
+
+export function rewriteCssForProxy(
+  css: string,
+  options: {
+    baseUrl: string;
+    proxyOrigin: string;
+    referrerUrl?: string;
+    sessionId?: string | null;
+  }
+): { css: string; count: number } {
+  let count = 0;
+  const proxyOptions = {
+    ...options,
+    resourceType: "other" as ProxyResourceType,
+  };
+
+  let rewritten = css.replace(
+    /url\(\s*(["']?)(.*?)\1\s*\)/gi,
+    (match, quote, rawUrl) => {
+      const proxied = createProxyUrl(rawUrl, {
+        ...proxyOptions,
+        resourceType: "image",
+      });
+      if (!proxied) return match;
+      count += 1;
+      return `url(${quote || '"'}${proxied}${quote || '"'})`;
+    }
+  );
+
+  rewritten = rewritten.replace(
+    /@import\s+(?:url\(\s*)?(["'])(.*?)\1\s*\)?/gi,
+    (match, quote, rawUrl) => {
+      const proxied = createProxyUrl(rawUrl, {
+        ...proxyOptions,
+        resourceType: "style",
+      });
+      if (!proxied) return match;
+      count += 1;
+      return `@import ${quote}${proxied}${quote}`;
+    }
+  );
+
+  return { css: rewritten, count };
+}
+
+export function rewriteHtmlForProxy(
+  html: string,
+  options: {
+    baseUrl: string;
+    proxyOrigin: string;
+    referrerUrl?: string;
+    sessionId?: string | null;
+    theme?: string | null;
+  }
+): RewriteResult {
+  const stats = createEmptyRewriteStats();
+  const baseOptions = {
+    ...options,
+    resourceType: "other" as ProxyResourceType,
+  };
+
+  let rewritten = html.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, (tag) => {
+    const closeIndex = tag.toLowerCase().lastIndexOf("</style>");
+    if (closeIndex === -1) return tag;
+    const open = tag.slice(0, tag.indexOf(">") + 1);
+    const content = tag.slice(open.length, closeIndex);
+    const close = tag.slice(closeIndex);
+    const cssResult = rewriteCssForProxy(content, baseOptions);
+    stats.cssUrls += cssResult.count;
+    return `${open}${cssResult.css}${close}`;
+  });
+
+  rewritten = rewritten.replace(/<script\b[^>]*>/gi, (tag) => {
+    const result = rewriteTagAttributes(rewriteNonceAndIntegrity(tag), baseOptions, [
+      { name: "src", resourceType: "script" },
+    ]);
+    addStats(stats, result.stats);
+    return result.tag;
+  });
+
+  rewritten = rewritten.replace(/<link\b[^>]*>/gi, (tag) => {
+    const resourceType = resourceTypeForLinkTag(tag);
+    if (!resourceType) return tag;
+    const result = rewriteTagAttributes(rewriteNonceAndIntegrity(tag), baseOptions, [
+      { name: "href", resourceType },
+    ]);
+    addStats(stats, result.stats);
+    return result.tag;
+  });
+
+  rewritten = rewritten.replace(
+    /<(?:img|source|video|audio|track|embed|object)\b[^>]*>/gi,
+    (tag) => {
+      const result = rewriteTagAttributes(tag, baseOptions, [
+        { name: "src", resourceType: "image" },
+        { name: "data", resourceType: "other" },
+        { name: "poster", resourceType: "image" },
+        { name: "srcset", resourceType: "image", srcset: true },
+      ]);
+      addStats(stats, result.stats);
+      return result.tag;
+    }
+  );
+
+  rewritten = rewritten.replace(/<iframe\b[^>]*>/gi, (tag) => {
+    const result = rewriteTagAttributes(tag, baseOptions, [
+      { name: "src", resourceType: "iframe" },
+    ]);
+    addStats(stats, result.stats);
+    return result.tag;
+  });
+
+  rewritten = rewritten.replace(/<form\b[^>]*>/gi, (tag) => {
+    const result = rewriteTagAttributes(
+      tag,
+      { ...baseOptions, resourceType: "document", form: true },
+      [{ name: "action", resourceType: "document" }]
+    );
+    stats.forms += result.stats.htmlAttributes;
+    stats.htmlAttributes += result.stats.htmlAttributes;
+    return result.tag;
+  });
+
+  return { html: rewritten, stats };
+}
+
+function rewriteNonceAndIntegrity(tag: string): string {
+  // Rewritten scripts/stylesheets are no longer byte-identical to upstream assets.
+  return tag
+    .replace(/\snonce\s*=\s*(["']).*?\1/gi, "")
+    .replace(/\sintegrity\s*=\s*(["']).*?\1/gi, "");
+}
+
+function defaultCookiePath(pathname: string): string {
+  if (!pathname || !pathname.startsWith("/")) return "/";
+  if (pathname === "/") return "/";
+  const slashIndex = pathname.lastIndexOf("/");
+  return slashIndex <= 0 ? "/" : pathname.slice(0, slashIndex);
+}
+
+function domainMatches(hostname: string, domain: string, hostOnly: boolean): boolean {
+  const normalizedHostname = hostname.toLowerCase();
+  const normalizedDomain = domain.toLowerCase().replace(/^\./, "");
+  if (hostOnly) return normalizedHostname === normalizedDomain;
+  return (
+    normalizedHostname === normalizedDomain ||
+    normalizedHostname.endsWith(`.${normalizedDomain}`)
+  );
+}
+
+function pathMatches(requestPath: string, cookiePath: string): boolean {
+  return requestPath === cookiePath || requestPath.startsWith(`${cookiePath}/`);
+}
+
+export function getSetCookieHeaders(headers: Headers): string[] {
+  const maybeGetSetCookie = headers as Headers & {
+    getSetCookie?: () => string[];
+    raw?: () => Record<string, string[]>;
+  };
+  const direct = maybeGetSetCookie.getSetCookie?.();
+  if (direct?.length) return direct;
+  const raw = maybeGetSetCookie.raw?.()["set-cookie"];
+  if (raw?.length) return raw;
+  const combined = headers.get("set-cookie");
+  if (!combined) return [];
+  return combined.split(/,(?=\s*[^;,=\s]+=[^;,]*)/g).map((value) => value.trim());
+}
+
+export function mergeProxyCookies(
+  currentCookies: StoredProxyCookie[],
+  setCookieHeaders: string[],
+  responseUrl: string,
+  now = Date.now()
+): StoredProxyCookie[] {
+  if (!setCookieHeaders.length) return currentCookies;
+  const response = new URL(responseUrl);
+  const hostname = response.hostname.toLowerCase();
+  const merged = currentCookies.filter(
+    (cookie) => !cookie.expiresAt || cookie.expiresAt > now
+  );
+
+  for (const header of setCookieHeaders.slice(0, 20)) {
+    const parts = header.split(";").map((part) => part.trim());
+    const [nameValue, ...attributes] = parts;
+    const separatorIndex = nameValue.indexOf("=");
+    if (separatorIndex <= 0) continue;
+
+    const name = nameValue.slice(0, separatorIndex).trim();
+    const value = nameValue.slice(separatorIndex + 1);
+    if (!name || name.length > 128 || value.length > 4096) continue;
+
+    let domain = hostname;
+    let hostOnly = true;
+    let path = defaultCookiePath(response.pathname);
+    let expiresAt: number | null = null;
+    let maxAge: number | null = null;
+    let secure = false;
+
+    for (const attribute of attributes) {
+      const [rawKey, ...rawValueParts] = attribute.split("=");
+      const key = rawKey.trim().toLowerCase();
+      const attrValue = rawValueParts.join("=").trim();
+      if (key === "domain" && attrValue) {
+        const normalizedDomain = attrValue.toLowerCase().replace(/^\./, "");
+        if (domainMatches(hostname, normalizedDomain, false)) {
+          domain = normalizedDomain;
+          hostOnly = false;
+        }
+      } else if (key === "path" && attrValue.startsWith("/")) {
+        path = attrValue;
+      } else if (key === "expires") {
+        const parsed = Date.parse(attrValue);
+        if (!Number.isNaN(parsed)) expiresAt = parsed;
+      } else if (key === "max-age") {
+        const parsed = Number.parseInt(attrValue, 10);
+        if (Number.isFinite(parsed)) maxAge = parsed;
+      } else if (key === "secure") {
+        secure = true;
+      }
+    }
+
+    if (maxAge !== null) {
+      expiresAt = maxAge <= 0 ? now - 1 : now + maxAge * 1000;
+    }
+
+    const existingIndex = merged.findIndex(
+      (cookie) =>
+        cookie.name === name &&
+        cookie.domain === domain &&
+        cookie.path === path &&
+        cookie.hostOnly === hostOnly
+    );
+
+    if (expiresAt !== null && expiresAt <= now) {
+      if (existingIndex !== -1) merged.splice(existingIndex, 1);
+      continue;
+    }
+
+    const nextCookie: StoredProxyCookie = {
+      name,
+      value,
+      domain,
+      path,
+      expiresAt,
+      secure,
+      hostOnly,
+      createdAt: now,
+    };
+
+    if (existingIndex === -1) merged.push(nextCookie);
+    else merged[existingIndex] = nextCookie;
+  }
+
+  return merged
+    .sort((a, b) => b.path.length - a.path.length || a.createdAt - b.createdAt)
+    .slice(0, 80);
+}
+
+export function getCookieHeaderForUrl(
+  cookies: StoredProxyCookie[],
+  targetUrl: string,
+  now = Date.now()
+): string | null {
+  const target = new URL(targetUrl);
+  const matching = cookies.filter((cookie) => {
+    if (cookie.expiresAt && cookie.expiresAt <= now) return false;
+    if (cookie.secure && target.protocol !== "https:") return false;
+    if (!domainMatches(target.hostname, cookie.domain, cookie.hostOnly)) return false;
+    return pathMatches(target.pathname || "/", cookie.path || "/");
+  });
+
+  if (!matching.length) return null;
+  return matching
+    .map((cookie) => `${cookie.name}=${cookie.value}`)
+    .join("; ")
+    .slice(0, 8192);
+}

--- a/api/_utils/iframe-proxy-helpers.ts
+++ b/api/_utils/iframe-proxy-helpers.ts
@@ -226,6 +226,111 @@ export function createProxyUrl(
   }
 }
 
+export function isBingSearchUrl(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    const hostname = url.hostname.toLowerCase();
+    return (
+      (hostname === "bing.com" || hostname.endsWith(".bing.com")) &&
+      url.pathname.replace(/\/+$/, "") === "/search" &&
+      Boolean(url.searchParams.get("q")?.trim())
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function buildBingRssSearchUrl(rawUrl: string): string | null {
+  if (!isBingSearchUrl(rawUrl)) return null;
+  const url = new URL(rawUrl);
+  url.searchParams.set("format", "rss");
+  return url.toString();
+}
+
+export function htmlContainsBingChallenge(html: string): boolean {
+  return /CfConfig|challenge\/verify|captchaSuccessPostMessage|verificationComplete|One last step|Please solve the challenge/i.test(html);
+}
+
+const stripCdata = (value: string): string =>
+  value.replace(/^<!\[CDATA\[/, "").replace(/\]\]>$/, "");
+
+const stripMarkup = (value: string): string =>
+  value.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const readXmlTag = (xml: string, tagName: string): string => {
+  const match = xml.match(new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\\/${tagName}>`, "i"));
+  if (!match?.[1]) return "";
+  return stripMarkup(decodeHtmlEntitiesOnce(stripCdata(match[1]).trim()));
+};
+
+export function renderBingRssSearchFallbackHtml(options: {
+  originalSearchUrl: string;
+  rssUrl: string;
+  rssXml: string;
+}): string | null {
+  if (!isBingSearchUrl(options.originalSearchUrl)) return null;
+
+  const originalUrl = new URL(options.originalSearchUrl);
+  const query = originalUrl.searchParams.get("q")?.trim() || "Bing search";
+  const items = Array.from(options.rssXml.matchAll(/<item\b[^>]*>([\s\S]*?)<\/item>/gi))
+    .slice(0, 10)
+    .map((match) => {
+      const itemXml = match[1] ?? "";
+      const title = readXmlTag(itemXml, "title");
+      const link = readXmlTag(itemXml, "link");
+      const description = readXmlTag(itemXml, "description");
+      return { title, link, description };
+    })
+    .filter((item) => item.title && item.link);
+
+  const resultItems = items.length
+    ? items
+        .map(
+          (item) => `<li class="result"><a href="${escapeHtml(item.link)}">${escapeHtml(
+            item.title
+          )}</a><p>${escapeHtml(item.description)}</p><span>${escapeHtml(item.link)}</span></li>`
+        )
+        .join("")
+    : `<li class="empty">No RSS results returned for ${escapeHtml(query)}.</li>`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${escapeHtml(query)} - Search</title>
+<style>
+body{margin:0;background:#fff;color:#111;font:14px Arial,Helvetica,sans-serif}
+header{border-bottom:1px solid #d9d9d9;padding:16px 24px}
+h1{font-size:20px;font-weight:400;margin:0}
+main{max-width:820px;padding:18px 24px}
+.notice{background:#fff8d6;border:1px solid #ead27a;margin:0 0 18px;padding:10px 12px}
+ol{list-style:none;margin:0;padding:0}
+.result{margin:0 0 18px}
+.result a{color:#04c;font-size:18px;text-decoration:underline}
+.result p{margin:4px 0;color:#333;line-height:1.35}
+.result span{color:#080;font-size:12px}
+.empty{color:#555}
+</style>
+</head>
+<body>
+<header><h1>Bing results for "${escapeHtml(query)}"</h1></header>
+<main>
+<p class="notice">Bing returned a browser challenge for the full results page, so ryOS is showing Bing RSS results instead.</p>
+<ol>${resultItems}</ol>
+<p><a href="${escapeHtml(options.rssUrl)}">Open Bing RSS feed</a></p>
+</main>
+</body>
+</html>`;
+}
+
 function rewriteQuotedAttribute(
   tag: string,
   attr: string,

--- a/api/_utils/iframe-proxy-helpers.ts
+++ b/api/_utils/iframe-proxy-helpers.ts
@@ -1,3 +1,5 @@
+import { decodeHtmlEntitiesOnce } from "./html-entities.js";
+
 export type ProxyResourceType =
   | "document"
   | "style"
@@ -189,11 +191,15 @@ export function createProxyUrl(
     sessionId?: string | null;
     form?: boolean;
     theme?: string | null;
+    decodeHtmlEntities?: boolean;
   }
 ): string | null {
-  if (!shouldProxyUrl(rawUrl)) return null;
+  const urlForParsing = options.decodeHtmlEntities
+    ? decodeHtmlEntitiesOnce(rawUrl)
+    : rawUrl;
+  if (!shouldProxyUrl(urlForParsing)) return null;
   try {
-    const absoluteUrl = new URL(rawUrl, options.baseUrl);
+    const absoluteUrl = new URL(urlForParsing, options.baseUrl);
     if (absoluteUrl.protocol !== "http:" && absoluteUrl.protocol !== "https:") {
       return null;
     }
@@ -277,7 +283,11 @@ function rewriteTagAttributes(
   const stats = createEmptyRewriteStats();
 
   for (const attr of attrs) {
-    const attrOptions = { ...options, resourceType: attr.resourceType };
+    const attrOptions = {
+      ...options,
+      resourceType: attr.resourceType,
+      decodeHtmlEntities: true,
+    };
     const result = rewriteQuotedAttribute(next, attr.name, (value) =>
       attr.srcset
         ? rewriteSrcset(value, attrOptions)

--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -6,131 +6,27 @@ import { safeFetchWithRedirects, validatePublicUrl, SsrfBlockedError } from "./_
 import { getAppPublicOrigin } from "./_utils/runtime-config.js";
 import { decodeHtmlEntitiesOnce } from "./_utils/html-entities.js";
 import { redisKeys, sha256RedisIdentifier } from "../src/shared/redisKeys.js";
+import {
+  buildBrowserHeaders,
+  createProxyUrl,
+  getCookieHeaderForUrl,
+  getSetCookieHeaders,
+  mergeProxyCookies,
+  normalizeProxyResourceType,
+  rewriteCssForProxy,
+  rewriteHtmlForProxy,
+  type ProxyResourceType,
+  type RewriteStats,
+  type StoredProxyCookie,
+} from "./_utils/iframe-proxy-helpers.js";
+import {
+  getIeDomainCompatibility,
+  shouldAutoProxyUrl,
+} from "../src/shared/ieCompatibility.js";
 
 export const runtime = "nodejs";
 
 // --- Utility Functions ----------------------------------------------------
-
-/**
- * List of domains that should be automatically proxied.
- * Domains should be lowercase and without protocol.
- */
-const AUTO_PROXY_DOMAINS = [
-  "wikipedia.org",
-  "wikimedia.org",
-  "wikipedia.com",
-  "cursor.com",
-  "github.com",
-  "stackoverflow.com",
-  "stackexchange.com",
-  "reddit.com",
-  "twitter.com",
-  "x.com",
-  "medium.com",
-  "nytimes.com",
-  "bbc.com",
-  "bbc.co.uk",
-  "theguardian.com",
-  "cnn.com",
-  "washingtonpost.com",
-  "linkedin.com",
-  "instagram.com",
-  "facebook.com",
-  "amazon.com",
-  "youtube.com",
-  "twitch.tv",
-  "netflix.com",
-  "docs.google.com",
-  "drive.google.com",
-  "mail.google.com",
-];
-
-/**
- * Check if a URL's domain matches or is a subdomain of any auto-proxy domain
- */
-const shouldAutoProxy = (url: string): boolean => {
-  try {
-    const hostname = new URL(url).hostname.toLowerCase();
-    return AUTO_PROXY_DOMAINS.some(
-      (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
-    );
-  } catch {
-    // Return false if URL parsing fails
-    return false;
-  }
-};
-
-// ------------------------------------------------------------------------
-// Dynamic browser header generation
-// ------------------------------------------------------------------------
-/** A curated list of realistic desktop browser fingerprints to rotate through. */
-const USER_AGENT_SAMPLES = [
-  {
-    ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
-    secChUa: '"Not_A Brand";v="8", "Chromium";v="122", "Google Chrome";v="122"',
-    platform: '"Windows"',
-  },
-  {
-    ua: "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_6_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15",
-    // Safari does not currently send Sec-CH-UA headers
-    secChUa: "",
-    platform: '"macOS"',
-  },
-  {
-    ua: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
-    secChUa: '"Not_A Brand";v="8", "Chromium";v="121", "Google Chrome";v="121"',
-    platform: '"Linux"',
-  },
-  {
-    ua: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0",
-    // Firefox also omits Sec-CH-UA headers
-    secChUa: "",
-    platform: '"Windows"',
-  },
-];
-
-const ACCEPT_LANGUAGE_SAMPLES = [
-  "en-US,en;q=0.9",
-  "en-GB,en;q=0.8",
-  "en-US,en;q=0.8,fr;q=0.6",
-  "en-US,en;q=0.8,de;q=0.6",
-];
-
-const SEC_FETCH_SITE_SAMPLES = ["none", "same-origin", "cross-site"];
-
-// Generic helper to pick a random member of an array
-const pickRandom = <T>(arr: T[]): T =>
-  arr[Math.floor(Math.random() * arr.length)];
-
-/**
- * Builds a pseudo-random, yet realistic, browser header set.
- * We purposefully limit the pool to a handful of common fingerprints so that
- * the generated headers stay coherent and pass basic heuristics.
- */
-const generateRandomBrowserHeaders = (): Record<string, string> => {
-  const fp = pickRandom(USER_AGENT_SAMPLES);
-
-  const headers: Record<string, string> = {
-    "User-Agent": fp.ua,
-    Accept:
-      "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
-    "Accept-Language": pickRandom(ACCEPT_LANGUAGE_SAMPLES),
-    "Sec-Fetch-Dest": "document",
-    "Sec-Fetch-Mode": "navigate",
-    "Sec-Fetch-Site": pickRandom(SEC_FETCH_SITE_SAMPLES),
-    "Sec-Fetch-User": "?1",
-    "Upgrade-Insecure-Requests": "1",
-  };
-
-  // Only attach Client-Hint headers if present in the selected fingerprint
-  if (fp.secChUa) {
-    headers["Sec-Ch-Ua"] = fp.secChUa;
-    headers["Sec-Ch-Ua-Mobile"] = "?0";
-    headers["Sec-Ch-Ua-Platform"] = fp.platform;
-  }
-
-  return headers;
-};
 
 async function getIeCacheKey(normalizedUrlForKey: string, year: string): Promise<string> {
   return redisKeys.cache.ieVersions(
@@ -147,6 +43,220 @@ async function getWaybackCacheKey(
     await sha256RedisIdentifier(normalizedUrlForKey),
     yearMonth
   );
+}
+
+type ProxyDiagnostics = {
+  mode: string;
+  resourceType: ProxyResourceType;
+  targetHost?: string;
+  upstreamStatus?: number;
+  finalUrl?: string;
+  contentType?: string;
+  redirectCount?: number;
+  rewrites?: RewriteStats;
+  cookieSession?: boolean;
+  compatibilityMode?: string;
+  errorType?: string;
+};
+
+const emptyRewriteStats = (): RewriteStats => ({
+  htmlAttributes: 0,
+  srcset: 0,
+  cssUrls: 0,
+  forms: 0,
+});
+
+const getQueryValue = (value: string | string[] | undefined): string | undefined =>
+  Array.isArray(value) ? value[0] : value;
+
+const getSafeReferrerUrl = (rawRef: string | string[] | undefined): string | null => {
+  const ref = getQueryValue(rawRef);
+  if (!ref) return null;
+  try {
+    const parsed = new URL(ref);
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? parsed.toString()
+      : null;
+  } catch {
+    return null;
+  }
+};
+
+const getProxySessionId = (rawSession: string | string[] | undefined): string | null => {
+  const session = getQueryValue(rawSession);
+  if (!session) return null;
+  return /^[a-zA-Z0-9_-]{8,96}$/.test(session) ? session : null;
+};
+
+const shouldUseLocalProxyFixture = (
+  rawFixture: string | string[] | undefined
+): string | null => {
+  if (process.env.NODE_ENV === "production") return null;
+  const fixture = getQueryValue(rawFixture);
+  return fixture && /^[a-z0-9_-]{1,64}$/i.test(fixture) ? fixture : null;
+};
+
+const setDiagnosticsHeader = (
+  res: { setHeader: (name: string, value: string) => void },
+  enabled: boolean,
+  diagnostics: ProxyDiagnostics
+) => {
+  if (!enabled) return;
+  res.setHeader(
+    "X-Proxy-Diagnostics",
+    encodeURIComponent(JSON.stringify(diagnostics))
+  );
+};
+
+function createLocalProxyFixtureResponse(
+  fixture: string,
+  targetUrl: string,
+  headers: Record<string, string>
+): { response: Response; finalUrl: string; redirectChain: string[] } | null {
+  const fixtureOrigin = new URL(targetUrl).origin;
+  if (fixture === "html-assets") {
+    return {
+      finalUrl: targetUrl,
+      redirectChain: [],
+      response: new Response(
+        `<!doctype html><html><head><title>Proxy Fixture</title><link rel="stylesheet" href="/assets/site.css"><script src="/assets/app.js" integrity="sha256-test" nonce="abc"></script><style>.hero{background:url('/assets/hero.png')}@import "/assets/extra.css";</style></head><body><img src="/assets/logo.png" srcset="/assets/logo-1x.png 1x, /assets/logo-2x.png 2x"><video poster="/assets/poster.jpg"><source src="/assets/movie.mp4"></video><iframe src="/nested"></iframe><form method="post" action="/submit"><input name="q" value="ryos"></form></body></html>`,
+        {
+          status: 200,
+          headers: {
+            "content-type": "text/html; charset=utf-8",
+            "x-fixture-accept": headers.Accept || "",
+          },
+        }
+      ),
+    };
+  }
+
+  if (fixture === "stylesheet") {
+    return {
+      finalUrl: targetUrl,
+      redirectChain: [],
+      response: new Response(
+        `.logo{background:url("./logo.png")}@import url("/nested.css");`,
+        {
+          status: 200,
+          headers: { "content-type": "text/css; charset=utf-8" },
+        }
+      ),
+    };
+  }
+
+  if (fixture === "headers") {
+    return {
+      finalUrl: targetUrl,
+      redirectChain: [],
+      response: new Response(JSON.stringify({
+        accept: headers.Accept,
+        secFetchDest: headers["Sec-Fetch-Dest"],
+        userAgent: headers["User-Agent"],
+        cookie: headers.Cookie || "",
+        referer: headers.Referer || "",
+        origin: fixtureOrigin,
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    };
+  }
+
+  if (fixture === "set-cookie") {
+    return {
+      finalUrl: targetUrl,
+      redirectChain: [],
+      response: new Response("<!doctype html><title>Cookie Fixture</title>", {
+        status: 200,
+        headers: {
+          "content-type": "text/html; charset=utf-8",
+          "set-cookie": "proxy_fixture=stored; Path=/; Max-Age=600; SameSite=Lax",
+        },
+      }),
+    };
+  }
+
+  if (fixture === "post-echo") {
+    return {
+      finalUrl: targetUrl,
+      redirectChain: [],
+      response: new Response(JSON.stringify({
+        method: "POST",
+        contentType: headers["Content-Type"] || "",
+        cookie: headers.Cookie || "",
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    };
+  }
+
+  return null;
+}
+
+async function readProxyRequestBody(req: {
+  body?: unknown;
+  headers: Record<string, string | string[] | undefined>;
+  [Symbol.asyncIterator]?: () => AsyncIterator<Buffer | Uint8Array | string>;
+}): Promise<BodyInit | undefined> {
+  const contentType = getQueryValue(req.headers["content-type"]) || "";
+  const bodyValue = req.body;
+
+  if (
+    bodyValue &&
+    typeof bodyValue === "object" &&
+    contentType.includes("application/x-www-form-urlencoded")
+  ) {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(bodyValue as Record<string, unknown>)) {
+      if (Array.isArray(value)) {
+        for (const item of value) params.append(key, String(item));
+      } else if (value !== undefined && value !== null) {
+        params.append(key, String(value));
+      }
+    }
+    return params.toString();
+  }
+
+  if (typeof bodyValue === "string") return bodyValue;
+  if (bodyValue instanceof Uint8Array) return bodyValue;
+
+  if (typeof req[Symbol.asyncIterator] === "function") {
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for await (const chunk of req as AsyncIterable<Buffer | Uint8Array | string>) {
+      const buffer = typeof chunk === "string" ? Buffer.from(chunk) : Buffer.from(chunk);
+      total += buffer.length;
+      if (total > 1024 * 1024) {
+        throw new Error("POST body is too large for proxying");
+      }
+      chunks.push(buffer);
+    }
+    return Buffer.concat(chunks);
+  }
+
+  return undefined;
+}
+
+async function loadProxyCookies(
+  redis: { get: (key: string) => Promise<unknown> },
+  sessionId: string | null
+): Promise<{ key: string; cookies: StoredProxyCookie[] } | null> {
+  if (!sessionId) return null;
+  const sessionHash = await sha256RedisIdentifier(sessionId);
+  const key = redisKeys.cache.ieProxyCookies(sessionHash);
+  const raw = await redis.get(key);
+  if (!raw) return { key, cookies: [] };
+  try {
+    const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+    return {
+      key,
+      cookies: Array.isArray(parsed) ? (parsed as StoredProxyCookie[]) : [],
+    };
+  } catch {
+    return { key, cookies: [] };
+  }
 }
 
 /**
@@ -169,7 +279,7 @@ async function getWaybackCacheKey(
 
 export default apiHandler(
   {
-    methods: ["GET"],
+    methods: ["GET", "POST"],
     contentType: null,
   },
   async ({ req, res, redis, logger, startTime, origin }) => {
@@ -178,12 +288,26 @@ export default apiHandler(
   const year = req.query.year as string | undefined;
   const month = req.query.month as string | undefined;
   const effectiveOrigin = origin;
-
-  // Generate a fresh, randomized browser header set for this request
-  const BROWSER_HEADERS = generateRandomBrowserHeaders();
+  const method = (req.method || "GET").toUpperCase();
+  const resourceType = normalizeProxyResourceType(req.query.resource);
+  const referrerUrl = getSafeReferrerUrl(req.query.ref);
+  const proxySessionId = getProxySessionId(req.query.session);
+  const debugProxy = getQueryValue(req.query.debug as string | string[] | undefined) === "1";
+  const fixtureName = shouldUseLocalProxyFixture(req.query.fixture);
+  const diagnostics: ProxyDiagnostics = {
+    mode,
+    resourceType,
+    cookieSession: !!proxySessionId,
+  };
 
   // Helper for consistent error responses with CORS
-  const errorResponseWithCors = (message: string, status: number = 400) => {
+  const errorResponseWithCors = (
+    message: string,
+    status: number = 400,
+    errorType = "request_error"
+  ) => {
+    diagnostics.errorType = errorType;
+    setDiagnosticsHeader(res, debugProxy, diagnostics);
     if (effectiveOrigin) {
       res.setHeader("Access-Control-Allow-Origin", effectiveOrigin);
     }
@@ -197,10 +321,35 @@ export default apiHandler(
     return errorResponseWithCors("Missing 'url' query parameter");
   }
 
+  if (method !== "GET" && mode !== "proxy") {
+    return errorResponseWithCors("POST proxying is only supported in proxy mode", 405);
+  }
+  if (
+    method === "POST" &&
+    getQueryValue(req.query.form as string | string[] | undefined) !== "1"
+  ) {
+    return errorResponseWithCors("POST proxying requires a proxied form action", 400);
+  }
+  if (method === "POST") {
+    const contentType = getQueryValue(req.headers["content-type"]) || "";
+    const allowedPostContentType =
+      contentType.includes("application/x-www-form-urlencoded") ||
+      contentType.includes("multipart/form-data") ||
+      contentType.includes("text/plain");
+    if (!allowedPostContentType) {
+      return errorResponseWithCors("Unsupported proxied form content type", 415);
+    }
+  }
+
   // Ensure the URL starts with a protocol for fetch()
   const normalizedUrl = urlParam.startsWith("http")
     ? urlParam
     : `https://${urlParam}`;
+  try {
+    diagnostics.targetHost = new URL(normalizedUrl).hostname;
+  } catch {
+    // validatePublicUrl will produce the user-facing error below.
+  }
 
   // Log normalized URL
   logger.info(`Normalized URL: ${normalizedUrl}`);
@@ -211,7 +360,7 @@ export default apiHandler(
     const message =
       error instanceof SsrfBlockedError ? error.message : "Invalid URL format";
     logger.warn("Blocked URL for iframe check", { normalizedUrl, message, mode });
-    return errorResponseWithCors(message, 400);
+    return errorResponseWithCors(message, 400, "ssrf_blocked");
   }
 
   // ---------------------------
@@ -449,7 +598,9 @@ export default apiHandler(
   // --- Regular Check/Proxy Logic ---
 
   // Check if this is an auto-proxy domain
-  const isAutoProxyDomain = shouldAutoProxy(normalizedUrl);
+  const compatibilityRule = getIeDomainCompatibility(normalizedUrl);
+  const isAutoProxyDomain = shouldAutoProxyUrl(normalizedUrl);
+  diagnostics.compatibilityMode = compatibilityRule?.mode;
   if (isAutoProxyDomain) {
     logger.info(`Domain ${new URL(normalizedUrl).hostname} is auto-proxied`);
   }
@@ -538,7 +689,12 @@ export default apiHandler(
         targetUrl,
         {
           method: "GET",
-          headers: BROWSER_HEADERS,
+          headers: buildBrowserHeaders({
+            targetUrl,
+            resourceType: "document",
+            referrerUrl,
+            method: "GET",
+          }),
         },
         { maxRedirects: 10 }
       );
@@ -635,6 +791,7 @@ export default apiHandler(
       logger.info("Executing in 'check' mode");
       const result = await checkSiteEmbeddingAllowed();
       res.setHeader("Content-Type", "application/json");
+      setDiagnosticsHeader(res, debugProxy, diagnostics);
       logger.response(200, Date.now() - startTime);
       return res.status(200).json(result);
     }
@@ -645,29 +802,60 @@ export default apiHandler(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 30000); // 30-second timeout
 
-    // Add Referer header for the target site (some sites require valid referer)
     try {
-      BROWSER_HEADERS['Referer'] = new URL(targetUrl).origin + '/';
-    } catch { /* ignore URL parse errors */ }
-
-    try {
-      const { response: upstreamRes, finalUrl } = await safeFetchWithRedirects(
+      const cookieJar = await loadProxyCookies(redis, proxySessionId);
+      const cookieHeader = cookieJar
+        ? getCookieHeaderForUrl(cookieJar.cookies, targetUrl)
+        : null;
+      const contentTypeHeader = getQueryValue(req.headers["content-type"]);
+      const upstreamBody = method === "POST" ? await readProxyRequestBody(req) : undefined;
+      const browserHeaders = buildBrowserHeaders({
         targetUrl,
-        {
-          method: "GET",
-          signal: controller.signal,
-          headers: BROWSER_HEADERS,
-        },
-        { maxRedirects: 10 }
-      );
+        resourceType,
+        referrerUrl,
+        method,
+        contentType: contentTypeHeader,
+        cookieHeader,
+      });
+      const fixtureResponse = fixtureName
+        ? createLocalProxyFixtureResponse(fixtureName, targetUrl, browserHeaders)
+        : null;
+      const { response: upstreamRes, finalUrl, redirectChain } =
+        fixtureResponse ??
+        (await safeFetchWithRedirects(
+          targetUrl,
+          {
+            method,
+            signal: controller.signal,
+            headers: browserHeaders,
+            body: upstreamBody,
+          },
+          { maxRedirects: 10 }
+        ));
 
       clearTimeout(timeout); // Clear timeout on successful fetch
+      diagnostics.upstreamStatus = upstreamRes.status;
+      diagnostics.finalUrl = finalUrl;
+      diagnostics.redirectCount = redirectChain.length;
+
+      if (cookieJar) {
+        const updatedCookies = mergeProxyCookies(
+          cookieJar.cookies,
+          getSetCookieHeaders(upstreamRes.headers),
+          finalUrl
+        );
+        await redis.set(cookieJar.key, JSON.stringify(updatedCookies), {
+          ex: 60 * 60 * 2,
+        });
+      }
 
       // If the upstream fetch failed (e.g., 403 Forbidden, 404 Not Found), return an error response
       if (!upstreamRes.ok) {
         logger.error(`Upstream fetch failed with status ${upstreamRes.status}`, { url: targetUrl });
         res.setHeader("Content-Type", "application/json");
         res.setHeader("Access-Control-Allow-Origin", "*");
+        diagnostics.errorType = "http_error";
+        setDiagnosticsHeader(res, debugProxy, diagnostics);
         logger.response(upstreamRes.status, Date.now() - startTime);
         return res.status(upstreamRes.status).json({
           error: true,
@@ -681,6 +869,7 @@ export default apiHandler(
       }
 
       const contentType = upstreamRes.headers.get("content-type") || "";
+      diagnostics.contentType = contentType;
       logger.info(`Proxying content type: ${contentType}`);
       let pageTitle: string | undefined = undefined; // Initialize title for proxy mode
 
@@ -704,6 +893,18 @@ export default apiHandler(
         // Strip Content-Security-Policy headers embedded via <meta> with reversed attribute order
         html = html.replace(/<meta[^>]*content\s*=\s*["'][^"']*["'][^>]*http-equiv\s*=\s*["']?Content-Security-Policy["']?[^>]*>/gi, '');
 
+        const appPublicOrigin = getAppPublicOrigin(origin);
+        const rewriteResult = rewriteHtmlForProxy(html, {
+          baseUrl: finalUrl,
+          proxyOrigin: appPublicOrigin,
+          referrerUrl: finalUrl,
+          sessionId: proxySessionId,
+          theme,
+        });
+        html = rewriteResult.html;
+        diagnostics.rewrites = rewriteResult.stats;
+        logger.info("Rewrote proxied HTML resources", rewriteResult.stats);
+
         // Extract title before modifying HTML
         const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
         if (titleMatch && titleMatch[1]) {
@@ -720,7 +921,6 @@ export default apiHandler(
           : "";
 
         // Add font override styles (conditionally injected based on theme)
-        const appPublicOrigin = getAppPublicOrigin(origin);
         const fontOverrideStyles = shouldInjectFontOverrides
           ? `
 <link rel="stylesheet" href="${appPublicOrigin}/fonts/fonts.css">
@@ -969,23 +1169,37 @@ export default apiHandler(
     return originalOpen ? originalOpen.call(window, url, target, features) : null;
   };
 
-  // --- Sub-resource proxy: route fetch/XHR through the proxy for CORS-blocked requests ---
+  // --- Sub-resource proxy: route dynamic fetch/XHR GETs through the proxy ---
   var proxyOrigin = window.location.origin;
   var baseOrigin = null;
+  var proxySession = ${JSON.stringify(proxySessionId || "")};
+  var proxyTheme = ${JSON.stringify(theme || "")};
   try { baseOrigin = new URL(document.baseURI).origin; } catch(e) {}
+
+  function buildProxyUrl(url, resourceType) {
+    var resolved = new URL(url, document.baseURI);
+    if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') return null;
+    var proxyUrl = new URL('/api/iframe-check', proxyOrigin);
+    proxyUrl.searchParams.set('url', resolved.href);
+    proxyUrl.searchParams.set('resource', resourceType || 'xhr');
+    proxyUrl.searchParams.set('ref', document.baseURI || window.location.href);
+    if (proxySession) proxyUrl.searchParams.set('session', proxySession);
+    if (proxyTheme) proxyUrl.searchParams.set('theme', proxyTheme);
+    return proxyUrl.toString();
+  }
 
   if (baseOrigin && baseOrigin !== proxyOrigin) {
     var origFetch = window.fetch;
     window.fetch = function(input, init) {
       try {
         var url = typeof input === 'string' ? input : (input instanceof Request ? input.url : String(input));
-        var resolved = new URL(url, document.baseURI);
         var method = 'GET';
         if (init && init.method) method = init.method.toUpperCase();
         else if (input instanceof Request) method = input.method.toUpperCase();
 
-        if (method === 'GET' && resolved.origin === baseOrigin) {
-          var proxyUrl = proxyOrigin + '/api/iframe-check?url=' + encodeURIComponent(resolved.href);
+        if (method === 'GET') {
+          var proxyUrl = buildProxyUrl(url, 'xhr');
+          if (!proxyUrl) return origFetch.call(window, input, init);
           return origFetch.call(window, proxyUrl, init);
         }
       } catch(e) {}
@@ -998,10 +1212,8 @@ export default apiHandler(
         var method = arguments[0];
         var url = arguments[1];
         if (typeof url === 'string' && method && method.toUpperCase() === 'GET') {
-          var resolved = new URL(url, document.baseURI);
-          if (resolved.origin === baseOrigin) {
-            arguments[1] = proxyOrigin + '/api/iframe-check?url=' + encodeURIComponent(resolved.href);
-          }
+          var proxyUrl = buildProxyUrl(url, 'xhr');
+          if (proxyUrl) arguments[1] = proxyUrl;
         }
       } catch(e) {}
       return origXHROpen.apply(this, arguments);
@@ -1066,13 +1278,33 @@ export default apiHandler(
         }
 
         res.setHeader("Content-Type", "text/html; charset=utf-8");
+        setDiagnosticsHeader(res, debugProxy, diagnostics);
         logger.response(upstreamRes.status, Date.now() - startTime);
         return res.status(upstreamRes.status).send(html);
+      } else if (contentType.includes("text/css")) {
+        const css = await upstreamRes.text();
+        const appPublicOrigin = getAppPublicOrigin(origin);
+        const rewriteResult = rewriteCssForProxy(css, {
+          baseUrl: finalUrl,
+          proxyOrigin: appPublicOrigin,
+          referrerUrl: finalUrl,
+          sessionId: proxySessionId,
+        });
+        diagnostics.rewrites = {
+          ...emptyRewriteStats(),
+          cssUrls: rewriteResult.count,
+        };
+        res.setHeader("Content-Type", contentType || "text/css; charset=utf-8");
+        setDiagnosticsHeader(res, debugProxy, diagnostics);
+        logger.response(upstreamRes.status, Date.now() - startTime);
+        return res.status(upstreamRes.status).send(rewriteResult.css);
       } else {
         logger.info("Proxying non-HTML content directly");
         // For non‑HTML content, stream the body directly
         const arrayBuffer = await upstreamRes.arrayBuffer();
         res.setHeader("Content-Type", contentType);
+        diagnostics.rewrites = emptyRewriteStats();
+        setDiagnosticsHeader(res, debugProxy, diagnostics);
         logger.response(upstreamRes.status, Date.now() - startTime);
         return res.status(upstreamRes.status).send(Buffer.from(arrayBuffer));
       }
@@ -1085,6 +1317,8 @@ export default apiHandler(
         if (effectiveOrigin) {
           res.setHeader("Access-Control-Allow-Origin", effectiveOrigin);
         }
+        diagnostics.errorType = "ssrf_blocked";
+        setDiagnosticsHeader(res, debugProxy, diagnostics);
         logger.response(400, Date.now() - startTime);
         return res.status(400).json({
           error: true,
@@ -1102,6 +1336,8 @@ export default apiHandler(
       if (effectiveOrigin) {
         res.setHeader("Access-Control-Allow-Origin", effectiveOrigin);
       }
+      diagnostics.errorType = "connection_error";
+      setDiagnosticsHeader(res, debugProxy, diagnostics);
       logger.response(503, Date.now() - startTime);
       return res.status(503).json({
         error: true,

--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -66,6 +66,22 @@ const emptyRewriteStats = (): RewriteStats => ({
   forms: 0,
 });
 
+// Live modern sites can overwhelm the sandboxed iframe; keep their HTML static
+// while preserving ryOS's own injected navigation helper.
+const disableExecutableScripts = (
+  html: string
+): string =>
+  html.replace(
+    /<script\b([^>]*)>/gi,
+    (_match, attrs: string) => {
+      const strippedAttrs = attrs.replace(
+        /\s+type\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/i,
+        ""
+      );
+      return `<script type="text/plain" data-ryos-blocked-script="true"${strippedAttrs}>`;
+    }
+  );
+
 const getQueryValue = (value: string | string[] | undefined): string | undefined =>
   Array.isArray(value) ? value[0] : value;
 
@@ -892,6 +908,10 @@ export default apiHandler(
         html = html.replace(/<meta[^>]*http-equiv\s*=\s*["']?refresh["']?[^>]*>/gi, '');
         // Strip Content-Security-Policy headers embedded via <meta> with reversed attribute order
         html = html.replace(/<meta[^>]*content\s*=\s*["'][^"']*["'][^>]*http-equiv\s*=\s*["']?Content-Security-Policy["']?[^>]*>/gi, '');
+
+        if (!isWaybackRequest) {
+          html = disableExecutableScripts(html);
+        }
 
         const appPublicOrigin = getAppPublicOrigin(origin);
         const rewriteResult = rewriteHtmlForProxy(html, {

--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -8,11 +8,13 @@ import { decodeHtmlEntitiesOnce } from "./_utils/html-entities.js";
 import { redisKeys, sha256RedisIdentifier } from "../src/shared/redisKeys.js";
 import {
   buildBrowserHeaders,
-  createProxyUrl,
+  buildBingRssSearchUrl,
   getCookieHeaderForUrl,
   getSetCookieHeaders,
+  htmlContainsBingChallenge,
   mergeProxyCookies,
   normalizeProxyResourceType,
+  renderBingRssSearchFallbackHtml,
   rewriteCssForProxy,
   rewriteHtmlForProxy,
   type ProxyResourceType,
@@ -57,6 +59,7 @@ type ProxyDiagnostics = {
   rewrites?: RewriteStats;
   cookieSession?: boolean;
   compatibilityMode?: string;
+  bingRssFallback?: boolean;
   errorType?: string;
 };
 
@@ -234,6 +237,38 @@ function createLocalProxyFixtureResponse(
   }
 
   return null;
+}
+
+async function buildBingSearchChallengeFallbackHtml(
+  finalUrl: string
+): Promise<string | null> {
+  const rssUrl = buildBingRssSearchUrl(finalUrl);
+  if (!rssUrl) return null;
+
+  const { response } = await safeFetchWithRedirects(
+    rssUrl,
+    {
+      method: "GET",
+      headers: {
+        ...buildBrowserHeaders({
+          targetUrl: rssUrl,
+          resourceType: "document",
+          referrerUrl: "https://www.bing.com/",
+          method: "GET",
+        }),
+        Accept: "application/rss+xml, application/xml;q=0.9, text/xml;q=0.8, */*;q=0.5",
+      },
+    },
+    { maxRedirects: 5 }
+  );
+
+  if (!response.ok) return null;
+  const rssXml = await response.text();
+  return renderBingRssSearchFallbackHtml({
+    originalSearchUrl: finalUrl,
+    rssUrl,
+    rssXml,
+  });
 }
 
 async function readProxyRequestBody(req: {
@@ -921,6 +956,21 @@ export default apiHandler(
       // If it's HTML, inject the <base> tag and click interceptor script
       if (contentType.includes("text/html")) {
         let html = await upstreamRes.text();
+
+        if (htmlContainsBingChallenge(html)) {
+          try {
+            const fallbackHtml = await buildBingSearchChallengeFallbackHtml(finalUrl);
+            if (fallbackHtml) {
+              html = fallbackHtml;
+              diagnostics.bingRssFallback = true;
+              logger.info("Rendered Bing RSS fallback for challenged search page", {
+                finalUrl,
+              });
+            }
+          } catch (fallbackError) {
+            logger.warn("Bing RSS fallback failed", fallbackError);
+          }
+        }
 
         // --- Sanitize HTML for proxy embedding ---
         // Strip existing <base> tags to prevent conflicts with our injected base tag

--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -86,6 +86,13 @@ const disableExecutableScripts = (
     }
   );
 
+const promoteNoscriptImageFallbacks = (html: string): string =>
+  html.replace(
+    /<noscript\b[^>]*>([\s\S]*?)<\/noscript>/gi,
+    (match, content: string) =>
+      /<(?:picture|img)\b/i.test(content) ? content : match
+  );
+
 const getQueryValue = (value: string | string[] | undefined): string | undefined =>
   Array.isArray(value) ? value[0] : value;
 
@@ -146,6 +153,20 @@ function createLocalProxyFixtureResponse(
             "content-type": "text/html; charset=utf-8",
             "x-fixture-accept": headers.Accept || "",
           },
+        }
+      ),
+    };
+  }
+
+  if (fixture === "noscript-images") {
+    return {
+      finalUrl: targetUrl,
+      redirectChain: [],
+      response: new Response(
+        `<!doctype html><html><head><title>Noscript Fixture</title><script src="/assets/app.js"></script></head><body><picture><img alt="lazy placeholder" loading="lazy"></picture><noscript><picture><source srcset="/assets/fallback.webp 1x"><img src="/assets/fallback.jpg" alt="fallback"></picture></noscript><noscript><p>No image fallback</p></noscript></body></html>`,
+        {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
         }
       ),
     };
@@ -914,6 +935,7 @@ export default apiHandler(
         html = html.replace(/<meta[^>]*content\s*=\s*["'][^"']*["'][^>]*http-equiv\s*=\s*["']?Content-Security-Policy["']?[^>]*>/gi, '');
 
         if (!isWaybackRequest && shouldUseInertProxyScripts(finalUrl)) {
+          html = promoteNoscriptImageFallbacks(html);
           html = disableExecutableScripts(html);
         }
 

--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -972,6 +972,7 @@ export default apiHandler(
 <link rel="stylesheet" href="${appPublicOrigin}/fonts/fonts.css">
 <style>img{image-rendering:pixelated!important}body,div,span,p,h1,h2,h3,h4,h5,h6,button,input,select,textarea,[style*="font-family"],[style*="sans-serif"],[style*="SF Pro Text"],[style*="-apple-system"],[style*="BlinkMacSystemFont"],[style*="Segoe UI"],[style*="Roboto"],[style*="Oxygen"],[style*="Ubuntu"],[style*="Cantarell"],[style*="Fira Sans"],[style*="Droid Sans"],[style*="Helvetica Neue"],[style*="Helvetica"],[style*="Arial"],[style*="Verdana"],[style*="Geneva"],[style*="Inter"],[style*="Hiragino Sans"],[style*="Hiragino Kaku Gothic"],[style*="Yu Gothic"],[style*="Meiryo"],[style*="MS PGothic"],[style*="MS Gothic"],[style*="Microsoft YaHei"],[style*="PingFang"],[style*="Noto Sans"],[style*="Source Han Sans"],[style*="WenQuanYi"]{font-family:"Geneva-12","ArkPixel","SerenityOS-Emoji",sans-serif!important}[style*="serif"],[style*="Georgia"],[style*="Times New Roman"],[style*="Times"],[style*="Palatino"],[style*="Bookman"],[style*="Garamond"],[style*="Cambria"],[style*="Constantia"],[style*="Hiragino Mincho"],[style*="Yu Mincho"],[style*="MS Mincho"],[style*="SimSun"],[style*="NSimSun"],[style*="Source Han Serif"],[style*="Noto Serif CJK"]{font-family:"Mondwest","Yu Mincho","Hiragino Mincho Pro","Songii TC","Georgia","Palatino","SerenityOS-Emoji",serif!important}code,pre,[style*="monospace"],[style*="Courier New"],[style*="Courier"],[style*="Lucida Console"],[style*="Monaco"],[style*="Consolas"],[style*="Inconsolata"],[style*="Source Code Pro"],[style*="Menlo"],[style*="Andale Mono"],[style*="Ubuntu Mono"]{font-family:"Monaco","ArkPixel","SerenityOS-Emoji",monospace!important}*{font-family:"Geneva-12","ArkPixel","SerenityOS-Emoji",sans-serif}</style>`
           : "";
+        const proxyBaseStyles = `<style data-ryos-proxy-base="true">html,body{background:#fff!important;}</style>`;
 
         // Comprehensive navigation interceptor script - injected in head for early execution
         const navigationInterceptorScript = `
@@ -981,6 +982,17 @@ export default apiHandler(
 
   // Save real parent reference BEFORE any overrides
   var realParent = window.parent;
+
+  function applyProxyBaseStyles() {
+    try {
+      if (document.documentElement) {
+        document.documentElement.style.setProperty('background', '#fff', 'important');
+      }
+      if (document.body) {
+        document.body.style.setProperty('background', '#fff', 'important');
+      }
+    } catch (e) {}
+  }
 
   // Helper to resolve and post navigation URL to real parent
   function postNavigation(url, source) {
@@ -1013,15 +1025,18 @@ export default apiHandler(
     } catch (e) {}
   }
 
+  applyProxyBaseStyles();
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', function() { postReady('dom-content-loaded'); }, { once: true });
+    document.addEventListener('DOMContentLoaded', function() { applyProxyBaseStyles(); postReady('dom-content-loaded'); }, { once: true });
   } else {
-    setTimeout(function() { postReady('already-ready'); }, 0);
+    setTimeout(function() { applyProxyBaseStyles(); postReady('already-ready'); }, 0);
   }
 
   // Some pages keep subresources pending for a long time; unblock ryOS once
   // the static document has had a chance to paint.
-  setTimeout(function() { postReady('timeout'); }, 1500);
+  setTimeout(applyProxyBaseStyles, 250);
+  setTimeout(applyProxyBaseStyles, 1500);
+  setTimeout(function() { applyProxyBaseStyles(); postReady('timeout'); }, 1500);
 
   // --- Frame-busting neutralization ---
   // Make the page think it is the top-level window so that
@@ -1301,6 +1316,7 @@ export default apiHandler(
             baseTag +
             titleMetaTag +
             navigationInterceptorScript +
+            proxyBaseStyles +
             fontOverrideStyles +
             html.slice(insertPos);
         } else {
@@ -1310,10 +1326,16 @@ export default apiHandler(
             baseTag +
             titleMetaTag +
             navigationInterceptorScript +
+            proxyBaseStyles +
             fontOverrideStyles +
             '</head>' +
             html;
         }
+
+        // Keep proxied documents opaque even when a site's own chrome uses
+        // transparent page margins. Append this after upstream head content so
+        // ResourceLoader-style CSS cannot override it back to transparent.
+        html = html.replace(/<\/head>/i, `${proxyBaseStyles}</head>`);
 
         // Add the extracted title to a custom header (URL-encoded)
         if (pageTitle) {

--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -67,6 +67,9 @@ const emptyRewriteStats = (): RewriteStats => ({
   forms: 0,
 });
 
+const getProxyAssetOrigin = (requestOrigin: string | null): string =>
+  requestOrigin || getAppPublicOrigin(requestOrigin);
+
 // Live modern sites can overwhelm the sandboxed iframe; keep their HTML static
 // while preserving ryOS's own injected navigation helper.
 const disableExecutableScripts = (
@@ -914,7 +917,7 @@ export default apiHandler(
           html = disableExecutableScripts(html);
         }
 
-        const appPublicOrigin = getAppPublicOrigin(origin);
+        const appPublicOrigin = getProxyAssetOrigin(origin);
         const rewriteResult = rewriteHtmlForProxy(html, {
           baseUrl: finalUrl,
           proxyOrigin: appPublicOrigin,
@@ -1328,7 +1331,7 @@ export default apiHandler(
         return res.status(upstreamRes.status).send(html);
       } else if (contentType.includes("text/css")) {
         const css = await upstreamRes.text();
-        const appPublicOrigin = getAppPublicOrigin(origin);
+        const appPublicOrigin = getProxyAssetOrigin(origin);
         const rewriteResult = rewriteCssForProxy(css, {
           baseUrl: finalUrl,
           proxyOrigin: appPublicOrigin,

--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -22,6 +22,7 @@ import {
 import {
   getIeDomainCompatibility,
   shouldAutoProxyUrl,
+  shouldUseInertProxyScripts,
 } from "../src/shared/ieCompatibility.js";
 
 export const runtime = "nodejs";
@@ -909,7 +910,7 @@ export default apiHandler(
         // Strip Content-Security-Policy headers embedded via <meta> with reversed attribute order
         html = html.replace(/<meta[^>]*content\s*=\s*["'][^"']*["'][^>]*http-equiv\s*=\s*["']?Content-Security-Policy["']?[^>]*>/gi, '');
 
-        if (!isWaybackRequest) {
+        if (!isWaybackRequest && shouldUseInertProxyScripts(finalUrl)) {
           html = disableExecutableScripts(html);
         }
 

--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -973,6 +973,30 @@ export default apiHandler(
     }
   }
 
+  var readyPosted = false;
+  function postReady(source) {
+    if (readyPosted) return;
+    readyPosted = true;
+    try {
+      var metaTitle = document.querySelector('meta[name="page-title"]');
+      realParent.postMessage({
+        type: 'iframeReady',
+        title: document.title || (metaTitle && metaTitle.getAttribute('content')) || '',
+        source: source
+      }, '*');
+    } catch (e) {}
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function() { postReady('dom-content-loaded'); }, { once: true });
+  } else {
+    setTimeout(function() { postReady('already-ready'); }, 0);
+  }
+
+  // Some pages keep subresources pending for a long time; unblock ryOS once
+  // the static document has had a chance to paint.
+  setTimeout(function() { postReady('timeout'); }, 1500);
+
   // --- Frame-busting neutralization ---
   // Make the page think it is the top-level window so that
   // "if (top !== self) top.location = ..." guards become no-ops.

--- a/docs/2.2-internet-explorer.md
+++ b/docs/2.2-internet-explorer.md
@@ -57,6 +57,12 @@ The app consists of 4 component file(s):
 **Custom Hooks:**
 *   `src/apps/internet-explorer/hooks/useAiGeneration.ts`: A custom hook responsible for interfacing with the AI backend to reconstruct historical web pages and generate future web content.
 
+**Proxy compatibility:**
+*   Modern browsing uses `api/iframe-check.ts` as an SSRF-guarded web proxy for sites that cannot be embedded directly.
+*   Proxied pages rewrite common asset URLs, stylesheet URLs, iframe URLs, and form actions through the proxy so resources stay in the same browsing session.
+*   Each Internet Explorer window sends a random per-tab proxy session ID; upstream cookies are stored server-side for that session and are not exposed as ryOS-origin cookies.
+*   Domain behavior is cataloged in `src/shared/ieCompatibility.ts` so direct-passthrough, auto-proxy, and future blocked-domain decisions share one source of truth.
+
 ### State Management
 Internet Explorer utilizes Zustand for its global state management. This includes managing the current URL, selected year, browsing history, user favorites, and settings related to AI generation and display. Local component state is used for UI interactions within individual components.
 

--- a/docs/8.9-utility-apis.md
+++ b/docs/8.9-utility-apis.md
@@ -109,6 +109,10 @@ Checks if a URL allows iframe embedding and optionally proxies content to bypass
 | `year` | string | No | Year for Wayback Machine or AI cache (e.g., "2020", "1000 BC") |
 | `month` | string | No | Month for Wayback Machine (e.g., "01" for January) |
 | `theme` | string | No | Theme name - font overrides are skipped for "macosx" theme |
+| `resource` | string | No | Resource type for proxied subresources: `document`, `style`, `script`, `image`, `media`, `font`, `xhr`, `iframe`, or `other` |
+| `ref` | string | No | Referrer URL used for resource-aware upstream headers |
+| `session` | string | No | Per-tab proxy session identifier for isolated cookie replay |
+| `debug` | string | No | Set to `1` to include URL-encoded `X-Proxy-Diagnostics` metadata |
 
 ### Modes
 
@@ -141,6 +145,9 @@ Proxies the content with embedding-blocking headers removed. Injects:
 - Click interceptor script for navigation handling
 - History API patch for cross-origin compatibility
 - Font override styles (unless theme is "macosx")
+- Server-side URL rewriting for common HTML assets, `srcset`, iframe sources, form actions, stylesheet `url(...)`, and `@import`
+- Resource-aware browser headers so document, stylesheet, image, script, media, font, iframe, and XHR requests use coherent `Accept` and `Sec-Fetch-*` values
+- Per-session cookie replay when the client supplies a `session` value; third-party cookies are stored server-side and are not exposed as ryOS-origin cookies
 
 **Response:** The proxied HTML content with modified headers.
 
@@ -150,6 +157,9 @@ Proxies the content with embedding-blocking headers removed. Injects:
 |--------|-------------|
 | `X-Proxied-Page-Title` | URL-encoded page title (if available) |
 | `X-Wayback-Cache` | "HIT" if content was served from Wayback cache |
+| `X-Proxy-Diagnostics` | URL-encoded JSON metadata when `debug=1` |
+
+**POST form proxying:** `POST` is accepted only for proxy URLs generated from rewritten form actions (`form=1`) and only for normal browser form encodings (`application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`). The endpoint continues to validate every target and redirect with the shared SSRF guard.
 
 #### `ai` Mode
 
@@ -187,11 +197,17 @@ Lists all available cached years (both AI-generated and Wayback Machine) for a U
 
 ### Auto-Proxy Domains
 
-The following domains are automatically proxied regardless of mode:
-- `wikipedia.org` (and subdomains)
-- `wikimedia.org` (and subdomains)
-- `wikipedia.com`
-- `cursor.com`
+Domain compatibility rules are centralized in `src/shared/ieCompatibility.ts`.
+The catalog currently supports:
+- `auto-proxy` — sites known to use restrictive embedding headers or resource behavior.
+- `direct-passthrough` — sites that work better without rewriting.
+- `blocked` — reserved for future explicit deny rules.
+
+When proxying still fails, Internet Explorer should surface the upstream status or proxy error, offer a direct-open path, and keep Time Machine / AI reconstruction available as a fallback.
+
+### Compatibility Boundaries
+
+The browser proxy is intended for normal rendering compatibility: consistent browser-like headers, URL rewriting, isolated cookies, and clearer error handling. It does not solve CAPTCHAs, bypass paywalls or authentication, rotate IP addresses, or attempt to defeat a site's anti-abuse controls. Sites that intentionally reject proxy traffic may still fail and should fall back to direct open, cached historical views, or AI reconstruction.
 
 ### Rate Limits
 

--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerContentPane.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerContentPane.tsx
@@ -74,11 +74,27 @@ export function InternetExplorerContentPane({
     const primaryMessage =
       errorDetails.message || t("apps.internet-explorer.anErrorOccurred");
     const secondaryMessage = errorDetails.details;
-    const suggestions = [
+    const suggestions: (string | ReactNode)[] = [
       t("apps.internet-explorer.checkWebAddressAndTryAgain"),
       t("apps.internet-explorer.goBackToPreviousPage"),
       t("apps.internet-explorer.tryRefreshingThePage"),
     ];
+    const directOpenUrl = url.startsWith("http") ? url : `https://${url}`;
+    try {
+      const parsedDirectOpenUrl = new URL(directOpenUrl);
+      suggestions.push(
+        <a
+          href={parsedDirectOpenUrl.toString()}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-red-600 underline"
+        >
+          {parsedDirectOpenUrl.toString()}
+        </a>
+      );
+    } catch {
+      // Invalid user input is already covered by the primary error message.
+    }
     const footerText = errorDetails.hostname
       ? t("apps.internet-explorer.host", {
           hostname: errorDetails.hostname,

--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerContentPane.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerContentPane.tsx
@@ -146,7 +146,7 @@ export function InternetExplorerContentPane({
         ) : (
           <iframe
             ref={iframeRef}
-            src={finalUrl || ""}
+            src={finalUrl ?? undefined}
             className="border-0 block"
             style={{
               width: "calc(100% + 1px)",

--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerContentPane.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerContentPane.tsx
@@ -118,7 +118,12 @@ export function InternetExplorerContentPane({
 
   return (
     <>
-      <div className="flex-1 relative bg-white">
+      <div className="flex-1 relative bg-white" style={{ backgroundColor: "white" }}>
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-white"
+          style={{ backgroundColor: "white" }}
+        />
         {errorDetails ? (
           renderErrorPage()
         ) : isFutureYear ||
@@ -147,10 +152,11 @@ export function InternetExplorerContentPane({
           <iframe
             ref={iframeRef}
             src={finalUrl ?? undefined}
-            className="border-0 block"
+            className="border-0 block relative z-10"
             style={{
               width: "calc(100% + 1px)",
               height: "calc(100% + 1px)",
+              backgroundColor: "white",
             }}
             sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-pointer-lock"
             onLoad={handleIframeLoad}

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -57,6 +57,14 @@ const logDirectPassthrough = (url: string) => {
   log.debug("Direct passthrough mode", { url });
 };
 
+const createProxySessionId = (instanceId: string): string => {
+  const randomPart =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  return `ie_${instanceId}_${randomPart}`.replace(/[^a-zA-Z0-9_-]/g, "_");
+};
+
 interface UseInternetExplorerLogicProps {
   isWindowOpen: boolean;
   isForeground?: boolean;
@@ -79,6 +87,10 @@ export function useInternetExplorerLogic({
   const bringInstanceToForeground = useAppStore(
     (state) => state.bringInstanceToForeground
   );
+  const proxySessionIdRef = useRef<string | null>(null);
+  if (!proxySessionIdRef.current) {
+    proxySessionIdRef.current = createProxySessionId(instanceId);
+  }
   const clearInstanceInitialData = useAppStore(
     (state) => state.clearInstanceInitialData
   );
@@ -520,9 +532,12 @@ export function useInternetExplorerLogic({
       typeof currentTheme === "string"
         ? `&theme=${encodeURIComponent(currentTheme)}`
         : "";
+    const sessionParam = proxySessionIdRef.current
+      ? `&session=${encodeURIComponent(proxySessionIdRef.current)}`
+      : "";
     return `/api/iframe-check?url=${encodeURIComponent(
       formattedUrl
-    )}&year=${year}&month=${month}${themeParam}`;
+    )}&year=${year}&month=${month}${themeParam}${sessionParam}`;
   }, [currentTheme]);
 
   // Ref to keep the most recent navigation token in sync without waiting for a render
@@ -945,7 +960,11 @@ export function useInternetExplorerLogic({
               // Proxy current year sites through iframe-check
               urlToLoad = `/api/iframe-check?url=${encodeURIComponent(
                 normalizedTargetUrl
-              )}&theme=${encodeURIComponent(currentTheme)}`;
+              )}&theme=${encodeURIComponent(currentTheme)}${
+                proxySessionIdRef.current
+                  ? `&session=${encodeURIComponent(proxySessionIdRef.current)}`
+                  : ""
+              }`;
             }
 
             try {

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -545,6 +545,10 @@ export function useInternetExplorerLogic({
   const pendingNavigationRequestRef = useRef<string | null>(null);
 
   const handleIframeLoad = async () => {
+    if (useInternetExplorerStore.getState().status !== "loading") {
+      return;
+    }
+
     if (
       iframeRef.current &&
       iframeRef.current.dataset.navToken === navTokenRef.current.toString()
@@ -1697,7 +1701,7 @@ export function useInternetExplorerLogic({
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       const messageData = event.data as
-        | { type?: string; url?: string }
+        | { type?: string; url?: string; title?: string }
         | undefined;
       if (!messageData?.type) {
         return;
@@ -1739,6 +1743,48 @@ export function useInternetExplorerLogic({
         // truncated) by loadSuccess.
         useInternetExplorerStore.getState().setNavigatingHistory(false);
         latestNavigateRef.current(messageData.url, latestYearRef.current);
+      } else if (messageData.type === "iframeReady") {
+        const state = useInternetExplorerStore.getState();
+        if (state.status !== "loading") {
+          return;
+        }
+
+        const targetUrl = state.url;
+        const targetYear = state.year;
+        let loadedTitle =
+          typeof messageData.title === "string" && messageData.title
+            ? messageData.title
+            : state.prefetchedTitle;
+        if (loadedTitle) {
+          try {
+            loadedTitle = decodeHtmlEntities(
+              decodeURIComponent(loadedTitle)
+            ).trim();
+          } catch {
+            loadedTitle = decodeHtmlEntities(loadedTitle).trim();
+          }
+        }
+
+        const fallbackTitle = formatTitle(getHostnameFromUrl(targetUrl));
+        const favicon = `https://www.google.com/s2/favicons?domain=${getHostnameFromUrl(
+          targetUrl
+        )}&sz=32`;
+
+        track(IE_ANALYTICS.NAVIGATION_SUCCESS, {
+          ...normalizeUrlForAnalytics(targetUrl),
+          year: targetYear,
+          mode: state.mode,
+          hasTitle: Boolean(loadedTitle || fallbackTitle),
+          source: "iframeReady",
+        });
+
+        state.loadSuccess({
+          title: loadedTitle || fallbackTitle,
+          targetUrl,
+          targetYear,
+          favicon,
+          addToHistory: !state.isNavigatingHistory,
+        });
       } else if (messageData.type === "goBack") {
         log.debug("Received back button request from iframe");
         latestGoBackRef.current();

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -542,6 +542,7 @@ export function useInternetExplorerLogic({
 
   // Ref to keep the most recent navigation token in sync without waiting for a render
   const navTokenRef = useRef<number>(0);
+  const pendingNavigationRequestRef = useRef<string | null>(null);
 
   const handleIframeLoad = async () => {
     if (
@@ -752,6 +753,36 @@ export function useInternetExplorerLogic({
 
       clearErrorDetails();
 
+      const newMode =
+        targetYearParam === "current"
+          ? "now"
+          : parseInt(targetYearParam) > new Date().getFullYear()
+          ? "future"
+          : "past";
+
+      // --- Trim the URL from input before navigating ---
+      // Use targetUrlParam directly as it's passed in, or trim the current store url if not passed
+      const urlToNavigate = (
+        targetUrlParam === url ? url.trim() : targetUrlParam
+      ).trim();
+      // --- End Trim ---
+
+      const navigationRequestKey = JSON.stringify([
+        urlToNavigate,
+        targetYearParam,
+        newMode,
+        forceRegenerate,
+      ]);
+      if (pendingNavigationRequestRef.current === navigationRequestKey) {
+        log.debug("Ignoring duplicate in-flight navigation", {
+          url: urlToNavigate,
+          year: targetYearParam,
+          mode: newMode,
+        });
+        return;
+      }
+      pendingNavigationRequestRef.current = navigationRequestKey;
+
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
       }
@@ -765,19 +796,7 @@ export function useInternetExplorerLogic({
         iframeRef.current.src = "about:blank";
       }
 
-      const newMode =
-        targetYearParam === "current"
-          ? "now"
-          : parseInt(targetYearParam) > new Date().getFullYear()
-          ? "future"
-          : "past";
       const newToken = Date.now();
-
-      // --- Trim the URL from input before navigating ---
-      // Use targetUrlParam directly as it's passed in, or trim the current store url if not passed
-      const urlToNavigate = (
-        targetUrlParam === url ? url.trim() : targetUrlParam
-      ).trim();
       // Update store immediately so the input reflects the trimmed URL during loading
       setUrl(urlToNavigate);
       // --- End Trim ---
@@ -996,12 +1015,11 @@ export function useInternetExplorerLogic({
             }_t=${Date.now()}`;
           }
 
-          setFinalUrl(urlToLoad);
-
           if (iframeRef.current) {
             iframeRef.current.dataset.navToken = newToken.toString();
-            iframeRef.current.src = urlToLoad;
           }
+
+          setFinalUrl(urlToLoad);
         }
       } catch (error) {
         if (!abortController.signal.aborted) {
@@ -1017,6 +1035,10 @@ export function useInternetExplorerLogic({
             },
             normalizedTargetUrl
           );
+        }
+      } finally {
+        if (pendingNavigationRequestRef.current === navigationRequestKey) {
+          pendingNavigationRequestRef.current = null;
         }
       }
     },

--- a/src/shared/ieCompatibility.ts
+++ b/src/shared/ieCompatibility.ts
@@ -1,0 +1,87 @@
+export type IeDomainCompatibilityMode =
+  | "auto-proxy"
+  | "direct-passthrough"
+  | "blocked";
+
+export interface IeDomainCompatibilityRule {
+  domain: string;
+  mode: IeDomainCompatibilityMode;
+  notes: string;
+}
+
+export const IE_DOMAIN_COMPATIBILITY_RULES: IeDomainCompatibilityRule[] = [
+  { domain: "wikipedia.org", mode: "auto-proxy", notes: "Embeds and subresources are more reliable through the proxy." },
+  { domain: "wikimedia.org", mode: "auto-proxy", notes: "Static assets need proxy-aware URL handling." },
+  { domain: "wikipedia.com", mode: "auto-proxy", notes: "Redirects to Wikipedia projects." },
+  { domain: "cursor.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "github.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "stackoverflow.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "stackexchange.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "reddit.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "twitter.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "x.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "medium.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "nytimes.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "bbc.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "bbc.co.uk", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "theguardian.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "cnn.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "washingtonpost.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "linkedin.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "instagram.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "facebook.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "amazon.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "youtube.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "twitch.tv", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "netflix.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "docs.google.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "drive.google.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "mail.google.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "os.ryo.lu", mode: "direct-passthrough", notes: "First-party app shell is safest as a direct iframe." },
+  { domain: "hcsimulator.com", mode: "direct-passthrough", notes: "Works better without HTML rewriting." },
+  { domain: "os.rocorgi.wang", mode: "direct-passthrough", notes: "Works better without HTML rewriting." },
+  { domain: "iso-city.com", mode: "direct-passthrough", notes: "Works better without HTML rewriting." },
+  { domain: "shaoruu.io", mode: "direct-passthrough", notes: "Works better without HTML rewriting." },
+];
+
+export const AUTO_PROXY_DOMAINS = IE_DOMAIN_COMPATIBILITY_RULES
+  .filter((rule) => rule.mode === "auto-proxy")
+  .map((rule) => rule.domain);
+
+export const DIRECT_PASSTHROUGH_DOMAINS = IE_DOMAIN_COMPATIBILITY_RULES
+  .filter((rule) => rule.mode === "direct-passthrough")
+  .map((rule) => rule.domain);
+
+export function hostnameMatchesDomain(hostname: string, domain: string): boolean {
+  const normalizedHostname = hostname.toLowerCase();
+  const normalizedDomain = domain.toLowerCase();
+  return (
+    normalizedHostname === normalizedDomain ||
+    normalizedHostname.endsWith(`.${normalizedDomain}`)
+  );
+}
+
+export function getIeDomainCompatibility(
+  url: string
+): IeDomainCompatibilityRule | null {
+  try {
+    const hostname = new URL(url.startsWith("http") ? url : `https://${url}`)
+      .hostname
+      .toLowerCase();
+    return (
+      IE_DOMAIN_COMPATIBILITY_RULES.find((rule) =>
+        hostnameMatchesDomain(hostname, rule.domain)
+      ) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function shouldAutoProxyUrl(url: string): boolean {
+  return getIeDomainCompatibility(url)?.mode === "auto-proxy";
+}
+
+export function shouldDirectPassthroughUrl(url: string): boolean {
+  return getIeDomainCompatibility(url)?.mode === "direct-passthrough";
+}

--- a/src/shared/ieCompatibility.ts
+++ b/src/shared/ieCompatibility.ts
@@ -7,6 +7,7 @@ export interface IeDomainCompatibilityRule {
   domain: string;
   mode: IeDomainCompatibilityMode;
   notes: string;
+  inertScripts?: boolean;
 }
 
 export const IE_DOMAIN_COMPATIBILITY_RULES: IeDomainCompatibilityRule[] = [
@@ -21,7 +22,7 @@ export const IE_DOMAIN_COMPATIBILITY_RULES: IeDomainCompatibilityRule[] = [
   { domain: "twitter.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
   { domain: "x.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
   { domain: "medium.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
-  { domain: "nytimes.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
+  { domain: "nytimes.com", mode: "auto-proxy", inertScripts: true, notes: "Modern live scripts can freeze the sandboxed IE iframe." },
   { domain: "bbc.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
   { domain: "bbc.co.uk", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
   { domain: "theguardian.com", mode: "auto-proxy", notes: "Uses restrictive embedding headers." },
@@ -84,4 +85,8 @@ export function shouldAutoProxyUrl(url: string): boolean {
 
 export function shouldDirectPassthroughUrl(url: string): boolean {
   return getIeDomainCompatibility(url)?.mode === "direct-passthrough";
+}
+
+export function shouldUseInertProxyScripts(url: string): boolean {
+  return getIeDomainCompatibility(url)?.inertScripts === true;
 }

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -192,6 +192,8 @@ export const redisKeys = {
     geoip: (ipHash: string) => redisKey("cache", "geoip", ipHash),
     ieVersions: (urlHash: string, year: string | number) =>
       redisKey("cache", "ie", urlHash, year, "versions"),
+    ieProxyCookies: (sessionHash: string) =>
+      redisKey("cache", "ie", "proxy-cookies", sessionHash),
     wayback: (urlHash: string, year: string | number) =>
       redisKey("cache", "wayback", urlHash, year),
   },

--- a/src/stores/useInternetExplorerStore.ts
+++ b/src/stores/useInternetExplorerStore.ts
@@ -2,6 +2,12 @@ import { create } from "zustand";
 import { useStoreShallow } from "./helpers";
 import { persist } from "zustand/middleware";
 import { abortableFetch } from "@/utils/abortableFetch";
+import {
+  DIRECT_PASSTHROUGH_DOMAINS,
+  shouldDirectPassthroughUrl,
+} from "@/shared/ieCompatibility";
+
+export { DIRECT_PASSTHROUGH_DOMAINS };
 
 // Define types
 export interface Favorite {
@@ -12,15 +18,6 @@ export interface Favorite {
   children?: Favorite[]; // Add children for nested folders
   isDirectory?: boolean; // New: Flag to indicate if it's a folder
 }
-
-// Define a constant for domains that bypass the proxy when in "now" mode
-export const DIRECT_PASSTHROUGH_DOMAINS = [
-  "os.ryo.lu",
-  "hcsimulator.com",
-  "os.rocorgi.wang",
-  "iso-city.com",
-  "shaoruu.io",
-];
 
 export interface HistoryEntry {
   url: string;
@@ -887,15 +884,7 @@ export const useInternetExplorerStore = create<InternetExplorerStore>()(
 
 // Utility function to check if a URL should bypass the proxy
 export const isDirectPassthrough = (url: string): boolean => {
-  try {
-    const hostname = new URL(url.startsWith("http") ? url : `https://${url}`)
-      .hostname;
-    return DIRECT_PASSTHROUGH_DOMAINS.some(
-      (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
-    );
-  } catch {
-    return false;
-  }
+  return shouldDirectPassthroughUrl(url);
 };
 
 /**

--- a/tests/test-ie-iframe-navigation.test.ts
+++ b/tests/test-ie-iframe-navigation.test.ts
@@ -25,8 +25,16 @@ describe("internet explorer iframe navigation", () => {
     expect(hookSource).not.toMatch(/iframeRef\.current\.src\s*=\s*urlToLoad/);
     expect(hookSource).toContain("pendingNavigationRequestRef");
     expect(hookSource).toContain("Ignoring duplicate in-flight navigation");
+    expect(hookSource).toContain('messageData.type === "iframeReady"');
+    expect(hookSource).toContain('source: "iframeReady"');
     expect(hookSource).toMatch(
       /iframeRef\.current\.dataset\.navToken = newToken\.toString\(\);\s*\}\s*setFinalUrl\(urlToLoad\);/
     );
+  });
+
+  test("proxied documents can clear loading before every subresource finishes", () => {
+    expect(hookSource).toContain("state.status !== \"loading\"");
+    expect(hookSource).toContain("state.loadSuccess({");
+    expect(contentPaneSource).toContain("onLoad={handleIframeLoad}");
   });
 });

--- a/tests/test-ie-iframe-navigation.test.ts
+++ b/tests/test-ie-iframe-navigation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const hookSource = readFileSync(
+  join(
+    import.meta.dir,
+    "../src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts"
+  ),
+  "utf8"
+);
+
+const contentPaneSource = readFileSync(
+  join(
+    import.meta.dir,
+    "../src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerContentPane.tsx"
+  ),
+  "utf8"
+);
+
+describe("internet explorer iframe navigation", () => {
+  test("React owns the iframe URL to avoid duplicate top-level proxy loads", () => {
+    expect(contentPaneSource).toContain("src={finalUrl ?? undefined}");
+    expect(contentPaneSource).not.toContain("src={finalUrl || \"\"}");
+    expect(hookSource).not.toMatch(/iframeRef\.current\.src\s*=\s*urlToLoad/);
+    expect(hookSource).toContain("pendingNavigationRequestRef");
+    expect(hookSource).toContain("Ignoring duplicate in-flight navigation");
+    expect(hookSource).toMatch(
+      /iframeRef\.current\.dataset\.navToken = newToken\.toString\(\);\s*\}\s*setFinalUrl\(urlToLoad\);/
+    );
+  });
+});

--- a/tests/test-ie-iframe-navigation.test.ts
+++ b/tests/test-ie-iframe-navigation.test.ts
@@ -21,6 +21,9 @@ const contentPaneSource = readFileSync(
 describe("internet explorer iframe navigation", () => {
   test("React owns the iframe URL to avoid duplicate top-level proxy loads", () => {
     expect(contentPaneSource).toContain("src={finalUrl ?? undefined}");
+    expect(contentPaneSource).toContain('style={{ backgroundColor: "white" }}');
+    expect(contentPaneSource).toContain('className="absolute inset-0 bg-white"');
+    expect(contentPaneSource).toContain('className="border-0 block relative z-10"');
     expect(contentPaneSource).not.toContain("src={finalUrl || \"\"}");
     expect(hookSource).not.toMatch(/iframeRef\.current\.src\s*=\s*urlToLoad/);
     expect(hookSource).toContain("pendingNavigationRequestRef");

--- a/tests/test-iframe-check.test.ts
+++ b/tests/test-iframe-check.test.ts
@@ -138,6 +138,22 @@ describe("iframe-check", () => {
       expect(diagnostics.cookieSession).toBe(true);
     });
 
+    test("Proxy mode - rewrites assets to the request origin", async () => {
+      const res = await fetchWithOrigin(
+        `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(
+          "https://example.com/fixture/page"
+        )}&mode=proxy&fixture=html-assets&debug=1`,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      const stylesheetHref = html.match(
+        /<link\b[^>]*href="([^"]*resource=style[^"]*)"[^>]*>/i
+      )?.[1];
+      expect(stylesheetHref).toBeTruthy();
+      expect(new URL(stylesheetHref ?? "").origin).toBe("http://localhost:3000");
+    });
+
     test("Proxy mode - disables scripts only for flagged compatibility domains", async () => {
       const res = await fetchWithOrigin(
         `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(

--- a/tests/test-iframe-check.test.ts
+++ b/tests/test-iframe-check.test.ts
@@ -125,6 +125,10 @@ describe("iframe-check", () => {
       expect(html).not.toContain('type="text/plain" data-ryos-blocked-script="true"');
       expect(html).toContain("type: 'iframeReady'");
       expect(html).toContain("postReady('timeout')");
+      expect(html).toContain("function applyProxyBaseStyles()");
+      expect(html).toContain("style.setProperty('background', '#fff', 'important')");
+      expect(html).toContain('data-ryos-proxy-base="true"');
+      expect(html).toContain("html,body{background:#fff!important;}");
       expect(html).toContain("resource=image");
       expect(html).toContain("resource=iframe");
       expect(html).toContain("form=1");

--- a/tests/test-iframe-check.test.ts
+++ b/tests/test-iframe-check.test.ts
@@ -122,6 +122,8 @@ describe("iframe-check", () => {
       expect(html).toContain("/api/iframe-check");
       expect(html).toContain("resource=style");
       expect(html).toContain("resource=script");
+      expect(html).toContain('type="text/plain"');
+      expect(html).toContain('data-ryos-blocked-script="true"');
       expect(html).toContain("resource=image");
       expect(html).toContain("resource=iframe");
       expect(html).toContain("form=1");

--- a/tests/test-iframe-check.test.ts
+++ b/tests/test-iframe-check.test.ts
@@ -124,6 +124,8 @@ describe("iframe-check", () => {
       expect(html).toContain("resource=script");
       expect(html).toContain('type="text/plain"');
       expect(html).toContain('data-ryos-blocked-script="true"');
+      expect(html).toContain("type: 'iframeReady'");
+      expect(html).toContain("postReady('timeout')");
       expect(html).toContain("resource=image");
       expect(html).toContain("resource=iframe");
       expect(html).toContain("form=1");

--- a/tests/test-iframe-check.test.ts
+++ b/tests/test-iframe-check.test.ts
@@ -122,8 +122,7 @@ describe("iframe-check", () => {
       expect(html).toContain("/api/iframe-check");
       expect(html).toContain("resource=style");
       expect(html).toContain("resource=script");
-      expect(html).toContain('type="text/plain"');
-      expect(html).toContain('data-ryos-blocked-script="true"');
+      expect(html).not.toContain('type="text/plain" data-ryos-blocked-script="true"');
       expect(html).toContain("type: 'iframeReady'");
       expect(html).toContain("postReady('timeout')");
       expect(html).toContain("resource=image");
@@ -137,6 +136,20 @@ describe("iframe-check", () => {
       expect(diagnostics.rewrites.htmlAttributes).toBeGreaterThan(0);
       expect(diagnostics.rewrites.cssUrls).toBeGreaterThan(0);
       expect(diagnostics.cookieSession).toBe(true);
+    });
+
+    test("Proxy mode - disables scripts only for flagged compatibility domains", async () => {
+      const res = await fetchWithOrigin(
+        `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(
+          "https://www.nytimes.com/fixture/page"
+        )}&mode=proxy&fixture=html-assets&debug=1&session=test_nytimes_assets`,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('type="text/plain"');
+      expect(html).toContain('data-ryos-blocked-script="true"');
+      expect(html).toContain("resource=script");
     });
 
     test("Proxy mode - rewrites stylesheet urls", async () => {

--- a/tests/test-iframe-check.test.ts
+++ b/tests/test-iframe-check.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, test, expect } from "bun:test";
-import { BASE_URL, fetchWithOrigin } from "./test-utils";
+import {
+  BASE_URL,
+  fetchWithOrigin,
+  makeRateLimitBypassHeaders,
+} from "./test-utils";
 
 describe("iframe-check", () => {
   describe("Input Validation", () => {
@@ -104,6 +108,125 @@ describe("iframe-check", () => {
       const contentType = res.headers.get("content-type") || "";
       // Default mode is proxy, which streams the rewritten HTML document.
       expect(contentType).toContain("text/html");
+    });
+
+    test("Proxy mode - rewrites HTML assets, forms, and diagnostics", async () => {
+      const res = await fetchWithOrigin(
+        `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(
+          "https://example.com/fixture/page"
+        )}&mode=proxy&fixture=html-assets&debug=1&session=test_html_assets`,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("/api/iframe-check");
+      expect(html).toContain("resource=style");
+      expect(html).toContain("resource=script");
+      expect(html).toContain("resource=image");
+      expect(html).toContain("resource=iframe");
+      expect(html).toContain("form=1");
+      expect(html).not.toContain("integrity=");
+      expect(html).not.toContain("nonce=");
+      const diagnostics = JSON.parse(
+        decodeURIComponent(res.headers.get("X-Proxy-Diagnostics") || "{}")
+      );
+      expect(diagnostics.rewrites.htmlAttributes).toBeGreaterThan(0);
+      expect(diagnostics.rewrites.cssUrls).toBeGreaterThan(0);
+      expect(diagnostics.cookieSession).toBe(true);
+    });
+
+    test("Proxy mode - rewrites stylesheet urls", async () => {
+      const res = await fetchWithOrigin(
+        `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(
+          "https://example.com/assets/site.css"
+        )}&mode=proxy&fixture=stylesheet&resource=style&debug=1`,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(res.status).toBe(200);
+      const css = await res.text();
+      expect(css).toContain("/api/iframe-check");
+      expect(css).toContain("resource=image");
+      expect(css).toContain("resource=style");
+      const diagnostics = JSON.parse(
+        decodeURIComponent(res.headers.get("X-Proxy-Diagnostics") || "{}")
+      );
+      expect(diagnostics.resourceType).toBe("style");
+      expect(diagnostics.rewrites.cssUrls).toBe(2);
+    });
+
+    test("Proxy mode - uses resource-aware request headers", async () => {
+      const res = await fetchWithOrigin(
+        `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(
+          "https://example.com/assets/logo.png"
+        )}&mode=proxy&fixture=headers&resource=image&debug=1`,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.accept).toContain("image/");
+      expect(data.secFetchDest).toBe("image");
+      const diagnostics = JSON.parse(
+        decodeURIComponent(res.headers.get("X-Proxy-Diagnostics") || "{}")
+      );
+      expect(diagnostics.resourceType).toBe("image");
+    });
+
+    test("Proxy mode - stores cookies per proxy session", async () => {
+      const session = `test_cookie_${Date.now()}`;
+      const first = await fetchWithOrigin(
+        `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(
+          "https://example.com/cookie"
+        )}&mode=proxy&fixture=set-cookie&session=${session}`,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(first.status).toBe(200);
+
+      const second = await fetchWithOrigin(
+        `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(
+          "https://example.com/headers"
+        )}&mode=proxy&fixture=headers&resource=xhr&session=${session}`,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(second.status).toBe(200);
+      const data = await second.json();
+      expect(data.cookie).toContain("proxy_fixture=stored");
+    });
+
+    test("Proxy mode - supports constrained form POST proxying", async () => {
+      const res = await fetchWithOrigin(
+        `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(
+          "https://example.com/submit"
+        )}&mode=proxy&fixture=post-echo&form=1`,
+        {
+          method: "POST",
+          headers: {
+            ...makeRateLimitBypassHeaders(),
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: new URLSearchParams({ q: "ryos" }).toString(),
+        }
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.method).toBe("POST");
+      expect(data.contentType).toContain("application/x-www-form-urlencoded");
+    });
+
+    test("Proxy mode - rejects arbitrary POST tunneling", async () => {
+      const res = await fetchWithOrigin(
+        `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(
+          "https://example.com/submit"
+        )}&mode=proxy&fixture=post-echo`,
+        {
+          method: "POST",
+          headers: {
+            ...makeRateLimitBypassHeaders(),
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: new URLSearchParams({ q: "ryos" }).toString(),
+        }
+      );
+      expect(res.status).toBe(400);
     });
   });
 

--- a/tests/test-iframe-check.test.ts
+++ b/tests/test-iframe-check.test.ts
@@ -168,6 +168,40 @@ describe("iframe-check", () => {
       expect(html).toContain("resource=script");
     });
 
+    test("Proxy mode - promotes noscript image fallbacks only when scripts are inert", async () => {
+      const inertRes = await fetchWithOrigin(
+        `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(
+          "https://www.nytimes.com/fixture/page"
+        )}&mode=proxy&fixture=noscript-images&debug=1&session=test_nytimes_noscript`,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(inertRes.status).toBe(200);
+      const inertHtml = await inertRes.text();
+      const inertVisibleHtml = inertHtml.replace(
+        /<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi,
+        ""
+      );
+      expect(inertHtml).toContain('data-ryos-blocked-script="true"');
+      expect(inertVisibleHtml).toContain("fallback.jpg");
+      expect(inertVisibleHtml).toContain("resource=image");
+      expect(inertHtml).toContain("<noscript><p>No image fallback</p></noscript>");
+
+      const passthroughRes = await fetchWithOrigin(
+        `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(
+          "https://example.com/fixture/page"
+        )}&mode=proxy&fixture=noscript-images&debug=1`,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(passthroughRes.status).toBe(200);
+      const passthroughHtml = await passthroughRes.text();
+      const passthroughVisibleHtml = passthroughHtml.replace(
+        /<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi,
+        ""
+      );
+      expect(passthroughHtml).toContain("<noscript><picture>");
+      expect(passthroughVisibleHtml).not.toContain("fallback.jpg");
+    });
+
     test("Proxy mode - rewrites stylesheet urls", async () => {
       const res = await fetchWithOrigin(
         `${BASE_URL}/api/iframe-check?url=${encodeURIComponent(

--- a/tests/test-iframe-proxy-helpers.test.ts
+++ b/tests/test-iframe-proxy-helpers.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildBrowserHeaders,
+  getCookieHeaderForUrl,
+  mergeProxyCookies,
+  rewriteCssForProxy,
+  rewriteHtmlForProxy,
+} from "../api/_utils/iframe-proxy-helpers";
+
+describe("iframe proxy helpers", () => {
+  test("buildBrowserHeaders uses coherent resource-specific headers", () => {
+    const documentHeaders = buildBrowserHeaders({
+      targetUrl: "https://example.com/page",
+      resourceType: "document",
+      method: "GET",
+    });
+    const imageHeaders = buildBrowserHeaders({
+      targetUrl: "https://example.com/image.png",
+      resourceType: "image",
+      referrerUrl: "https://example.com/page",
+      method: "GET",
+    });
+
+    expect(documentHeaders["Sec-Fetch-Dest"]).toBe("document");
+    expect(documentHeaders.Accept).toContain("text/html");
+    expect(imageHeaders["Sec-Fetch-Dest"]).toBe("image");
+    expect(imageHeaders.Accept).toContain("image/");
+    expect(imageHeaders["User-Agent"]).toBe(documentHeaders["User-Agent"]);
+  });
+
+  test("rewriteHtmlForProxy proxies assets and avoids unsafe schemes", () => {
+    const result = rewriteHtmlForProxy(
+      `<html><head><link rel="stylesheet" href="/app.css"><script src="/app.js" integrity="sha256-x"></script></head><body><a href="javascript:alert(1)">x</a><img src="/logo.png" srcset="/logo@2x.png 2x"><form method="post" action="/submit"></form><style>.x{background:url('/x.png')}</style></body></html>`,
+      {
+        baseUrl: "https://example.com/page",
+        proxyOrigin: "https://os.example",
+        referrerUrl: "https://example.com/page",
+        sessionId: "session_1",
+      }
+    );
+
+    expect(result.html).toContain("https://os.example/api/iframe-check");
+    expect(result.html).toContain("resource=style");
+    expect(result.html).toContain("resource=script");
+    expect(result.html).toContain("resource=image");
+    expect(result.html).toContain("form=1");
+    expect(result.html).toContain("javascript:alert(1)");
+    expect(result.html).not.toContain("integrity=");
+    expect(result.stats.htmlAttributes).toBeGreaterThanOrEqual(4);
+    expect(result.stats.cssUrls).toBe(1);
+  });
+
+  test("rewriteCssForProxy proxies imports and url references", () => {
+    const result = rewriteCssForProxy(
+      `@import "/theme.css"; .hero{background:url(./hero.png)} .inline{background:url(data:image/png;base64,abc)}`,
+      {
+        baseUrl: "https://example.com/assets/app.css",
+        proxyOrigin: "https://os.example",
+        referrerUrl: "https://example.com/page",
+      }
+    );
+
+    expect(result.css).toContain("resource=style");
+    expect(result.css).toContain("resource=image");
+    expect(result.css).toContain("data:image/png");
+    expect(result.count).toBe(2);
+  });
+
+  test("mergeProxyCookies scopes cookies by host, domain, path, and secure flag", () => {
+    const cookies = mergeProxyCookies(
+      [],
+      [
+        "host_only=1; Path=/account; Max-Age=600",
+        "domain_cookie=1; Domain=.example.com; Path=/; Max-Age=600",
+        "secure_cookie=1; Path=/; Secure; Max-Age=600",
+      ],
+      "https://example.com/account/login",
+      1_000
+    );
+
+    expect(getCookieHeaderForUrl(cookies, "https://example.com/account", 2_000))
+      .toContain("host_only=1");
+    expect(getCookieHeaderForUrl(cookies, "https://cdn.example.com/", 2_000))
+      .toContain("domain_cookie=1");
+    expect(getCookieHeaderForUrl(cookies, "https://cdn.example.com/", 2_000))
+      .not.toContain("host_only=1");
+    expect(getCookieHeaderForUrl(cookies, "http://example.com/", 2_000))
+      .not.toContain("secure_cookie=1");
+  });
+});

--- a/tests/test-iframe-proxy-helpers.test.ts
+++ b/tests/test-iframe-proxy-helpers.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
+  buildBingRssSearchUrl,
   buildBrowserHeaders,
   getCookieHeaderForUrl,
+  htmlContainsBingChallenge,
   mergeProxyCookies,
+  renderBingRssSearchFallbackHtml,
   rewriteCssForProxy,
   rewriteHtmlForProxy,
 } from "../api/_utils/iframe-proxy-helpers";
@@ -85,6 +88,33 @@ describe("iframe proxy helpers", () => {
     expect(result.css).toContain("resource=image");
     expect(result.css).toContain("data:image/png");
     expect(result.count).toBe(2);
+  });
+
+  test("renders a Bing RSS fallback for challenged search HTML", () => {
+    const searchUrl = "https://www.bing.com/search?q=ryos";
+    const rssUrl = buildBingRssSearchUrl(searchUrl);
+    const challengeHtml =
+      '<script>var CfConfig = { verifyEndpoint: "https://www.bing.com/challenge/verify" };</script>';
+    const rssXml = `<?xml version="1.0" encoding="utf-8" ?>
+<rss><channel><title>Bing: ryos</title>
+<item><title>ryOS</title><link>https://ryo.lu/</link><description>A web desktop.</description></item>
+<item><title><![CDATA[Ryo Lu]]></title><link>https://example.com/?a=1&amp;b=2</link><description><![CDATA[Creator <b>profile</b>.]]></description></item>
+</channel></rss>`;
+
+    expect(rssUrl).toBe("https://www.bing.com/search?q=ryos&format=rss");
+    expect(htmlContainsBingChallenge(challengeHtml)).toBe(true);
+
+    const fallbackHtml = renderBingRssSearchFallbackHtml({
+      originalSearchUrl: searchUrl,
+      rssUrl: rssUrl ?? "",
+      rssXml,
+    });
+
+    expect(fallbackHtml).toContain('Bing results for "ryos"');
+    expect(fallbackHtml).toContain("Bing returned a browser challenge");
+    expect(fallbackHtml).toContain("https://ryo.lu/");
+    expect(fallbackHtml).toContain("https://example.com/?a=1&amp;b=2");
+    expect(fallbackHtml).not.toContain("<b>profile</b>");
   });
 
   test("mergeProxyCookies scopes cookies by host, domain, path, and secure flag", () => {

--- a/tests/test-iframe-proxy-helpers.test.ts
+++ b/tests/test-iframe-proxy-helpers.test.ts
@@ -50,6 +50,27 @@ describe("iframe proxy helpers", () => {
     expect(result.stats.cssUrls).toBe(1);
   });
 
+  test("rewriteHtmlForProxy decodes HTML entities in ResourceLoader links", () => {
+    const result = rewriteHtmlForProxy(
+      `<html><head><link rel="stylesheet" href="/w/load.php?lang=en&amp;modules=site.styles&amp;only=styles&amp;skin=vector-2022"></head></html>`,
+      {
+        baseUrl: "https://en.wikipedia.org/wiki/Internet_Explorer",
+        proxyOrigin: "https://os.example",
+        referrerUrl: "https://en.wikipedia.org/wiki/Internet_Explorer",
+      }
+    );
+
+    const href = result.html.match(/href="([^"]+)"/)?.[1];
+    expect(href).toBeTruthy();
+    const proxyUrl = new URL(href ?? "");
+    const upstreamUrl = proxyUrl.searchParams.get("url");
+    expect(upstreamUrl).toBeTruthy();
+    const resourceLoaderUrl = new URL(upstreamUrl ?? "");
+    expect(resourceLoaderUrl.searchParams.get("modules")).toBe("site.styles");
+    expect(resourceLoaderUrl.searchParams.get("only")).toBe("styles");
+    expect(resourceLoaderUrl.searchParams.has("amp;modules")).toBe(false);
+  });
+
   test("rewriteCssForProxy proxies imports and url references", () => {
     const result = rewriteCssForProxy(
       `@import "/theme.css"; .hero{background:url(./hero.png)} .inline{background:url(data:image/png;base64,abc)}`,

--- a/tests/test-iframe-proxy-helpers.test.ts
+++ b/tests/test-iframe-proxy-helpers.test.ts
@@ -82,6 +82,8 @@ describe("iframe proxy helpers", () => {
       .toContain("host_only=1");
     expect(getCookieHeaderForUrl(cookies, "https://cdn.example.com/", 2_000))
       .toContain("domain_cookie=1");
+    expect(getCookieHeaderForUrl(cookies, "https://example.com/other/page", 2_000))
+      .toContain("domain_cookie=1");
     expect(getCookieHeaderForUrl(cookies, "https://cdn.example.com/", 2_000))
       .not.toContain("host_only=1");
     expect(getCookieHeaderForUrl(cookies, "http://example.com/", 2_000))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Improve Internet Explorer proxy compatibility with resource-aware rewriting, per-session cookies, and safer proxied navigation.
- Fix NYTimes proxy regressions by limiting inert scripts to flagged domains and promoting noscript image fallbacks.
- Fix Wikipedia ResourceLoader CSS/JS layout by decoding HTML entity-encoded attribute URLs before proxying and keeping proxied iframe backgrounds opaque.
- Handle Bing search challenge pages by rendering Bing RSS results as a usable fallback instead of showing the browser challenge.

## Verification
- `bun test tests/test-iframe-proxy-helpers.test.ts`
- `bun test tests/test-iframe-proxy-helpers.test.ts tests/test-ie-iframe-navigation.test.ts`
- `bun test tests/test-iframe-check.test.ts`
- `bun run test:iframe-check`
- `bun run build`
- Live Wikipedia ResourceLoader probe confirmed `modules` and `only=styles` survive proxy rewriting and CSS returns `text/css`.
- Live Bing proxy probe confirmed `bingRssFallback: true` and no challenge signatures in the rendered response.
- Manual IE walkthrough confirms Wikipedia renders with normal Vector styling, no wallpaper bleed-through, no unresponsive dialog, and responsive IE menus.
- Manual IE walkthrough confirms Bing search shows RSS fallback results instead of a challenge and responsive IE menus.

<a href="https://cursor.com/agents/bc-019f0dc4-443e-7f74-b0d0-8f1a546252cd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwikipedia_ie_styled_no_bleed.mp4"><img src="https://cursor.com/artifacts/c/art-142217d5-2b92-46ca-8e87-612c86fe57f7" alt="wikipedia_ie_styled_no_bleed.mp4" /></a>
<a href="https://cursor.com/agents/bc-019f0dc4-443e-7f74-b0d0-8f1a546252cd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbing_ie_challenge_fallback.mp4"><img src="https://cursor.com/artifacts/c/art-448efe38-47cc-4fa0-a81f-84294bc82c4f" alt="bing_ie_challenge_fallback.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0dc4-443e-7f74-b0d0-8f1a546252cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0dc4-443e-7f74-b0d0-8f1a546252cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

