### PR TITLE
Fix custom local realtime WebSocket paths

### DIFF
--- a/tests/test-realtime-ws-local.test.ts
+++ b/tests/test-realtime-ws-local.test.ts
@@ -21,6 +21,12 @@ const PASSWORD = "testpassword123";
 
 const origin = LOCAL_URL || "http://localhost:3001";
 const wsOrigin = origin.replace(/^http/, "ws");
+const configuredWsPath = process.env.REALTIME_WS_PATH?.trim();
+const wsPath = configuredWsPath
+  ? configuredWsPath.startsWith("/")
+    ? configuredWsPath
+    : `/${configuredWsPath}`
+  : "/ws";
 
 async function register(
   username: string
@@ -66,8 +72,8 @@ function subscribeOnce(
 ): Promise<SubscribeResult> {
   const { waitMs = 1500, triggerAfterSubscribe } = options;
   const url = ticket
-    ? `${wsOrigin}/ws?ticket=${encodeURIComponent(ticket)}`
-    : `${wsOrigin}/ws`;
+    ? `${wsOrigin}${wsPath}?ticket=${encodeURIComponent(ticket)}`
+    : `${wsOrigin}${wsPath}`;
 
   return new Promise<SubscribeResult>((resolve) => {
     const ws = new WebSocket(url);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,12 @@ const __dirname = path.dirname(__filename);
 const isBuildCommand = process.argv.includes("build");
 const isDev = !isBuildCommand && process.env.NODE_ENV !== 'production' && !process.env.VERCEL;
 const standaloneApiProxyTarget = process.env.STANDALONE_API_PROXY_TARGET?.trim();
+const configuredRealtimeWebSocketPath = process.env.REALTIME_WS_PATH?.trim();
+const realtimeWebSocketPath = configuredRealtimeWebSocketPath
+  ? configuredRealtimeWebSocketPath.startsWith("/")
+    ? configuredRealtimeWebSocketPath
+    : `/${configuredRealtimeWebSocketPath}`
+  : "/ws";
 
 // Browserslist warns if caniuse-lite is stale; suppress when up-to-date
 process.env.BROWSERSLIST_IGNORE_OLD_DATA ??= "1";
@@ -189,6 +195,7 @@ export default defineConfig({
     'import.meta.env.VITE_PUSHER_KEY': JSON.stringify(process.env.PUSHER_KEY || ''),
     'import.meta.env.VITE_PUSHER_CLUSTER': JSON.stringify(process.env.PUSHER_CLUSTER || ''),
     'import.meta.env.VITE_REALTIME_PROVIDER': JSON.stringify(process.env.REALTIME_PROVIDER || ''),
+    'import.meta.env.VITE_REALTIME_WS_PATH': JSON.stringify(realtimeWebSocketPath),
   },
   // Optimize JSON imports for better performance
   json: {
@@ -210,7 +217,7 @@ export default defineConfig({
               target: standaloneApiProxyTarget,
               changeOrigin: true,
             },
-            "/ws": {
+            [realtimeWebSocketPath]: {
               target: standaloneApiProxyTarget,
               ws: true,
             },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- expose the normalized `REALTIME_WS_PATH` to the Vite client
- proxy that configured path instead of hardcoding `/ws`
- make the local realtime integration suite exercise custom WebSocket paths

## Testing
- `REALTIME_LOCAL_URL=http://localhost:5173 REALTIME_WS_PATH=socket bun run test:realtime-ws-local` (6 passed)
- custom WebSocket ping/pong through `ws://localhost:5173/socket`
- `bun test tests/test-self-host-runtime-config.test.ts` (3 passed)
- `bun run test:registration`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1772-bbd4-7ef2-bfd0-fa1bb37b517d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1772-bbd4-7ef2-bfd0-fa1bb37b517d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

