### PR TITLE
Restore Preview documents with windows

### DIFF
--- a/src/apps/preview/hooks/usePreviewLogic.ts
+++ b/src/apps/preview/hooks/usePreviewLogic.ts
@@ -81,8 +81,8 @@ export function usePreviewLogic({
   } = useAppHelpAboutDialogs();
   const launchApp = useLaunchApp();
   const { saveFile } = useVfsFileOperations("/");
-  const clearInstanceInitialData = useAppStore(
-    (state) => state.clearInstanceInitialData,
+  const updateInstanceInitialData = useAppStore(
+    (state) => state.updateInstanceInitialData,
   );
 
   const [currentPath, setCurrentPath] = useState("");
@@ -97,11 +97,13 @@ export function usePreviewLogic({
   const [saveAsFileName, setSaveAsFileName] = useState("");
   const [isSaving, setIsSaving] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const loadedPathRef = useRef("");
 
   const loadPreview = useCallback(
     async (
       path: string,
       suppliedContent?: string | Blob | ArrayBuffer,
+      rememberPath = true,
     ): Promise<void> => {
       setIsLoading(true);
       setError(null);
@@ -134,6 +136,10 @@ export function usePreviewLogic({
         setCurrentPath(path);
         setKind(nextKind);
         setContent(nextContent);
+        loadedPathRef.current = path;
+        if (rememberPath) {
+          updateInstanceInitialData(instanceId, { path });
+        }
       } catch (loadError) {
         console.error("[Preview] Failed to load file:", loadError);
         setCurrentPath(path);
@@ -148,18 +154,18 @@ export function usePreviewLogic({
         setIsLoading(false);
       }
     },
-    [t],
+    [instanceId, t, updateInstanceInitialData],
   );
 
   useEffect(() => {
     if (!isWindowOpen || (!initialData?.path && !initialData?.content)) return;
     const path = initialData.path || t("apps.preview.untitled");
-    void loadPreview(path, initialData.content);
-    clearInstanceInitialData(instanceId);
+    if (initialData.content === undefined && loadedPathRef.current === path) {
+      return;
+    }
+    void loadPreview(path, initialData.content, Boolean(initialData.path));
   }, [
-    clearInstanceInitialData,
     initialData,
-    instanceId,
     isWindowOpen,
     loadPreview,
     t,
@@ -300,6 +306,8 @@ export function usePreviewLogic({
         });
         emitFileSaved({ name: fileName, path, content });
         setCurrentPath(path);
+        loadedPathRef.current = path;
+        updateInstanceInitialData(instanceId, { path });
         setIsSaveAsDialogOpen(false);
         toast.success(t("apps.preview.toasts.saved"), {
           description: path,
@@ -311,7 +319,15 @@ export function usePreviewLogic({
         setIsSaving(false);
       }
     },
-    [content, currentPath, kind, saveFile, t],
+    [
+      content,
+      currentPath,
+      instanceId,
+      kind,
+      saveFile,
+      t,
+      updateInstanceInitialData,
+    ],
   );
 
   const handleExport = useCallback(async () => {

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -10,6 +10,7 @@ import { APP_ANALYTICS, track } from "@/utils/analytics";
 import { requestCloudSyncCheck } from "@/utils/cloudSyncEvents";
 import { shouldRequestCloudSyncOnAppLaunch } from "@/utils/cloudSyncLaunch";
 import { createClientLogger } from "@/utils/logger";
+import { getRestorablePreviewInitialData } from "@/types/appInitialData";
 export type { AIModel } from "@/types/aiModels";
 
 // ---------------- Types ---------------------------------------------------------
@@ -850,6 +851,13 @@ const createUseAppStore = () =>
                     ...appletData,
                     content: "", // Exclude content - it should be loaded from IndexedDB
                   },
+                } as AppInstance]);
+                return acc;
+              }
+              if (inst.appId === "preview") {
+                acc.push([id, {
+                  ...instWithoutRuntimeState,
+                  initialData: getRestorablePreviewInitialData(inst.initialData),
                 } as AppInstance]);
                 return acc;
               }

--- a/src/types/appInitialData.ts
+++ b/src/types/appInitialData.ts
@@ -25,6 +25,26 @@ export interface PreviewInitialData {
   content?: string | Blob | ArrayBuffer;
 }
 
+/**
+ * Keep only the VFS path needed to restore a Preview window.
+ * Inline content can be large and is not reliably JSON-serializable.
+ */
+export function getRestorablePreviewInitialData(
+  data: unknown,
+): PreviewInitialData | undefined {
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    !("path" in data) ||
+    typeof data.path !== "string" ||
+    data.path.length === 0
+  ) {
+    return undefined;
+  }
+
+  return { path: data.path };
+}
+
 /** Internet Explorer initial data - for URL navigation or share codes */
 export interface InternetExplorerInitialData {
   url?: string;

--- a/tests/test-preview-wiring.test.ts
+++ b/tests/test-preview-wiring.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { supportsMultiWindowApp } from "../src/apps/base/app-manager/instanceHelpers";
 import { DOCK_MULTI_WINDOW_APPS } from "../src/components/layout/dock/dockConstants";
+import { getRestorablePreviewInitialData } from "../src/types/appInitialData";
 
 describe("Preview app wiring", () => {
   test("is registered in shared multi-window gates", async () => {
@@ -19,6 +20,37 @@ describe("Preview app wiring", () => {
     ).text();
     expect(component).toContain(
       'isAquaGlass ? "bg-transparent" : "bg-os-panel-bg"',
+    );
+  });
+
+  test("persists only the document path needed to restore a window", () => {
+    const content = new Blob(["preview"]);
+
+    expect(
+      getRestorablePreviewInitialData({
+        path: "/Documents/guide.pdf",
+        content,
+      }),
+    ).toEqual({ path: "/Documents/guide.pdf" });
+    expect(getRestorablePreviewInitialData({ content })).toBeUndefined();
+    expect(getRestorablePreviewInitialData({ path: "" })).toBeUndefined();
+  });
+
+  test("retains and reloads each window's last document", async () => {
+    const previewLogic = await Bun.file(
+      "src/apps/preview/hooks/usePreviewLogic.ts",
+    ).text();
+    const appStore = await Bun.file("src/stores/useAppStore.ts").text();
+
+    expect(previewLogic).toContain(
+      "updateInstanceInitialData(instanceId, { path });",
+    );
+    expect(previewLogic).toContain("loadedPathRef.current === path");
+    expect(previewLogic).not.toContain(
+      "clearInstanceInitialData(instanceId)",
+    );
+    expect(appStore).toContain(
+      "getRestorablePreviewInitialData(inst.initialData)",
     );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- retain each Preview window's last VFS document path after loading or saving
- reload that path when the persisted window session is restored
- omit inline Preview content from persisted app state

## Walkthrough
![Preview restored with its previous image after a full desktop reload](https://cursor.com/artifacts/c/art-5d216fc9-42ba-450a-aa68-9fabd08a2473)

The `steve-jobs.png` Preview window remains open and renders the same VFS image after a full page reload.

## Testing
- `bun test tests/test-preview-wiring.test.ts`
- `bun run test:registration`
- `bunx eslint src/apps/preview/hooks/usePreviewLogic.ts src/stores/useAppStore.ts src/types/appInitialData.ts tests/test-preview-wiring.test.ts`
- `bun run build`
- Playwright browser flow: open `/Images/steve-jobs.png`, verify persisted state is path-only, reload the desktop, and verify the image remains visible
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1dfe-c643-7898-b207-896a9ddbf957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1dfe-c643-7898-b207-896a9ddbf957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

