### PR TITLE
Add live Chinese conversion to Books

### DIFF
--- a/src/apps/books/components/BooksMenuBar.tsx
+++ b/src/apps/books/components/BooksMenuBar.tsx
@@ -153,6 +153,35 @@ export function BooksMenuBar({
         },
         {
           type: "submenu",
+          label: t("apps.books.menu.chineseScript"),
+          items: [
+            {
+              type: "radioGroup",
+              value: settings.chineseScript,
+              onValueChange: (value) =>
+                updateSettings({
+                  chineseScript:
+                    value as BooksReaderSettings["chineseScript"],
+                }),
+              options: [
+                {
+                  label: t("apps.books.chineseScript.original"),
+                  value: "original",
+                },
+                {
+                  label: t("apps.books.chineseScript.simplified"),
+                  value: "simplified",
+                },
+                {
+                  label: t("apps.books.chineseScript.traditional"),
+                  value: "traditional",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "submenu",
           label: t("apps.books.menu.theme"),
           items: [
             {

--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -22,6 +22,11 @@ import {
   isLikelyEpubBuffer,
   resolveReadingPalette,
 } from "../utils/booksReader";
+import {
+  applyChineseScriptToDocument,
+  createChineseScriptConversionSession,
+  resolveChineseScriptReadingLanguage,
+} from "../utils/chineseScriptConverter";
 import { useBookCover } from "../utils/useBookCover";
 import { BookCover } from "./BookCover";
 import type {
@@ -282,6 +287,11 @@ export const BooksReaderPane = forwardRef<
   const bookRef = useRef<Book | null>(null);
   const renditionRef = useRef<Rendition | null>(null);
   const bookLanguageRef = useRef<string | null>(null);
+  const chineseScriptRef = useRef(settings.chineseScript);
+  chineseScriptRef.current = settings.chineseScript;
+  const chineseScriptSessionRef = useRef(
+    createChineseScriptConversionSession()
+  );
   const flipLockRef = useRef(false);
   const onProgressRef = useRef(onProgress);
   onProgressRef.current = onProgress;
@@ -673,7 +683,10 @@ export const BooksReaderPane = forwardRef<
         const bookLanguage =
           readyBook.package?.metadata?.language?.trim() || null;
         bookLanguageRef.current = bookLanguage;
-        const readingLanguage = bookLanguage ?? uiLanguage;
+        const readingLanguage = resolveChineseScriptReadingLanguage(
+          chineseScriptRef.current,
+          bookLanguage ?? uiLanguage
+        );
         appendDebugEvent("epubjs:bookReady:success", {
           packagePath: readyBook.container?.packagePath,
           metadata: readyBook.package?.metadata,
@@ -750,7 +763,7 @@ export const BooksReaderPane = forwardRef<
 
         const fontFaceCss = buildFontFaceCss(window.location.origin);
         rendition.hooks.content.register(
-          (contents: {
+          async (contents: {
             addStylesheetCss: (css: string, key: string) => void;
             document?: Document;
           }) => {
@@ -790,6 +803,28 @@ export const BooksReaderPane = forwardRef<
               }
             } catch {
               // ignore
+            }
+            const document = contents.document;
+            if (document) {
+              const target = chineseScriptRef.current;
+              try {
+                const changedNodeCount = await applyChineseScriptToDocument(
+                  document,
+                  target,
+                  chineseScriptSessionRef.current,
+                  () => !cancelled && chineseScriptRef.current === target
+                );
+                appendDebugEvent("epubjs:contentHook:chineseScript:success", {
+                  target,
+                  changedNodeCount,
+                });
+              } catch (error) {
+                appendDebugEvent(
+                  "epubjs:contentHook:chineseScript:failed",
+                  error,
+                  "warn"
+                );
+              }
             }
           }
         );
@@ -921,17 +956,62 @@ export const BooksReaderPane = forwardRef<
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entry.path]);
 
+  // Convert the already-rendered section immediately when the reader setting
+  // changes. Each section retains its original text so switching directions or
+  // returning to Original never requires reloading the chapter.
+  useEffect(() => {
+    const rendition = renditionRef.current;
+    if (!isReady || !rendition) return;
+    let cancelled = false;
+    const target = settings.chineseScript;
+    const renditionContents = rendition.getContents() as unknown;
+    const contentsList = (
+      Array.isArray(renditionContents)
+        ? renditionContents
+        : renditionContents
+          ? [renditionContents]
+          : []
+    ) as Array<{ document?: Document }>;
+
+    void Promise.all(
+      contentsList.map(async (contents) => {
+        if (!contents.document) return;
+        const changedNodeCount = await applyChineseScriptToDocument(
+          contents.document,
+          target,
+          chineseScriptSessionRef.current,
+          () => !cancelled && chineseScriptRef.current === target
+        );
+        appendDebugEvent("reader:chineseScript:applied", {
+          target,
+          changedNodeCount,
+        });
+      })
+    ).catch((error) =>
+      appendDebugEvent("reader:chineseScript:failed", error, "warn")
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [appendDebugEvent, isReady, settings.chineseScript]);
+
   // Apply theme (colors, font family, line height) live.
   useEffect(() => {
     if (!isReady || !renditionRef.current) return;
+    const readingLanguage = resolveChineseScriptReadingLanguage(
+      settings.chineseScript,
+      bookLanguageRef.current ?? uiLanguage
+    );
     renditionRef.current.themes.default(
-      buildEpubTheme(settings, palette, bookLanguageRef.current ?? uiLanguage)
+      buildEpubTheme(settings, palette, readingLanguage)
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isReady,
     settings.fontId,
     settings.themeOverride,
+    settings.chineseScript,
     settings.lineHeight,
     osIsDark,
     uiLanguage,

--- a/src/apps/books/utils/chineseScriptConverter.ts
+++ b/src/apps/books/utils/chineseScriptConverter.ts
@@ -1,0 +1,140 @@
+import type { ConverterFunction } from "opencc-js/core";
+import type { BooksChineseScript } from "@/stores/useBooksStore";
+
+type ConverterTarget = Exclude<BooksChineseScript, "original">;
+
+export interface ChineseScriptConversionSession {
+  originalTextByNode: WeakMap<Text, string>;
+  originalLangByDocument: WeakMap<Document, string | null>;
+}
+
+let simplifiedConverterPromise: Promise<ConverterFunction> | null = null;
+let traditionalConverterPromise: Promise<ConverterFunction> | null = null;
+
+export function createChineseScriptConversionSession(): ChineseScriptConversionSession {
+  return {
+    originalTextByNode: new WeakMap(),
+    originalLangByDocument: new WeakMap(),
+  };
+}
+
+export function resolveChineseScriptReadingLanguage(
+  target: BooksChineseScript,
+  fallbackLanguage: string
+): string {
+  if (target === "simplified") return "zh-CN";
+  if (target === "traditional") return "zh-TW";
+  return fallbackLanguage;
+}
+
+async function loadChineseConverter(
+  target: ConverterTarget
+): Promise<ConverterFunction> {
+  if (target === "simplified") {
+    simplifiedConverterPromise ??= import("opencc-js/t2cn").then(({ Converter }) =>
+      Converter({ from: "tw", to: "cn" })
+    );
+    return simplifiedConverterPromise;
+  }
+
+  traditionalConverterPromise ??= import("opencc-js/cn2t").then(({ Converter }) =>
+    Converter({ from: "cn", to: "tw" })
+  );
+  return traditionalConverterPromise;
+}
+
+const HAN_CHARACTER_REGEX = /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]/;
+const SKIPPED_TEXT_CONTAINERS = new Set([
+  "SCRIPT",
+  "STYLE",
+  "NOSCRIPT",
+  "TEXTAREA",
+]);
+
+function textNodesIn(document: Document): Text[] {
+  const root = document.body ?? document.documentElement;
+  if (!root) return [];
+
+  const walker = document.createTreeWalker(root, 4);
+  const nodes: Text[] = [];
+  let current = walker.nextNode();
+  while (current) {
+    if (
+      current.nodeType === 3 &&
+      !SKIPPED_TEXT_CONTAINERS.has(current.parentElement?.tagName ?? "")
+    ) {
+      nodes.push(current as Text);
+    }
+    current = walker.nextNode();
+  }
+  return nodes;
+}
+
+function restoreOriginalText(
+  document: Document,
+  session: ChineseScriptConversionSession
+): number {
+  let changedNodeCount = 0;
+  for (const node of textNodesIn(document)) {
+    const original = session.originalTextByNode.get(node);
+    if (original !== undefined && node.data !== original) {
+      node.data = original;
+      changedNodeCount += 1;
+    }
+  }
+
+  if (session.originalLangByDocument.has(document)) {
+    const originalLang = session.originalLangByDocument.get(document);
+    if (originalLang === null) {
+      document.documentElement?.removeAttribute("lang");
+    } else if (originalLang !== undefined) {
+      document.documentElement?.setAttribute("lang", originalLang);
+    }
+  }
+
+  return changedNodeCount;
+}
+
+/**
+ * Convert only rendered text nodes so EPUB markup, links, and attributes remain
+ * untouched. Original strings are retained per node, making every selection
+ * reversible without reloading the chapter.
+ */
+export async function applyChineseScriptToDocument(
+  document: Document,
+  target: BooksChineseScript,
+  session: ChineseScriptConversionSession,
+  isCurrent: () => boolean = () => true
+): Promise<number> {
+  if (target === "original") {
+    return restoreOriginalText(document, session);
+  }
+
+  const convert = await loadChineseConverter(target);
+  if (!isCurrent()) return 0;
+
+  if (!session.originalLangByDocument.has(document)) {
+    session.originalLangByDocument.set(
+      document,
+      document.documentElement?.getAttribute("lang") ?? null
+    );
+  }
+  document.documentElement?.setAttribute(
+    "lang",
+    resolveChineseScriptReadingLanguage(target, "")
+  );
+
+  let changedNodeCount = 0;
+  for (const node of textNodesIn(document)) {
+    if (!node.isConnected) continue;
+    const original = session.originalTextByNode.get(node) ?? node.data;
+    if (!HAN_CHARACTER_REGEX.test(original)) continue;
+    session.originalTextByNode.set(node, original);
+    const converted = convert(original);
+    if (node.data !== converted) {
+      node.data = converted;
+      changedNodeCount += 1;
+    }
+  }
+  return changedNodeCount;
+}

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -588,6 +588,11 @@
       }
     },
     "books": {
+      "chineseScript": {
+        "original": "Original",
+        "simplified": "Chinesisch (vereinfacht)",
+        "traditional": "Chinesisch (traditionell)"
+      },
       "columns": {
         "auto": "Automatisch",
         "double": "Zweiseitig",
@@ -633,6 +638,7 @@
         "backToShelf": "Zurück zum Regal",
         "booksHelp": "Books-Hilfe",
         "chapters": "Kapitel",
+        "chineseScript": "Chinesische Schrift",
         "columns": "Spalten",
         "font": "Schrift",
         "import": "Importieren …",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -4532,6 +4532,7 @@
         "textSizeDecrease": "Smaller",
         "textSizeReset": "Default Size",
         "columns": "Columns",
+        "chineseScript": "Chinese Script",
         "theme": "Theme",
         "booksHelp": "Books Help",
         "aboutBooks": "About Books"
@@ -4540,6 +4541,11 @@
         "auto": "Auto",
         "single": "Single",
         "double": "Double"
+      },
+      "chineseScript": {
+        "original": "Original",
+        "simplified": "Simplified Chinese",
+        "traditional": "Traditional Chinese"
       },
       "theme": {
         "auto": "Auto",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -590,6 +590,11 @@
       }
     },
     "books": {
+      "chineseScript": {
+        "original": "Original",
+        "simplified": "Chino simplificado",
+        "traditional": "Chino tradicional"
+      },
       "columns": {
         "auto": "Automático",
         "double": "Doble",
@@ -635,6 +640,7 @@
         "backToShelf": "Volver a la estantería",
         "booksHelp": "Ayuda de Libros",
         "chapters": "Capítulos",
+        "chineseScript": "Escritura china",
         "columns": "Columnas",
         "font": "Tipo de letra",
         "import": "Importar EPUB…",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -590,6 +590,11 @@
       }
     },
     "books": {
+      "chineseScript": {
+        "original": "Original",
+        "simplified": "Chinois simplifié",
+        "traditional": "Chinois traditionnel"
+      },
       "columns": {
         "auto": "Auto",
         "double": "Double",
@@ -635,6 +640,7 @@
         "backToShelf": "Retour à la bibliothèque",
         "booksHelp": "Aide Books",
         "chapters": "Chapitres",
+        "chineseScript": "Écriture chinoise",
         "columns": "Colonnes",
         "font": "Police",
         "import": "Importer un EPUB…",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -590,6 +590,11 @@
       }
     },
     "books": {
+      "chineseScript": {
+        "original": "Originale",
+        "simplified": "Cinese semplificato",
+        "traditional": "Cinese tradizionale"
+      },
       "columns": {
         "auto": "Automatico",
         "double": "Doppia",
@@ -635,6 +640,7 @@
         "backToShelf": "Torna alla libreria",
         "booksHelp": "Aiuto Libri",
         "chapters": "Capitoli",
+        "chineseScript": "Scrittura cinese",
         "columns": "Colonne",
         "font": "Font",
         "import": "Importa EPUB…",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -588,6 +588,11 @@
       }
     },
     "books": {
+      "chineseScript": {
+        "original": "オリジナル",
+        "simplified": "簡体字中国語",
+        "traditional": "繁体字中国語"
+      },
       "columns": {
         "auto": "自動",
         "double": "見開き",
@@ -633,6 +638,7 @@
         "backToShelf": "本棚に戻る",
         "booksHelp": "Booksヘルプ",
         "chapters": "章",
+        "chineseScript": "中国語の字体",
         "columns": "段組み",
         "font": "フォント",
         "import": "EPUBを読み込む…",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -588,6 +588,11 @@
       }
     },
     "books": {
+      "chineseScript": {
+        "original": "원본",
+        "simplified": "중국어 간체",
+        "traditional": "중국어 번체"
+      },
       "columns": {
         "auto": "자동",
         "double": "두 페이지",
@@ -633,6 +638,7 @@
         "backToShelf": "서재로 돌아가기",
         "booksHelp": "Books 도움말",
         "chapters": "장",
+        "chineseScript": "중국어 문자",
         "columns": "단",
         "font": "서체",
         "import": "EPUB 가져오기…",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -590,6 +590,11 @@
       }
     },
     "books": {
+      "chineseScript": {
+        "original": "Original",
+        "simplified": "Chinês Simplificado",
+        "traditional": "Chinês Tradicional"
+      },
       "columns": {
         "auto": "Automático",
         "double": "Duplo",
@@ -635,6 +640,7 @@
         "backToShelf": "Voltar para a Estante",
         "booksHelp": "Ajuda do Books",
         "chapters": "Capítulos",
+        "chineseScript": "Escrita Chinesa",
         "columns": "Colunas",
         "font": "Fonte",
         "import": "Importar EPUB…",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -592,6 +592,11 @@
       }
     },
     "books": {
+      "chineseScript": {
+        "original": "Оригинал",
+        "simplified": "Упрощенный китайский",
+        "traditional": "Традиционный китайский"
+      },
       "columns": {
         "auto": "Авто",
         "double": "Две страницы",
@@ -637,6 +642,7 @@
         "backToShelf": "На полку",
         "booksHelp": "Справка Книг",
         "chapters": "Главы",
+        "chineseScript": "Китайское письмо",
         "columns": "Колонки",
         "font": "Шрифт",
         "import": "Импортировать EPUB…",

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -588,6 +588,11 @@
       }
     },
     "books": {
+      "chineseScript": {
+        "original": "原文",
+        "simplified": "简体中文",
+        "traditional": "繁体中文"
+      },
       "columns": {
         "auto": "自动",
         "double": "双页",
@@ -633,6 +638,7 @@
         "backToShelf": "返回书架",
         "booksHelp": "书籍帮助",
         "chapters": "章节",
+        "chineseScript": "简繁转换",
         "columns": "分栏",
         "font": "字体",
         "import": "导入 EPUB…",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -588,6 +588,11 @@
       }
     },
     "books": {
+      "chineseScript": {
+        "original": "原文",
+        "simplified": "簡體中文",
+        "traditional": "繁體中文"
+      },
       "columns": {
         "auto": "自動",
         "double": "雙頁",
@@ -633,6 +638,7 @@
         "backToShelf": "返回書架",
         "booksHelp": "書籍輔助說明",
         "chapters": "章節",
+        "chineseScript": "簡繁轉換",
         "columns": "直欄",
         "font": "字體",
         "import": "匯入 EPUB⋯",

--- a/src/stores/useBooksStore.ts
+++ b/src/stores/useBooksStore.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage } from "zustand/middleware";
 
 export type BooksColumnMode = "auto" | "single" | "double";
 export type BooksThemeOverride = "auto" | "light" | "sepia" | "dark";
+export type BooksChineseScript = "original" | "simplified" | "traditional";
 export type BooksShelfView = "grid" | "list";
 
 export interface BookProgress {
@@ -22,6 +23,8 @@ export interface BooksReaderSettings {
   columnMode: BooksColumnMode;
   /** Reading theme override. "auto" follows the OS dark-mode setting. */
   themeOverride: BooksThemeOverride;
+  /** Optional live conversion for Chinese text in the rendered EPUB. */
+  chineseScript: BooksChineseScript;
   /** Line height multiplier. */
   lineHeight: number;
 }
@@ -31,6 +34,7 @@ export const DEFAULT_BOOKS_SETTINGS: BooksReaderSettings = {
   fontSizePct: 100,
   columnMode: "auto",
   themeOverride: "auto",
+  chineseScript: "original",
   lineHeight: 1.5,
 };
 
@@ -154,7 +158,17 @@ export const useBooksStore = create<BooksStoreState>()(
     {
       name: "ryos:books",
       storage: createJSONStorage(() => localStorage),
-      version: 2,
+      version: 3,
+      migrate: (persistedState) => {
+        const state = (persistedState ?? {}) as Partial<BooksStoreState>;
+        return {
+          ...state,
+          settings: {
+            ...DEFAULT_BOOKS_SETTINGS,
+            ...(state.settings ?? {}),
+          },
+        } as BooksStoreState;
+      },
       partialize: (state) => ({
         progressByPath: state.progressByPath,
         settings: state.settings,

--- a/tests/test-books-chinese-script-converter.test.ts
+++ b/tests/test-books-chinese-script-converter.test.ts
@@ -1,0 +1,115 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { readFileSync } from "node:fs";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import {
+  applyChineseScriptToDocument,
+  createChineseScriptConversionSession,
+  resolveChineseScriptReadingLanguage,
+} from "../src/apps/books/utils/chineseScriptConverter";
+
+beforeAll(() => {
+  if (typeof document === "undefined") {
+    GlobalRegistrator.register();
+  }
+});
+
+afterAll(() => {
+  if (GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.unregister();
+  }
+});
+
+function createBookDocument(text: string, language = "zh-Hans"): Document {
+  const bookDocument = document.implementation.createHTMLDocument("Book");
+  bookDocument.documentElement.setAttribute("lang", language);
+  bookDocument.body.innerHTML = `
+    <p title="汉字元数据">${text}</p>
+    <script>const label = "汉字脚本";</script>
+  `;
+  return bookDocument;
+}
+
+describe("Books live Chinese script conversion", () => {
+  test("switches scripts live and restores the exact original text", async () => {
+    const bookDocument = createBookDocument("汉字发型");
+    const session = createChineseScriptConversionSession();
+    const paragraph = bookDocument.querySelector("p")!;
+    const script = bookDocument.querySelector("script")!;
+
+    expect(
+      await applyChineseScriptToDocument(
+        bookDocument,
+        "traditional",
+        session
+      )
+    ).toBe(1);
+    expect(paragraph.textContent).toBe("漢字髮型");
+    expect(bookDocument.documentElement.lang).toBe("zh-TW");
+    expect(paragraph.getAttribute("title")).toBe("汉字元数据");
+    expect(script.textContent).toContain("汉字脚本");
+
+    await applyChineseScriptToDocument(bookDocument, "simplified", session);
+    expect(paragraph.textContent).toBe("汉字发型");
+    expect(bookDocument.documentElement.lang).toBe("zh-CN");
+
+    await applyChineseScriptToDocument(bookDocument, "traditional", session);
+    await applyChineseScriptToDocument(bookDocument, "original", session);
+    expect(paragraph.textContent).toBe("汉字发型");
+    expect(bookDocument.documentElement.lang).toBe("zh-Hans");
+  });
+
+  test("converts Traditional Chinese text to Simplified Chinese", async () => {
+    const bookDocument = createBookDocument("漢字髮型", "zh-Hant");
+
+    await applyChineseScriptToDocument(
+      bookDocument,
+      "simplified",
+      createChineseScriptConversionSession()
+    );
+
+    expect(bookDocument.querySelector("p")?.textContent).toBe("汉字发型");
+  });
+
+  test("ignores a stale async selection", async () => {
+    const bookDocument = createBookDocument("汉字");
+
+    await applyChineseScriptToDocument(
+      bookDocument,
+      "traditional",
+      createChineseScriptConversionSession(),
+      () => false
+    );
+
+    expect(bookDocument.querySelector("p")?.textContent).toBe("汉字");
+  });
+
+  test("resolves matching Chinese font locales", () => {
+    expect(resolveChineseScriptReadingLanguage("original", "ja")).toBe("ja");
+    expect(resolveChineseScriptReadingLanguage("simplified", "ja")).toBe(
+      "zh-CN"
+    );
+    expect(resolveChineseScriptReadingLanguage("traditional", "ja")).toBe(
+      "zh-TW"
+    );
+  });
+
+  test("keeps both OpenCC directions behind dynamic imports", () => {
+    const source = readFileSync(
+      new URL(
+        "../src/apps/books/utils/chineseScriptConverter.ts",
+        import.meta.url
+      ),
+      "utf8"
+    );
+
+    expect(source).toContain('import("opencc-js/t2cn")');
+    expect(source).toContain('import("opencc-js/cn2t")');
+    expect(source).not.toContain('from "opencc-js"');
+  });
+});

--- a/tests/test-books-reader-fonts.test.ts
+++ b/tests/test-books-reader-fonts.test.ts
@@ -11,6 +11,7 @@ const settings = {
   fontSizePct: 100,
   columnMode: "auto" as const,
   themeOverride: "light" as const,
+  chineseScript: "original" as const,
   lineHeight: 1.5,
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a View menu setting for Original, Simplified Chinese, and Traditional Chinese text
- convert rendered EPUB text live while preserving markup and reversible original text
- lazy-load direction-specific OpenCC bundles and persist the reader preference
- localize the new controls and add converter coverage

## Walkthrough
<a href="https://cursor.com/agents/bc-019f1fe9-a027-7b52-b6e3-067b0db1dfa4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbooks_live_chinese_conversion.mp4"><img src="https://cursor.com/artifacts/c/art-a5d77a8f-0984-4639-955e-eaea7f24cec5" alt="books_live_chinese_conversion.mp4" /></a>

![Simplified Chinese rendered live in Books](https://cursor.com/artifacts/c/art-ac984f8d-cc21-4857-a63c-1cb49045312c)

## Testing
- `bun test tests/test-books-chinese-script-converter.test.ts tests/test-books-reader-fonts.test.ts`
- `bun run i18n:sync:dry-run`
- `bun run i18n:audit`
- `bun run build`
- targeted ESLint (0 errors; one pre-existing Fast Refresh warning)
- manual Original → Simplified → Traditional → Original conversion using Project Gutenberg’s public-domain Chinese Analects EPUB
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1fe9-a027-7b52-b6e3-067b0db1dfa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1fe9-a027-7b52-b6e3-067b0db1dfa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

