### PR TITLE
Fix memory extraction on clear and heartbeat

### DIFF
--- a/api/ai/extract-memories.ts
+++ b/api/ai/extract-memories.ts
@@ -174,6 +174,22 @@ export function resolveDailyNoteSourceTimestamp(
   return null;
 }
 
+export function getDailyNoteDatesToMarkProcessed({
+  today,
+  touchedDates,
+  hasExistingDailyEntries,
+}: {
+  today: string;
+  touchedDates: Iterable<string>;
+  hasExistingDailyEntries: boolean;
+}): string[] {
+  const dates = new Set<string>();
+  if (hasExistingDailyEntries || [...touchedDates].includes(today)) {
+    dates.add(today);
+  }
+  return [...dates];
+}
+
 const EXTRACTION_PROMPT = `You are analyzing a conversation between a USER and an AI assistant named "Ryo" to extract memories.
 
 CRITICAL - WHO IS WHO:
@@ -442,11 +458,13 @@ export async function extractMemoriesFromConversation({
   }
 
   if (markTodayProcessed && (dailyNotesStored > 0 || hasExistingDailyEntries)) {
-    if (hasExistingDailyEntries) {
-      touchedDates.add(today);
-    }
+    const datesToMarkProcessed = getDailyNoteDatesToMarkProcessed({
+      today,
+      touchedDates,
+      hasExistingDailyEntries,
+    });
     await Promise.all(
-      [...touchedDates].map((date) => markDailyNoteProcessed(redis, username, date))
+      datesToMarkProcessed.map((date) => markDailyNoteProcessed(redis, username, date))
     );
   }
 

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -1901,7 +1901,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               : undefined,
           })),
         }),
-        timeout: 15000,
+        timeout: 65000,
         retry: { maxAttempts: 1, initialDelayMs: 250 },
       })
         .then(res => res.json())

--- a/src/apps/chats/utils/systemState.ts
+++ b/src/apps/chats/utils/systemState.ts
@@ -10,6 +10,7 @@ import { useTvStore } from "@/stores/useTvStore";
 import { buildTvChannelLineup, DEFAULT_CHANNELS } from "@/apps/tv/data/channels";
 import { htmlToMarkdown } from "@/utils/markdown";
 import { generateHtmlFromJsonSync } from "@/utils/tiptapHtml";
+import { getEffectiveTimezone } from "@/lib/timezoneConfig";
 
 export const detectUserOS = (): string => {
   if (typeof navigator === "undefined") return "Unknown";
@@ -139,8 +140,7 @@ export const getSystemState = () => {
   );
 
   const nowClient = new Date();
-  const userTimeZone =
-    Intl.DateTimeFormat().resolvedOptions().timeZone || "Unknown";
+  const userTimeZone = getEffectiveTimezone();
   const userTimeString = nowClient.toLocaleTimeString([], {
     hour: "numeric",
     minute: "2-digit",

--- a/tests/test-extract-memories.test.ts
+++ b/tests/test-extract-memories.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   getChatMessageTimestamp,
+  getDailyNoteDatesToMarkProcessed,
   resolveDailyNoteSourceTimestamp,
   type NormalizedConversationMessage,
 } from "../api/ai/extract-memories";
@@ -75,5 +76,33 @@ describe("extract memories timestamp helpers", () => {
     ];
 
     expect(resolveDailyNoteSourceTimestamp(messages, 2)).toBe(100);
+  });
+
+  test("only marks today processed when clear extraction stores source-dated notes", () => {
+    expect(
+      getDailyNoteDatesToMarkProcessed({
+        today: "2026-01-16",
+        touchedDates: ["2026-01-15"],
+        hasExistingDailyEntries: false,
+      })
+    ).toEqual([]);
+
+    expect(
+      getDailyNoteDatesToMarkProcessed({
+        today: "2026-01-16",
+        touchedDates: ["2026-01-15", "2026-01-16"],
+        hasExistingDailyEntries: false,
+      })
+    ).toEqual(["2026-01-16"]);
+  });
+
+  test("marks today processed when existing daily entries were part of clear extraction", () => {
+    expect(
+      getDailyNoteDatesToMarkProcessed({
+        today: "2026-01-16",
+        touchedDates: [],
+        hasExistingDailyEntries: true,
+      })
+    ).toEqual(["2026-01-16"]);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep clear-chat memory extraction alive for the server extraction window instead of aborting early.
- Only mark the current local day processed after clear extraction so source-timestamped past notes remain eligible for heartbeat/daily-note promotion.
- Align chat system-state timezone with the International preference used by API headers.

## Testing
- `bun test tests/test-extract-memories.test.ts tests/test-memory-system.test.ts`
- `bun test tests/test-timezone-config.test.ts tests/test-extract-memories.test.ts`
- `bun run test:unit`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0ded-dd14-7e4d-a33e-547eb3365952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0ded-dd14-7e4d-a33e-547eb3365952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

