### PR TITLE
Sync Books reader settings across devices

### DIFF
--- a/src/shared/sync2/namespaces.ts
+++ b/src/shared/sync2/namespaces.ts
@@ -19,11 +19,14 @@ export const SYNC_NAMESPACES = [
   "maps",
   "images",
   // `books` owns the EPUB *files* (blob namespace, lives under the "files"
-  // category). `bookshelf` owns the Books app's per-book reading state
-  // (progress, shelf ordering, last-opened) and lives under its own "books"
-  // category so it syncs independently of the (large) file blobs.
+  // category). `bookshelf` owns the Books app's per-book reading state, while
+  // `books-settings` owns reader preferences. Both live under the "books"
+  // category so they sync independently of the large file blobs. Keeping
+  // preferences separate also prevents older bookshelf codecs from
+  // tombstoning settings keys they do not recognize.
   "books",
   "bookshelf",
+  "books-settings",
   "trash",
   "applets",
   "wallpapers",
@@ -74,6 +77,7 @@ const NAMESPACE_TO_CATEGORY: Record<SyncNamespace, SyncCategory> = {
   // differs from the `books` category — the former is the blob namespace).
   books: "files",
   bookshelf: "books",
+  "books-settings": "books",
   trash: "files",
   applets: "files",
   wallpapers: "files",

--- a/src/sync/codecs.ts
+++ b/src/sync/codecs.ts
@@ -36,7 +36,13 @@ import { useStickiesStore, type StickyNote } from "@/stores/useStickiesStore";
 import { useCalendarStore } from "@/stores/useCalendarStore";
 import { useContactsStore } from "@/stores/useContactsStore";
 import { useMapsStore } from "@/stores/useMapsStore";
-import { useBooksStore, type BookProgress } from "@/stores/useBooksStore";
+import {
+  BOOKS_FONT_SIZE_MAX,
+  BOOKS_FONT_SIZE_MIN,
+  useBooksStore,
+  type BookProgress,
+  type BooksReaderSettings,
+} from "@/stores/useBooksStore";
 import {
   useCloudSyncStore,
   type CloudSyncDeletionBucket,
@@ -1406,9 +1412,8 @@ const mapsCodec: SyncCodec = {
 //
 // Reading progress reconciles per book with `updatedAt`-aware last-writer-wins
 // on apply (a stale remote op never clobbers newer local progress), layered on
-// top of the engine's per-key timestamp LWW. Reader font/theme `settings` and
-// `shelfView` are intentionally NOT synced — they are device-local display
-// preferences.
+// top of the engine's per-key timestamp LWW. Reader preferences sync through
+// the separate `books-settings` namespace. `shelfView` remains device-local.
 //
 // Deleting a book: `useBooksLogic.deleteBook` calls `useBooksStore.removeBook`,
 // which drops the book's `progress` entry and prunes it from the order. On the
@@ -1529,6 +1534,143 @@ const bookshelfCodec: SyncCodec = {
 };
 
 // ---------------------------------------------------------------------------
+// Books settings codec
+//
+// Each reader preference gets its own key so unrelated changes on different
+// devices merge independently. This intentionally uses a namespace separate
+// from `bookshelf`: older clients collect that namespace without these keys
+// and would otherwise infer deletions when reading progress changes.
+// ---------------------------------------------------------------------------
+
+const BOOKS_SETTINGS_KEYS = {
+  fontId: "books-settings/fontId",
+  fontSizePct: "books-settings/fontSizePct",
+  columnMode: "books-settings/columnMode",
+  themeOverride: "books-settings/themeOverride",
+  chineseScript: "books-settings/chineseScript",
+  lineHeight: "books-settings/lineHeight",
+} as const satisfies Record<keyof BooksReaderSettings, string>;
+
+function collectBooksSettings(
+  keys?: ReadonlySet<string>
+): Map<string, unknown> {
+  const docs = new Map<string, unknown>();
+  const settings = useBooksStore.getState().settings;
+  const add = (key: string, value: unknown) => {
+    if (!keys || keys.has(key)) docs.set(key, value);
+  };
+
+  add(BOOKS_SETTINGS_KEYS.fontId, settings.fontId);
+  add(BOOKS_SETTINGS_KEYS.fontSizePct, settings.fontSizePct);
+  add(BOOKS_SETTINGS_KEYS.columnMode, settings.columnMode);
+  add(BOOKS_SETTINGS_KEYS.themeOverride, settings.themeOverride);
+  add(BOOKS_SETTINGS_KEYS.chineseScript, settings.chineseScript);
+  add(BOOKS_SETTINGS_KEYS.lineHeight, settings.lineHeight);
+  return docs;
+}
+
+function applyBooksSettings(ops: AppliedSyncOp[]): void {
+  let updates: Partial<BooksReaderSettings> = {};
+
+  for (const op of ops) {
+    if (op.del) continue;
+
+    switch (op.k) {
+      case BOOKS_SETTINGS_KEYS.fontId:
+        if (typeof op.v === "string" && op.v.length > 0) {
+          updates = { ...updates, fontId: op.v };
+        }
+        break;
+      case BOOKS_SETTINGS_KEYS.fontSizePct:
+        if (
+          typeof op.v === "number" &&
+          Number.isFinite(op.v) &&
+          op.v >= BOOKS_FONT_SIZE_MIN &&
+          op.v <= BOOKS_FONT_SIZE_MAX
+        ) {
+          updates = { ...updates, fontSizePct: op.v };
+        }
+        break;
+      case BOOKS_SETTINGS_KEYS.columnMode:
+        if (op.v === "auto" || op.v === "single" || op.v === "double") {
+          updates = { ...updates, columnMode: op.v };
+        }
+        break;
+      case BOOKS_SETTINGS_KEYS.themeOverride:
+        if (
+          op.v === "auto" ||
+          op.v === "light" ||
+          op.v === "sepia" ||
+          op.v === "dark"
+        ) {
+          updates = { ...updates, themeOverride: op.v };
+        }
+        break;
+      case BOOKS_SETTINGS_KEYS.chineseScript:
+        if (
+          op.v === "original" ||
+          op.v === "simplified" ||
+          op.v === "traditional"
+        ) {
+          updates = { ...updates, chineseScript: op.v };
+        }
+        break;
+      case BOOKS_SETTINGS_KEYS.lineHeight:
+        if (
+          typeof op.v === "number" &&
+          Number.isFinite(op.v) &&
+          op.v > 0
+        ) {
+          updates = { ...updates, lineHeight: op.v };
+        }
+        break;
+    }
+  }
+
+  if (Object.keys(updates).length > 0) {
+    useBooksStore.getState().updateSettings(updates);
+  }
+}
+
+const booksSettingsCodec: SyncCodec = {
+  namespace: "books-settings",
+  collect(_ctx, keys) {
+    return collectBooksSettings(keys);
+  },
+  apply(ops) {
+    applyBooksSettings(ops);
+  },
+  subscribe(onChange) {
+    return useBooksStore.subscribe((state, prev) => {
+      const keys: string[] = [];
+      if (state.settings.fontId !== prev.settings.fontId) {
+        keys.push(BOOKS_SETTINGS_KEYS.fontId);
+      }
+      if (state.settings.fontSizePct !== prev.settings.fontSizePct) {
+        keys.push(BOOKS_SETTINGS_KEYS.fontSizePct);
+      }
+      if (state.settings.columnMode !== prev.settings.columnMode) {
+        keys.push(BOOKS_SETTINGS_KEYS.columnMode);
+      }
+      if (state.settings.themeOverride !== prev.settings.themeOverride) {
+        keys.push(BOOKS_SETTINGS_KEYS.themeOverride);
+      }
+      if (state.settings.chineseScript !== prev.settings.chineseScript) {
+        keys.push(BOOKS_SETTINGS_KEYS.chineseScript);
+      }
+      if (state.settings.lineHeight !== prev.settings.lineHeight) {
+        keys.push(BOOKS_SETTINGS_KEYS.lineHeight);
+      }
+      if (keys.length === 0 || !useBooksStore.persist.hasHydrated()) return;
+      onChange(keys);
+    });
+  },
+  isReady() {
+    return useBooksStore.persist.hasHydrated();
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Blob codecs (images / trash / applets / wallpapers)
 // ---------------------------------------------------------------------------
 
@@ -1636,6 +1778,7 @@ export const SYNC_CODECS: Record<SyncNamespace, SyncCodec> = {
   images: imagesCodec,
   books: booksCodec,
   bookshelf: bookshelfCodec,
+  "books-settings": booksSettingsCodec,
   trash: trashCodec,
   applets: appletsCodec,
   wallpapers: wallpapersCodec,
@@ -1658,6 +1801,7 @@ export const NAMESPACE_APPLY_ORDER: SyncNamespace[] = [
   "settings",
   "files",
   "bookshelf",
+  "books-settings",
   "songs",
   "videos",
   "tv",

--- a/tests/test-sync-v2-codecs.test.ts
+++ b/tests/test-sync-v2-codecs.test.ts
@@ -13,7 +13,10 @@ import { useVideoStore } from "../src/stores/useVideoStore";
 import { useTvStore } from "../src/stores/useTvStore";
 import { useIpodStore } from "../src/stores/useIpodStore";
 import { useMapsStore } from "../src/stores/useMapsStore";
-import { useBooksStore } from "../src/stores/useBooksStore";
+import {
+  DEFAULT_BOOKS_SETTINGS,
+  useBooksStore,
+} from "../src/stores/useBooksStore";
 import { useAudioSettingsStore } from "../src/stores/useAudioSettingsStore";
 import {
   mergePersistedCloudSyncCategoryStatus,
@@ -409,6 +412,100 @@ describe("bookshelf codec", () => {
     const docs = SYNC_CODECS.bookshelf.collect(ctx) as Map<string, unknown>;
     expect(docs.has("bookshelf/progress:/Books/a.epub")).toBe(false);
     expect(docs.has("bookshelf/progress:/Books/b.epub")).toBe(true);
+  });
+});
+
+describe("books settings codec", () => {
+  beforeEach(() => {
+    useBooksStore.setState({
+      settings: { ...DEFAULT_BOOKS_SETTINGS },
+    });
+  });
+
+  test("collect emits one document per reader preference", () => {
+    useBooksStore.getState().updateSettings({
+      fontId: "eb-garamond",
+      fontSizePct: 130,
+      columnMode: "double",
+      themeOverride: "sepia",
+      chineseScript: "traditional",
+      lineHeight: 1.8,
+    });
+
+    const docs = SYNC_CODECS["books-settings"].collect(ctx) as Map<
+      string,
+      unknown
+    >;
+    expect(Object.fromEntries(docs)).toEqual({
+      "books-settings/fontId": "eb-garamond",
+      "books-settings/fontSizePct": 130,
+      "books-settings/columnMode": "double",
+      "books-settings/themeOverride": "sepia",
+      "books-settings/chineseScript": "traditional",
+      "books-settings/lineHeight": 1.8,
+    });
+  });
+
+  test("apply updates every reader preference", async () => {
+    await SYNC_CODECS["books-settings"].apply(
+      [
+        { k: "books-settings/fontId", v: "sans", t },
+        { k: "books-settings/fontSizePct", v: 140, t },
+        { k: "books-settings/columnMode", v: "single", t },
+        { k: "books-settings/themeOverride", v: "dark", t },
+        { k: "books-settings/chineseScript", v: "simplified", t },
+        { k: "books-settings/lineHeight", v: 1.7, t },
+      ],
+      ctx
+    );
+
+    expect(useBooksStore.getState().settings).toEqual({
+      fontId: "sans",
+      fontSizePct: 140,
+      columnMode: "single",
+      themeOverride: "dark",
+      chineseScript: "simplified",
+      lineHeight: 1.7,
+    });
+  });
+
+  test("apply ignores malformed values and tombstones", async () => {
+    await SYNC_CODECS["books-settings"].apply(
+      [
+        { k: "books-settings/fontId", v: "", t },
+        { k: "books-settings/fontSizePct", v: 1_000, t },
+        { k: "books-settings/columnMode", v: "triple", t },
+        { k: "books-settings/themeOverride", v: "blue", t },
+        { k: "books-settings/chineseScript", v: "translated", t },
+        { k: "books-settings/lineHeight", v: -1, t },
+        { k: "books-settings/fontId", del: true, t },
+      ],
+      ctx
+    );
+
+    expect(useBooksStore.getState().settings).toEqual(DEFAULT_BOOKS_SETTINGS);
+  });
+
+  test("subscription scopes dirty work to changed settings", () => {
+    const changes: string[][] = [];
+    const unsubscribe = SYNC_CODECS["books-settings"].subscribe((keys) => {
+      changes.push(keys ? [...keys] : []);
+    });
+
+    try {
+      useBooksStore.getState().updateSettings({
+        fontSizePct: 120,
+        themeOverride: "sepia",
+      });
+      expect(changes).toEqual([
+        [
+          "books-settings/fontSizePct",
+          "books-settings/themeOverride",
+        ],
+      ]);
+    } finally {
+      unsubscribe();
+    }
   });
 });
 

--- a/tests/test-sync-v2-core.test.ts
+++ b/tests/test-sync-v2-core.test.ts
@@ -100,10 +100,12 @@ describe("sync v2 keys", () => {
   test("validates namespaced keys", () => {
     expect(isValidSyncKey("settings/theme")).toBe(true);
     expect(isValidSyncKey("files/item:/Documents/notes.md")).toBe(true);
+    expect(isValidSyncKey("books-settings/fontSizePct")).toBe(true);
     expect(isValidSyncKey("bogus/key")).toBe(false);
     expect(isValidSyncKey("settings")).toBe(false);
     expect(getSyncKeyNamespace("images/item:abc")).toBe("images");
     expect(getSyncNamespaceCategory("wallpapers")).toBe("files");
+    expect(getSyncNamespaceCategory("books-settings")).toBe("books");
   });
 
   test("validateSyncOps rejects malformed batches", () => {

--- a/tests/test-sync-v2-engine-e2e.test.ts
+++ b/tests/test-sync-v2-engine-e2e.test.ts
@@ -5,6 +5,10 @@ import { formatHlc } from "../src/shared/sync2/hlc";
 import { CloudSyncEngine } from "../src/sync/engine";
 import { useStickiesStore } from "../src/stores/useStickiesStore";
 import { useCloudSyncStore } from "../src/stores/useCloudSyncStore";
+import {
+  DEFAULT_BOOKS_SETTINGS,
+  useBooksStore,
+} from "../src/stores/useBooksStore";
 
 /**
  * End-to-end test of the v2 client engine against the live API server
@@ -12,7 +16,8 @@ import { useCloudSyncStore } from "../src/stores/useCloudSyncStore";
  *
  * Drives the real engine: store change → shadow diff → ops POST, then a
  * foreign client's write → pull → codec apply, then local delete →
- * tombstone upload. Uses the stickies namespace (no IndexedDB required).
+ * tombstone upload. Uses the stickies and Books settings namespaces, which
+ * do not require IndexedDB.
  */
 
 const USERNAME = `sync2eng${Date.now().toString(36)}`;
@@ -66,8 +71,10 @@ beforeAll(async () => {
   syncStore.setCategoryEnabled("files", false);
   syncStore.setCategoryEnabled("songs", true);
   syncStore.setCategoryEnabled("stickies", true);
+  syncStore.setCategoryEnabled("books", true);
 
   useStickiesStore.setState({ notes: [] });
+  useBooksStore.setState({ settings: { ...DEFAULT_BOOKS_SETTINGS } });
 
   engine = new CloudSyncEngine(USERNAME);
   await engine.start();
@@ -102,6 +109,52 @@ describe("sync v2 engine end-to-end", () => {
     expect(snapshot.entries["stickies/note:e2e-1"]?.v).toMatchObject({
       id: "e2e-1",
       content: "from engine",
+    });
+  });
+
+  test("book reader settings upload and remote fields apply independently", async () => {
+    useBooksStore.getState().updateSettings({
+      fontId: "sans",
+      fontSizePct: 130,
+    });
+    engine.markDirty("books-settings", [
+      "books-settings/fontId",
+      "books-settings/fontSizePct",
+    ]);
+    await engine.flush();
+
+    const uploaded = await readServerSnapshot();
+    expect(uploaded.entries["books-settings/fontId"]?.v).toBe("sans");
+    expect(uploaded.entries["books-settings/fontSizePct"]?.v).toBe(130);
+
+    const foreignT = formatHlc(Date.now() + 1000, 0, "book-device");
+    const response = await fetchWithAuth(
+      `${BASE_URL}/api/sync/v2/ops`,
+      USERNAME,
+      token,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          clientId: "book-device",
+          ops: [
+            {
+              k: "books-settings/themeOverride",
+              v: "sepia",
+              t: foreignT,
+            },
+          ],
+        }),
+      }
+    );
+    expect(response.status).toBe(200);
+
+    await engine.pull();
+
+    expect(useBooksStore.getState().settings).toMatchObject({
+      fontId: "sans",
+      fontSizePct: 130,
+      themeOverride: "sepia",
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a dedicated Books settings sync namespace under the Books category
- sync font, font size, columns, theme, Chinese script, and line height as independent fields
- validate remote values and keep bookshelf layout device-local
- cover codec, namespace, and live engine round trips

## Testing
- `bun test tests/test-sync-v2-codecs.test.ts tests/test-sync-v2-core.test.ts`
- `bun run test:registration`
- `bun test tests/test-sync-v2-engine-e2e.test.ts`
- `bun run test:sync-v2`
- `bunx eslint src/shared/sync2/namespaces.ts src/sync/codecs.ts tests/test-sync-v2-codecs.test.ts tests/test-sync-v2-core.test.ts tests/test-sync-v2-engine-e2e.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2047-ae1d-737e-819e-451bd8cea05c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2047-ae1d-737e-819e-451bd8cea05c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

