### PR TITLE
Align Books typography and Chinese conversion

### DIFF
--- a/src/apps/books/utils/booksReader.ts
+++ b/src/apps/books/utils/booksReader.ts
@@ -11,7 +11,7 @@ const BOOK_GENEVA_STACK =
   '"Geneva-12", Geneva, "ArkPixel", "SerenityOS-Emoji", system-ui, -apple-system, sans-serif';
 
 const BOOK_ROUNDED_STACK =
-  '"ryOS VAG Rounded", "Chiron GoRound TC WS", "Hiragino Maru Gothic ProN", "Nanum Gothic", "Yuanti SC", "SerenityOS-Emoji", ui-rounded, sans-serif';
+  '"ryOS VAG Rounded", "Chiron GoRound TC WS", "Hiragino Maru Gothic ProN", "Nanum Gothic", "Yuanti SC", ui-rounded, sans-serif';
 
 const BOOK_CJK_SERIF_STACKS = {
   "zh-CN":

--- a/src/apps/books/utils/chineseScriptConverter.ts
+++ b/src/apps/books/utils/chineseScriptConverter.ts
@@ -11,6 +11,20 @@ export interface ChineseScriptConversionSession {
 let simplifiedConverterPromise: Promise<ConverterFunction> | null = null;
 let traditionalConverterPromise: Promise<ConverterFunction> | null = null;
 
+const SIMPLIFIED_PUNCTUATION = [
+  ["「", "“"],
+  ["」", "”"],
+  ["『", "‘"],
+  ["』", "’"],
+] as const;
+
+const TRADITIONAL_PUNCTUATION = [
+  ["“", "「"],
+  ["”", "」"],
+  ["‘", "『"],
+  ["’", "』"],
+] as const;
+
 export function createChineseScriptConversionSession(): ChineseScriptConversionSession {
   return {
     originalTextByNode: new WeakMap(),
@@ -31,19 +45,34 @@ async function loadChineseConverter(
   target: ConverterTarget
 ): Promise<ConverterFunction> {
   if (target === "simplified") {
-    simplifiedConverterPromise ??= import("opencc-js/t2cn").then(({ Converter }) =>
-      Converter({ from: "tw", to: "cn" })
+    simplifiedConverterPromise ??= import("opencc-js/t2cn").then(
+      ({ Converter, CustomConverter }) => {
+        const convertScriptAndTerms = Converter({
+          from: "twp",
+          to: "cn",
+        });
+        const convertPunctuation = CustomConverter(SIMPLIFIED_PUNCTUATION);
+        return (text) => convertPunctuation(convertScriptAndTerms(text));
+      }
     );
     return simplifiedConverterPromise;
   }
 
-  traditionalConverterPromise ??= import("opencc-js/cn2t").then(({ Converter }) =>
-    Converter({ from: "cn", to: "tw" })
+  traditionalConverterPromise ??= import("opencc-js/cn2t").then(
+    ({ Converter, CustomConverter }) => {
+      const convertScriptAndTerms = Converter({
+        from: "cn",
+        to: "twp",
+      });
+      const convertPunctuation = CustomConverter(TRADITIONAL_PUNCTUATION);
+      return (text) => convertPunctuation(convertScriptAndTerms(text));
+    }
   );
   return traditionalConverterPromise;
 }
 
-const HAN_CHARACTER_REGEX = /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]/;
+const CONVERTIBLE_TEXT_REGEX =
+  /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff“”‘’「」『』]/;
 const SKIPPED_TEXT_CONTAINERS = new Set([
   "SCRIPT",
   "STYLE",
@@ -128,7 +157,7 @@ export async function applyChineseScriptToDocument(
   for (const node of textNodesIn(document)) {
     if (!node.isConnected) continue;
     const original = session.originalTextByNode.get(node) ?? node.data;
-    if (!HAN_CHARACTER_REGEX.test(original)) continue;
+    if (!CONVERTIBLE_TEXT_REGEX.test(original)) continue;
     session.originalTextByNode.set(node, original);
     const converted = convert(original);
     if (node.data !== converted) {

--- a/tests/test-books-chinese-script-converter.test.ts
+++ b/tests/test-books-chinese-script-converter.test.ts
@@ -76,6 +76,36 @@ describe("Books live Chinese script conversion", () => {
     expect(bookDocument.querySelector("p")?.textContent).toBe("汉字发型");
   });
 
+  test("converts regional terms and quotation punctuation in both directions", async () => {
+    const simplifiedBook = createBookDocument("");
+    simplifiedBook.body.innerHTML =
+      "<p>鼠标和自行车。悟空道：<span>“</span>怎么叫做<span>‘</span>水中捞月<span>’</span>？<span>”</span></p>";
+
+    await applyChineseScriptToDocument(
+      simplifiedBook,
+      "traditional",
+      createChineseScriptConversionSession()
+    );
+
+    expect(simplifiedBook.querySelector("p")?.textContent).toBe(
+      "滑鼠和腳踏車。悟空道：「怎麼叫做『水中撈月』？」"
+    );
+
+    const traditionalBook = createBookDocument("", "zh-Hant");
+    traditionalBook.body.innerHTML =
+      "<p>滑鼠和腳踏車。悟空道：<span>「</span>怎麼叫做<span>『</span>水中撈月<span>』</span>？<span>」</span></p>";
+
+    await applyChineseScriptToDocument(
+      traditionalBook,
+      "simplified",
+      createChineseScriptConversionSession()
+    );
+
+    expect(traditionalBook.querySelector("p")?.textContent).toBe(
+      "鼠标和自行车。悟空道：“怎么叫做‘水中捞月’？”"
+    );
+  });
+
   test("ignores a stale async selection", async () => {
     const bookDocument = createBookDocument("汉字");
 
@@ -111,5 +141,8 @@ describe("Books live Chinese script conversion", () => {
     expect(source).toContain('import("opencc-js/t2cn")');
     expect(source).toContain('import("opencc-js/cn2t")');
     expect(source).not.toContain('from "opencc-js"');
+    expect(source).toContain('from: "twp"');
+    expect(source).toContain('to: "twp"');
+    expect(source).toContain("CustomConverter");
   });
 });

--- a/tests/test-books-reader-fonts.test.ts
+++ b/tests/test-books-reader-fonts.test.ts
@@ -16,6 +16,22 @@ const appFontsCss = readFileSync(
   join(import.meta.dir, "../public/fonts/fonts.css"),
   "utf8"
 );
+const appCss = readFileSync(
+  join(import.meta.dir, "../src/index.css"),
+  "utf8"
+);
+
+function extractFontFamily(css: string, selector: string): string | null {
+  const selectorStart = css.indexOf(selector);
+  const blockStart = css.indexOf("{", selectorStart);
+  const blockEnd = css.indexOf("}", blockStart);
+  if (selectorStart === -1 || blockStart === -1 || blockEnd === -1) return null;
+
+  const declaration = css
+    .slice(blockStart, blockEnd)
+    .match(/font-family:\s*([^;]+);/);
+  return declaration?.[1].replace(/\s+/g, " ").trim() ?? null;
+}
 
 const settings = {
   fontId: "serif",
@@ -34,11 +50,12 @@ const palette = {
 };
 
 describe("Books reader font choices", () => {
-  test("offers the bundled rounded face in the font menu", () => {
+  test("uses the same rounded stack as Karaoke", () => {
     expect(BOOK_FONTS.map((font) => font.id)).toContain("rounded");
-    expect(getBookFontCssStack("rounded")).toStartWith(
-      '"ryOS VAG Rounded"'
+    expect(getBookFontCssStack("rounded")).toBe(
+      extractFontFamily(appCss, ".font-lyrics-rounded")
     );
+    expect(getBookFontCssStack("rounded")).not.toContain("SerenityOS-Emoji");
   });
 
   test("gives Geneva bundled CJK and emoji fallbacks", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove `SerenityOS-Emoji` from the Books rounded reader stack and enforce parity with Karaoke.
- Use OpenCC's Taiwan phrase presets for Books Chinese conversion.
- Convert Chinese quotation punctuation in both directions, including punctuation-only text nodes.
- Add regression coverage for terms and punctuation across Simplified and Traditional conversion.

## Testing
- `bun test tests/test-books-reader-fonts.test.ts tests/test-simplified-chinese-aqua-fonts.test.ts` (23 pass, 0 fail)
- `bun test tests/test-books-chinese-script-converter.test.ts tests/test-books-reader-fonts.test.ts` (23 pass, 0 fail)
- `bun run build` (pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f203b-3075-7b54-b442-1dd0f94e295d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f203b-3075-7b54-b442-1dd0f94e295d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

