### PR TITLE
Update login label and Cloud Sync pane

### DIFF
--- a/scripts/apple-ui-terminology.ts
+++ b/scripts/apple-ui-terminology.ts
@@ -42,7 +42,7 @@ export const ENGLISH_STYLE_EXPECTATIONS = {
   "common.colors.pink": "Pink",
   "common.colors.purple": "Purple",
   "common.colors.orange": "Orange",
-  "common.auth.username": "user name",
+  "common.auth.username": "User name",
   "common.auth.recovery.identifier": "user name or email",
 } as const satisfies Record<string, string>;
 

--- a/src/apps/control-panels/components/control-panels-app/DotMacPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/DotMacPaneContent.tsx
@@ -84,176 +84,176 @@ export function DotMacPaneContent({
   setIsConfirmForceDownloadOpen,
 }: DotMacPaneContentProps) {
   return (
-    <div className="control-panels-pref-form h-full overflow-y-auto">
-      <div className="control-panels-pref-well space-y-3">
-            {username ? (
-              <div className="flex items-center justify-between gap-4">
-                <SyncSectionTitle
-                  title={t("apps.control-panels.autoSync.title")}
-                  subtitle={
-                    autoSyncEnabled
-                      ? isAutoSyncChecking
-                        ? t("apps.control-panels.autoSync.checking")
-                        : formatRelativeTime(autoSyncLastCheckedAt, t)
-                          ? t("apps.control-panels.autoSync.lastChecked", {
-                              date: formatRelativeTime(autoSyncLastCheckedAt, t),
-                            })
-                          : t("apps.control-panels.autoSync.waiting")
-                      : t("apps.control-panels.autoSync.description")
-                  }
-                />
-                <Switch
-                  checked={autoSyncEnabled}
-                  onCheckedChange={setAutoSyncEnabled}
-                  className="data-[state=checked]:bg-[#000000]"
-                />
-              </div>
-            ) : (
-              <div className="flex items-center justify-between">
-                <SyncSectionTitle
-                  title={t("apps.control-panels.autoSync.title")}
-                  subtitle={t("apps.control-panels.autoSync.description")}
-                />
-                <Button variant="default" onClick={promptSetUsername} className="h-7">
-                  {t("apps.control-panels.login")}
-                </Button>
-              </div>
-            )}
+    <div className="control-panels-pref-form space-y-0 h-full overflow-y-auto">
+      <div className="control-panels-pref-form-section space-y-3">
+        {username ? (
+          <div className="flex items-center justify-between gap-4">
+            <SyncSectionTitle
+              title={t("apps.control-panels.autoSync.title")}
+              subtitle={
+                autoSyncEnabled
+                  ? isAutoSyncChecking
+                    ? t("apps.control-panels.autoSync.checking")
+                    : formatRelativeTime(autoSyncLastCheckedAt, t)
+                      ? t("apps.control-panels.autoSync.lastChecked", {
+                          date: formatRelativeTime(autoSyncLastCheckedAt, t),
+                        })
+                      : t("apps.control-panels.autoSync.waiting")
+                  : t("apps.control-panels.autoSync.description")
+              }
+            />
+            <Switch
+              checked={autoSyncEnabled}
+              onCheckedChange={setAutoSyncEnabled}
+              className="data-[state=checked]:bg-[#000000]"
+            />
+          </div>
+        ) : (
+          <div className="flex items-center justify-between">
+            <SyncSectionTitle
+              title={t("apps.control-panels.autoSync.title")}
+              subtitle={t("apps.control-panels.autoSync.description")}
+            />
+            <Button variant="default" onClick={promptSetUsername} className="h-7">
+              {t("apps.control-panels.login")}
+            </Button>
+          </div>
+        )}
 
-            {username && autoSyncEnabled && (
-              <>
-                <hr className="mt-2 mb-4 border-t" style={tabStyles.separatorStyle} />
-                <div className="space-y-3">
-                  <SyncDomainRow
-                    appId={AUTO_SYNC_ITEM_ICONS.files}
-                    label={t("apps.control-panels.autoSync.files")}
-                    status={formatSyncStatus(autoSyncDomainStatus.files, t)}
-                    checked={syncFiles}
-                    onCheckedChange={setSyncFiles}
-                  />
-                  <SyncDomainRow
-                    appId={AUTO_SYNC_ITEM_ICONS.settings}
-                    label={t("apps.control-panels.autoSync.settings")}
-                    status={formatSyncStatus(autoSyncDomainStatus.settings, t)}
-                    checked={syncSettings}
-                    onCheckedChange={setSyncSettings}
-                  />
-                  <SyncDomainRow
-                    appId={AUTO_SYNC_ITEM_ICONS.calendar}
-                    label={t("apps.control-panels.autoSync.calendar")}
-                    status={formatSyncStatus(autoSyncDomainStatus.calendar, t)}
-                    checked={syncCalendar}
-                    onCheckedChange={setSyncCalendar}
-                  />
-                  <SyncDomainRow
-                    appId={AUTO_SYNC_ITEM_ICONS.contacts}
-                    label={t("apps.control-panels.autoSync.contacts")}
-                    status={formatSyncStatus(autoSyncDomainStatus.contacts, t)}
-                    checked={syncContacts}
-                    onCheckedChange={setSyncContacts}
-                  />
-                  <SyncDomainRow
-                    appId={AUTO_SYNC_ITEM_ICONS.books}
-                    label={t("apps.control-panels.autoSync.books")}
-                    status={formatSyncStatus(autoSyncDomainStatus.books, t)}
-                    checked={syncBooks}
-                    onCheckedChange={setSyncBooks}
-                  />
-                  <SyncDomainRow
-                    appId={AUTO_SYNC_ITEM_ICONS.maps}
-                    label={t("apps.control-panels.autoSync.maps")}
-                    status={formatSyncStatus(autoSyncDomainStatus.maps, t)}
-                    checked={syncMaps}
-                    onCheckedChange={setSyncMaps}
-                  />
-                  <SyncDomainRow
-                    appId={AUTO_SYNC_ITEM_ICONS.songs}
-                    label={t("apps.control-panels.autoSync.songs")}
-                    status={formatSyncStatus(autoSyncDomainStatus.songs, t)}
-                    checked={syncSongs}
-                    onCheckedChange={setSyncSongs}
-                  />
-                  <SyncDomainRow
-                    appId={AUTO_SYNC_ITEM_ICONS.videos}
-                    label={t("apps.control-panels.autoSync.videos")}
-                    status={formatSyncStatus(autoSyncDomainStatus.videos, t)}
-                    checked={syncVideos}
-                    onCheckedChange={setSyncVideos}
-                  />
-                  <SyncDomainRow
-                    appId={AUTO_SYNC_ITEM_ICONS.tv}
-                    label={t("apps.control-panels.autoSync.tvChannels")}
-                    status={formatSyncStatus(autoSyncDomainStatus.tv, t)}
-                    checked={syncTv}
-                    onCheckedChange={setSyncTv}
-                  />
-                  <SyncDomainRow
-                    appId={AUTO_SYNC_ITEM_ICONS.stickies}
-                    label={t("apps.control-panels.autoSync.stickies")}
-                    status={formatSyncStatus(autoSyncDomainStatus.stickies, t)}
-                    checked={syncStickies}
-                    onCheckedChange={setSyncStickies}
-                  />
-                </div>
-
-                {autoSyncLastError && (
-                  <div className="flex items-start justify-between gap-3">
-                    <p className="min-w-0 flex-1 text-[11px] text-red-700 font-geneva-12">
-                      {t("apps.control-panels.autoSync.error", {
-                        error: autoSyncLastError,
-                      })}
-                    </p>
-                    <Button
-                      variant="retro"
-                      size="sm"
-                      onClick={requestCloudSyncCheck}
-                      disabled={isAutoSyncChecking}
-                      className="h-7 shrink-0"
-                    >
-                      {isAutoSyncChecking
-                        ? t("apps.control-panels.autoSync.checking")
-                        : t("common.retry", { defaultValue: "Retry" })}
-                    </Button>
-                  </div>
-                )}
-              </>
-            )}
-
+        {username && autoSyncEnabled && (
+          <>
             <hr className="mt-2 mb-4 border-t" style={tabStyles.separatorStyle} />
-            <div
-              className={cn(
-                "space-y-2",
-                !username && "opacity-50 pointer-events-none select-none"
-              )}
-            >
-              <div className="flex gap-2">
+            <div className="space-y-3">
+              <SyncDomainRow
+                appId={AUTO_SYNC_ITEM_ICONS.files}
+                label={t("apps.control-panels.autoSync.files")}
+                status={formatSyncStatus(autoSyncDomainStatus.files, t)}
+                checked={syncFiles}
+                onCheckedChange={setSyncFiles}
+              />
+              <SyncDomainRow
+                appId={AUTO_SYNC_ITEM_ICONS.settings}
+                label={t("apps.control-panels.autoSync.settings")}
+                status={formatSyncStatus(autoSyncDomainStatus.settings, t)}
+                checked={syncSettings}
+                onCheckedChange={setSyncSettings}
+              />
+              <SyncDomainRow
+                appId={AUTO_SYNC_ITEM_ICONS.calendar}
+                label={t("apps.control-panels.autoSync.calendar")}
+                status={formatSyncStatus(autoSyncDomainStatus.calendar, t)}
+                checked={syncCalendar}
+                onCheckedChange={setSyncCalendar}
+              />
+              <SyncDomainRow
+                appId={AUTO_SYNC_ITEM_ICONS.contacts}
+                label={t("apps.control-panels.autoSync.contacts")}
+                status={formatSyncStatus(autoSyncDomainStatus.contacts, t)}
+                checked={syncContacts}
+                onCheckedChange={setSyncContacts}
+              />
+              <SyncDomainRow
+                appId={AUTO_SYNC_ITEM_ICONS.books}
+                label={t("apps.control-panels.autoSync.books")}
+                status={formatSyncStatus(autoSyncDomainStatus.books, t)}
+                checked={syncBooks}
+                onCheckedChange={setSyncBooks}
+              />
+              <SyncDomainRow
+                appId={AUTO_SYNC_ITEM_ICONS.maps}
+                label={t("apps.control-panels.autoSync.maps")}
+                status={formatSyncStatus(autoSyncDomainStatus.maps, t)}
+                checked={syncMaps}
+                onCheckedChange={setSyncMaps}
+              />
+              <SyncDomainRow
+                appId={AUTO_SYNC_ITEM_ICONS.songs}
+                label={t("apps.control-panels.autoSync.songs")}
+                status={formatSyncStatus(autoSyncDomainStatus.songs, t)}
+                checked={syncSongs}
+                onCheckedChange={setSyncSongs}
+              />
+              <SyncDomainRow
+                appId={AUTO_SYNC_ITEM_ICONS.videos}
+                label={t("apps.control-panels.autoSync.videos")}
+                status={formatSyncStatus(autoSyncDomainStatus.videos, t)}
+                checked={syncVideos}
+                onCheckedChange={setSyncVideos}
+              />
+              <SyncDomainRow
+                appId={AUTO_SYNC_ITEM_ICONS.tv}
+                label={t("apps.control-panels.autoSync.tvChannels")}
+                status={formatSyncStatus(autoSyncDomainStatus.tv, t)}
+                checked={syncTv}
+                onCheckedChange={setSyncTv}
+              />
+              <SyncDomainRow
+                appId={AUTO_SYNC_ITEM_ICONS.stickies}
+                label={t("apps.control-panels.autoSync.stickies")}
+                status={formatSyncStatus(autoSyncDomainStatus.stickies, t)}
+                checked={syncStickies}
+                onCheckedChange={setSyncStickies}
+              />
+            </div>
+
+            {autoSyncLastError && (
+              <div className="flex items-start justify-between gap-3">
+                <p className="min-w-0 flex-1 text-[11px] text-red-700 font-geneva-12">
+                  {t("apps.control-panels.autoSync.error", {
+                    error: autoSyncLastError,
+                  })}
+                </p>
                 <Button
                   variant="retro"
-                  onClick={() => setIsConfirmForceUploadOpen(true)}
-                  disabled={isCloudForceSyncing}
-                  tabIndex={!username ? -1 : undefined}
-                  className="flex-1"
+                  size="sm"
+                  onClick={requestCloudSyncCheck}
+                  disabled={isAutoSyncChecking}
+                  className="h-7 shrink-0"
                 >
-                  {isCloudForceUploading
-                    ? t("apps.control-panels.cloudSync.forceUploading")
-                    : t("apps.control-panels.cloudSync.forceUpload")}
-                </Button>
-                <Button
-                  variant="retro"
-                  onClick={() => setIsConfirmForceDownloadOpen(true)}
-                  disabled={isCloudForceSyncing}
-                  tabIndex={!username ? -1 : undefined}
-                  className="flex-1"
-                >
-                  {isCloudForceDownloading
-                    ? t("apps.control-panels.cloudSync.forceDownloading")
-                    : t("apps.control-panels.cloudSync.forceDownload")}
+                  {isAutoSyncChecking
+                    ? t("apps.control-panels.autoSync.checking")
+                    : t("common.retry", { defaultValue: "Retry" })}
                 </Button>
               </div>
-              <p className="text-[11px] text-neutral-600 font-geneva-12">
-                {t("apps.control-panels.cloudSync.forceSyncDescription")}
-              </p>
-            </div>
+            )}
+          </>
+        )}
+
+        <hr className="mt-2 mb-4 border-t" style={tabStyles.separatorStyle} />
+        <div
+          className={cn(
+            "space-y-2",
+            !username && "opacity-50 pointer-events-none select-none"
+          )}
+        >
+          <div className="flex gap-2">
+            <Button
+              variant="retro"
+              onClick={() => setIsConfirmForceUploadOpen(true)}
+              disabled={isCloudForceSyncing}
+              tabIndex={!username ? -1 : undefined}
+              className="flex-1"
+            >
+              {isCloudForceUploading
+                ? t("apps.control-panels.cloudSync.forceUploading")
+                : t("apps.control-panels.cloudSync.forceUpload")}
+            </Button>
+            <Button
+              variant="retro"
+              onClick={() => setIsConfirmForceDownloadOpen(true)}
+              disabled={isCloudForceSyncing}
+              tabIndex={!username ? -1 : undefined}
+              className="flex-1"
+            >
+              {isCloudForceDownloading
+                ? t("apps.control-panels.cloudSync.forceDownloading")
+                : t("apps.control-panels.cloudSync.forceDownload")}
+            </Button>
+          </div>
+          <p className="text-[11px] text-neutral-600 font-geneva-12">
+            {t("apps.control-panels.cloudSync.forceSyncDescription")}
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -240,7 +240,7 @@
     },
     "auth": {
       "dialogTitle": "Sign In to ryOS",
-      "username": "user name",
+      "username": "User name",
       "password": "Password",
       "logIn": "Sign In",
       "createAccount": "Create Account",

--- a/tests/test-control-panels-mac-layout.test.ts
+++ b/tests/test-control-panels-mac-layout.test.ts
@@ -248,6 +248,8 @@ describe("Control Panels macOS 10.3 layout", () => {
     expect(dotMacSource.includes("cloudSyncTabs.sync")).toBe(false);
     expect(dotMacSource.includes("cloudSyncTabs.backup")).toBe(false);
     expect(dotMacSource.includes("control-panels-pref-tab-panel")).toBe(false);
+    expect(dotMacSource.includes("control-panels-pref-well")).toBe(false);
+    expect(dotMacSource.includes("control-panels-pref-form-section")).toBe(true);
     expect(dotMacSource.includes("handleCloudBackup")).toBe(false);
     expect(dotMacSource.includes("setIsConfirmForceUploadOpen")).toBe(true);
     expect(dotMacSource.includes("setIsConfirmForceDownloadOpen")).toBe(true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Update the English login/sign-up auth label from `user name` to `User name`.
- Remove the extra platter/well container from the Cloud Sync control panel pane so it matches Security and Displays.
- Keep the translation and Control Panels layout audit expectations aligned with the changed UI.

### Walkthrough
<a href="https://cursor.com/agents/bc-019f0ebf-cf5e-7366-8fc6-f888ea4a5af3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcloud_sync_plain_control_panel.mp4"><img src="https://cursor.com/artifacts/c/art-ec374f02-6434-4bf7-a4eb-6ec765a91d47" alt="cloud_sync_plain_control_panel.mp4" /></a>

### Testing
- `bun test tests/test-translation-audit.test.ts` — passed (7 tests).
- `bun test tests/test-control-panels-mac-layout.test.ts` — passed (25 tests).
- `bun run build` — passed.
- Manual browser verification — passed; compared Cloud Sync with Security and Displays.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0ebf-cf5e-7366-8fc6-f888ea4a5af3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0ebf-cf5e-7366-8fc6-f888ea4a5af3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

