### PR TITLE
Improve Electron system notification handling

### DIFF
--- a/electron/chat-notifications.ts
+++ b/electron/chat-notifications.ts
@@ -15,6 +15,10 @@ import {
 } from "../src/shared/contracts/chat";
 import { decodeHtmlEntities } from "../src/utils/decodeHtmlEntities";
 import {
+  buildChatRoomNotificationTag,
+  toSafeSystemNotificationText,
+} from "../src/utils/systemNotifications";
+import {
   buildLocalRealtimeClientMessage,
   buildLocalRealtimeTicketWebSocketUrl,
 } from "../src/utils/desktopChatNotificationRealtime";
@@ -27,7 +31,6 @@ import {
   type DesktopChatNotificationConfig,
   type DesktopChatNotificationManageFailureReason,
   type DesktopChatNotificationManageResult,
-  type DesktopChatNotificationRoom,
   type DesktopChatNotificationState,
 } from "../src/utils/desktopChatNotificationPolicy";
 
@@ -138,13 +141,6 @@ function removeRoom(rooms: ChatRoom[], roomId: string): ChatRoom[] {
   return rooms.filter((room) => room.id !== roomId);
 }
 
-function getRoomType(
-  rooms: DesktopChatNotificationRoom[],
-  roomId: string
-): ChatRoom["type"] | undefined {
-  return rooms.find((room) => room.id === roomId)?.type ?? undefined;
-}
-
 function isChatRoom(value: unknown): value is ChatRoom {
   return isRecord(value) && typeof value.id === "string";
 }
@@ -160,7 +156,7 @@ function isChatMessage(value: unknown): value is ChatMessage {
 
 function toNotificationPreview(content: unknown): string {
   const decoded = decodeHtmlEntities(String(content || ""));
-  return decoded.replace(/\s+/g, " ").trim().slice(0, MAX_NOTIFICATION_PREVIEW_LENGTH);
+  return toSafeSystemNotificationText(decoded, MAX_NOTIFICATION_PREVIEW_LENGTH) ?? "";
 }
 
 function asPusherConstructor(namespace: unknown): PusherConstructor {
@@ -976,14 +972,12 @@ export class ElectronChatNotificationService {
       return;
     }
 
-    const roomType = getRoomType(this.state.rooms, message.roomId);
-    const channelName = getChatRoomChannelName(message.roomId, roomType);
     const body = toNotificationPreview(message.content);
     this.options.showNotification(
       {
         title: `@${message.username}`,
         body,
-        tag: `chat-${channelName}`,
+        tag: buildChatRoomNotificationTag(message.roomId),
       },
       () => this.openChatRoom(message.roomId)
     );

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,7 +14,11 @@ import path from "node:path";
 import { setupAutoUpdater } from "./updater";
 import { buildApplicationMenu } from "./menu";
 import { registerChatNotificationIpcHandlers } from "./chat-notifications";
-import { replaceControlCharacters } from "../src/shared/sanitizeControlCharacters";
+import {
+  sanitizeSystemNotificationPayload,
+  type SystemNotificationPayload,
+  type SystemNotificationStatus,
+} from "../src/utils/systemNotifications";
 
 const DEFAULT_APP_URL = "https://os.ryo.lu";
 const APP_URL = process.env.RYOS_ELECTRON_URL?.trim() || DEFAULT_APP_URL;
@@ -48,12 +52,6 @@ type NativeSaveFileOptions = {
   defaultPath?: string;
   filters?: NativeFileFilter[];
   data: ArrayBuffer | ArrayBufferView;
-};
-
-type NativeNotificationOptions = {
-  title?: string;
-  body?: string;
-  chatRoomId?: string | null;
 };
 
 const ALLOWED_WEB_PERMISSIONS = new Set([
@@ -98,45 +96,21 @@ function isTrustedWebContents(contents: WebContents | null | undefined): boolean
   return isInAppNavigation(contents.getURL()) || isBlankUrl(contents.getURL());
 }
 
-function sanitizeNotificationText(
-  value: unknown,
-  maxLength: number
-): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  const normalized = replaceControlCharacters(value)
-    .replace(/\s+/g, " ")
-    .trim();
-
-  if (!normalized) {
-    return undefined;
-  }
-
-  if (normalized.length <= maxLength) {
-    return normalized;
-  }
-
-  return `${normalized.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
-}
-
 function sanitizeNotificationOptions(
-  options: NativeNotificationOptions
+  options: SystemNotificationPayload
 ): Electron.NotificationConstructorOptions | null {
-  const title = sanitizeNotificationText(options?.title, 120);
-  if (!title) {
-    return null;
-  }
-
   return {
-    title,
-    body: sanitizeNotificationText(options?.body, 240),
+    title: options.title,
+    body: options.body,
+    tag: options.tag,
+    silent: options.silent,
+    urgency: options.urgency,
+    timeoutType: options.timeoutType,
   };
 }
 
 function getNotificationChatRoomId(
-  options: NativeNotificationOptions
+  options: SystemNotificationPayload
 ): string | null | undefined {
   if (!("chatRoomId" in options)) {
     return undefined;
@@ -151,6 +125,27 @@ function canShowNativeNotifications(): boolean {
     typeof Notification.isSupported === "function" &&
     Notification.isSupported()
   );
+}
+
+function getNativeNotificationStatus(
+  trusted: boolean
+): SystemNotificationStatus {
+  if (!trusted) {
+    return {
+      supported: false,
+      foreground: isMainWindowForeground(),
+      platform: process.platform,
+      reason: "untrusted",
+    };
+  }
+
+  const supported = canShowNativeNotifications();
+  return {
+    supported,
+    foreground: isMainWindowForeground(),
+    platform: process.platform,
+    reason: supported ? undefined : "unsupported",
+  };
 }
 
 function isMainWindowForeground(): boolean {
@@ -382,6 +377,10 @@ function registerIpcHandlers(): void {
     return isTrustedWebContents(event.sender) && canShowNativeNotifications();
   });
 
+  ipcMain.handle("ryos-desktop:get-notification-status", (event) => {
+    return getNativeNotificationStatus(isTrustedWebContents(event.sender));
+  });
+
   ipcMain.handle("ryos-desktop:should-show-native-notification", (event) => {
     return (
       isTrustedWebContents(event.sender) &&
@@ -392,7 +391,7 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle(
     "ryos-desktop:show-notification",
-    (event, options: NativeNotificationOptions = {}) => {
+    (event, options: unknown = {}) => {
       if (!isTrustedWebContents(event.sender)) {
         return { shown: false, reason: "untrusted" };
       }
@@ -403,7 +402,11 @@ function registerIpcHandlers(): void {
         return { shown: false, reason: "unsupported" };
       }
 
-      const notificationOptions = sanitizeNotificationOptions(options);
+      const payload = sanitizeSystemNotificationPayload(options);
+      if (!payload) {
+        return { shown: false, reason: "invalid-payload" };
+      }
+      const notificationOptions = sanitizeNotificationOptions(payload);
       if (!notificationOptions) {
         return { shown: false, reason: "invalid-payload" };
       }
@@ -411,7 +414,7 @@ function registerIpcHandlers(): void {
         return { shown: false, reason: "foreground" };
       }
 
-      const chatRoomId = getNotificationChatRoomId(options);
+      const chatRoomId = getNotificationChatRoomId(payload);
       showRetainedNativeNotification(
         notificationOptions,
         chatRoomId !== undefined

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -23,6 +23,10 @@ contextBridge.exposeInMainWorld("ryosDesktop", {
     ipcRenderer.invoke("ryos-desktop:get-app-version") as Promise<string>,
   canShowNotifications: () =>
     ipcRenderer.invoke("ryos-desktop:can-show-notifications") as Promise<boolean>,
+  getNotificationStatus: () =>
+    ipcRenderer.invoke(
+      "ryos-desktop:get-notification-status"
+    ) as Promise<unknown>,
   shouldShowNativeNotification: () =>
     ipcRenderer.invoke(
       "ryos-desktop:should-show-native-notification"

--- a/src/apps/chats/components/ChatsMenuBar.tsx
+++ b/src/apps/chats/components/ChatsMenuBar.tsx
@@ -194,9 +194,6 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
   const systemNotificationsChecked = hasDesktopNotificationStatus
     ? desktopNotificationSupported
     : notificationPermission === "granted";
-  const systemNotificationsDisabled = hasDesktopNotificationStatus
-    ? !desktopNotificationSupported
-    : notificationPermission === "denied";
   const shouldRenderSystemNotificationsItem =
     hasDesktopNotificationStatus || isNotificationApiAvailable();
 
@@ -464,9 +461,16 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
                 <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
                 <MenubarCheckboxItem
                   checked={systemNotificationsChecked}
-                  disabled={systemNotificationsDisabled}
+                  aria-disabled={
+                    hasDesktopNotificationStatus
+                      ? !desktopNotificationSupported
+                      : notificationPermission === "denied"
+                  }
                   onCheckedChange={(checked) => {
                     if (hasDesktopNotificationStatus) {
+                      return;
+                    }
+                    if (notificationPermission === "denied") {
                       return;
                     }
                     if (checked && notificationPermission === "default") {

--- a/src/apps/chats/components/ChatsMenuBar.tsx
+++ b/src/apps/chats/components/ChatsMenuBar.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback, useEffect, useState } from "react";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -22,6 +22,7 @@ import {
   useNotificationPermission,
   isNotificationApiAvailable,
 } from "@/utils/browserNotifications";
+import { sanitizeSystemNotificationStatus } from "@/utils/systemNotifications";
 import type {
   TelegramLinkCreateResponse,
   TelegramHeartbeatSettings,
@@ -153,6 +154,51 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
 
   const { permission: notificationPermission, requestPermission: requestNotificationPermission } =
     useNotificationPermission();
+  const [desktopNotificationSupported, setDesktopNotificationSupported] =
+    useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.ryosDesktop) {
+      setDesktopNotificationSupported(null);
+      return;
+    }
+
+    let cancelled = false;
+    void (window.ryosDesktop.getNotificationStatus?.() ??
+      window.ryosDesktop
+        .canShowNotifications()
+        .then((supported) => ({
+          supported,
+          foreground: false,
+          platform: window.ryosDesktop?.platform ?? "unknown",
+        })))
+      .then((status) => {
+        if (cancelled) {
+          return;
+        }
+        const sanitized = sanitizeSystemNotificationStatus(status);
+        setDesktopNotificationSupported(sanitized?.supported ?? false);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDesktopNotificationSupported(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hasDesktopNotificationStatus = desktopNotificationSupported !== null;
+  const systemNotificationsChecked = hasDesktopNotificationStatus
+    ? desktopNotificationSupported
+    : notificationPermission === "granted";
+  const systemNotificationsDisabled = hasDesktopNotificationStatus
+    ? !desktopNotificationSupported
+    : notificationPermission === "denied";
+  const shouldRenderSystemNotificationsItem =
+    hasDesktopNotificationStatus || isNotificationApiAvailable();
 
   const openTelegramDialog = async () => {
     const status = await onRefreshTelegramLinkStatus();
@@ -413,13 +459,16 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
             >
               {t("apps.chats.menu.showRooms")}
             </MenubarCheckboxItem>
-            {isNotificationApiAvailable() && (
+            {shouldRenderSystemNotificationsItem && (
               <>
                 <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
                 <MenubarCheckboxItem
-                  checked={notificationPermission === "granted"}
-                  disabled={notificationPermission === "denied"}
+                  checked={systemNotificationsChecked}
+                  disabled={systemNotificationsDisabled}
                   onCheckedChange={(checked) => {
+                    if (hasDesktopNotificationStatus) {
+                      return;
+                    }
                     if (checked && notificationPermission === "default") {
                       void requestNotificationPermission();
                     }

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -363,7 +363,12 @@ const MenubarCheckboxItem = (
         isMacOSTheme && "rounded-none focus:bg-[var(--os-color-selection-bg)] focus:text-[var(--os-color-selection-text)] hover:bg-[var(--os-color-selection-bg)] hover:text-[var(--os-color-selection-text)]",
         !isSystem7Theme && !isMacOSTheme && "rounded-sm focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground",
         className,
-        "data-[state=checked]:text-foreground"
+        "data-[state=checked]:text-foreground",
+        (isSystem7Theme || isMacOSTheme) &&
+          "data-[state=checked]:focus:text-[var(--os-color-selection-text)] data-[state=checked]:hover:text-[var(--os-color-selection-text)]",
+        !isSystem7Theme &&
+          !isMacOSTheme &&
+          "data-[state=checked]:focus:text-accent-foreground data-[state=checked]:hover:text-accent-foreground"
       )}
       style={{
         fontFamily:

--- a/src/types/ryos-desktop.d.ts
+++ b/src/types/ryos-desktop.d.ts
@@ -1,5 +1,9 @@
 import type { ChatMessage, ChatRoom } from "@/shared/contracts/chat";
 import type {
+  SystemNotificationPayload,
+  SystemNotificationStatus,
+} from "@/utils/systemNotifications";
+import type {
   DesktopChatNotificationConfig,
   DesktopChatNotificationManageResult,
   DesktopChatNotificationState,
@@ -50,11 +54,7 @@ export type RyosDesktopSaveFileResult =
   | { canceled: true }
   | { canceled: false; filePath: string };
 
-export interface RyosDesktopNotificationOptions {
-  title: string;
-  body?: string;
-  chatRoomId?: string | null;
-}
+export type RyosDesktopNotificationOptions = SystemNotificationPayload;
 
 export type RyosDesktopNotificationResult =
   | { shown: true }
@@ -103,6 +103,8 @@ export interface RyosDesktopApi {
   getVersion: () => Promise<string>;
   /** Whether this trusted desktop renderer can ask the OS to show notifications. */
   canShowNotifications: () => Promise<boolean>;
+  /** Current native notification capability and foreground state. */
+  getNotificationStatus: () => Promise<SystemNotificationStatus>;
   /** Whether the desktop shell should mirror the next toast to a native OS notification. */
   shouldShowNativeNotification: () => Promise<boolean>;
   /** Show a text-only native OS notification from the sandboxed renderer. */

--- a/src/utils/chatNotificationDisplay.ts
+++ b/src/utils/chatNotificationDisplay.ts
@@ -8,6 +8,11 @@ import i18n from "@/lib/i18n";
 import { showChatNotification } from "@/utils/browserNotifications";
 import { openChatRoomFromNotification } from "@/utils/openChatRoomFromNotification";
 import { showNativeToastNotification } from "@/utils/nativeToastNotifications";
+import {
+  buildChatAiNotificationTag,
+  buildChatRoomNotificationTag,
+  toSafeSystemNotificationText,
+} from "@/utils/systemNotifications";
 
 const openLabel = () => i18n.t("apps.chats.notification.openAction");
 
@@ -23,6 +28,7 @@ function showNotificationFallback(params: {
   void showNativeToastNotification("basic", title, {
     ...(body ? { description: body } : {}),
     chatRoomId,
+    tag,
   }).then((shown) => {
     if (shown) {
       return;
@@ -56,9 +62,9 @@ export function showRoomMessageNotification(
   params: ShowRoomMessageNotificationParams
 ): void {
   const { username, content, roomId, messageId } = params;
-  const preview = content.replace(/\s+/g, " ").trim().slice(0, 80);
+  const preview = toSafeSystemNotificationText(content, 80) ?? "";
   const title = `@${username}`;
-  const tag = `room-${roomId}`;
+  const tag = buildChatRoomNotificationTag(roomId);
 
   showNotificationFallback({
     title,
@@ -91,10 +97,10 @@ export function showAiMessageNotification(
   params: ShowAiMessageNotificationParams
 ): void {
   const { content, messageId } = params;
-  const preview = content.replace(/\s+/g, " ").trim().slice(0, 100);
+  const preview = toSafeSystemNotificationText(content, 100) ?? "";
   const title = "@Ryo";
-  const tag = "chat-ai";
-  const body = preview + (content.length > 100 ? "…" : "");
+  const tag = buildChatAiNotificationTag();
+  const body = preview;
 
   showNotificationFallback({
     title,

--- a/src/utils/nativeToastNotifications.ts
+++ b/src/utils/nativeToastNotifications.ts
@@ -3,7 +3,11 @@ import type {
   RyosDesktopNotificationOptions,
 } from "@/types/ryos-desktop";
 import { toast } from "sonner";
-import { replaceControlCharacters } from "@/shared/sanitizeControlCharacters";
+import {
+  sanitizeSystemNotificationPayload,
+  type SystemNotificationTimeoutType,
+  type SystemNotificationUrgency,
+} from "@/utils/systemNotifications";
 
 export type NativeToastKind = "basic" | "success" | "error" | "info" | "warning";
 
@@ -14,18 +18,13 @@ export type NativeToastOptions = {
   duration?: unknown;
   id?: unknown;
   chatRoomId?: unknown;
+  tag?: unknown;
+  silent?: unknown;
+  urgency?: unknown;
+  timeoutType?: unknown;
 };
 
-const MAX_TITLE_LENGTH = 120;
-const MAX_BODY_LENGTH = 240;
 const PROGRESS_TOAST_ID_PATTERN = /(progress|loading|prefetch)/i;
-const SENSITIVE_TEXT_PATTERNS = [
-  /\bBearer\s+[A-Za-z0-9._~+/=-]+/i,
-  /\b(?:access|refresh|id)?_?token\s*[:=]\s*\S+/i,
-  /\b(?:api[_-]?key|secret|password|authorization)\s*[:=]\s*\S+/i,
-  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/,
-  /\b[A-Za-z0-9+/=_-]{48,}\b/,
-];
 
 let installed = false;
 
@@ -67,33 +66,6 @@ export function getNativeToastOptions(
   return isPlainObject(value) ? value : undefined;
 }
 
-function hasSensitiveText(value: string): boolean {
-  return SENSITIVE_TEXT_PATTERNS.some((pattern) => pattern.test(value));
-}
-
-function toSafeNotificationText(
-  value: unknown,
-  maxLength: number
-): string | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  const normalized = replaceControlCharacters(value)
-    .replace(/\s+/g, " ")
-    .trim();
-
-  if (!normalized || hasSensitiveText(normalized)) {
-    return null;
-  }
-
-  if (normalized.length <= maxLength) {
-    return normalized;
-  }
-
-  return `${normalized.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
-}
-
 function shouldSkipNativeToast(options: NativeToastOptions | undefined): boolean {
   if (!options) {
     return false;
@@ -126,6 +98,24 @@ function getNativeToastChatRoomId(
     : undefined;
 }
 
+function getNativeToastUrgency(
+  options: NativeToastOptions | undefined
+): SystemNotificationUrgency | undefined {
+  return options?.urgency === "low" ||
+    options?.urgency === "normal" ||
+    options?.urgency === "critical"
+    ? options.urgency
+    : undefined;
+}
+
+function getNativeToastTimeoutType(
+  options: NativeToastOptions | undefined
+): SystemNotificationTimeoutType | undefined {
+  return options?.timeoutType === "default" || options?.timeoutType === "never"
+    ? options.timeoutType
+    : undefined;
+}
+
 export function getNativeToastNotification(
   _kind: NativeToastKind,
   message: unknown,
@@ -135,22 +125,24 @@ export function getNativeToastNotification(
     return null;
   }
 
-  const title = toSafeNotificationText(message, MAX_TITLE_LENGTH);
-  if (!title) {
+  const chatRoomId = getNativeToastChatRoomId(options);
+  const hasDescription =
+    options?.description !== undefined && options.description !== null;
+  const payload = sanitizeSystemNotificationPayload({
+    title: message,
+    body: hasDescription ? options.description : undefined,
+    chatRoomId,
+    tag: options?.tag,
+    silent: options?.silent === true,
+    urgency: getNativeToastUrgency(options),
+    timeoutType: getNativeToastTimeoutType(options),
+  });
+
+  if (hasDescription && !payload?.body) {
     return null;
   }
 
-  if (options?.description !== undefined && options.description !== null) {
-    const body = toSafeNotificationText(options.description, MAX_BODY_LENGTH);
-    if (!body) {
-      return null;
-    }
-    const chatRoomId = getNativeToastChatRoomId(options);
-    return chatRoomId !== undefined ? { title, body, chatRoomId } : { title, body };
-  }
-
-  const chatRoomId = getNativeToastChatRoomId(options);
-  return chatRoomId !== undefined ? { title, chatRoomId } : { title };
+  return payload;
 }
 
 function getDesktopApi() {

--- a/src/utils/systemNotifications.ts
+++ b/src/utils/systemNotifications.ts
@@ -1,0 +1,151 @@
+import { replaceControlCharacters } from "../shared/sanitizeControlCharacters";
+
+export type SystemNotificationUrgency = "low" | "normal" | "critical";
+export type SystemNotificationTimeoutType = "default" | "never";
+
+export interface SystemNotificationPayload {
+  title: string;
+  body?: string;
+  tag?: string;
+  chatRoomId?: string | null;
+  silent?: boolean;
+  urgency?: SystemNotificationUrgency;
+  timeoutType?: SystemNotificationTimeoutType;
+}
+
+export interface SystemNotificationStatus {
+  supported: boolean;
+  foreground: boolean;
+  platform: NodeJS.Platform | string;
+  reason?: "untrusted" | "unsupported";
+}
+
+const MAX_TITLE_LENGTH = 120;
+const MAX_BODY_LENGTH = 240;
+const MAX_TAG_LENGTH = 160;
+
+const SENSITIVE_TEXT_PATTERNS = [
+  /\bBearer\s+[A-Za-z0-9._~+/=-]+/i,
+  /\b(?:access|refresh|id)?_?token\s*[:=]\s*\S+/i,
+  /\b(?:api[_-]?key|secret|password|authorization)\s*[:=]\s*\S+/i,
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/,
+  /\b[A-Za-z0-9+/=_-]{48,}\b/,
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function hasSensitiveNotificationText(value: string): boolean {
+  return SENSITIVE_TEXT_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+export function toSafeSystemNotificationText(
+  value: unknown,
+  maxLength: number
+): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = replaceControlCharacters(value)
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!normalized || hasSensitiveNotificationText(normalized)) {
+    return undefined;
+  }
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+function sanitizeTag(value: unknown): string | undefined {
+  const tag = toSafeSystemNotificationText(value, MAX_TAG_LENGTH);
+  if (!tag) {
+    return undefined;
+  }
+  return tag.replace(/[^\w:.-]/g, "-");
+}
+
+function sanitizeChatRoomId(value: unknown): string | null | undefined {
+  if (value === null) {
+    return null;
+  }
+  const roomId = toSafeSystemNotificationText(value, MAX_TAG_LENGTH);
+  return roomId || undefined;
+}
+
+function sanitizeUrgency(value: unknown): SystemNotificationUrgency | undefined {
+  return value === "low" || value === "normal" || value === "critical"
+    ? value
+    : undefined;
+}
+
+function sanitizeTimeoutType(
+  value: unknown
+): SystemNotificationTimeoutType | undefined {
+  return value === "default" || value === "never" ? value : undefined;
+}
+
+export function sanitizeSystemNotificationPayload(
+  value: unknown
+): SystemNotificationPayload | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const title = toSafeSystemNotificationText(value.title, MAX_TITLE_LENGTH);
+  if (!title) {
+    return null;
+  }
+
+  const payload: SystemNotificationPayload = { title };
+  const body = toSafeSystemNotificationText(value.body, MAX_BODY_LENGTH);
+  const tag = sanitizeTag(value.tag);
+  const chatRoomId = sanitizeChatRoomId(value.chatRoomId);
+  const urgency = sanitizeUrgency(value.urgency);
+  const timeoutType = sanitizeTimeoutType(value.timeoutType);
+
+  if (body) payload.body = body;
+  if (tag) payload.tag = tag;
+  if (chatRoomId !== undefined) payload.chatRoomId = chatRoomId;
+  if (value.silent === true) payload.silent = true;
+  if (urgency) payload.urgency = urgency;
+  if (timeoutType) payload.timeoutType = timeoutType;
+
+  return payload;
+}
+
+export function buildChatRoomNotificationTag(roomId: string): string {
+  return `chat-room-${roomId.replace(/[^\w:.-]/g, "-")}`;
+}
+
+export function buildChatAiNotificationTag(): string {
+  return "chat-ai";
+}
+
+export function sanitizeSystemNotificationStatus(
+  value: unknown
+): SystemNotificationStatus | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  if (typeof value.supported !== "boolean") {
+    return null;
+  }
+
+  return {
+    supported: value.supported,
+    foreground: value.foreground === true,
+    platform: typeof value.platform === "string" ? value.platform : "unknown",
+    reason:
+      value.reason === "untrusted" || value.reason === "unsupported"
+        ? value.reason
+        : undefined,
+  };
+}

--- a/tests/test-desktop-chat-notification-policy.test.ts
+++ b/tests/test-desktop-chat-notification-policy.test.ts
@@ -117,8 +117,26 @@ describe("desktop chat notification policy", () => {
     expect(source).toContain("/api/realtime/ticket");
     expect(source).toContain("subscription_error");
     expect(source).toContain("ryos-desktop:chat-notification-status");
+    expect(source).toContain("buildChatRoomNotificationTag(message.roomId)");
     expect(source).toContain('"channel-auth-failed"');
     expect(source).toContain('"service-start-failed"');
+  });
+
+  test("desktop shell exposes notification status and shared sanitizer", () => {
+    const mainSource = readSource("electron/main.ts");
+    const preloadSource = readSource("electron/preload.ts");
+    const typeSource = readSource("src/types/ryos-desktop.d.ts");
+    expect(mainSource).toContain("ryos-desktop:get-notification-status");
+    expect(mainSource).toContain("sanitizeSystemNotificationPayload(options)");
+    expect(preloadSource).toContain("getNotificationStatus");
+    expect(typeSource).toContain("getNotificationStatus");
+  });
+
+  test("renderer chat display uses stable shared notification tags", () => {
+    const source = readSource("src/utils/chatNotificationDisplay.ts");
+    expect(source).toContain("buildChatRoomNotificationTag(roomId)");
+    expect(source).toContain("buildChatAiNotificationTag()");
+    expect(source).toContain("tag,");
   });
 
   test("sanitizes local WebSocket config and strips ticket params", () => {

--- a/tests/test-native-toast-notifications.test.ts
+++ b/tests/test-native-toast-notifications.test.ts
@@ -23,11 +23,13 @@ describe("native toast notifications", () => {
       getNativeToastNotification("info", "@Ryo", {
         description: "I found the answer.",
         chatRoomId: null,
+        tag: "chat-ai",
       })
     ).toEqual({
       title: "@Ryo",
       body: "I found the answer.",
       chatRoomId: null,
+      tag: "chat-ai",
     });
 
     expect(
@@ -104,6 +106,25 @@ describe("native toast notifications", () => {
     expect(payload?.title.endsWith("...")).toBe(true);
     expect(payload?.body).toHaveLength(240);
     expect(payload?.body?.endsWith("...")).toBe(true);
+  });
+
+  test("passes through supported desktop notification hints", () => {
+    expect(
+      getNativeToastNotification("warning", "Connection unstable", {
+        description: "Messages may be delayed.",
+        tag: "chat-room-general",
+        silent: true,
+        urgency: "normal",
+        timeoutType: "default",
+      })
+    ).toEqual({
+      title: "Connection unstable",
+      body: "Messages may be delayed.",
+      tag: "chat-room-general",
+      silent: true,
+      urgency: "normal",
+      timeoutType: "default",
+    });
   });
 
   test("only mirrors native toasts when desktop gate allows it", async () => {

--- a/tests/test-system-notifications.test.ts
+++ b/tests/test-system-notifications.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildChatAiNotificationTag,
+  buildChatRoomNotificationTag,
+  sanitizeSystemNotificationPayload,
+  sanitizeSystemNotificationStatus,
+  toSafeSystemNotificationText,
+} from "../src/utils/systemNotifications";
+
+describe("system notifications", () => {
+  test("sanitizes rich notification payloads", () => {
+    expect(
+      sanitizeSystemNotificationPayload({
+        title: "  Saved\nfile  ",
+        body: "Done\twith import",
+        tag: "room id / one",
+        chatRoomId: "room-a",
+        silent: true,
+        urgency: "critical",
+        timeoutType: "never",
+      })
+    ).toEqual({
+      title: "Saved file",
+      body: "Done with import",
+      tag: "room-id---one",
+      chatRoomId: "room-a",
+      silent: true,
+      urgency: "critical",
+      timeoutType: "never",
+    });
+  });
+
+  test("rejects missing titles and sensitive-looking text", () => {
+    expect(sanitizeSystemNotificationPayload({ title: "" })).toBeNull();
+    expect(
+      sanitizeSystemNotificationPayload({
+        title: "Request failed: token=abc123",
+      })
+    ).toBeNull();
+    expect(
+      sanitizeSystemNotificationPayload({
+        title: "Failed",
+        body: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature",
+      })
+    ).toEqual({ title: "Failed" });
+  });
+
+  test("caps text and builds stable chat tags", () => {
+    expect(toSafeSystemNotificationText("Long title ".repeat(16), 120)).toHaveLength(
+      120
+    );
+    expect(buildChatRoomNotificationTag("room/a b")).toBe("chat-room-room-a-b");
+    expect(buildChatAiNotificationTag()).toBe("chat-ai");
+  });
+
+  test("sanitizes desktop notification status", () => {
+    expect(
+      sanitizeSystemNotificationStatus({
+        supported: true,
+        foreground: false,
+        platform: "darwin",
+      })
+    ).toEqual({
+      supported: true,
+      foreground: false,
+      platform: "darwin",
+      reason: undefined,
+    });
+
+    expect(
+      sanitizeSystemNotificationStatus({
+        supported: false,
+        foreground: true,
+        platform: "linux",
+        reason: "unsupported",
+      })
+    ).toEqual({
+      supported: false,
+      foreground: true,
+      platform: "linux",
+      reason: "unsupported",
+    });
+    expect(sanitizeSystemNotificationStatus({ foreground: false })).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add shared system notification sanitization/status helpers for Electron and renderer paths.
- Extend Electron notification IPC with capability status and richer sanitized payload fields.
- Align chat notification tags across main/renderer paths and make Chats Settings desktop-aware.
- Fix checked menubar checkbox hover contrast so notification/settings rows stay readable.
- Add focused unit/wiring coverage for notification payloads, native toast hints, and IPC/tag wiring.

### Walkthrough
<a href="https://cursor.com/agents/bc-019f0e58-ca03-7518-a205-be490b14bbb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchats_notification_menu_checked_hover_contrast.mp4"><img src="https://cursor.com/artifacts/c/art-830e22a4-b80e-4dd4-a73a-b44120606d0f" alt="chats_notification_menu_checked_hover_contrast.mp4" /></a>

### Testing
- `bun test tests/test-system-notifications.test.ts tests/test-native-toast-notifications.test.ts tests/test-desktop-chat-notification-policy.test.ts tests/test-chat-notification-integration-wiring.test.ts`
- `bun run build`
- `bun run electron:bundle`
- `bun run test:registration`
- Manual GUI walkthrough in the running app showing Chats Settings > System Notifications and checked-row hover contrast.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0e58-ca03-7518-a205-be490b14bbb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0e58-ca03-7518-a205-be490b14bbb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

