### PR TITLE
Fix aggregate unit test isolation

### DIFF
--- a/src/utils/debouncedPersistStorage.ts
+++ b/src/utils/debouncedPersistStorage.ts
@@ -29,6 +29,7 @@ type PendingFlush = () => void;
 
 // name -> flush, so a global flush can drain every adapter instance.
 const pendingFlushes = new Map<string, PendingFlush>();
+const adapterResetters = new Set<() => void>();
 let lifecycleFlushRegistered = false;
 let halted = false;
 
@@ -54,6 +55,9 @@ export function haltDebouncedPersistWrites(): void {
 /** @internal Test-only reset for Bun's shared-process test runner. */
 export function resetDebouncedPersistWritesForTests(): void {
   halted = false;
+  for (const resetAdapter of Array.from(adapterResetters)) {
+    resetAdapter();
+  }
   pendingFlushes.clear();
 }
 
@@ -101,6 +105,20 @@ export function createDebouncedPersistStorage<S>(
       );
     }
   };
+
+  const resetForTests = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (pendingName !== null) {
+      pendingFlushes.delete(pendingName);
+    }
+    pendingName = null;
+    pendingValue = null;
+  };
+
+  adapterResetters.add(resetForTests);
 
   return {
     getItem: (name) => {

--- a/tests/local-storage-stub.ts
+++ b/tests/local-storage-stub.ts
@@ -3,29 +3,8 @@
  * module FIRST (before any src/stores import) so module-level storage
  * reads don't crash under bun's bare runtime.
  */
+import { ensureTestLocalStorage as installLocalStorageStub } from "./setup";
 
-class MemoryStorage implements Storage {
-  private readonly map = new Map<string, string>();
-  get length(): number {
-    return this.map.size;
-  }
-  clear(): void {
-    this.map.clear();
-  }
-  getItem(key: string): string | null {
-    return this.map.get(key) ?? null;
-  }
-  key(index: number): string | null {
-    return Array.from(this.map.keys())[index] ?? null;
-  }
-  removeItem(key: string): void {
-    this.map.delete(key);
-  }
-  setItem(key: string, value: string): void {
-    this.map.set(key, value);
-  }
-}
+export { MemoryStorage, ensureTestLocalStorage } from "./setup";
 
-if (typeof globalThis.localStorage === "undefined") {
-  (globalThis as { localStorage?: Storage }).localStorage = new MemoryStorage();
-}
+installLocalStorageStub();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,95 @@
+import { afterEach, beforeEach } from "bun:test";
+import {
+  flushDebouncedPersistWrites,
+  resetDebouncedPersistWritesForTests,
+} from "../src/utils/debouncedPersistStorage";
+
 /**
  * Global test setup — preloaded before every bun test run.
  */
 
 export const BASE_URL = process.env.API_URL || "http://localhost:3000";
+
+export class MemoryStorage implements Storage {
+  private readonly map = new Map<string, string>();
+
+  get length(): number {
+    return this.map.size;
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.map.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+}
+
+const sharedTestLocalStorage = new MemoryStorage();
+
+function isUsableStorage(storage: unknown): storage is Storage {
+  return (
+    typeof storage === "object" &&
+    storage !== null &&
+    typeof (storage as Storage).clear === "function" &&
+    typeof (storage as Storage).getItem === "function" &&
+    typeof (storage as Storage).setItem === "function" &&
+    typeof (storage as Storage).removeItem === "function"
+  );
+}
+
+export function installTestLocalStorage(
+  storage: Storage = sharedTestLocalStorage
+): Storage {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    enumerable: true,
+    value: storage,
+    writable: true,
+  });
+  return storage;
+}
+
+export function ensureTestLocalStorage(): Storage {
+  const storage = (globalThis as { localStorage?: Storage }).localStorage;
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  if (
+    isUsableStorage(storage) &&
+    descriptor &&
+    "value" in descriptor &&
+    descriptor.configurable &&
+    descriptor.writable
+  ) {
+    return storage;
+  }
+  return installTestLocalStorage(isUsableStorage(storage) ? storage : undefined);
+}
+
+installTestLocalStorage();
+
+beforeEach(() => {
+  ensureTestLocalStorage();
+  flushDebouncedPersistWrites();
+  resetDebouncedPersistWritesForTests();
+  ensureTestLocalStorage().clear();
+});
+
+afterEach(() => {
+  ensureTestLocalStorage();
+  flushDebouncedPersistWrites();
+  resetDebouncedPersistWritesForTests();
+  ensureTestLocalStorage().clear();
+});

--- a/tests/test-app-store-foreground-state.test.ts
+++ b/tests/test-app-store-foreground-state.test.ts
@@ -8,12 +8,21 @@ let useAppStore: typeof UseAppStoreHook;
 // The partial `window` stub must not leak into later test files (e.g. code
 // guarded by `typeof window !== "undefined"` expecting addEventListener).
 const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const originalLocalStorage = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "localStorage"
+);
 
 afterAll(() => {
   if (originalWindow) {
     Object.defineProperty(globalThis, "window", originalWindow);
   } else {
     delete (globalThis as { window?: unknown }).window;
+  }
+  if (originalLocalStorage) {
+    Object.defineProperty(globalThis, "localStorage", originalLocalStorage);
+  } else {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
   }
 });
 
@@ -31,6 +40,7 @@ function installBrowserStubs() {
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
     value: localStorageStub,
+    writable: true,
   });
 
   if (typeof globalThis.CustomEvent === "undefined") {

--- a/tests/test-books-cloud-blob-sync.test.ts
+++ b/tests/test-books-cloud-blob-sync.test.ts
@@ -17,6 +17,7 @@ Object.defineProperty(globalThis, "localStorage", {
         localStorageMap.delete(key);
       },
     } satisfies Pick<Storage, "getItem" | "setItem" | "removeItem">),
+  writable: true,
 });
 
 const { SYNC_CODECS, isBlobCodec } = await import("../src/sync/codecs");
@@ -50,6 +51,7 @@ describe("Books cloud blob sync", () => {
     Object.defineProperty(globalThis, "localStorage", {
       configurable: true,
       value: originalLocalStorage,
+      writable: true,
     });
   });
 

--- a/tests/test-books-cover-load-queue.test.ts
+++ b/tests/test-books-cover-load-queue.test.ts
@@ -14,6 +14,7 @@ import React from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { dbOperations, STORES } from "../src/utils/indexedDB";
 import type { FileSystemItem } from "../src/stores/useFilesStore";
+import { ensureTestLocalStorage } from "./setup";
 
 let activeParses = 0;
 let maxActiveParses = 0;
@@ -142,6 +143,7 @@ describe("Books cover loading queue", () => {
     if (GlobalRegistrator.isRegistered) {
       GlobalRegistrator.unregister();
     }
+    ensureTestLocalStorage();
   });
 
   test("serializes shelf EPUB cover reads to limit startup memory", async () => {

--- a/tests/test-books-default-epub.test.ts
+++ b/tests/test-books-default-epub.test.ts
@@ -17,6 +17,7 @@ Object.defineProperty(globalThis, "localStorage", {
         localStorageMap.delete(key);
       },
     } satisfies Pick<Storage, "getItem" | "setItem" | "removeItem">),
+  writable: true,
 });
 
 const { readBookBlobContent } = await import(
@@ -83,6 +84,7 @@ afterAll(() => {
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
     value: originalLocalStorage,
+    writable: true,
   });
 });
 

--- a/tests/test-boot-screen-accent.test.ts
+++ b/tests/test-boot-screen-accent.test.ts
@@ -14,6 +14,10 @@ import { createRoot, type Root } from "react-dom/client";
 import { getAccentCssVars } from "../src/themes/accents";
 import { darkAquaThemeCss } from "./theme-css-fixtures";
 import type { OsThemeId } from "../src/themes/types";
+import { ensureTestLocalStorage } from "./setup";
+
+const actualSound = await import("../src/hooks/useSound");
+const actualReactI18next = await import("react-i18next");
 
 beforeAll(() => {
   if (typeof document === "undefined") {
@@ -26,9 +30,13 @@ afterAll(async () => {
   if (GlobalRegistrator.isRegistered) {
     GlobalRegistrator.unregister();
   }
+  ensureTestLocalStorage();
+  mock.module("@/hooks/useSound", () => actualSound);
+  mock.module("react-i18next", () => actualReactI18next);
 });
 
 mock.module("@/hooks/useSound", () => ({
+  ...actualSound,
   Sounds: {
     BOOT: "/sounds/boot.mp3",
     WINDOW_CLOSE: "/sounds/window-close.mp3",
@@ -38,6 +46,7 @@ mock.module("@/hooks/useSound", () => ({
 }));
 
 mock.module("react-i18next", () => ({
+  ...actualReactI18next,
   useTranslation: () => ({
     t: (key: string) =>
       key === "common.system.systemRestoring" ? "System Restoring..." : key,

--- a/tests/test-chat-store-guards-wiring.test.ts
+++ b/tests/test-chat-store-guards-wiring.test.ts
@@ -41,7 +41,11 @@ class MemoryStorage implements Storage {
 
 const globals = globalThis as typeof globalThis & { localStorage?: Storage };
 if (!globals.localStorage) {
-  globals.localStorage = new MemoryStorage();
+  Object.defineProperty(globals, "localStorage", {
+    configurable: true,
+    value: new MemoryStorage(),
+    writable: true,
+  });
 }
 
 let listRoomsImpl: () => Promise<{ rooms: ChatRoom[] }> = async () => ({

--- a/tests/test-chat-streaming-perf.test.ts
+++ b/tests/test-chat-streaming-perf.test.ts
@@ -21,6 +21,7 @@ import type { AIChatMessage, ChatMessage } from "../src/types/chat";
 import { buildDisplayMessages } from "../src/apps/chats/utils/messages";
 import { getStreamPreviewThrottleMs } from "../src/components/shared/html-preview/hooks/useStreamPreview";
 import { decodeHtmlEntities } from "../src/utils/decodeHtmlEntities";
+import { ensureTestLocalStorage } from "./setup";
 
 const readSource = (relPath: string): string =>
   readFileSync(resolve(process.cwd(), relPath), "utf-8");
@@ -173,6 +174,7 @@ describe("decodeHtmlEntities streaming fast path", () => {
       if (GlobalRegistrator.isRegistered) {
         GlobalRegistrator.unregister();
       }
+      ensureTestLocalStorage();
     });
 
     test("does not take the fast path when tags are present", () => {

--- a/tests/test-client-logger.test.ts
+++ b/tests/test-client-logger.test.ts
@@ -60,6 +60,7 @@ function installMemoryStorage() {
       removeItem: (key: string) => data.delete(key),
       clear: () => data.clear(),
     } satisfies Pick<Storage, "getItem" | "setItem" | "removeItem" | "clear">,
+    writable: true,
   });
 }
 
@@ -100,6 +101,7 @@ describe("client logger", () => {
       Object.defineProperty(globalThis, "localStorage", {
         configurable: true,
         value: originalLocalStorage,
+        writable: true,
       });
     }
     refreshRuntimeDebugFlag();

--- a/tests/test-confirmed-playback-state.test.ts
+++ b/tests/test-confirmed-playback-state.test.ts
@@ -36,6 +36,7 @@ if (!originalLocalStorage) {
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
     value: new MemoryStorage(),
+    writable: true,
   });
 }
 

--- a/tests/test-debounced-persist-storage.test.ts
+++ b/tests/test-debounced-persist-storage.test.ts
@@ -7,9 +7,21 @@
  * semantics and explicit flush/halt hooks for backup/restore/reset flows.
  */
 
-import { describe, test, expect, beforeEach, afterEach, jest } from "bun:test";
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+  jest,
+} from "bun:test";
 
 // Minimal localStorage polyfill for the bun test environment.
+const originalLocalStorage = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "localStorage"
+);
 const backing = new Map<string, string>();
 Object.defineProperty(globalThis, "localStorage", {
   configurable: true,
@@ -46,6 +58,15 @@ beforeEach(() => {
 afterEach(() => {
   jest.useRealTimers();
   resetDebouncedPersistWritesForTests();
+});
+
+afterAll(() => {
+  resetDebouncedPersistWritesForTests();
+  if (originalLocalStorage) {
+    Object.defineProperty(globalThis, "localStorage", originalLocalStorage);
+  } else {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+  }
 });
 
 describe("createDebouncedPersistStorage", () => {

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -30,7 +30,11 @@ const browserGlobals = globalThis as typeof globalThis & {
   navigator?: Navigator;
 };
 if (!browserGlobals.localStorage) {
-  browserGlobals.localStorage = new MemoryStorage();
+  Object.defineProperty(browserGlobals, "localStorage", {
+    configurable: true,
+    value: new MemoryStorage(),
+    writable: true,
+  });
 }
 Object.defineProperty(browserGlobals, "navigator", {
   value: {

--- a/tests/test-ipod-lyrics-track-metadata.test.ts
+++ b/tests/test-ipod-lyrics-track-metadata.test.ts
@@ -31,10 +31,17 @@ const browserGlobals = globalThis as typeof globalThis & {
   navigator?: Navigator;
 };
 if (!browserGlobals.localStorage) {
-  browserGlobals.localStorage = new MemoryStorage();
+  Object.defineProperty(browserGlobals, "localStorage", {
+    configurable: true,
+    value: new MemoryStorage(),
+    writable: true,
+  });
 }
 if (!browserGlobals.navigator) {
-  browserGlobals.navigator = { onLine: true, userAgent: "test" } as Navigator;
+  Object.defineProperty(browserGlobals, "navigator", {
+    configurable: true,
+    value: { onLine: true, userAgent: "test" } as Navigator,
+  });
 }
 
 const {

--- a/tests/test-ipod-playback-navigation.test.ts
+++ b/tests/test-ipod-playback-navigation.test.ts
@@ -30,7 +30,11 @@ const browserGlobals = globalThis as typeof globalThis & {
   navigator?: Navigator;
 };
 if (!browserGlobals.localStorage) {
-  browserGlobals.localStorage = new MemoryStorage();
+  Object.defineProperty(browserGlobals, "localStorage", {
+    configurable: true,
+    value: new MemoryStorage(),
+    writable: true,
+  });
 }
 Object.defineProperty(browserGlobals, "navigator", {
   value: {

--- a/tests/test-listen-sync-adapter.test.ts
+++ b/tests/test-listen-sync-adapter.test.ts
@@ -27,6 +27,7 @@ describe("broadcastListenState", () => {
     Object.defineProperty(globalThis, "localStorage", {
       configurable: true,
       value: new MemoryStorage(),
+      writable: true,
     });
     const { broadcastListenState } = await import(
       "../src/shared/media/playbackListenSync"

--- a/tests/test-prefetch-manifest-flag.test.ts
+++ b/tests/test-prefetch-manifest-flag.test.ts
@@ -27,6 +27,7 @@ beforeEach(() => {
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
     value: new MemoryStorage(),
+    writable: true,
   });
 });
 
@@ -34,6 +35,7 @@ afterEach(() => {
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
     value: originalLocalStorage,
+    writable: true,
   });
 });
 

--- a/tests/test-ryos-fullscreen.test.ts
+++ b/tests/test-ryos-fullscreen.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { ensureTestLocalStorage } from "./setup";
 
 // These helpers operate on the real DOM (document.getElementById,
 // document.documentElement, document.fullscreenElement). Bun has no DOM by
@@ -17,6 +18,7 @@ afterAll(() => {
   if (GlobalRegistrator.isRegistered) {
     GlobalRegistrator.unregister();
   }
+  ensureTestLocalStorage();
 });
 
 import {

--- a/tests/test-system-font-options.test.ts
+++ b/tests/test-system-font-options.test.ts
@@ -91,6 +91,7 @@ beforeEach(() => {
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
     value: new MemoryStorage(),
+    writable: true,
   });
 });
 
@@ -104,6 +105,7 @@ afterEach(async () => {
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
     value: originalLocalStorage,
+    writable: true,
   });
 });
 

--- a/tests/test-textedit-markdown-paste.test.ts
+++ b/tests/test-textedit-markdown-paste.test.ts
@@ -9,6 +9,7 @@ import TableCell from "@tiptap/extension-table-cell";
 import TableHeader from "@tiptap/extension-table-header";
 import TableRow from "@tiptap/extension-table-row";
 import StarterKit from "@tiptap/starter-kit";
+import { ensureTestLocalStorage } from "./setup";
 import { handleMarkdownPaste } from "../src/apps/textedit/extensions/MarkdownPaste";
 import {
   getMarkdownTextForPaste,
@@ -67,6 +68,7 @@ afterAll(() => {
   if (GlobalRegistrator.isRegistered) {
     GlobalRegistrator.unregister();
   }
+  ensureTestLocalStorage();
 });
 
 describe("TextEdit Markdown paste detection", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Install a shared writable in-memory `localStorage` in the Bun test preload and reset debounced persist writes around each test.
- Cancel adapter-local debounced persist timers during test resets so delayed writes cannot leak into later suites.
- Restore storage and module mocks in DOM/store-heavy test harnesses that previously polluted the aggregate run.

## Testing
- `bun test tests/test-boot-screen-accent.test.ts tests/test-ipod-playback-navigation.test.ts tests/test-tv-store-default-channel-removal.test.ts tests/test-confirmed-playback-state.test.ts tests/test-listen-sync-adapter.test.ts tests/test-app-store-foreground-state.test.ts`
- `bun run test:unit`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c99487c6-cbb2-47ff-ab42-ef56299b7147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c99487c6-cbb2-47ff-ab42-ef56299b7147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

