### PR TITLE
Avoid Cloud Sync full scan on warm startup

### DIFF
--- a/src/hooks/useAutoCloudSync.ts
+++ b/src/hooks/useAutoCloudSync.ts
@@ -26,6 +26,7 @@ import {
   clearManualRestoreIntent,
   getManualRestoreIntent,
 } from "@/sync/manualRestoreIntent";
+import { markSyncLocalReconcileRequired } from "@/sync/state";
 
 // Realtime delivers changes; polling is only a safety net for missed events.
 const POLL_INTERVAL_CONNECTED_MS = 30 * 60 * 1000;
@@ -50,6 +51,7 @@ export function useAutoCloudSync() {
 
   const lastVisibilityCheckRef = useRef(0);
   const lastExplicitCheckRef = useRef(0);
+  const activeSyncUsernameRef = useRef<string | null>(null);
   const pendingRestoreIntent = username
     ? getManualRestoreIntent(username)
     : null;
@@ -131,6 +133,14 @@ export function useAutoCloudSync() {
 
   useEffect(() => {
     if (!isSyncActive || !username) {
+      const activeUsername = activeSyncUsernameRef.current;
+      if (activeUsername) {
+        markSyncLocalReconcileRequired(activeUsername);
+        activeSyncUsernameRef.current = null;
+        cloudSyncLog.debug("Auto Sync inactive; marked local reconcile", {
+          username: activeUsername,
+        });
+      }
       cloudSyncLog.debug("Auto Sync inactive; destroying engine", {
         hasUsername: Boolean(username),
         isSyncActive,
@@ -140,6 +150,7 @@ export function useAutoCloudSync() {
     }
 
     cloudSyncLog.debug("Starting Cloud Sync engine", { username });
+    activeSyncUsernameRef.current = username;
     const engine = createCloudSyncEngine(username, {
       onError: (error) => useCloudSyncStore.getState().setLastError(error),
     });

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -142,10 +142,15 @@ export class CloudSyncEngine {
   async start(): Promise<void> {
     if (this.started) return;
     this.started = true;
+    const hadCursor = this.state.cursor !== null;
+    const hadPersistedDirty = this.state.dirtyNamespaces.length > 0;
+    const needsLocalReconcile = this.state.localReconcileRequired;
     cloudSyncLog.debug("Engine start requested", {
-      hasCursor: this.state.cursor !== null,
+      hasCursor: hadCursor,
       cursor: this.state.cursor,
       namespaceCount: SYNC_NAMESPACES.length,
+      dirtyNamespaceCount: this.state.dirtyNamespaces.length,
+      needsLocalReconcile,
     });
 
     for (const namespace of SYNC_NAMESPACES) {
@@ -173,15 +178,53 @@ export class CloudSyncEngine {
 
     if (!initialSyncSucceeded || this.stopped) return;
 
-    // Upload anything that changed while sync was off / offline.
+    // Fresh bootstraps and recorded inactive periods need a one-time local
+    // reconciliation. Warm starts rely on persisted dirty namespaces instead.
+    if (!hadCursor || needsLocalReconcile) {
+      const namespaceCount = this.markAllEnabledNamespacesDirty();
+      cloudSyncLog.debug("Initial sync succeeded; queued local reconcile", {
+        reason: !hadCursor ? "bootstrap" : "marked",
+        namespaceCount,
+      });
+      this.scheduleFlush();
+      return;
+    }
+
+    if (hadPersistedDirty || this.state.dirtyNamespaces.length > 0) {
+      cloudSyncLog.debug("Initial sync succeeded; queued persisted local work", {
+        namespaceCount: this.state.dirtyNamespaces.length,
+      });
+      this.schedulePendingFlush();
+      return;
+    }
+
+    cloudSyncLog.debug("Initial sync succeeded; local scan skipped", {
+      cursor: this.state.cursor,
+    });
+  }
+
+  private clearLocalReconcileIfSettled(): void {
+    if (!this.state.localReconcileRequired) return;
+    if (
+      this.state.dirtyNamespaces.length > 0 ||
+      this.fullDirtyNamespaces.size > 0 ||
+      this.dirtyKeysByNamespace.size > 0
+    ) {
+      return;
+    }
+    this.state.setLocalReconcileRequired(false);
+    cloudSyncLog.debug("Local reconcile marker cleared");
+  }
+
+  private markAllEnabledNamespacesDirty(): number {
+    let namespaceCount = 0;
     for (const namespace of SYNC_NAMESPACES) {
+      if (!this.isNamespaceEnabled(namespace)) continue;
       this.state.markDirty(namespace);
       this.fullDirtyNamespaces.add(namespace);
+      namespaceCount += 1;
     }
-    cloudSyncLog.debug("Initial sync succeeded; queued local scan", {
-      namespaceCount: SYNC_NAMESPACES.length,
-    });
-    this.scheduleFlush();
+    return namespaceCount;
   }
 
   stop(): void {
@@ -544,6 +587,7 @@ export class CloudSyncEngine {
             namespaces: flushedNamespaces,
           });
           this.resetFlushBackoff();
+          this.clearLocalReconcileIfSettled();
           return;
         }
 
@@ -569,6 +613,7 @@ export class CloudSyncEngine {
             ops: summarizeSyncOps(ops),
           });
           this.resetFlushBackoff();
+          this.clearLocalReconcileIfSettled();
           this.reportError(null);
         } catch (error) {
           for (const namespace of flushedNamespaces) {

--- a/src/sync/state.ts
+++ b/src/sync/state.ts
@@ -52,6 +52,7 @@ interface PersistedSyncState {
   lastHlc: string | null;
   shadow: Record<string, ShadowEntry>;
   dirty: SyncNamespace[];
+  localReconcileRequired: boolean;
 }
 
 function storageKey(username: string): string {
@@ -74,6 +75,7 @@ export class SyncClientState {
       lastHlc: null,
       shadow: {},
       dirty: [],
+      localReconcileRequired: false,
     };
     if (typeof localStorage === "undefined") return fallback;
     try {
@@ -93,6 +95,7 @@ export class SyncClientState {
         dirty: Array.isArray(parsed.dirty)
           ? (parsed.dirty as SyncNamespace[])
           : [],
+        localReconcileRequired: parsed.localReconcileRequired === true,
       };
     } catch {
       return fallback;
@@ -174,6 +177,16 @@ export class SyncClientState {
     return [...this.state.dirty];
   }
 
+  get localReconcileRequired(): boolean {
+    return this.state.localReconcileRequired;
+  }
+
+  setLocalReconcileRequired(required: boolean): void {
+    if (this.state.localReconcileRequired === required) return;
+    this.state.localReconcileRequired = required;
+    this.schedulePersist();
+  }
+
   markDirty(namespace: SyncNamespace): void {
     if (!this.state.dirty.includes(namespace)) {
       this.state.dirty.push(namespace);
@@ -192,9 +205,21 @@ export class SyncClientState {
 
   /** Wipe cursor + shadow (force re-bootstrap). Keeps the client id. */
   reset(): void {
-    this.state = { cursor: null, lastHlc: this.state.lastHlc, shadow: {}, dirty: [] };
+    this.state = {
+      cursor: null,
+      lastHlc: this.state.lastHlc,
+      shadow: {},
+      dirty: [],
+      localReconcileRequired: false,
+    };
     this.persistNow();
   }
+}
+
+export function markSyncLocalReconcileRequired(username: string): void {
+  const state = new SyncClientState(username);
+  state.setLocalReconcileRequired(true);
+  state.persistNow();
 }
 
 /** Fast 53-bit string hash (cyrb53) for shadow content hashes. */

--- a/tests/test-sync-v2-codecs.test.ts
+++ b/tests/test-sync-v2-codecs.test.ts
@@ -2,7 +2,11 @@ import "./local-storage-stub";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { SYNC_CODECS } from "../src/sync/codecs";
 import { CloudSyncEngine } from "../src/sync/engine";
-import { hashDoc, SyncClientState } from "../src/sync/state";
+import {
+  hashDoc,
+  markSyncLocalReconcileRequired,
+  SyncClientState,
+} from "../src/sync/state";
 import { useStickiesStore } from "../src/stores/useStickiesStore";
 import { useCalendarStore } from "../src/stores/useCalendarStore";
 import { useVideoStore } from "../src/stores/useVideoStore";
@@ -630,6 +634,97 @@ describe("cloud sync logging summaries", () => {
 });
 
 describe("cloud sync engine resilience", () => {
+  test("warm start with a cursor skips the full local reconciliation scan", async () => {
+    const username = `sync-warm-${Date.now().toString(36)}`;
+    localStorage.setItem(
+      `ryos:sync2:state:${username}`,
+      JSON.stringify({
+        cursor: 7,
+        lastHlc: null,
+        shadow: {},
+        dirty: [],
+        localReconcileRequired: false,
+      })
+    );
+    useCloudSyncStore.setState({
+      autoSyncEnabled: true,
+      syncStickies: true,
+    });
+
+    const requests: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input) => {
+      requests.push(String(input instanceof Request ? input.url : input));
+      return new Response(JSON.stringify({ ok: true, seq: 7, ops: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const engine = new CloudSyncEngine(username);
+    try {
+      await engine.start();
+      const state = (engine as unknown as { state: SyncClientState }).state;
+      expect(state.dirtyNamespaces).toEqual([]);
+      expect(state.localReconcileRequired).toBe(false);
+      expect(requests.some((url) => url.includes("/api/sync/v2/changes?since=7"))).toBe(true);
+    } finally {
+      engine.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("local reconcile marker queues one startup scan and clears after flush", async () => {
+    const username = `sync-reconcile-${Date.now().toString(36)}`;
+    localStorage.setItem(
+      `ryos:sync2:state:${username}`,
+      JSON.stringify({
+        cursor: 8,
+        lastHlc: null,
+        shadow: {},
+        dirty: [],
+        localReconcileRequired: false,
+      })
+    );
+    markSyncLocalReconcileRequired(username);
+    useStickiesStore.setState({ notes: [] });
+    useCloudSyncStore.setState({
+      autoSyncEnabled: true,
+      syncFiles: false,
+      syncSettings: false,
+      syncSongs: false,
+      syncVideos: false,
+      syncTv: false,
+      syncStickies: true,
+      syncCalendar: false,
+      syncContacts: false,
+      syncMaps: false,
+      syncBooks: false,
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: true, seq: 8, ops: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof fetch;
+
+    const engine = new CloudSyncEngine(username);
+    try {
+      await engine.start();
+      const state = (engine as unknown as { state: SyncClientState }).state;
+      expect(state.localReconcileRequired).toBe(true);
+      expect(state.dirtyNamespaces).toEqual(["stickies"]);
+
+      await engine.flush();
+      expect(state.dirtyNamespaces).toEqual([]);
+      expect(state.localReconcileRequired).toBe(false);
+    } finally {
+      engine.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("does not schedule a full upload scan after the initial pull fails", async () => {
     const username = `sync-failure-${Date.now().toString(36)}`;
     localStorage.setItem(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Skip the Cloud Sync startup full local reconciliation when a user already has a cursor, no persisted dirty namespaces, and no recorded inactive-sync recovery marker.
- Persist a per-user local reconciliation marker when an active sync session is deactivated, then clear it after the one-time reconcile flush settles.
- Add sync-v2 unit coverage for warm-start skip behavior and marker-driven reconciliation.

### Testing
- `bun test tests/test-sync-v2-codecs.test.ts` — passed.
- `bun run test:sync-v2:unit` — passed; output includes existing Pusher 401 broadcast warnings while tests still pass.
- `bun run build` — passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0dd5-c7dc-74b9-85f7-1d98d000ddf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0dd5-c7dc-74b9-85f7-1d98d000ddf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

