### PR TITLE
Improve locale-aware CJK reading and lyrics fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,11 +31,13 @@
     <link rel="preconnect" href="https://i.ytimg.com" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
     <link rel="dns-prefetch" href="https://www.youtube.com" />
     <link rel="dns-prefetch" href="https://i.ytimg.com" />
     
-    <!-- Google Fonts: Noto/Source Han Serif SC + JP/KR, Kosugi Maru, and Nanum Gothic -->
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;700&family=Noto+Serif+JP:wght@400;700&family=Noto+Serif+KR:wght@400;700&family=Kosugi+Maru&family=Nanum+Gothic:wght@700&display=swap" rel="stylesheet" />
+    <!-- CJK fonts: Noto/Source Han Serif, Nanum Gothic, and Chiron GoRound TC -->
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;700&family=Noto+Serif+JP:wght@400;700&family=Noto+Serif+KR:wght@400;700&family=Nanum+Gothic:wght@700&display=swap" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/chiron-go-round-tc-webfont@1.0.11/css/vf.css" rel="stylesheet" />
 
     <!-- Preload critical fonts (used immediately on page load) -->
     <link rel="preload" href="/fonts/ChicagoKare-Regular.woff2" as="font" type="font/woff2" crossorigin />

--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -281,13 +281,17 @@ export const BooksReaderPane = forwardRef<
   const renderHostRef = useRef<HTMLDivElement>(null);
   const bookRef = useRef<Book | null>(null);
   const renditionRef = useRef<Rendition | null>(null);
+  const bookLanguageRef = useRef<string | null>(null);
   const flipLockRef = useRef(false);
   const onProgressRef = useRef(onProgress);
   onProgressRef.current = onProgress;
   const initialCfiRef = useRef(initialCfi);
   const activeSectionHrefRef = useRef<string | undefined>(undefined);
 
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const uiLanguage = i18n.resolvedLanguage ?? i18n.language ?? "en";
+  const uiLanguageRef = useRef(uiLanguage);
+  uiLanguageRef.current = uiLanguage;
   const [isReady, setIsReady] = useState(false);
   const [coverVisible, setCoverVisible] = useState(true);
   // Set when the EPUB can't be opened (missing blob or display failure) so the
@@ -446,6 +450,7 @@ export const BooksReaderPane = forwardRef<
     setIsReady(false);
     setCoverVisible(true);
     setLoadError(null);
+    bookLanguageRef.current = null;
     activeSectionHrefRef.current = undefined;
     setNavigationState(createInitialBooksNavigationState());
     appendDebugEvent("open:start", {
@@ -663,8 +668,12 @@ export const BooksReaderPane = forwardRef<
         await watch("epubjs:bookReady", book.ready);
         const readyBook = book as unknown as {
           container?: { packagePath?: string };
-          package?: { metadata?: unknown };
+          package?: { metadata?: { language?: string } };
         };
+        const bookLanguage =
+          readyBook.package?.metadata?.language?.trim() || null;
+        bookLanguageRef.current = bookLanguage;
+        const readingLanguage = bookLanguage ?? uiLanguage;
         appendDebugEvent("epubjs:bookReady:success", {
           packagePath: readyBook.container?.packagePath,
           metadata: readyBook.package?.metadata,
@@ -751,12 +760,15 @@ export const BooksReaderPane = forwardRef<
             } catch {
               appendDebugEvent("epubjs:contentHook:fonts:failed", undefined, "warn");
             }
-            // `hyphens: auto` only kicks in when the content language is known.
-            // Many EPUBs omit it, so default to English when absent.
+            // `hyphens: auto` and locale-specific CJK glyph forms depend on the
+            // content language. Prefer EPUB metadata, then the ryOS UI locale.
             try {
               const docEl = contents.document?.documentElement;
               if (docEl && !docEl.getAttribute("lang")) {
-                docEl.setAttribute("lang", "en");
+                docEl.setAttribute(
+                  "lang",
+                  bookLanguageRef.current ?? uiLanguageRef.current
+                );
               }
             } catch {
               // ignore
@@ -782,7 +794,9 @@ export const BooksReaderPane = forwardRef<
           }
         );
 
-        rendition.themes.default(buildEpubTheme(settings, palette));
+        rendition.themes.default(
+          buildEpubTheme(settings, palette, readingLanguage)
+        );
         rendition.themes.fontSize(`${settings.fontSizePct}%`);
         appendDebugEvent("epubjs:theme:applied");
 
@@ -910,7 +924,9 @@ export const BooksReaderPane = forwardRef<
   // Apply theme (colors, font family, line height) live.
   useEffect(() => {
     if (!isReady || !renditionRef.current) return;
-    renditionRef.current.themes.default(buildEpubTheme(settings, palette));
+    renditionRef.current.themes.default(
+      buildEpubTheme(settings, palette, bookLanguageRef.current ?? uiLanguage)
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isReady,
@@ -918,6 +934,7 @@ export const BooksReaderPane = forwardRef<
     settings.themeOverride,
     settings.lineHeight,
     osIsDark,
+    uiLanguage,
   ]);
 
   // Apply font size live.

--- a/src/apps/books/utils/booksReader.ts
+++ b/src/apps/books/utils/booksReader.ts
@@ -2,6 +2,54 @@ import type {
   BooksReaderSettings,
   BooksThemeOverride,
 } from "@/stores/useBooksStore";
+import { detectLanguageFromLocale } from "@/lib/languageConfig";
+
+const BOOK_SERIF_LATIN_FALLBACKS =
+  '"Iowan Old Style", "Palatino", "Palatino Linotype", "Book Antiqua", Georgia, "Times New Roman", serif';
+
+const BOOK_CJK_SERIF_STACKS = {
+  "zh-CN":
+    '"Noto Serif SC", "Source Han Serif SC", "Noto Serif CJK SC", "Songti SC", STSong, SimSun, "Noto Serif JP", "Source Han Serif JP", "Noto Serif KR", "Source Han Serif KR"',
+  "zh-TW":
+    '"Noto Serif TC", "Source Han Serif TC", "Noto Serif CJK TC", "Songti TC", PMingLiU, MingLiU, "Noto Serif JP", "Source Han Serif JP", "Noto Serif SC", "Source Han Serif SC"',
+  ja: '"Noto Serif JP", "Source Han Serif JP", "Noto Serif CJK JP", "Source Han Serif", "Hiragino Mincho ProN", "Hiragino Mincho Pro", "Yu Mincho", "Noto Serif SC", "Source Han Serif SC", "Noto Serif KR", "Source Han Serif KR"',
+  ko: '"Noto Serif KR", "Source Han Serif KR", "Noto Serif CJK KR", "Nanum Myeongjo", "AppleMyungjo", Batang, "Noto Serif JP", "Source Han Serif JP", "Noto Serif SC", "Source Han Serif SC"',
+} as const;
+
+const DEFAULT_BOOK_CJK_SERIF_STACK = `${BOOK_CJK_SERIF_STACKS.ja}, "Noto Serif TC", "Source Han Serif TC", "Noto Serif CJK SC", "Songti TC", "Songti SC", SimSun`;
+
+/**
+ * Resolve locale-specific CJK serif fallbacks. Simplified Chinese must prefer
+ * SC glyph families; otherwise a JP-first stack can render mainland forms with
+ * Japanese glyph variants.
+ */
+export function resolveBookCjkSerifStack(
+  language?: string | null
+): string {
+  const resolvedLanguage = language
+    ? detectLanguageFromLocale(language)
+    : null;
+
+  switch (resolvedLanguage) {
+    case "zh-CN":
+      return BOOK_CJK_SERIF_STACKS["zh-CN"];
+    case "zh-TW":
+      return BOOK_CJK_SERIF_STACKS["zh-TW"];
+    case "ko":
+      return BOOK_CJK_SERIF_STACKS.ko;
+    case "ja":
+      return BOOK_CJK_SERIF_STACKS.ja;
+    default:
+      return DEFAULT_BOOK_CJK_SERIF_STACK;
+  }
+}
+
+function buildBookSerifStack(
+  primaryFonts: string,
+  language?: string | null
+): string {
+  return `${primaryFonts}, ${resolveBookCjkSerifStack(language)}, ${BOOK_SERIF_LATIN_FALLBACKS}`;
+}
 
 export interface BookFontOption {
   id: string;
@@ -19,14 +67,12 @@ export const BOOK_FONTS: BookFontOption[] = [
   {
     id: "eb-garamond",
     label: "EB Garamond",
-    cssStack:
-      '"EB Garamond", "Charter", "Iowan Old Style", "Palatino", "Palatino Linotype", "Book Antiqua", Georgia, "Times New Roman", serif',
+    cssStack: buildBookSerifStack('"EB Garamond", "Charter"'),
   },
   {
     id: "serif",
     label: "Serif",
-    cssStack:
-      '"Charter", "Iowan Old Style", "Palatino", "Palatino Linotype", "Book Antiqua", Georgia, "Times New Roman", serif',
+    cssStack: buildBookSerifStack('"Charter"'),
   },
   {
     id: "sans",
@@ -44,6 +90,21 @@ export const BOOK_FONTS: BookFontOption[] = [
 
 export function getBookFont(fontId: string): BookFontOption {
   return BOOK_FONTS.find((f) => f.id === fontId) ?? BOOK_FONTS[0];
+}
+
+/** Resolve a reading font stack, including locale-specific CJK serif faces. */
+export function getBookFontCssStack(
+  fontId: string,
+  language?: string | null
+): string | null {
+  const font = getBookFont(fontId);
+  if (font.id === "eb-garamond") {
+    return buildBookSerifStack('"EB Garamond", "Charter"', language);
+  }
+  if (font.id === "serif") {
+    return buildBookSerifStack('"Charter"', language);
+  }
+  return font.cssStack;
 }
 
 export interface ReadingPalette {
@@ -111,10 +172,11 @@ export function isLikelyEpubBuffer(buffer: ArrayBuffer): boolean {
  */
 export function buildEpubTheme(
   settings: BooksReaderSettings,
-  palette: ReadingPalette
+  palette: ReadingPalette,
+  language?: string | null
 ): Record<string, Record<string, string>> {
-  const font = getBookFont(settings.fontId);
-  const fontFamily = font.cssStack ? `${font.cssStack} !important` : null;
+  const fontStack = getBookFontCssStack(settings.fontId, language);
+  const fontFamily = fontStack ? `${fontStack} !important` : null;
 
   // Left-align with automatic hyphenation reads far better than justified text
   // in a narrow column (justify opens up ugly rivers of whitespace). Applied
@@ -190,11 +252,13 @@ export function buildEpubTheme(
 }
 
 /**
- * @font-face CSS injected into every section iframe so custom reading fonts
- * (EB Garamond is loaded from the app origin) resolve inside the book.
+ * Font CSS injected into every section iframe so custom reading fonts resolve
+ * inside the book. EPUB sections cannot inherit fonts loaded by the app shell,
+ * so Noto's CJK serif families are imported again here.
  */
 export function buildFontFaceCss(origin: string): string {
   return `
+@import url("https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;700&family=Noto+Serif+KR:wght@400;700&family=Noto+Serif+SC:wght@400;700&family=Noto+Serif+TC:wght@400;700&display=swap");
 @font-face {
   font-family: "EB Garamond";
   src: url("${origin}/fonts/EBGaramond-Latin.woff2") format("woff2");

--- a/src/index.css
+++ b/src/index.css
@@ -515,10 +515,11 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   }
 
   /* Rounded lyrics font utility */
-  /* VAGRounded is the bundled font, with CJK fallbacks for non-Latin characters */
+  /* Chiron provides rounded CJK glyphs after bundled VAGRounded. */
   .font-lyrics-rounded {
-    font-family: "VAGRounded", "Kosugi Maru", "Hiragino Maru Gothic ProN",
-      "Nanum Gothic", "Yuanti SC", ui-rounded, sans-serif;
+    font-family: "VAGRounded", "Chiron GoRound TC WS",
+      "Hiragino Maru Gothic ProN", "Nanum Gothic", "Yuanti SC", ui-rounded,
+      sans-serif;
     font-weight: normal;
     line-height: 1.1;
     font-synthesis: none;
@@ -557,8 +558,9 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
 
   /* Glow - Album art primary color glow style (uses rounded font) */
   .font-lyrics-gold-glow {
-    font-family: "VAGRounded", "Kosugi Maru", "Hiragino Maru Gothic ProN",
-      "Nanum Gothic", "Yuanti SC", ui-rounded, sans-serif;
+    font-family: "VAGRounded", "Chiron GoRound TC WS",
+      "Hiragino Maru Gothic ProN", "Nanum Gothic", "Yuanti SC", ui-rounded,
+      sans-serif;
     font-weight: normal;
     line-height: 1.1;
     font-synthesis: none;

--- a/src/styles/themes/aqua.css
+++ b/src/styles/themes/aqua.css
@@ -1576,10 +1576,11 @@
 }
 
 /* Preserve rounded lyrics font inside iPod fullscreen on macOS theme */
-/* VAGRounded is the bundled font, with CJK fallbacks for non-Latin characters */
+/* Chiron provides rounded CJK glyphs after bundled VAGRounded. */
 :root[data-os-theme="macosx"] .ipod-force-font .font-lyrics-rounded {
-  font-family: "VAGRounded", "Kosugi Maru", "Hiragino Maru Gothic ProN",
-    "Nanum Gothic", "Yuanti SC", ui-rounded, sans-serif !important;
+  font-family: "VAGRounded", "Chiron GoRound TC WS",
+    "Hiragino Maru Gothic ProN", "Nanum Gothic", "Yuanti SC", ui-rounded,
+    sans-serif !important;
   font-weight: normal !important;
   line-height: 1.1 !important;
   font-synthesis: none !important;
@@ -1588,10 +1589,11 @@
 }
 
 /* Preserve rounded lyrics font inside Karaoke app on macOS theme */
-/* VAGRounded is the bundled font, with CJK fallbacks for non-Latin characters */
+/* Chiron provides rounded CJK glyphs after bundled VAGRounded. */
 :root[data-os-theme="macosx"] .karaoke-force-font .font-lyrics-rounded {
-  font-family: "VAGRounded", "Kosugi Maru", "Hiragino Maru Gothic ProN",
-    "Nanum Gothic", "Yuanti SC", ui-rounded, sans-serif !important;
+  font-family: "VAGRounded", "Chiron GoRound TC WS",
+    "Hiragino Maru Gothic ProN", "Nanum Gothic", "Yuanti SC", ui-rounded,
+    sans-serif !important;
   font-weight: normal !important;
   line-height: 1.1 !important;
   font-synthesis: none !important;
@@ -1654,8 +1656,9 @@
 /* Preserve glow lyrics font on macOS theme */
 :root[data-os-theme="macosx"] .ipod-force-font .font-lyrics-gold-glow,
 :root[data-os-theme="macosx"] .karaoke-force-font .font-lyrics-gold-glow {
-  font-family: "VAGRounded", "Kosugi Maru", "Hiragino Maru Gothic ProN",
-    "Nanum Gothic", "Yuanti SC", ui-rounded, sans-serif !important;
+  font-family: "VAGRounded", "Chiron GoRound TC WS",
+    "Hiragino Maru Gothic ProN", "Nanum Gothic", "Yuanti SC", ui-rounded,
+    sans-serif !important;
   font-weight: normal !important;
   line-height: 1.1 !important;
   font-synthesis: none !important;
@@ -1676,16 +1679,17 @@
   font-smooth: auto !important;
 }
 
-/* Aqua/Aqua Glass Simplified Chinese: use mainland glyph families without
-   changing Traditional Chinese, Japanese, or the pixel-font themes. */
+/* Aqua/Aqua Glass Simplified Chinese: keep Chiron first for rounded lyrics,
+   followed by mainland fallbacks; use mainland serif/sans stacks. */
 :root[data-os-theme="macosx"]:lang(zh-CN)
   .ipod-force-font
   :is(.font-lyrics-rounded, .font-lyrics-gold-glow),
 :root[data-os-theme="macosx"]:lang(zh-CN)
   .karaoke-force-font
   :is(.font-lyrics-rounded, .font-lyrics-gold-glow) {
-  font-family: "VAGRounded", "Yuanti SC", "PingFang SC", "Microsoft YaHei",
-    "Noto Sans CJK SC", ui-rounded, sans-serif !important;
+  font-family: "VAGRounded", "Chiron GoRound TC WS", "Yuanti SC",
+    "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", ui-rounded,
+    sans-serif !important;
 }
 
 :root[data-os-theme="macosx"]:lang(zh-CN)

--- a/tests/test-books-reader-fonts.test.ts
+++ b/tests/test-books-reader-fonts.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildEpubTheme,
+  buildFontFaceCss,
+  getBookFontCssStack,
+  resolveBookCjkSerifStack,
+} from "../src/apps/books/utils/booksReader";
+
+const settings = {
+  fontId: "serif",
+  fontSizePct: 100,
+  columnMode: "auto" as const,
+  themeOverride: "light" as const,
+  lineHeight: 1.5,
+};
+
+const palette = {
+  background: "#fff",
+  text: "#111",
+  link: "#00f",
+  isDark: false,
+};
+
+describe("Books reader CJK serif fonts", () => {
+  test("prefers Simplified Chinese faces for zh-CN and Hans locales", () => {
+    for (const language of ["zh", "zh-CN", "zh-Hans", "zh-Hans-CN", "zh-SG"]) {
+      const stack = resolveBookCjkSerifStack(language);
+
+      expect(stack).toContain('"Noto Serif SC"');
+      expect(stack).toContain('"Source Han Serif SC"');
+      expect(stack).toContain('"Noto Serif CJK SC"');
+      expect(stack).toContain('"Songti SC"');
+      expect(stack.indexOf('"Noto Serif SC"')).toBeLessThan(
+        stack.indexOf('"Noto Serif JP"')
+      );
+    }
+  });
+
+  test("selects region-appropriate CJK faces for other locales", () => {
+    const traditional = resolveBookCjkSerifStack("zh-Hant-TW");
+    const japanese = resolveBookCjkSerifStack("ja-JP");
+    const korean = resolveBookCjkSerifStack("ko-KR");
+
+    expect(traditional.indexOf('"Noto Serif TC"')).toBeLessThan(
+      traditional.indexOf('"Noto Serif JP"')
+    );
+    expect(japanese.indexOf('"Noto Serif JP"')).toBeLessThan(
+      japanese.indexOf('"Noto Serif SC"')
+    );
+    expect(korean.indexOf('"Noto Serif KR"')).toBeLessThan(
+      korean.indexOf('"Noto Serif JP"')
+    );
+  });
+
+  test("adds locale-aware CJK fallbacks to both serif reading choices", () => {
+    const serif = getBookFontCssStack("serif", "zh-CN");
+    const garamond = getBookFontCssStack("eb-garamond", "ko");
+
+    expect(serif).toStartWith('"Charter", "Noto Serif SC"');
+    expect(serif).toContain('"Source Han Serif SC"');
+    expect(garamond).toStartWith(
+      '"EB Garamond", "Charter", "Noto Serif KR"'
+    );
+    expect(garamond).toContain('"Source Han Serif KR"');
+  });
+
+  test("applies the resolved stack throughout the epub.js serif theme", () => {
+    const theme = buildEpubTheme(settings, palette, "zh-CN");
+
+    expect(theme.body["font-family"]).toContain(
+      '"Charter", "Noto Serif SC", "Source Han Serif SC"'
+    );
+    expect(theme.p["font-family"]).toBe(theme.body["font-family"]);
+    expect(theme.h1["font-family"]).toBe(theme.body["font-family"]);
+
+    const originalTheme = buildEpubTheme(
+      { ...settings, fontId: "original" },
+      palette,
+      "zh-CN"
+    );
+    expect(originalTheme.body["font-family"]).toBeUndefined();
+  });
+
+  test("loads Noto CJK serif families inside isolated EPUB iframes", () => {
+    const css = buildFontFaceCss("https://os.example");
+
+    expect(css).toContain("family=Noto+Serif+SC:wght@400;700");
+    expect(css).toContain("family=Noto+Serif+TC:wght@400;700");
+    expect(css).toContain("family=Noto+Serif+JP:wght@400;700");
+    expect(css).toContain("family=Noto+Serif+KR:wght@400;700");
+    expect(css.indexOf("@import")).toBeLessThan(css.indexOf("@font-face"));
+    expect(css).toContain(
+      'url("https://os.example/fonts/EBGaramond-Latin.woff2")'
+    );
+  });
+});

--- a/tests/test-simplified-chinese-aqua-fonts.test.ts
+++ b/tests/test-simplified-chinese-aqua-fonts.test.ts
@@ -74,6 +74,27 @@ describe("Simplified Chinese Aqua fonts", () => {
     );
   });
 
+  test("uses Chiron before the Simplified Chinese rounded fallbacks", () => {
+    const simplifiedRoundedBlock = extractRuleBlock(
+      aquaCss,
+      ':root[data-os-theme="macosx"]:lang(zh-CN)'
+    );
+
+    expect(indexHtml).toContain(
+      "chiron-go-round-tc-webfont@1.0.11/css/vf.css"
+    );
+    expect(appCss).toContain('"Chiron GoRound TC WS"');
+    expect(aquaCss).toContain('"Chiron GoRound TC WS"');
+    expect(indexHtml).not.toContain("Kosugi+Maru");
+    expect(appCss).not.toContain('"Kosugi Maru"');
+    expect(aquaCss).not.toContain('"Kosugi Maru"');
+    expect(simplifiedRoundedBlock).toContain('"Chiron GoRound TC WS"');
+    expect(simplifiedRoundedBlock).toContain('"Yuanti SC"');
+    expect(simplifiedRoundedBlock.indexOf('"Chiron GoRound TC WS"')).toBeLessThan(
+      simplifiedRoundedBlock.indexOf('"Yuanti SC"')
+    );
+  });
+
   test("routes Aqua UI overrides through the locale-aware font token", () => {
     const synthBlock = extractRuleBlock(
       aquaCss,

--- a/tests/test-simplified-chinese-aqua-fonts.test.ts
+++ b/tests/test-simplified-chinese-aqua-fonts.test.ts
@@ -57,7 +57,7 @@ describe("Simplified Chinese Aqua fonts", () => {
     expect(aquaCss).toContain('"Noto Serif CJK SC"');
     expect(aquaCss).toContain('"Songti SC"');
     expect(aquaCss).toContain(
-      'font-family: "VAGRounded", "Yuanti SC", "PingFang SC"'
+      'font-family: "VAGRounded", "Chiron GoRound TC WS", "Yuanti SC"'
     );
     expect(aquaCss).toContain(
       'font-family: "LucidaGrande", "Lucida Grande", "Hiragino Sans GB"'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add Noto/Source Han CJK fallbacks to the Books serif and EB Garamond reading fonts
- select SC-first glyph families for Simplified Chinese and locale-specific TC/JP/KR stacks elsewhere
- load Noto Serif inside EPUB iframes and derive their language from EPUB metadata or the ryOS locale
- replace Kosugi Maru with Chiron GoRound TC for rounded lyrics, including before Yuanti in Simplified Chinese
- add focused Books and CJK font tests

## Testing
- `bun test tests/test-simplified-chinese-aqua-fonts.test.ts tests/test-books-reader-fonts.test.ts tests/test-language-config.test.ts`
- `bun run test:registration`
- `bun run build`
- `curl -fsSI https://cdn.jsdelivr.net/npm/chiron-go-round-tc-webfont@1.0.11/woff2/vf/t0/lgc.woff2`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1f78-ea50-7548-916d-e20aef35084f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1f78-ea50-7548-916d-e20aef35084f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

