### PR TITLE
Tighten divider spacing in Cloud Sync settings

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/DotMacPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/DotMacPaneContent.tsx
@@ -85,7 +85,7 @@ export function DotMacPaneContent({
 }: DotMacPaneContentProps) {
   return (
     <div className="control-panels-pref-form space-y-0 h-full overflow-y-auto">
-      <div className="control-panels-pref-form-section space-y-3">
+      <div className="control-panels-pref-form-section">
         {username ? (
           <div className="flex items-center justify-between gap-4">
             <SyncSectionTitle
@@ -122,7 +122,7 @@ export function DotMacPaneContent({
 
         {username && autoSyncEnabled && (
           <>
-            <hr className="mt-2 mb-4 border-t" style={tabStyles.separatorStyle} />
+            <hr className="my-2 border-t" style={tabStyles.separatorStyle} />
             <div className="space-y-3">
               <SyncDomainRow
                 appId={AUTO_SYNC_ITEM_ICONS.files}
@@ -197,7 +197,7 @@ export function DotMacPaneContent({
             </div>
 
             {autoSyncLastError && (
-              <div className="flex items-start justify-between gap-3">
+              <div className="mt-3 flex items-start justify-between gap-3">
                 <p className="min-w-0 flex-1 text-[11px] text-red-700 font-geneva-12">
                   {t("apps.control-panels.autoSync.error", {
                     error: autoSyncLastError,
@@ -219,7 +219,7 @@ export function DotMacPaneContent({
           </>
         )}
 
-        <hr className="mt-2 mb-4 border-t" style={tabStyles.separatorStyle} />
+        <hr className="my-2 border-t" style={tabStyles.separatorStyle} />
         <div
           className={cn(
             "space-y-2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cuts the extra padding before and after the horizontal dividers in the Cloud Sync (.Mac) Control Panels pane.

Previously each `<hr>` used asymmetric margins (`mt-2 mb-4`) while sitting inside a `space-y-3` section, so the next sibling's `space-y-3` margin stacked on top of the divider's bottom margin — producing a noticeably large, lopsided gap below each divider.

Changes in `DotMacPaneContent.tsx`:
- Removed `space-y-3` from the section container so the dividers own their spacing.
- Set both dividers to symmetric, tight `my-2` margins.
- Added an explicit `mt-3` to the auto-sync error row (it previously relied on the section's `space-y-3`).

## Testing

- Verified visually in the running app (Control Panels → Cloud Sync) that the dividers now sit snug with symmetric spacing above/below.

![Cloud Sync divider above Upload/Download buttons](https://cursor.com/artifacts/c/art-e62bcc53-85d1-452a-a693-b2b7878a7d23)
![Cloud Sync top divider under header](https://cursor.com/artifacts/c/art-1dae6322-a044-40a3-93b5-85916f3aded9)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f0ff3-8068-7f41-8333-88944b48df9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f0ff3-8068-7f41-8333-88944b48df9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

