### PR TITLE
Add compact expandable JSON debug logs

### DIFF
--- a/src/components/debug/DebugLogOverlay.tsx
+++ b/src/components/debug/DebugLogOverlay.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
+import { OS_NATIVE_CHROME_SKIP_CLASS } from "@/lib/themeChrome";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
@@ -184,7 +185,7 @@ function ConsoleEntryContent({
     const partKey = `${entry.id}:${partIndex}`;
     const expanded = expandedJsonParts.has(partKey);
     return (
-      <div key={partKey} className="contents">
+      <div key={partKey} className={cn("contents", OS_NATIVE_CHROME_SKIP_CLASS)}>
         <button
           type="button"
           aria-expanded={expanded}
@@ -192,9 +193,14 @@ function ConsoleEntryContent({
           data-debug-json-toggle
           className={cn(
             "inline-flex max-w-full items-baseline gap-0.5 border-0 bg-transparent p-0 align-baseline",
-            "font-os-mono text-[10px] leading-[1.45] text-inherit",
+            "font-os-mono text-[10px] leading-[1.45] text-os-text-secondary",
             "opacity-75 hover:opacity-100 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-os-selection-bg"
           )}
+          style={{
+            fontFamily: "var(--os-font-mono)",
+            fontSize: "10px",
+            lineHeight: 1.45,
+          }}
         >
           <span className="shrink-0 no-underline" aria-hidden>
             {expanded ? "▾" : "▸"}

--- a/src/components/debug/DebugLogOverlay.tsx
+++ b/src/components/debug/DebugLogOverlay.tsx
@@ -12,7 +12,6 @@ import {
   ArrowDown,
   Bug,
   CaretDown,
-  CaretRight,
   Check,
   Copy,
   Trash,
@@ -192,29 +191,23 @@ function ConsoleEntryContent({
           onClick={() => onToggleJsonPart(partKey)}
           data-debug-json-toggle
           className={cn(
-            "inline-flex max-w-full items-center gap-0.5 rounded px-1 align-middle",
-            "border border-[color:var(--os-color-separator)] bg-os-panel-bg",
-            "font-os-mono text-[9px] leading-[1.45] text-os-text-secondary",
-            "hover:brightness-105 active:brightness-95"
+            "inline-flex max-w-full items-baseline gap-0.5 border-0 bg-transparent p-0 align-baseline",
+            "font-os-mono text-[10px] leading-[1.45] text-inherit",
+            "opacity-75 hover:opacity-100 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-os-selection-bg"
           )}
         >
-          <CaretRight
-            weight="bold"
-            className={cn(
-              "size-2.5 shrink-0 transition-transform",
-              expanded && "rotate-90"
-            )}
-            aria-hidden
-          />
+          <span className="shrink-0 no-underline" aria-hidden>
+            {expanded ? "▾" : "▸"}
+          </span>
           <span className="truncate">{part.summary}</span>
         </button>
         {expanded ? (
           <pre
             data-debug-json-content
             className={cn(
-              "my-0.5 max-w-full overflow-x-auto rounded p-1",
-              "border border-[color:var(--os-color-separator)] bg-os-panel-bg",
-              "whitespace-pre font-os-mono text-[9px] leading-[1.35] text-os-text-primary"
+              "my-0.5 max-w-full overflow-x-auto border-l pl-2",
+              "border-[color:var(--os-color-separator)]",
+              "whitespace-pre font-os-mono text-[10px] leading-[1.45] text-inherit"
             )}
           >
             {part.text}

--- a/src/components/debug/DebugLogOverlay.tsx
+++ b/src/components/debug/DebugLogOverlay.tsx
@@ -12,6 +12,7 @@ import {
   ArrowDown,
   Bug,
   CaretDown,
+  CaretRight,
   Check,
   Copy,
   Trash,
@@ -147,6 +148,83 @@ function findFirstVisibleIndex(
   return Math.min(result, Math.max(0, offsets.length - 1));
 }
 
+function ConsoleEntryContent({
+  entry,
+  expandedJsonParts,
+  onToggleJsonPart,
+}: {
+  entry: ConsoleLogEntry;
+  expandedJsonParts: ReadonlySet<string>;
+  onToggleJsonPart: (partKey: string) => void;
+}) {
+  if (!entry.displayParts) {
+    return entry.styledSegments
+      ? entry.styledSegments.map((segment, segmentIndex) => (
+          <span
+            key={`${entry.id}-${segmentIndex}`}
+            style={segment.style as CSSProperties | undefined}
+          >
+            {segment.text}
+          </span>
+        ))
+      : entry.text;
+  }
+
+  return entry.displayParts.map((part, partIndex) => {
+    if (part.type === "text") {
+      return (
+        <span
+          key={`${entry.id}-${partIndex}`}
+          style={part.style as CSSProperties | undefined}
+        >
+          {part.text}
+        </span>
+      );
+    }
+
+    const partKey = `${entry.id}:${partIndex}`;
+    const expanded = expandedJsonParts.has(partKey);
+    return (
+      <div key={partKey} className="contents">
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={() => onToggleJsonPart(partKey)}
+          data-debug-json-toggle
+          className={cn(
+            "inline-flex max-w-full items-center gap-0.5 rounded px-1 align-middle",
+            "border border-[color:var(--os-color-separator)] bg-os-panel-bg",
+            "font-os-mono text-[9px] leading-[1.45] text-os-text-secondary",
+            "hover:brightness-105 active:brightness-95"
+          )}
+        >
+          <CaretRight
+            weight="bold"
+            className={cn(
+              "size-2.5 shrink-0 transition-transform",
+              expanded && "rotate-90"
+            )}
+            aria-hidden
+          />
+          <span className="truncate">{part.summary}</span>
+        </button>
+        {expanded ? (
+          <pre
+            data-debug-json-content
+            className={cn(
+              "my-0.5 max-w-full overflow-x-auto rounded p-1",
+              "border border-[color:var(--os-color-separator)] bg-os-panel-bg",
+              "whitespace-pre font-os-mono text-[9px] leading-[1.35] text-os-text-primary"
+            )}
+          >
+            {part.text}
+          </pre>
+        ) : null}
+      </div>
+    );
+  });
+}
+
 /**
  * Floating, togglable console overlay shown only while Debug Mode is enabled
  * (Control Panels → Accounts → Debug). Mirrors captured `console.*` output into an
@@ -169,6 +247,9 @@ export function DebugLogOverlay() {
   const [loggerFilter, setLoggerFilter] = useState(ALL_LOGGERS_FILTER);
   const [networkFilter, setNetworkFilter] =
     useState<NetworkFilter>(ALL_NETWORK_FILTER);
+  const [expandedJsonParts, setExpandedJsonParts] = useState<Set<string>>(
+    () => new Set()
+  );
   const [copied, setCopied] = useState(false);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const liveReportRef = useRef("");
@@ -374,6 +455,7 @@ export function DebugLogOverlay() {
   const handleClear = useCallback(() => {
     clearConsoleCapture();
     rowHeightsRef.current.clear();
+    setExpandedJsonParts(new Set());
     stickToBottomRef.current = true;
     pendingStickToBottomRef.current = false;
     setIsAtBottom(true);
@@ -393,7 +475,22 @@ export function DebugLogOverlay() {
       scrollTopRef.current = 0;
       setScrollTop(0);
     }
+    setExpandedJsonParts((previous) => {
+      const next = new Set(
+        [...previous].filter((partKey) => ids.has(Number(partKey.split(":")[0])))
+      );
+      return next.size === previous.size ? previous : next;
+    });
   }, [entries]);
+
+  const toggleJsonPart = useCallback((partKey: string) => {
+    setExpandedJsonParts((previous) => {
+      const next = new Set(previous);
+      if (next.has(partKey)) next.delete(partKey);
+      else next.add(partKey);
+      return next;
+    });
+  }, []);
 
   useLayoutEffect(() => {
     if (!open || activeTab !== "logs") return;
@@ -838,23 +935,18 @@ export function DebugLogOverlay() {
                       <span className="shrink-0 tabular-nums opacity-40">
                         {formatTime(entry.timestamp)}
                       </span>
-                      <span
+                      <div
                         className={cn(
-                          "min-w-0 whitespace-pre-wrap break-words",
+                          "min-w-0 flex-1 whitespace-pre-wrap break-words",
                           LEVEL_TEXT_CLASS[entry.level]
                         )}
                       >
-                        {entry.styledSegments
-                          ? entry.styledSegments.map((segment, segmentIndex) => (
-                              <span
-                                key={`${entry.id}-${segmentIndex}`}
-                                style={segment.style as CSSProperties | undefined}
-                              >
-                                {segment.text}
-                              </span>
-                            ))
-                          : entry.text}
-                      </span>
+                        <ConsoleEntryContent
+                          entry={entry}
+                          expandedJsonParts={expandedJsonParts}
+                          onToggleJsonPart={toggleJsonPart}
+                        />
+                      </div>
                     </div>
                   ))}
                 </div>

--- a/src/utils/consoleCapture.ts
+++ b/src/utils/consoleCapture.ts
@@ -113,21 +113,43 @@ interface FormattedConsoleArg {
   jsonSummary?: string;
 }
 
+function previewJsonValue(value: unknown): string {
+  if (typeof value === "string") {
+    return JSON.stringify(value.length > 22 ? `${value.slice(0, 21)}…` : value);
+  }
+  if (
+    value === null ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return String(value);
+  }
+  if (Array.isArray(value)) return value.length === 0 ? "[]" : "[…]";
+  return typeof value === "object" ? "{…}" : String(value);
+}
+
+function previewJsonKey(key: string): string {
+  const preview = key.length > 18 ? `${key.slice(0, 17)}…` : key;
+  return /^[A-Za-z_$][\w$]*$/.test(preview) ? preview : JSON.stringify(preview);
+}
+
 function summarizeJson(serialized: string): string | null {
   try {
     const value = JSON.parse(serialized) as unknown;
-    if (Array.isArray(value)) return `Array(${value.length})`;
+    if (Array.isArray(value)) {
+      const items = value.slice(0, 3).map(previewJsonValue);
+      return `[${items.join(", ")}${value.length > 3 ? ", …" : ""}]`;
+    }
     if (typeof value !== "object" || value === null) return null;
 
-    const keys = Object.keys(value);
-    const visibleKeys = keys
+    const entries = Object.entries(value);
+    const visibleEntries = entries
       .slice(0, 3)
-      .map((key) => (key.length > 18 ? `${key.slice(0, 17)}…` : key));
-    const keySummary =
-      visibleKeys.length > 0
-        ? ` { ${visibleKeys.join(", ")}${keys.length > 3 ? ", …" : ""} }`
-        : "";
-    return `Object(${keys.length})${keySummary}`;
+      .map(
+        ([key, entryValue]) =>
+          `${previewJsonKey(key)}: ${previewJsonValue(entryValue)}`
+      );
+    return `{ ${visibleEntries.join(", ")}${entries.length > 3 ? ", …" : ""} }`;
   } catch {
     return null;
   }

--- a/src/utils/consoleCapture.ts
+++ b/src/utils/consoleCapture.ts
@@ -45,6 +45,18 @@ export interface ConsoleStyledSegment {
   style?: ConsoleSegmentStyle;
 }
 
+export type ConsoleDisplayPart =
+  | {
+      type: "text";
+      text: string;
+      style?: ConsoleSegmentStyle;
+    }
+  | {
+      type: "json";
+      text: string;
+      summary: string;
+    };
+
 export interface ConsoleLogEntry {
   id: number;
   level: ConsoleLogLevel;
@@ -54,6 +66,8 @@ export interface ConsoleLogEntry {
   text: string;
   /** Optional safe representation of browser console `%c` segments. */
   styledSegments?: ConsoleStyledSegment[];
+  /** Optional structured representation used for compact, expandable JSON. */
+  displayParts?: ConsoleDisplayPart[];
 }
 
 const MAX_ENTRIES = 500;
@@ -94,17 +108,42 @@ function scheduleFlush(): void {
   }
 }
 
-function formatArg(arg: unknown): string {
-  if (typeof arg === "string") return arg;
-  if (arg instanceof Error) {
-    return arg.stack || `${arg.name}: ${arg.message}`;
+interface FormattedConsoleArg {
+  text: string;
+  jsonSummary?: string;
+}
+
+function summarizeJson(serialized: string): string | null {
+  try {
+    const value = JSON.parse(serialized) as unknown;
+    if (Array.isArray(value)) return `Array(${value.length})`;
+    if (typeof value !== "object" || value === null) return null;
+
+    const keys = Object.keys(value);
+    const visibleKeys = keys
+      .slice(0, 3)
+      .map((key) => (key.length > 18 ? `${key.slice(0, 17)}…` : key));
+    const keySummary =
+      visibleKeys.length > 0
+        ? ` { ${visibleKeys.join(", ")}${keys.length > 3 ? ", …" : ""} }`
+        : "";
+    return `Object(${keys.length})${keySummary}`;
+  } catch {
+    return null;
   }
-  if (arg === null) return "null";
-  if (arg === undefined) return "undefined";
+}
+
+function formatArg(arg: unknown): FormattedConsoleArg {
+  if (typeof arg === "string") return { text: arg };
+  if (arg instanceof Error) {
+    return { text: arg.stack || `${arg.name}: ${arg.message}` };
+  }
+  if (arg === null) return { text: "null" };
+  if (arg === undefined) return { text: "undefined" };
   if (typeof arg === "object") {
     try {
       const seen = new WeakSet<object>();
-      return JSON.stringify(
+      const serialized = JSON.stringify(
         arg,
         (_key, value) => {
           if (typeof value === "object" && value !== null) {
@@ -117,11 +156,31 @@ function formatArg(arg: unknown): string {
         },
         2
       );
+      if (typeof serialized !== "string") return { text: String(arg) };
+      return {
+        text: serialized,
+        jsonSummary: summarizeJson(serialized) ?? undefined,
+      };
     } catch {
-      return String(arg);
+      return { text: String(arg) };
     }
   }
-  return String(arg);
+  return { text: String(arg) };
+}
+
+function buildDisplayParts(
+  formattedArgs: readonly FormattedConsoleArg[]
+): ConsoleDisplayPart[] {
+  const parts: ConsoleDisplayPart[] = [];
+  formattedArgs.forEach((arg, index) => {
+    if (index > 0) parts.push({ type: "text", text: " " });
+    parts.push(
+      arg.jsonSummary
+        ? { type: "json", text: arg.text, summary: arg.jsonSummary }
+        : { type: "text", text: arg.text }
+    );
+  });
+  return parts;
 }
 
 const SAFE_NAMED_COLORS = new Set([
@@ -231,6 +290,7 @@ export function sanitizeConsoleStyle(cssText: string): ConsoleSegmentStyle {
 interface FormattedConsoleArguments {
   text: string;
   styledSegments?: ConsoleStyledSegment[];
+  displayParts?: ConsoleDisplayPart[];
 }
 
 function findStyleTokenIndexes(format: string): number[] | null {
@@ -259,10 +319,17 @@ function findStyleTokenIndexes(format: string): number[] | null {
 export function formatConsoleArguments(
   args: readonly unknown[]
 ): FormattedConsoleArguments {
-  const fallbackText = args.map(formatArg).join(" ");
+  const formattedArgs = args.map(formatArg);
+  const fallbackText = formattedArgs.map((arg) => arg.text).join(" ");
+  const fallbackDisplayParts = buildDisplayParts(formattedArgs);
+  const expandableFallbackParts = fallbackDisplayParts.some(
+    (part) => part.type === "json"
+  )
+    ? fallbackDisplayParts
+    : undefined;
   const format = args[0];
   if (typeof format !== "string" || !format.includes("%c")) {
-    return { text: fallbackText };
+    return { text: fallbackText, displayParts: expandableFallbackParts };
   }
 
   const tokenIndexes = findStyleTokenIndexes(format);
@@ -271,12 +338,12 @@ export function formatConsoleArguments(
     tokenIndexes.length === 0 ||
     args.length < tokenIndexes.length + 1
   ) {
-    return { text: fallbackText };
+    return { text: fallbackText, displayParts: expandableFallbackParts };
   }
 
   const styleArgs = args.slice(1, tokenIndexes.length + 1);
   if (!styleArgs.every((styleArg) => typeof styleArg === "string")) {
-    return { text: fallbackText };
+    return { text: fallbackText, displayParts: expandableFallbackParts };
   }
 
   const styledSegments: ConsoleStyledSegment[] = [];
@@ -305,17 +372,28 @@ export function formatConsoleArguments(
     });
   }
 
-  const trailingText = args
-    .slice(tokenIndexes.length + 1)
-    .map(formatArg)
-    .join(" ");
+  const trailingArgs = formattedArgs.slice(tokenIndexes.length + 1);
+  const trailingText = trailingArgs.map((arg) => arg.text).join(" ");
   if (trailingText) {
     styledSegments.push({ text: ` ${trailingText}` });
+  }
+
+  const displayParts: ConsoleDisplayPart[] = styledSegments
+    .slice(0, trailingText ? -1 : undefined)
+    .map((segment) => ({
+      type: "text",
+      text: segment.text,
+      style: segment.style,
+    }));
+  if (trailingText) {
+    displayParts.push({ type: "text", text: " " });
+    displayParts.push(...buildDisplayParts(trailingArgs));
   }
 
   return {
     text: styledSegments.map((segment) => segment.text).join(""),
     styledSegments,
+    displayParts,
   };
 }
 
@@ -328,6 +406,7 @@ function pushEntry(level: ConsoleLogLevel, args: unknown[]): void {
     timestamp: Date.now(),
     text: formatted.text,
     styledSegments: formatted.styledSegments,
+    displayParts: formatted.displayParts,
   });
   if (buffer.length > MAX_ENTRIES) {
     buffer = buffer.slice(buffer.length - MAX_ENTRIES);

--- a/tests/test-console-capture.test.ts
+++ b/tests/test-console-capture.test.ts
@@ -54,7 +54,7 @@ describe("consoleCapture", () => {
       {
         type: "json",
         text: '{\n  "a": 1,\n  "self": "[Circular]"\n}',
-        summary: "Object(2) { a, self }",
+        summary: '{ a: 1, self: "[Circular]" }',
       },
     ]);
   });
@@ -81,11 +81,11 @@ describe("consoleCapture", () => {
     ]);
     expect(formatted.displayParts?.[2]).toMatchObject({
       type: "json",
-      summary: "Object(4) { status, items, metadata, … }",
+      summary: '{ status: "ok", items: […], metadata: {…}, … }',
     });
     expect(formatted.displayParts?.[4]).toMatchObject({
       type: "json",
-      summary: "Array(2)",
+      summary: '["alpha", "beta"]',
     });
   });
 
@@ -206,7 +206,7 @@ describe("consoleCapture", () => {
       {
         type: "json",
         text: '{\n  "method": "GET",\n  "status": 200\n}',
-        summary: "Object(2) { method, status }",
+        summary: '{ method: "GET", status: 200 }',
       },
     ]);
   });

--- a/tests/test-console-capture.test.ts
+++ b/tests/test-console-capture.test.ts
@@ -48,6 +48,45 @@ describe("consoleCapture", () => {
     const last = entries[entries.length - 1];
     expect(last.text).toContain('"a": 1');
     expect(last.text).toContain("[Circular]");
+    expect(last.displayParts).toEqual([
+      { type: "text", text: "obj:" },
+      { type: "text", text: " " },
+      {
+        type: "json",
+        text: '{\n  "a": 1,\n  "self": "[Circular]"\n}',
+        summary: "Object(2) { a, self }",
+      },
+    ]);
+  });
+
+  test("represents JSON arguments as compact expandable display parts", () => {
+    const formatted = formatConsoleArguments([
+      "payload",
+      {
+        status: "ok",
+        items: [1, 2, 3],
+        metadata: { cached: true },
+        requestId: "abc",
+      },
+      ["alpha", "beta"],
+    ]);
+
+    expect(formatted.text).toContain('"status": "ok"');
+    expect(formatted.displayParts?.map((part) => part.type)).toEqual([
+      "text",
+      "text",
+      "json",
+      "text",
+      "json",
+    ]);
+    expect(formatted.displayParts?.[2]).toMatchObject({
+      type: "json",
+      summary: "Object(4) { status, items, metadata, … }",
+    });
+    expect(formatted.displayParts?.[4]).toMatchObject({
+      type: "json",
+      summary: "Array(2)",
+    });
   });
 
   test("clearConsoleCapture empties the buffer", async () => {
@@ -145,6 +184,31 @@ describe("consoleCapture", () => {
     expect(copied).toContain("[LOG]  * Tone.js v15.1.22 *");
     expect(copied).not.toContain("%c");
     expect(copied).not.toContain("background:");
+  });
+
+  test("keeps styled text while making a trailing object expandable", () => {
+    const formatted = formatConsoleArguments([
+      "%cRequest",
+      "color: blue; font-weight: bold",
+      { method: "GET", status: 200 },
+    ]);
+
+    expect(formatted.text).toBe(
+      'Request {\n  "method": "GET",\n  "status": 200\n}'
+    );
+    expect(formatted.displayParts).toEqual([
+      {
+        type: "text",
+        text: "Request",
+        style: { color: "blue", fontWeight: "bold" },
+      },
+      { type: "text", text: " " },
+      {
+        type: "json",
+        text: '{\n  "method": "GET",\n  "status": 200\n}',
+        summary: "Object(2) { method, status }",
+      },
+    ]);
   });
 
   test("falls back to plain text for unmatched %c placeholders", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Render captured object and array arguments as compact, value-rich inline disclosures in the debug logs panel.
- Expand JSON values inline without changing copied log output.
- Opt the disclosure out of Aqua button typography so it matches log monospace sizing, with secondary text color.
- Preserve styled console segments and virtualized row measurement.

## Testing
- Targeted unit tests and build pass.
- Final visual verification pending for the typography correction.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1771-c459-77c6-97b8-62b978e197dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1771-c459-77c6-97b8-62b978e197dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

