### PR TITLE
Fix Traditional Chinese translation regressions

### DIFF
--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1598,9 +1598,9 @@
       "bootScreenDescription": "測試開機畫面動畫",
       "changePassword": "更改密碼",
       "changePasswordButton": "更改",
-      "chatSynth": "聊天合成",
+      "chatSynth": "聊天合成器",
       "chatSynthDescription": "聊天打字音效的合成器預設",
-      "chatSynthVolume": "聊天合成音量",
+      "chatSynthVolume": "聊天合成器音量",
       "checkForUpdates": "檢查更新",
       "cloudSync": {
         "accountDescription": "在裝置間同步設定",
@@ -1742,7 +1742,7 @@
           "title": "著色器效果"
         },
         "sounds": {
-          "description": "切換使用者介面點擊聲、打字合成音以及終端機/IE 音效",
+          "description": "切換使用者介面點擊聲、打字合成器以及終端機/IE 音效",
           "title": "聲音"
         },
         "sync": {
@@ -1918,7 +1918,7 @@
       "startupDiskDescription": "選擇用來啟動電腦的系統",
       "startupDiskNote": "當「帳號」中啟用「除錯模式」時，即可預覽啟動畫面。",
       "sync": "同步",
-      "synth": "合成",
+      "synth": "合成器",
       "system": "系統",
       "systemFont": "系統字型",
       "systemFontDescription": "覆寫 OS UI 字型堆疊",
@@ -1959,8 +1959,8 @@
         "savingInstructions": "儲存中⋯",
         "title": "Telegram"
       },
-      "terminalIeAmbientSynth": "合成",
-      "terminalIeAmbientSynthDescription": "終端機與 IE 的音效與合成音",
+      "terminalIeAmbientSynth": "合成器",
+      "terminalIeAmbientSynthDescription": "終端機與 IE 的音效與合成器",
       "termsOfService": "服務條款",
       "theme": "主題",
       "themeDescription": "變更視窗、選單和控制項的外觀",
@@ -2765,7 +2765,7 @@
         },
         "coverFlow": {
           "description": "長按螢幕以開啟 Cover Flow 並翻閱專輯",
-          "title": "封面暢覽"
+          "title": "Cover Flow"
         },
         "displayFullscreen": {
           "description": "選擇封面、風景、扭曲、網格或水波視覺效果；Apple Music 預設使用封面並隱藏影片模式",
@@ -2800,7 +2800,7 @@
         "aboutIpod": "關於 iPod",
         "addSong": "加入歌曲⋯",
         "addToFavorites": "加入最愛",
-        "addToLibrary": "加入書庫⋯",
+        "addToLibrary": "加入資料庫⋯",
         "adjustTiming": "調整時間⋯",
         "allSongs": "所有歌曲",
         "alternating": "交替",
@@ -2815,7 +2815,7 @@
         "clearCache": "清除緩存",
         "clearLibrary": "清除資料庫⋯",
         "controls": "控制",
-        "coverFlow": "封面暢覽",
+        "coverFlow": "Cover Flow",
         "deviceTheme": "裝置主題",
         "display": "顯示",
         "displayCover": "封面",
@@ -2854,7 +2854,7 @@
         "lyrics": "歌詞",
         "menubarArtistLimit": "正在顯示 {{total}} 位演出者中的 {{limit}} 位",
         "menubarTrackLimit": "正在顯示 {{total}} 個中的 {{limit}} 個 — 開啟 iPod 以瀏覽全部",
-        "multi": "多聲道",
+        "multi": "多行",
         "next": "下一首",
         "pause": "暫停",
         "play": "播放",
@@ -3838,7 +3838,7 @@
         "resetSynth": "重設合成器",
         "synthHelp": "合成器輔助說明"
       },
-      "name": "合成",
+      "name": "合成器",
       "noPresetsYet": "尚無預設。請使用「新增」按鈕建立一個。",
       "oscillator": "振盪器",
       "selectPreset": "選擇預設",
@@ -4235,7 +4235,7 @@
       },
       "menu": {
         "aboutVideos": "關於影片",
-        "addToLibrary": "加入書庫⋯",
+        "addToLibrary": "加入資料庫⋯",
         "allVideos": "所有影片",
         "clearLibrary": "清除資料庫⋯",
         "controls": "控制",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Correct Traditional Chinese terminology regressions for Library, multi-line lyrics, Synth, and Cover Flow labels.

### Testing
- `bun run i18n:sync:dry-run`
- `node -e 'const fs = require("fs"); const data = JSON.parse(fs.readFileSync("src/lib/locales/zh-TW/translation.json", "utf8")); const cp = data.apps["control-panels"]; const checks = [["apps.ipod.menu.addToLibrary", data.apps.ipod.menu.addToLibrary, "加入資料庫⋯"], ["apps.videos.menu.addToLibrary", data.apps.videos.menu.addToLibrary, "加入資料庫⋯"], ["apps.ipod.menu.multi", data.apps.ipod.menu.multi, "多行"], ["apps.ipod.menu.coverFlow", data.apps.ipod.menu.coverFlow, "Cover Flow"], ["apps.ipod.help.coverFlow.title", data.apps.ipod.help.coverFlow.title, "Cover Flow"], ["apps.synth.name", data.apps.synth.name, "合成器"], ["apps.control-panels.synth", cp.synth, "合成器"], ["apps.control-panels.terminalIeAmbientSynth", cp.terminalIeAmbientSynth, "合成器"], ["apps.control-panels.chatSynth", cp.chatSynth, "聊天合成器"]]; for (const [key, actual, expected] of checks) { if (actual !== expected) { console.error(key + ": expected " + expected + ", got " + actual); process.exit(1); } console.log(key + " = " + actual); }'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0df4-e3ec-7da2-8584-5e51f2db9c1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0df4-e3ec-7da2-8584-5e51f2db9c1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

