### PR TITLE
i18n: fix inconsistent glossary term usage in translations

### DIFF
--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -2847,7 +2847,7 @@
         "fullScreen": "Vollbild",
         "furigana": "Furigana",
         "goToAlbum": "Zum Album",
-        "goToArtist": "Zum Interpreten",
+        "goToArtist": "Zum Künstler",
         "goToPlaylist": "Zur Playlist",
         "importLibrary": "Mediathek importieren…",
         "ipodHelp": "iPod-Hilfe",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -341,7 +341,7 @@
         "appleMusicId": "Apple Music ID",
         "createdAt": "作成",
         "delete": "曲を削除",
-        "forceRefresh": "強制リフレッシュ",
+        "forceRefresh": "強制更新",
         "forceRefreshTooltip": "Kugouから歌詞を再取得し、キャッシュされた注釈をクリアします",
         "furigana": "ふりがな",
         "info": "情報",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -906,7 +906,7 @@
         "monthView": "월 보기",
         "newEvent": "새로운 이벤트",
         "showToDoItems": "할 일 항목 보기",
-        "syncCalendar": "일정 동기화",
+        "syncCalendar": "캘린더 동기화",
         "weekView": "주 보기"
       },
       "name": "캘린더",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1020,7 +1020,7 @@
         "aboutChats": "О чатах",
         "chatSpeech": "Речь в чате",
         "chats": "Чаты",
-        "chatsHelp": "Помощь по чатам",
+        "chatsHelp": "Справка по чатам",
         "clearChat": "Очистить чат",
         "createAccount": "Создать учетную запись…",
         "decreaseFontSize": "Уменьшить размер шрифта",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -841,7 +841,7 @@
       "title": "計算機"
     },
     "calendar": {
-      "description": "含有事件的日曆",
+      "description": "含有事件的行事曆",
       "event": {
         "allDay": "整日",
         "calendar": "行事曆",
@@ -1524,7 +1524,7 @@
         "importVCard": "匯入 vCard⋯",
         "markAsMine": "標記為我的",
         "newContact": "新增聯絡人",
-        "syncContacts": "同步聯絡資訊"
+        "syncContacts": "同步聯絡人"
       },
       "messages": {
         "deleted": "已刪除 {{name}}",
@@ -2736,7 +2736,7 @@
         "lyricsSearchHttpError": "搜尋失敗（狀態 {{status}}）",
         "lyricsSearchInvalidResponse": "伺服器回應無效",
         "lyricsSearchNoResults": "找不到結果",
-        "lyricsSearchPlaceholder": "輸入搜尋關鍵字（例如：歌曲名稱、歌手）",
+        "lyricsSearchPlaceholder": "輸入搜尋關鍵字（例如：歌曲名稱、藝人）",
         "lyricsSearchReset": "重設為自動",
         "lyricsSearchSearch": "搜尋",
         "lyricsSearchSearching": "搜尋中⋯",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Several localized strings used a non-glossary synonym for a term, even though the rest of the same locale consistently uses the canonical Apple glossary word (`scripts/apple-ui-terminology-data.ts`). This fixes those lone outliers so each locale is internally consistent.

The existing `bun run i18n:audit` only enforces values that are an **exact standalone match** of a glossary term; it does not catch a glossary word used inconsistently *inside* a longer label/phrase. I wrote a throwaway analysis pass that grouped, per locale, how each glossary term is rendered across all keys, then kept only cases where one locale was overwhelmingly consistent with the canonical term and a single key diverged with a different word (filtering out false positives from inflection, verb forms, compounds, placeholders, and homographs like "logs" = logarithms).

## Fixes

| Locale | Key | Before | After | Glossary term |
|--------|-----|--------|-------|---------------|
| ja | `apps.admin.song.forceRefresh` | 強制リフレッシュ | 強制更新 | Refresh = 更新 |
| ko | `apps.calendar.menu.syncCalendar` | 일정 동기화 | 캘린더 동기화 | Calendar = 캘린더 |
| zh-TW | `apps.contacts.menu.syncContacts` | 同步聯絡資訊 | 同步聯絡人 | Contacts = 聯絡人 |
| zh-TW | `apps.calendar.description` | 含有事件的日曆 | 含有事件的行事曆 | Calendar = 行事曆 |
| zh-TW | `apps.ipod.dialogs.lyricsSearchPlaceholder` | …歌曲名稱、歌手 | …歌曲名稱、藝人 | Artist = 藝人 |
| de | `apps.ipod.menu.goToArtist` | Zum Interpreten | Zum Künstler | Artist = Künstler |
| ru | `apps.chats.menu.chatsHelp` | Помощь по чатам | Справка по чатам | Help = Справка |

Each target word is the term that locale already uses everywhere else (e.g. ja uses 更新 for Refresh on every other key; ru uses Справка for every other `*Help` menu item; zh-TW `calendar.event.calendar` is already 行事曆). `ru goToArtist` was intentionally left as «исполнитель» since that locale uses it app-wide (matching Apple Russian Music).

## Testing
- ✅ `bun run i18n:audit` — passes for 9 locales against 113 Apple terms
- ✅ `bun test tests/test-translation-audit.test.ts` — 7 pass / 0 fail
- ✅ `bun run i18n:sync:dry-run` — 0 missing keys across all languages
- ✅ JSON validity verified for all 5 edited locale files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1149-76bb-7218-823f-050e51606f0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1149-76bb-7218-823f-050e51606f0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

