### PR TITLE
Add debug logging across app and API lifecycle

### DIFF
--- a/api/_utils/_logging.ts
+++ b/api/_utils/_logging.ts
@@ -41,6 +41,13 @@ const C = {
 // ============================================================================
 
 const COMPACT_JSON = true;
+const REDACTED = "[redacted]";
+const MAX_STRING_LENGTH = 240;
+const MAX_STACK_LENGTH = 4000;
+const MAX_ARRAY_ITEMS = 8;
+const MAX_DEPTH = 3;
+const SENSITIVE_KEY_RE =
+  /(password|token|secret|authorization|cookie|message|prompt|content|html|markdown|base64|blob|dataurl|transcript|body|text|lyrics|deviceid|useragent)$/i;
 
 // ============================================================================
 // Helper Functions
@@ -54,26 +61,124 @@ function getTimestamp(): string {
   return `${C.dim}${now.toTimeString().slice(0, 8)}${C.reset}`;
 }
 
+function truncateString(value: string, maxLength = MAX_STRING_LENGTH): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}... (truncated, length=${value.length})`;
+}
+
+function isSerializedErrorRecord(record: Record<string, unknown>): boolean {
+  if (record.kind === "Error" || record.kind === "DOMException") {
+    return true;
+  }
+  return (
+    typeof record.name === "string" &&
+    typeof record.message === "string" &&
+    typeof record.stack === "string"
+  );
+}
+
+function shouldRedactKey(
+  key: string,
+  record: Record<string, unknown>
+): boolean {
+  if (!SENSITIVE_KEY_RE.test(key)) return false;
+  if (isSerializedErrorRecord(record) && key === "message") return false;
+  return true;
+}
+
+export function summarizeForApiLog(
+  value: unknown,
+  depth = 0,
+  seen = new WeakSet<object>(),
+  key?: string
+): unknown {
+  if (value === null || value === undefined) return value;
+
+  if (typeof value === "string") {
+    return truncateString(value, key === "stack" ? MAX_STACK_LENGTH : MAX_STRING_LENGTH);
+  }
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (typeof value === "bigint") return `${value}n`;
+  if (typeof value === "function") return `[Function ${value.name || "anonymous"}]`;
+
+  if (value instanceof Error) {
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+    return {
+      kind: "Error",
+      name: value.name,
+      message: truncateString(value.message),
+      stack: value.stack ? truncateString(value.stack, MAX_STACK_LENGTH) : undefined,
+      cause:
+        "cause" in value && value.cause !== undefined
+          ? summarizeForApiLog(value.cause, depth + 1, seen, "cause")
+          : undefined,
+    };
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return `ArrayBuffer(byteLength=${value.byteLength})`;
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return `${value.constructor.name}(byteLength=${value.byteLength})`;
+  }
+
+  if (typeof value !== "object") return String(value);
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+
+  if (depth >= MAX_DEPTH) {
+    return Array.isArray(value)
+      ? `array(length=${value.length})`
+      : `object(keys=${Object.keys(value as Record<string, unknown>).join(",") || "none"})`;
+  }
+
+  if (Array.isArray(value)) {
+    const items = value
+      .slice(0, MAX_ARRAY_ITEMS)
+      .map((item) => summarizeForApiLog(item, depth + 1, seen));
+    if (value.length > MAX_ARRAY_ITEMS) {
+      items.push(`... (${value.length - MAX_ARRAY_ITEMS} more)`);
+    }
+    return items;
+  }
+
+  const record = value as Record<string, unknown>;
+  const safe: Record<string, unknown> = {};
+  for (const [recordKey, item] of Object.entries(record)) {
+    safe[recordKey] = shouldRedactKey(recordKey, record)
+      ? REDACTED
+      : summarizeForApiLog(item, depth + 1, seen, recordKey);
+  }
+  return safe;
+}
+
+export function isApiDebugLoggingEnabled(): boolean {
+  const explicit = process.env.RYOS_DEBUG || process.env.API_DEBUG_LOGS;
+  if (explicit === "1" || explicit === "true") return true;
+  if (explicit === "0" || explicit === "false") return false;
+  return process.env.NODE_ENV !== "production";
+}
+
 /**
  * Format data for logging (handles objects, errors, etc.)
  */
 function formatData(data: unknown): string {
   if (data === undefined || data === null) return "";
-  if (data instanceof Error) {
-    return `${data.message}${data.stack ? `\n${C.dim}${data.stack}${C.reset}` : ""}`;
-  }
-  if (typeof data === "object") {
+  const safeData = summarizeForApiLog(data);
+  if (typeof safeData === "object") {
     try {
-      const json = COMPACT_JSON ? JSON.stringify(data) : JSON.stringify(data, null, 2);
-      if (json.length > 150) {
-        return `${C.dim}${json.substring(0, 150)}…${C.reset}`;
+      const json = COMPACT_JSON ? JSON.stringify(safeData) : JSON.stringify(safeData, null, 2);
+      if (json.length > 240) {
+        return `${C.dim}${json.substring(0, 240)}…${C.reset}`;
       }
       return `${C.dim}${json}${C.reset}`;
     } catch {
-      return String(data);
+      return String(safeData);
     }
   }
-  return String(data);
+  return String(safeData);
 }
 
 /**
@@ -186,7 +291,7 @@ export function logDebug(
   message: string,
   data?: unknown
 ): void {
-  if (process.env.NODE_ENV === "production") return;
+  if (!isApiDebugLoggingEnabled()) return;
   const ts = getTimestamp();
   const id = `${C.dim}${requestId}${C.reset}`;
   const d = data !== undefined ? ` ${formatData(data)}` : "";

--- a/api/_utils/api-handler.ts
+++ b/api/_utils/api-handler.ts
@@ -2,7 +2,7 @@ import type { VercelRequest, VercelResponse } from "@vercel/node";
 import type { Redis } from "./redis.js";
 import { initLogger } from "./_logging.js";
 import { getEffectiveOrigin, isAllowedOrigin, setCorsHeaders } from "./_cors.js";
-import { createRedis } from "./redis.js";
+import { createRedis, getRedisBackend } from "./redis.js";
 import { resolveRequestAuth, type AuthenticatedRequestUser } from "./request-auth.js";
 import { recordAnalyticsEvent } from "./_analytics.js";
 import { getClientIp } from "./_rate-limit.js";
@@ -72,6 +72,34 @@ function sendJsonError(
   res.status(status).json({ error });
 }
 
+function getRequestPath(url: string | undefined): string {
+  if (!url) return "/api/unknown";
+  try {
+    return new URL(url, "http://localhost").pathname;
+  } catch {
+    return url.split("?")[0] || "/api/unknown";
+  }
+}
+
+function describeBodyShape(body: unknown): Record<string, unknown> {
+  if (body === null) {
+    return { kind: "null" };
+  }
+  if (body === undefined) {
+    return { kind: "undefined" };
+  }
+  if (Array.isArray(body)) {
+    return { kind: "array", length: body.length };
+  }
+  if (typeof body === "object") {
+    return {
+      kind: "object",
+      keys: Object.keys(body as Record<string, unknown>).sort(),
+    };
+  }
+  return { kind: typeof body };
+}
+
 export function apiHandler<TBody = unknown>(
   options: ApiHandlerOptions<TBody>,
   handler: WrappedApiHandler<TBody>
@@ -92,14 +120,29 @@ export function apiHandler<TBody = unknown>(
     const startTime = Date.now();
     const origin = getEffectiveOrigin(req);
     const method = (req.method || "GET").toUpperCase();
+    const path = getRequestPath(req.url);
 
     logger.request(method, req.url || "/api/unknown");
+    logger.debug("API handler request context", {
+      path,
+      method,
+      allowedMethods: methods,
+      auth,
+      allowExpiredAuth,
+      shouldReadBody,
+      hasBodySchema: !!bodySchema,
+      contentType,
+      analytics,
+      hasOrigin: !!origin,
+      redisBackend: getRedisBackend(),
+    });
 
     if (method === "OPTIONS") {
       setCorsHeaders(res, origin, { methods: [...methods, "OPTIONS"] });
       if (contentType) {
         res.setHeader("Content-Type", contentType);
       }
+      logger.debug("Handled API preflight", { path, originAllowed: isAllowedOrigin(origin) });
       logger.response(204, Date.now() - startTime);
       res.status(204).end();
       return;
@@ -111,12 +154,14 @@ export function apiHandler<TBody = unknown>(
     }
 
     if (!isAllowedOrigin(origin)) {
+      logger.debug("Rejected API request origin", { path, hasOrigin: !!origin });
       logger.response(403, Date.now() - startTime);
       sendJsonError(res, 403, "Unauthorized");
       return;
     }
 
     if (!methods.includes(method)) {
+      logger.debug("Rejected API request method", { path, method, allowedMethods: methods });
       logger.response(405, Date.now() - startTime);
       sendJsonError(res, 405, "Method not allowed");
       return;
@@ -128,7 +173,12 @@ export function apiHandler<TBody = unknown>(
     if (shouldReadBody) {
       try {
         body = (req.body as TBody | undefined) ?? null;
+        logger.debug("Parsed API request body", {
+          path,
+          bodyShape: describeBodyShape(body),
+        });
       } catch {
+        logger.debug("Failed to parse API request body", { path });
         logger.response(400, Date.now() - startTime);
         sendJsonError(res, 400, "Invalid JSON body");
         return;
@@ -141,9 +191,22 @@ export function apiHandler<TBody = unknown>(
         required: auth === "required",
         allowExpired: allowExpiredAuth,
       });
+      logger.debug("Resolved API auth", {
+        path,
+        auth,
+        hasUser: !!authResult.user,
+        username: authResult.user?.username,
+        errorStatus: authResult.error?.status,
+      });
 
       if (auth === "admin") {
         if (authResult.error || !authResult.user || authResult.user.username !== "ryo") {
+          logger.debug("Rejected API admin auth", {
+            path,
+            hasUser: !!authResult.user,
+            username: authResult.user?.username,
+            errorStatus: authResult.error?.status,
+          });
           logger.response(403, Date.now() - startTime);
           sendJsonError(res, 403, "Forbidden - Admin access required");
           return;
@@ -151,6 +214,11 @@ export function apiHandler<TBody = unknown>(
 
         user = authResult.user;
       } else if (authResult.error) {
+        logger.debug("Rejected API auth", {
+          path,
+          auth,
+          status: authResult.error.status,
+        });
         logger.response(authResult.error.status, Date.now() - startTime);
         sendJsonError(res, authResult.error.status, authResult.error.error);
         return;
@@ -182,15 +250,25 @@ export function apiHandler<TBody = unknown>(
           path: issue.path.map((part) => String(part)).join("."),
           message: issue.message,
         }));
+        logger.debug("Rejected API body validation", {
+          path,
+          issueCount: issues.length,
+          issuePaths: issues.map((issue) => issue.path),
+        });
         logger.response(400, Date.now() - startTime);
         res.status(400).json({ error: "validation_error", issues });
         return;
       }
       body = result.data as TBody;
+      logger.debug("Validated API request body", {
+        path,
+        bodyShape: describeBodyShape(body),
+      });
     }
 
     let finalStatus = 200;
     try {
+      logger.debug("Starting API route handler", { path });
       await handler({
         req,
         res,
@@ -202,6 +280,12 @@ export function apiHandler<TBody = unknown>(
         body,
       });
       finalStatus = res.statusCode ?? 200;
+      logger.debug("Completed API route handler", {
+        path,
+        status: finalStatus,
+        durationMs: Date.now() - startTime,
+        headersSent: res.headersSent,
+      });
     } catch (error) {
       logger.error("Unhandled API handler error", error);
       logger.response(500, Date.now() - startTime);
@@ -210,6 +294,13 @@ export function apiHandler<TBody = unknown>(
     }
 
     if (analytics) {
+      logger.debug("Queued API analytics event", {
+        path,
+        method,
+        status: finalStatus,
+        hasUser: !!user,
+        durationMs: Date.now() - startTime,
+      });
       recordAnalyticsEvent(redis, {
         path: req.url || "/api/unknown",
         method,

--- a/scripts/api-standalone-server.ts
+++ b/scripts/api-standalone-server.ts
@@ -26,6 +26,10 @@ import {
 } from "../api/_utils/runtime-config.js";
 import { createOgShareResponse } from "../api/_utils/og-share.js";
 import {
+  isApiDebugLoggingEnabled,
+  summarizeForApiLog,
+} from "../api/_utils/_logging.js";
+import {
   ensureRealtimePubSubBridge,
   getRealtimeSocketUser,
   registerRealtimeSocket,
@@ -328,6 +332,33 @@ function toUint8Array(chunk: unknown): Uint8Array | null {
   }
   if (typeof chunk === "string") return new TextEncoder().encode(chunk);
   return new TextEncoder().encode(String(chunk));
+}
+
+function standaloneDebug(message: string, data?: unknown): void {
+  if (!isApiDebugLoggingEnabled()) return;
+  const suffix =
+    data === undefined ? "" : ` ${JSON.stringify(summarizeForApiLog(data))}`;
+  console.log(`[api-standalone:debug] ${message}${suffix}`);
+}
+
+function describeParsedBody(parsed: ParsedBody): Record<string, unknown> {
+  if (parsed.bodyError) {
+    return { kind: "invalid-json", error: parsed.bodyError.message };
+  }
+  if (parsed.rawBody) {
+    return { kind: "raw", byteLength: parsed.rawBody.byteLength };
+  }
+  const body = parsed.bodyValue;
+  if (body === undefined) return { kind: "undefined" };
+  if (body === null) return { kind: "null" };
+  if (Array.isArray(body)) return { kind: "array", length: body.length };
+  if (typeof body === "object") {
+    return {
+      kind: "object",
+      keys: Object.keys(body as Record<string, unknown>).sort(),
+    };
+  }
+  return { kind: typeof body };
 }
 
 function parseEnvLine(line: string): { key: string; value: string } | null {
@@ -770,6 +801,12 @@ async function bootstrap(): Promise<void> {
     workspaceRoot: WORKSPACE_ROOT,
     apiRoot: API_ROOT,
   });
+  standaloneDebug("Discovered API route manifest", {
+    routeCount: routes.length,
+    dynamicRouteCount: routes.filter((route) => route.dynamicSegmentCount > 0)
+      .length,
+    indexRouteCount: routes.filter((route) => route.isIndexRoute).length,
+  });
 
   if (shouldEnableLocalRealtime()) {
     await ensureRealtimePubSubBridge();
@@ -838,9 +875,16 @@ async function bootstrap(): Promise<void> {
         });
 
         if (upgraded) {
+          standaloneDebug("Accepted realtime websocket upgrade", {
+            authenticated: !!socketUsername,
+            username: socketUsername,
+          });
           return undefined as unknown as Response;
         }
 
+        standaloneDebug("Rejected realtime websocket upgrade", {
+          authenticated: !!socketUsername,
+        });
         return jsonResponse({ error: "WebSocket upgrade failed" }, 400);
       }
 
@@ -869,6 +913,10 @@ async function bootstrap(): Promise<void> {
 
       const matched = matchRoute(pathname, routes);
       if (!matched) {
+        standaloneDebug("No API route matched request", {
+          method: request.method,
+          pathname,
+        });
         return jsonResponse({ error: "Not found" }, 404);
       }
 
@@ -894,7 +942,22 @@ async function bootstrap(): Promise<void> {
         }
       }
 
-      const { bodyValue, bodyError, rawBody } = await parseBody(request);
+      standaloneDebug("Matched API route", {
+        method: request.method,
+        pathname,
+        routePath: matched.route.routePath,
+        relativePath: matched.route.relativePath,
+        paramNames: matched.route.paramNames,
+        peerIp,
+      });
+
+      const parsedBody = await parseBody(request);
+      const { bodyValue, bodyError, rawBody } = parsedBody;
+      standaloneDebug("Adapted API request body", {
+        routePath: matched.route.routePath,
+        contentType: request.headers.get("content-type"),
+        bodyShape: describeParsedBody(parsedBody),
+      });
       const reqShim = new BunRequestShim({
         method: request.method.toUpperCase(),
         url: `${url.pathname}${url.search}`,
@@ -908,6 +971,10 @@ async function bootstrap(): Promise<void> {
 
       try {
         const handler = await getHandler(matched.route);
+        standaloneDebug("Loaded API route handler", {
+          routePath: matched.route.routePath,
+          relativePath: matched.route.relativePath,
+        });
         const handlerPromise = Promise.resolve(handler(reqShim, resShim));
 
         // Race between handler completion and first write.
@@ -928,6 +995,12 @@ async function bootstrap(): Promise<void> {
             }
           });
         }
+        standaloneDebug("API route adapter completed", {
+          routePath: matched.route.routePath,
+          status: resShim.statusCode,
+          headersSent: resShim.headersSent,
+          streaming: !resShim.writableEnded,
+        });
       } catch (error) {
         console.error(
           `[api-standalone] Handler error in ${matched.route.routePath} (${matched.route.relativePath})`,
@@ -955,6 +1028,10 @@ async function bootstrap(): Promise<void> {
       open: (socket) => {
         registerRealtimeSocket(socket);
         setRealtimeSocketUser(socket, socket.data?.username ?? null);
+        standaloneDebug("Realtime websocket opened", {
+          authenticated: !!socket.data?.username,
+          username: socket.data?.username,
+        });
       },
       message: (socket, message) => {
         let payload: { type?: string; channel?: string };
@@ -969,6 +1046,9 @@ async function bootstrap(): Promise<void> {
         }
 
         if (payload.type === "ping") {
+          standaloneDebug("Realtime websocket ping", {
+            authenticated: !!getRealtimeSocketUser(socket),
+          });
           socket.send(JSON.stringify({ type: "pong" }));
           return;
         }
@@ -981,6 +1061,10 @@ async function bootstrap(): Promise<void> {
           void authorizeRealtimeChannel(channel, getRealtimeSocketUser(socket))
             .then((allowed) => {
               if (allowed) {
+                standaloneDebug("Allowed realtime subscribe", {
+                  channel,
+                  username: getRealtimeSocketUser(socket),
+                });
                 subscribeRealtimeSocket(socket, channel);
               } else {
                 console.warn("[api-standalone] Denied realtime subscribe", {
@@ -1005,10 +1089,17 @@ async function bootstrap(): Promise<void> {
         }
 
         if (payload.type === "unsubscribe" && payload.channel) {
+          standaloneDebug("Realtime websocket unsubscribe", {
+            channel: payload.channel,
+            username: getRealtimeSocketUser(socket),
+          });
           unsubscribeRealtimeSocket(socket, payload.channel);
         }
       },
       close: (socket) => {
+        standaloneDebug("Realtime websocket closed", {
+          username: getRealtimeSocketUser(socket),
+        });
         unregisterRealtimeSocket(socket);
       },
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,9 +29,11 @@ import { WallpaperAccentRunner } from "@/hooks/WallpaperAccentRunner";
 import { DesktopCornerMask } from "@/components/layout/desktop/DesktopCornerMask";
 import { installNativeToastNotifications } from "@/utils/nativeToastNotifications";
 import { DebugLogOverlay } from "@/components/debug/DebugLogOverlay";
+import { createClientLogger } from "@/utils/logger";
 
 // Convert registry to array
 const apps: AnyApp[] = Object.values(appRegistry);
+const appShellLog = createClientLogger("AppShell");
 
 installNativeToastNotifications();
 
@@ -133,12 +135,17 @@ export function App() {
 
   useEffect(() => {
     applyDisplayMode(displayMode);
+    appShellLog.debug("Applied display mode", { displayMode });
   }, [displayMode]);
 
   useEffect(() => {
     // Only show boot screen for system operations (reset/restore/format/debug)
     const persistedMessage = getNextBootMessage();
     if (persistedMessage) {
+      appShellLog.debug("Showing boot screen from persisted operation", {
+        hasMessage: true,
+        bootDebugMode: isBootDebugMode(),
+      });
       setBootScreenMessage(persistedMessage);
       setBootDebugMode(isBootDebugMode());
       setShowBootScreen(true);
@@ -146,6 +153,7 @@ export function App() {
 
     // Set first boot flag without showing boot screen
     if (isFirstBoot) {
+      appShellLog.debug("Marking first boot complete");
       setHasBooted();
     }
   }, [
@@ -162,6 +170,10 @@ export function App() {
   useEffect(() => {
     const desktopDownloadTarget = getSupportedDesktopDownloadTarget();
     const isInDesktop = isDesktop();
+    appShellLog.debug("Evaluating desktop update prompt", {
+      hasDesktopDownloadTarget: !!desktopDownloadTarget,
+      isInDesktop,
+    });
 
     if (!desktopDownloadTarget) {
       return;
@@ -169,6 +181,11 @@ export function App() {
 
     // Handler for showing the desktop update toast
     const showDesktopUpdateToast = (result: DesktopUpdateResult) => {
+      appShellLog.debug("Desktop update check result", {
+        type: result.type,
+        hasVersion: !!result.version,
+        isInDesktop,
+      });
       if (result.type === 'update' && result.version) {
         const downloadUrl = getDesktopDownloadUrl(result.version, desktopDownloadTarget);
         if (!downloadUrl) {
@@ -223,6 +240,7 @@ export function App() {
 
     // Initial check on load (delayed to let app render first)
     const timer = setTimeout(async () => {
+      appShellLog.debug("Running initial desktop update check");
       const result = await checkDesktopUpdate();
       showDesktopUpdateToast(result);
     }, 2000);
@@ -239,6 +257,7 @@ export function App() {
           title={bootScreenMessage || t("common.system.systemRestoring")}
           debugMode={bootDebugMode}
           onBootComplete={() => {
+            appShellLog.debug("Boot screen completed");
             clearNextBootMessage();
             setShowBootScreen(false);
           }}

--- a/src/apps/base/app-manager/AppManagerView.tsx
+++ b/src/apps/base/app-manager/AppManagerView.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from "react";
+import { memo, useCallback, useEffect } from "react";
 import type { ComponentType } from "react";
 import { MenuBar } from "@/components/layout/MenuBar";
 import { Desktop } from "@/components/layout/Desktop";
@@ -22,6 +22,9 @@ import { shouldMountInstance } from "../instanceMountPolicy";
 import { getZIndexForInstance, supportsMultiWindowApp } from "./instanceHelpers";
 import type { AppProps } from "../types";
 import type { AppManagerViewModel } from "./useAppManager";
+import { createClientLogger } from "@/utils/logger";
+
+const appManagerViewLog = createClientLogger("AppManagerView");
 
 export function AppManagerView({
   apps,
@@ -145,6 +148,26 @@ const ManagedAppInstance = memo(function ManagedAppInstance({
     navigateToPreviousInstance(instanceId);
   }, [instanceId, navigateToPreviousInstance]);
 
+  useEffect(() => {
+    appManagerViewLog.debug("Managed app instance state changed", {
+      instanceId,
+      appId: instance?.appId,
+      isOpen: !!instance?.isOpen,
+      isLoading: !!instance?.isLoading,
+      isForeground,
+      exposeMode,
+      zIndex,
+    });
+  }, [
+    exposeMode,
+    instance?.appId,
+    instance?.isLoading,
+    instance?.isOpen,
+    instanceId,
+    isForeground,
+    zIndex,
+  ]);
+
   if (!instance?.isOpen) return null;
   if (exposeMode && instance.appId === "stickies") return null;
 
@@ -183,6 +206,10 @@ const ManagedAppInstance = memo(function ManagedAppInstance({
         appName={crashDialogAppName}
         instanceId={instance.instanceId}
         onCrash={() => {
+          appManagerViewLog.debug("App instance crashed", {
+            appId,
+            instanceId: instance.instanceId,
+          });
           setCrashedInstanceIds((prev) => {
             if (prev.has(instance.instanceId)) {
               return prev;
@@ -194,6 +221,10 @@ const ManagedAppInstance = memo(function ManagedAppInstance({
           bringInstanceToForeground(instance.instanceId);
         }}
         onQuit={() => {
+          appManagerViewLog.debug("Quitting crashed app instance", {
+            appId,
+            instanceId: instance.instanceId,
+          });
           setCrashedInstanceIds((prev) => {
             if (!prev.has(instance.instanceId)) {
               return prev;
@@ -205,6 +236,11 @@ const ManagedAppInstance = memo(function ManagedAppInstance({
           closeAppInstance(instance.instanceId);
         }}
         onRelaunch={() => {
+          appManagerViewLog.debug("Relaunching crashed app instance", {
+            appId,
+            instanceId: instance.instanceId,
+            hasInitialData: instance.initialData !== undefined,
+          });
           setCrashedInstanceIds((prev) => {
             if (!prev.has(instance.instanceId)) {
               return prev;

--- a/src/apps/base/app-manager/useAppManager.ts
+++ b/src/apps/base/app-manager/useAppManager.ts
@@ -25,11 +25,14 @@ import {
 } from "@/config/lazyAppComponent";
 import { useAppStore } from "@/stores/useAppStore";
 import { useGlobalUndoRedo } from "@/hooks/useGlobalUndoRedo";
+import { createClientLogger } from "@/utils/logger";
 import { resolveInitialRoute } from "../appRouteRegistry";
 import { switcherInitialState } from "./constants";
 import { switcherReducer } from "./switcherReducer";
 import type { AppManagerProps } from "./types";
 import { useAppManagerKeyboardShortcuts } from "./useAppManagerKeyboardShortcuts";
+
+const appManagerLog = createClientLogger("AppManager");
 
 export function useAppManager({ apps }: AppManagerProps) {
   const { t } = useTranslation();
@@ -174,12 +177,31 @@ export function useAppManager({ apps }: AppManagerProps) {
   }, []);
 
   useEffect(() => {
+    appManagerLog.debug("Window manager state changed", {
+      openInstanceCount: openInstanceIds.length,
+      foregroundInstanceId,
+      exposeMode,
+      showDesktopMenuBar,
+      crashedInstanceCount: crashedInstanceIds.size,
+    });
+  }, [
+    crashedInstanceIds.size,
+    exposeMode,
+    foregroundInstanceId,
+    openInstanceIds.length,
+    showDesktopMenuBar,
+  ]);
+
+  useEffect(() => {
     const routeAction = resolveInitialRoute(
       window.location.pathname,
       window.location.search
     );
 
     if (!routeAction) {
+      appManagerLog.debug("No initial route action", {
+        pathname: window.location.pathname,
+      });
       return;
     }
 
@@ -188,10 +210,20 @@ export function useAppManager({ apps }: AppManagerProps) {
     };
 
     if (routeAction.kind === "cleanup") {
+      appManagerLog.debug("Cleaning up initial route", {
+        pathname: window.location.pathname,
+      });
       resetUrl();
       return;
     }
 
+    appManagerLog.debug("Scheduling initial route launch", {
+      appId: routeAction.request.appId,
+      initialPath: routeAction.request.initialPath,
+      hasInitialData: routeAction.request.initialData !== undefined,
+      delayMs: routeAction.delayMs,
+      urlCleanupTiming: routeAction.urlCleanupTiming,
+    });
     prefetchAppChunk(routeAction.request.appId);
 
     if (routeAction.toast) {
@@ -203,6 +235,10 @@ export function useAppManager({ apps }: AppManagerProps) {
     }
 
     const timer = window.setTimeout(() => {
+      appManagerLog.debug("Dispatching initial route launch", {
+        appId: routeAction.request.appId,
+        hasInitialData: routeAction.request.initialData !== undefined,
+      });
       requestAppLaunch(routeAction.request);
 
       if (routeAction.urlCleanupTiming === "after-dispatch") {
@@ -222,6 +258,9 @@ export function useAppManager({ apps }: AppManagerProps) {
   useEffect(() => {
     const run = () => {
       const recent = useAppStore.getState().recentApps;
+      appManagerLog.debug("Prefetching likely app chunks", {
+        recentApps: recent.map((r) => r.appId),
+      });
       prefetchLikelyAppChunks(recent.map((r) => r.appId));
     };
 
@@ -252,15 +291,29 @@ export function useAppManager({ apps }: AppManagerProps) {
       }>
     ) => {
       const { appId, initialPath, initialData } = event.detail;
+      appManagerLog.debug("Received app launch request", {
+        appId,
+        initialPath,
+        hasInitialData: initialData !== undefined,
+      });
 
       const existingInstance = Object.values(instancesRef.current).find(
         (instance) => instance.appId === appId && instance.isOpen
       );
 
       const instanceId = launchAppRef.current(appId, initialData);
+      appManagerLog.debug("Launch request resolved", {
+        appId,
+        instanceId,
+        reusedExistingInstance: existingInstance?.instanceId === instanceId,
+      });
 
       if (initialPath) {
         localStorage.setItem(`ryos:app:${appId}:initial-path`, initialPath);
+        appManagerLog.debug("Stored app initial path", {
+          appId,
+          initialPath,
+        });
       }
 
       if (
@@ -268,6 +321,10 @@ export function useAppManager({ apps }: AppManagerProps) {
         initialData &&
         instanceId === existingInstance.instanceId
       ) {
+        appManagerLog.debug("Emitting app update for existing instance", {
+          appId,
+          instanceId,
+        });
         emitAppUpdate({ appId, instanceId, initialData });
       }
     };
@@ -281,8 +338,12 @@ export function useAppManager({ apps }: AppManagerProps) {
       (inst) => inst.appId === "dashboard" && inst.isOpen
     );
     if (dashboardInstance) {
+      appManagerLog.debug("Closing dashboard from shell toggle", {
+        instanceId: dashboardInstance.instanceId,
+      });
       closeAppInstance(dashboardInstance.instanceId);
     } else {
+      appManagerLog.debug("Opening dashboard from shell toggle");
       launchAppRef.current("dashboard");
     }
   }, [closeAppInstance]);
@@ -293,6 +354,9 @@ export function useAppManager({ apps }: AppManagerProps) {
       (inst) => inst.appId === "dashboard" && inst.isOpen
     );
     if (dashboardInstance) {
+      appManagerLog.debug("Closing dashboard overlay", {
+        instanceId: dashboardInstance.instanceId,
+      });
       closeAppInstance(dashboardInstance.instanceId);
     }
   }, [closeAppInstance]);

--- a/src/components/debug/DebugLogOverlay.tsx
+++ b/src/components/debug/DebugLogOverlay.tsx
@@ -32,7 +32,6 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
 import { useIsRyoAdmin } from "@/hooks/useIsRyoAdmin";
-import { OS_NATIVE_CHROME_SKIP_CLASS } from "@/lib/themeChrome";
 import type { AdminInitialData } from "@/apps/admin/types";
 import {
   clearConsoleCapture,
@@ -637,7 +636,6 @@ export function DebugLogOverlay() {
       ref={overlayRootRef}
       className={cn(
         "fixed select-none flex flex-col",
-        OS_NATIVE_CHROME_SKIP_CLASS,
         isWindowsTheme ? "right-2 items-end" : "left-2 items-start"
       )}
       style={{
@@ -1011,7 +1009,7 @@ export function DebugLogOverlay() {
               <TabsTrigger
                 value="logs"
                 className={cn(
-                  "h-5 rounded px-2.5 py-0 font-os-mono text-[10px] shadow-none transition-none",
+                  "h-5 rounded px-2.5 py-0 font-os-ui text-[10px] font-medium shadow-none transition-none",
                   "border border-transparent",
                   "data-[state=active]:bg-os-selection-bg data-[state=active]:text-os-selection-text data-[state=active]:shadow-none",
                   "focus-visible:ring-1 focus-visible:ring-os-selection-bg focus-visible:ring-offset-0",
@@ -1023,7 +1021,7 @@ export function DebugLogOverlay() {
               <TabsTrigger
                 value="live"
                 className={cn(
-                  "h-5 rounded px-2.5 py-0 font-os-mono text-[10px] shadow-none transition-none",
+                  "h-5 rounded px-2.5 py-0 font-os-ui text-[10px] font-medium shadow-none transition-none",
                   "border border-transparent",
                   "data-[state=active]:bg-os-selection-bg data-[state=active]:text-os-selection-text data-[state=active]:shadow-none",
                   "focus-visible:ring-1 focus-visible:ring-os-selection-bg focus-visible:ring-offset-0",
@@ -1035,7 +1033,7 @@ export function DebugLogOverlay() {
               <TabsTrigger
                 value="network"
                 className={cn(
-                  "h-5 rounded px-2.5 py-0 font-os-mono text-[10px] shadow-none transition-none",
+                  "h-5 rounded px-2.5 py-0 font-os-ui text-[10px] font-medium shadow-none transition-none",
                   "border border-transparent",
                   "data-[state=active]:bg-os-selection-bg data-[state=active]:text-os-selection-text data-[state=active]:shadow-none",
                   "focus-visible:ring-1 focus-visible:ring-os-selection-bg focus-visible:ring-offset-0",
@@ -1059,7 +1057,7 @@ export function DebugLogOverlay() {
         className={cn(
           "flex items-center gap-1.5 rounded-full px-2.5 py-1.5 shadow-os-window",
           "border-[length:var(--os-metrics-border-width)] border-os-window",
-          "bg-os-window-bg text-os-text-secondary font-os-mono text-[10px]",
+          "bg-os-window-bg text-os-text-primary font-os-ui text-[11px] font-medium",
           "hover:brightness-105 active:brightness-95",
           open && "ring-1 ring-os-selection-bg"
         )}

--- a/src/components/debug/DebugLogOverlay.tsx
+++ b/src/components/debug/DebugLogOverlay.tsx
@@ -31,6 +31,7 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
 import { useIsRyoAdmin } from "@/hooks/useIsRyoAdmin";
+import { OS_NATIVE_CHROME_SKIP_CLASS } from "@/lib/themeChrome";
 import type { AdminInitialData } from "@/apps/admin/types";
 import {
   clearConsoleCapture,
@@ -540,6 +541,7 @@ export function DebugLogOverlay() {
       ref={overlayRootRef}
       className={cn(
         "fixed select-none flex flex-col",
+        OS_NATIVE_CHROME_SKIP_CLASS,
         isWindowsTheme ? "right-2 items-end" : "left-2 items-start"
       )}
       style={{
@@ -918,7 +920,7 @@ export function DebugLogOverlay() {
               <TabsTrigger
                 value="logs"
                 className={cn(
-                  "h-5 rounded px-2.5 py-0 font-os-ui text-[10px] font-medium shadow-none transition-none",
+                  "h-5 rounded px-2.5 py-0 font-os-mono text-[10px] shadow-none transition-none",
                   "border border-transparent",
                   "data-[state=active]:bg-os-selection-bg data-[state=active]:text-os-selection-text data-[state=active]:shadow-none",
                   "focus-visible:ring-1 focus-visible:ring-os-selection-bg focus-visible:ring-offset-0",
@@ -930,7 +932,7 @@ export function DebugLogOverlay() {
               <TabsTrigger
                 value="live"
                 className={cn(
-                  "h-5 rounded px-2.5 py-0 font-os-ui text-[10px] font-medium shadow-none transition-none",
+                  "h-5 rounded px-2.5 py-0 font-os-mono text-[10px] shadow-none transition-none",
                   "border border-transparent",
                   "data-[state=active]:bg-os-selection-bg data-[state=active]:text-os-selection-text data-[state=active]:shadow-none",
                   "focus-visible:ring-1 focus-visible:ring-os-selection-bg focus-visible:ring-offset-0",
@@ -942,7 +944,7 @@ export function DebugLogOverlay() {
               <TabsTrigger
                 value="network"
                 className={cn(
-                  "h-5 rounded px-2.5 py-0 font-os-ui text-[10px] font-medium shadow-none transition-none",
+                  "h-5 rounded px-2.5 py-0 font-os-mono text-[10px] shadow-none transition-none",
                   "border border-transparent",
                   "data-[state=active]:bg-os-selection-bg data-[state=active]:text-os-selection-text data-[state=active]:shadow-none",
                   "focus-visible:ring-1 focus-visible:ring-os-selection-bg focus-visible:ring-offset-0",
@@ -966,7 +968,7 @@ export function DebugLogOverlay() {
         className={cn(
           "flex items-center gap-1.5 rounded-full px-2.5 py-1.5 shadow-os-window",
           "border-[length:var(--os-metrics-border-width)] border-os-window",
-          "bg-os-window-bg text-os-text-primary font-os-ui text-[11px] font-medium",
+          "bg-os-window-bg text-os-text-secondary font-os-mono text-[10px]",
           "hover:brightness-105 active:brightness-95",
           open && "ring-1 ring-os-selection-bg"
         )}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,12 +18,16 @@ import {
 } from "./utils/reloadGuard";
 import { installConsoleCapture } from "./utils/consoleCapture";
 import { installNetworkCapture } from "./utils/networkCapture";
+import { createClientLogger } from "./utils/logger";
+
+const bootstrapLog = createClientLogger("Bootstrap");
 
 // Patch console output and fetch as early as possible; buffering is enabled
 // only when Debug Mode is on so normal sessions do not retain in-memory
 // log/network history.
 installConsoleCapture();
 installNetworkCapture();
+bootstrapLog.debug("Installed debug capture hooks");
 
 // Prime React 19 resource hints before anything else runs
 primeReactResources();
@@ -41,6 +45,7 @@ primeReactResources();
 try {
   if (new URL(window.location.href).searchParams.has("_cb")) {
     clearStaleReload();
+    bootstrapLog.debug("Cleared stale reload cooldown after cache-bust navigation");
   }
 } catch {
   // URL parsing or sessionStorage may throw in edge cases
@@ -132,13 +137,20 @@ if (import.meta.hot) {
 
 const scheduleIdleWork = (fn: () => void, timeoutMs = 2500) => {
   if (typeof window !== "undefined" && "requestIdleCallback" in window) {
+    bootstrapLog.debug("Scheduling idle bootstrap work with requestIdleCallback", {
+      timeoutMs,
+    });
     window.requestIdleCallback(() => fn(), { timeout: timeoutMs });
   } else {
+    bootstrapLog.debug("Scheduling idle bootstrap work with setTimeout fallback", {
+      timeoutMs,
+    });
     setTimeout(fn, 0);
   }
 };
 
 const renderApp = () => {
+  bootstrapLog.debug("Rendering React app");
   initializeAnalytics();
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
@@ -148,22 +160,30 @@ const renderApp = () => {
 };
 
 const bootstrap = async () => {
+  bootstrapLog.debug("Starting client bootstrap", {
+    development: import.meta.env.DEV === true,
+    mode: import.meta.env.MODE,
+  });
   // Theme attributes for first paint (before React)
   useThemeStore.getState().hydrate();
+  bootstrapLog.debug("Hydrated theme store for first paint");
 
   try {
     await initializeI18nForFirstPaint();
+    bootstrapLog.debug("Initialized i18n for first paint");
   } catch (error) {
     console.error("[ryOS] Failed to initialize i18n during bootstrap:", error);
   }
 
   useLanguageStore.getState().hydrate();
+  bootstrapLog.debug("Hydrated language store");
 
   renderApp();
 
   // Non-critical network work after first paint so it does not compete with
   // the initial JS/CSS/i18n critical path.
   scheduleIdleWork(() => {
+    bootstrapLog.debug("Running idle bootstrap work");
     preloadIpodData();
     initPrefetch();
   });

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { useStoreShallow } from "./helpers";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
 import { AppId, getWindowConfig, getMobileWindowSize } from "@/config/appRegistry";
 import { prefetchAppChunk } from "@/config/lazyAppComponent";
 import { useAppletStore } from "@/stores/useAppletStore";
@@ -9,6 +9,7 @@ import { AIModel } from "@/types/aiModels";
 import { APP_ANALYTICS, track } from "@/utils/analytics";
 import { requestCloudSyncCheck } from "@/utils/cloudSyncEvents";
 import { shouldRequestCloudSyncOnAppLaunch } from "@/utils/cloudSyncLaunch";
+import { createClientLogger } from "@/utils/logger";
 export type { AIModel } from "@/types/aiModels";
 
 // ---------------- Types ---------------------------------------------------------
@@ -116,6 +117,30 @@ interface AppStoreState {
 }
 
 const CURRENT_APP_STORE_VERSION = 6; // store foreground as foregroundInstanceId, not per-instance flags
+const appStoreLog = createClientLogger("AppStore");
+
+function describeInitialData(initialData: unknown): Record<string, unknown> {
+  if (initialData === undefined) return { hasInitialData: false };
+  if (initialData === null) return { hasInitialData: true, kind: "null" };
+  if (Array.isArray(initialData)) {
+    return { hasInitialData: true, kind: "array", length: initialData.length };
+  }
+  if (typeof initialData === "object") {
+    return {
+      hasInitialData: true,
+      kind: "object",
+      keys: Object.keys(initialData as Record<string, unknown>).sort(),
+    };
+  }
+  if (typeof initialData === "string") {
+    return {
+      hasInitialData: true,
+      kind: "string",
+      length: initialData.length,
+    };
+  }
+  return { hasInitialData: true, kind: typeof initialData };
+}
 
 function getDerivedForegroundInstanceId(state: Pick<AppStoreState, "foregroundInstanceId" | "instanceOrder" | "instances">): string | null {
   if (
@@ -168,6 +193,10 @@ const createUseAppStore = () =>
         const previousModel = get().aiModel;
         set({ aiModel: m });
         if (previousModel !== m) {
+          appStoreLog.debug("AI model changed", {
+            model: m || "auto",
+            previousModel: previousModel || "auto",
+          });
           track(APP_ANALYTICS.AI_MODEL_CHANGE, {
             model: m || "auto",
             previousModel: previousModel || "auto",
@@ -187,6 +216,7 @@ const createUseAppStore = () =>
       exposeMode: false,
       setExposeMode: (v) => {
         if (get().exposeMode !== v) {
+          appStoreLog.debug("Expose mode changed", { isOpen: v });
           track(APP_ANALYTICS.APP_EXPOSE, { isOpen: v });
         }
         set({ exposeMode: v });
@@ -262,6 +292,8 @@ const createUseAppStore = () =>
 
       createAppInstance: (appId, initialData, title, launchOrigin) => {
         let createdId = "";
+        // All app components are chunk-loaded so the shell can paint first.
+        const isLazy = true;
         set((state) => {
           const nextNum = state.nextInstanceId + 1;
           createdId = nextNum.toString();
@@ -297,9 +329,6 @@ const createUseAppStore = () =>
             }
           }
 
-          // All app components are chunk-loaded so the shell can paint first.
-          const isLazy = true;
-
           const instances = {
             ...state.instances,
             [createdId]: {
@@ -328,6 +357,15 @@ const createUseAppStore = () =>
           };
         });
         if (createdId) {
+          appStoreLog.debug("Created app instance", {
+            appId,
+            instanceId: createdId,
+            openWindowCount: get().instanceOrder.length,
+            isLazy,
+            hasLaunchOrigin: !!launchOrigin,
+            hasTitle: !!title,
+            initialData: describeInitialData(initialData),
+          });
           // Track recent app
           get().addRecentApp(appId);
           
@@ -394,6 +432,12 @@ const createUseAppStore = () =>
               },
             })
           );
+          appStoreLog.debug("Marked app instance as loaded", {
+            appId: inst.appId,
+            instanceId,
+            openWindowCount: Object.keys(instances).length,
+            foregroundInstanceId: instanceId,
+          });
 
           return {
             instances,
@@ -435,6 +479,12 @@ const createUseAppStore = () =>
             appId: inst.appId,
             openWindowCount: Object.keys(instances).length,
           });
+          appStoreLog.debug("Closed app instance", {
+            appId: inst.appId,
+            instanceId,
+            nextForegroundInstanceId: nextForeground,
+            openWindowCount: Object.keys(instances).length,
+          });
           return {
             instances,
             instanceOrder: order,
@@ -470,6 +520,12 @@ const createUseAppStore = () =>
           if (foreground && state.instances[foreground]) {
             track(APP_ANALYTICS.APP_FOCUS, {
               appId: state.instances[foreground].appId,
+              openWindowCount: Object.keys(state.instances).length,
+            });
+            appStoreLog.debug("Focused app instance", {
+              appId: state.instances[foreground].appId,
+              instanceId: foreground,
+              previousForegroundInstanceId: state.foregroundInstanceId,
               openWindowCount: Object.keys(state.instances).length,
             });
           }
@@ -556,6 +612,12 @@ const createUseAppStore = () =>
             appId: inst.appId,
             openWindowCount: Object.keys(instances).length,
           });
+          appStoreLog.debug("Minimized app instance", {
+            appId: inst.appId,
+            instanceId,
+            nextForegroundInstanceId: nextForeground,
+            openWindowCount: Object.keys(instances).length,
+          });
 
           return {
             instances,
@@ -588,6 +650,11 @@ const createUseAppStore = () =>
             appId: inst.appId,
             openWindowCount: Object.keys(instances).length,
           });
+          appStoreLog.debug("Restored app instance", {
+            appId: inst.appId,
+            instanceId,
+            openWindowCount: Object.keys(instances).length,
+          });
 
           return {
             instances,
@@ -602,6 +669,11 @@ const createUseAppStore = () =>
           if (!inst) return state;
           // Only update if displayTitle actually changed
           if (inst.displayTitle === title) return state;
+          appStoreLog.debug("Updated app instance title", {
+            appId: inst.appId,
+            instanceId,
+            titleLength: title.length,
+          });
           return {
             instances: {
               ...state.instances,
@@ -611,6 +683,13 @@ const createUseAppStore = () =>
         });
       },
       launchApp: (appId, initialData, title, multiWindow = false, launchOrigin) => {
+        appStoreLog.debug("Launch requested", {
+          appId,
+          multiWindow,
+          hasTitle: !!title,
+          hasLaunchOrigin: !!launchOrigin,
+          initialData: describeInitialData(initialData),
+        });
         prefetchAppChunk(appId);
 
         const state = get();
@@ -657,6 +736,12 @@ const createUseAppStore = () =>
                 appId,
                 restoredFromMinimized: true,
               });
+              appStoreLog.debug("Reopened minimized app instances", {
+                appId,
+                instanceId: lastRestoredId,
+                restoredCount: appInstances.length,
+                updatedInitialData: initialData !== undefined,
+              });
               return lastRestoredId;
             }
           }
@@ -689,6 +774,12 @@ const createUseAppStore = () =>
               reusedExistingWindow: true,
               hasInitialData: initialData !== undefined,
             });
+            appStoreLog.debug("Reused existing app instance", {
+              appId,
+              instanceId: existing.instanceId,
+              supportsMultiWindow,
+              updatedInitialData: initialData !== undefined,
+            });
             return existing.instanceId;
           }
         }
@@ -716,6 +807,7 @@ const createUseAppStore = () =>
       {
         name: "ryos:app-store",
         version: CURRENT_APP_STORE_VERSION,
+        storage: createJSONStorage(() => localStorage),
         partialize: (state): Partial<AppStoreState> => ({
         version: state.version,
         

--- a/tests/test-api-logging.test.ts
+++ b/tests/test-api-logging.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  createLogger,
+  isApiDebugLoggingEnabled,
+  summarizeForApiLog,
+} from "../api/_utils/_logging";
+
+const originalConsoleLog = console.log;
+const originalEnv = {
+  API_DEBUG_LOGS: process.env.API_DEBUG_LOGS,
+  NODE_ENV: process.env.NODE_ENV,
+  RYOS_DEBUG: process.env.RYOS_DEBUG,
+};
+
+function restoreEnv(): void {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+describe("API logging", () => {
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    restoreEnv();
+  });
+
+  test("redacts sensitive request fields while preserving error messages", () => {
+    const summarized = summarizeForApiLog({
+      authorization: "Bearer secret",
+      password: "secret",
+      body: { prompt: "private prompt" },
+      message: "private chat message",
+      safe: "ok",
+      error: {
+        kind: "Error",
+        name: "Error",
+        message: "Cannot read properties of undefined",
+        stack: "TypeError: Cannot read properties of undefined",
+      },
+    }) as Record<string, unknown>;
+
+    const error = summarized.error as Record<string, unknown>;
+
+    expect(summarized.authorization).toBe("[redacted]");
+    expect(summarized.password).toBe("[redacted]");
+    expect(summarized.body).toBe("[redacted]");
+    expect(summarized.message).toBe("[redacted]");
+    expect(summarized.safe).toBe("ok");
+    expect(error.message).toBe("Cannot read properties of undefined");
+  });
+
+  test("debug output is development-enabled and production opt-in", () => {
+    const logCalls: unknown[][] = [];
+    console.log = mock((...args: unknown[]) => {
+      logCalls.push(args);
+    }) as unknown as typeof console.log;
+
+    process.env.NODE_ENV = "production";
+    delete process.env.RYOS_DEBUG;
+    delete process.env.API_DEBUG_LOGS;
+
+    expect(isApiDebugLoggingEnabled()).toBe(false);
+    createLogger("req-test").debug("hidden", { token: "secret" });
+    expect(logCalls).toHaveLength(0);
+
+    process.env.RYOS_DEBUG = "1";
+
+    expect(isApiDebugLoggingEnabled()).toBe(true);
+    createLogger("req-test").debug("visible", { token: "secret" });
+    expect(logCalls).toHaveLength(1);
+    expect(String(logCalls[0][0])).toContain("visible");
+    expect(String(logCalls[0][0])).toContain("[redacted]");
+    expect(String(logCalls[0][0])).not.toContain("secret");
+  });
+});

--- a/tests/test-client-logger.test.ts
+++ b/tests/test-client-logger.test.ts
@@ -342,18 +342,4 @@ describe("client logging guardrails", () => {
     expect(bootstrapSource).toContain('"Starting client bootstrap"');
   });
 
-  test("debug overlay toggle matches log message typography", () => {
-    const source = readSource("src/components/debug/DebugLogOverlay.tsx");
-
-    expect(source).toContain(
-      "h-full overflow-auto px-2 py-1 font-os-mono text-[10px] leading-[1.45]"
-    );
-    expect(source).toContain(
-      "bg-os-window-bg text-os-text-secondary font-os-mono text-[10px]"
-    );
-    expect(source).toContain("OS_NATIVE_CHROME_SKIP_CLASS");
-    expect(source).not.toContain(
-      "bg-os-window-bg text-os-text-primary font-os-ui text-[11px]"
-    );
-  });
 });

--- a/tests/test-client-logger.test.ts
+++ b/tests/test-client-logger.test.ts
@@ -341,4 +341,19 @@ describe("client logging guardrails", () => {
     expect(bootstrapSource).toContain('createClientLogger("Bootstrap")');
     expect(bootstrapSource).toContain('"Starting client bootstrap"');
   });
+
+  test("debug overlay toggle matches log message typography", () => {
+    const source = readSource("src/components/debug/DebugLogOverlay.tsx");
+
+    expect(source).toContain(
+      "h-full overflow-auto px-2 py-1 font-os-mono text-[10px] leading-[1.45]"
+    );
+    expect(source).toContain(
+      "bg-os-window-bg text-os-text-secondary font-os-mono text-[10px]"
+    );
+    expect(source).toContain("OS_NATIVE_CHROME_SKIP_CLASS");
+    expect(source).not.toContain(
+      "bg-os-window-bg text-os-text-primary font-os-ui text-[11px]"
+    );
+  });
 });

--- a/tests/test-client-logger.test.ts
+++ b/tests/test-client-logger.test.ts
@@ -305,4 +305,40 @@ describe("client logging guardrails", () => {
     );
     expect(readSource("src/lib/audioContext.ts")).not.toContain("console.debug");
   });
+
+  test("major app lifecycle debug logs stay in shared shell paths", () => {
+    const appStoreSource = readSource("src/stores/useAppStore.ts");
+    const appManagerSource = readSource(
+      "src/apps/base/app-manager/useAppManager.ts"
+    );
+    const appManagerViewSource = readSource(
+      "src/apps/base/app-manager/AppManagerView.tsx"
+    );
+    const appShellSource = readSource("src/App.tsx");
+    const bootstrapSource = readSource("src/main.tsx");
+
+    expect(appStoreSource).toContain('createClientLogger("AppStore")');
+    expect(appStoreSource).toContain("describeInitialData(initialData)");
+    expect(appStoreSource).toContain('"Launch requested"');
+    expect(appStoreSource).toContain('"Created app instance"');
+    expect(appStoreSource).toContain('"Focused app instance"');
+    expect(appStoreSource).toContain('"Closed app instance"');
+
+    expect(appManagerSource).toContain('createClientLogger("AppManager")');
+    expect(appManagerSource).toContain('"Received app launch request"');
+    expect(appManagerSource).toContain('"Window manager state changed"');
+
+    expect(appManagerViewSource).toContain(
+      'createClientLogger("AppManagerView")'
+    );
+    expect(appManagerViewSource).toContain(
+      '"Managed app instance state changed"'
+    );
+    expect(appManagerViewSource).toContain('"App instance crashed"');
+
+    expect(appShellSource).toContain('createClientLogger("AppShell")');
+    expect(appShellSource).toContain('"Applied display mode"');
+    expect(bootstrapSource).toContain('createClientLogger("Bootstrap")');
+    expect(bootstrapSource).toContain('"Starting client bootstrap"');
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Merge latest `main` so the branch uses the current debug UI from upstream.
- Add redacted API log summarization plus opt-in production debug gating for request-scoped API logs.
- Add shared API handler and standalone Bun server debug traces for route matching, auth, validation, handler completion, analytics, and realtime adapter events.
- Add client debug-mode traces for bootstrap, app shell, app manager, and app store lifecycle events across registered apps.
- Revert this branch's debug overlay UI styling changes so UI comes from latest `main`.
- Add focused API/client logging guardrail tests and align `useAppStore` persisted storage with other Zustand stores.

## Testing
- `bun test tests/test-api-logging.test.ts tests/test-client-logger.test.ts tests/test-app-store-foreground-state.test.ts`
- `bun run build`
- `bun run lint` (fails on pre-existing unrelated errors in `BootScreen.tsx` and `useChatSynth.ts` plus warnings)
- `bunx eslint api/_utils/_logging.ts api/_utils/api-handler.ts scripts/api-standalone-server.ts src/stores/useAppStore.ts src/apps/base/app-manager/useAppManager.ts src/apps/base/app-manager/AppManagerView.tsx src/main.tsx src/App.tsx tests/test-api-logging.test.ts tests/test-client-logger.test.ts`
- `git diff --check && git diff --cached --check`
- `bun run test:registration`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1770-1902-76d2-985a-65c86b6e0eae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1770-1902-76d2-985a-65c86b6e0eae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

