### PR TITLE
Fix Books menus on narrow screens

### DIFF
--- a/src/apps/books/components/BooksMenuBar.tsx
+++ b/src/apps/books/components/BooksMenuBar.tsx
@@ -5,10 +5,12 @@ import {
   type MenuDescriptor,
 } from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import {
   BOOK_FONTS,
   type BookFontOption,
 } from "../utils/booksReader";
+import { flattenBooksMenuSubmenus } from "../utils/booksMenuLayout";
 import {
   BOOKS_FONT_SIZE_MAX,
   BOOKS_FONT_SIZE_MIN,
@@ -47,6 +49,7 @@ export function BooksMenuBar({
   onGoToChapter,
 }: BooksMenuBarProps) {
   const { t } = useTranslation();
+  const isCompactMenu = useMediaQuery("(max-width: 768px)");
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
@@ -65,144 +68,144 @@ export function BooksMenuBar({
   };
 
   const fileMenu: MenuDescriptor = {
-      label: t("common.menu.file"),
-      items: [
-        {
-          type: "action",
-          label: t("apps.books.menu.import"),
-          onClick: onImport,
-        },
-        {
-          type: "action",
-          label: t("apps.books.menu.backToShelf"),
-          onClick: onBackToShelf,
-          disabled: !isReading,
-        },
-        { type: "separator" },
-        {
-          type: "action",
-          label: t("common.menu.close"),
-          onClick: onClose,
-          shortcutId: "close",
-        },
-      ],
-    };
+    label: t("common.menu.file"),
+    items: [
+      {
+        type: "action",
+        label: t("apps.books.menu.import"),
+        onClick: onImport,
+      },
+      {
+        type: "action",
+        label: t("apps.books.menu.backToShelf"),
+        onClick: onBackToShelf,
+        disabled: !isReading,
+      },
+      { type: "separator" },
+      {
+        type: "action",
+        label: t("common.menu.close"),
+        onClick: onClose,
+        shortcutId: "close",
+      },
+    ],
+  };
 
   const viewMenu: MenuDescriptor = {
-      label: t("common.menu.view"),
-      items: [
-        {
-          type: "submenu",
-          label: t("apps.books.menu.font"),
-          items: [
-            {
-              type: "radioGroup",
-              value: settings.fontId,
-              onValueChange: (value) => updateSettings({ fontId: value }),
-              options: BOOK_FONTS.map((font: BookFontOption) => ({
-                label: font.label,
-                value: font.id,
-              })),
-            },
-          ],
-        },
-        {
-          type: "submenu",
-          label: t("apps.books.menu.textSize"),
-          items: [
-            {
-              type: "action",
-              label: t("apps.books.menu.textSizeIncrease"),
-              onClick: () => changeFontSize(BOOKS_FONT_SIZE_STEP),
-              shortcut: "+",
-              disabled: settings.fontSizePct >= BOOKS_FONT_SIZE_MAX,
-            },
-            {
-              type: "action",
-              label: t("apps.books.menu.textSizeDecrease"),
-              onClick: () => changeFontSize(-BOOKS_FONT_SIZE_STEP),
-              shortcut: "−",
-              disabled: settings.fontSizePct <= BOOKS_FONT_SIZE_MIN,
-            },
-            {
-              type: "action",
-              label: t("apps.books.menu.textSizeReset"),
-              onClick: () => updateSettings({ fontSizePct: 100 }),
-              disabled: settings.fontSizePct === 100,
-            },
-          ],
-        },
-        {
-          type: "submenu",
-          label: t("apps.books.menu.columns"),
-          items: [
-            {
-              type: "radioGroup",
-              value: settings.columnMode,
-              onValueChange: (value) =>
-                updateSettings({
-                  columnMode: value as BooksReaderSettings["columnMode"],
-                }),
-              options: [
-                { label: t("apps.books.columns.auto"), value: "auto" },
-                { label: t("apps.books.columns.single"), value: "single" },
-                { label: t("apps.books.columns.double"), value: "double" },
-              ],
-            },
-          ],
-        },
-        {
-          type: "submenu",
-          label: t("apps.books.menu.chineseScript"),
-          items: [
-            {
-              type: "radioGroup",
-              value: settings.chineseScript,
-              onValueChange: (value) =>
-                updateSettings({
-                  chineseScript:
-                    value as BooksReaderSettings["chineseScript"],
-                }),
-              options: [
-                {
-                  label: t("apps.books.chineseScript.original"),
-                  value: "original",
-                },
-                {
-                  label: t("apps.books.chineseScript.simplified"),
-                  value: "simplified",
-                },
-                {
-                  label: t("apps.books.chineseScript.traditional"),
-                  value: "traditional",
-                },
-              ],
-            },
-          ],
-        },
-        {
-          type: "submenu",
-          label: t("apps.books.menu.theme"),
-          items: [
-            {
-              type: "radioGroup",
-              value: settings.themeOverride,
-              onValueChange: (value) =>
-                updateSettings({
-                  themeOverride:
-                    value as BooksReaderSettings["themeOverride"],
-                }),
-              options: [
-                { label: t("apps.books.theme.auto"), value: "auto" },
-                { label: t("apps.books.theme.light"), value: "light" },
-                { label: t("apps.books.theme.sepia"), value: "sepia" },
-                { label: t("apps.books.theme.dark"), value: "dark" },
-              ],
-            },
-          ],
-        },
-      ],
-    };
+    label: t("common.menu.view"),
+    items: [
+      {
+        type: "submenu",
+        label: t("apps.books.menu.font"),
+        items: [
+          {
+            type: "radioGroup",
+            value: settings.fontId,
+            onValueChange: (value) => updateSettings({ fontId: value }),
+            options: BOOK_FONTS.map((font: BookFontOption) => ({
+              label: font.label,
+              value: font.id,
+            })),
+          },
+        ],
+      },
+      {
+        type: "submenu",
+        label: t("apps.books.menu.textSize"),
+        items: [
+          {
+            type: "action",
+            label: t("apps.books.menu.textSizeIncrease"),
+            onClick: () => changeFontSize(BOOKS_FONT_SIZE_STEP),
+            shortcut: "+",
+            disabled: settings.fontSizePct >= BOOKS_FONT_SIZE_MAX,
+          },
+          {
+            type: "action",
+            label: t("apps.books.menu.textSizeDecrease"),
+            onClick: () => changeFontSize(-BOOKS_FONT_SIZE_STEP),
+            shortcut: "−",
+            disabled: settings.fontSizePct <= BOOKS_FONT_SIZE_MIN,
+          },
+          {
+            type: "action",
+            label: t("apps.books.menu.textSizeReset"),
+            onClick: () => updateSettings({ fontSizePct: 100 }),
+            disabled: settings.fontSizePct === 100,
+          },
+        ],
+      },
+      {
+        type: "submenu",
+        label: t("apps.books.menu.columns"),
+        items: [
+          {
+            type: "radioGroup",
+            value: settings.columnMode,
+            onValueChange: (value) =>
+              updateSettings({
+                columnMode: value as BooksReaderSettings["columnMode"],
+              }),
+            options: [
+              { label: t("apps.books.columns.auto"), value: "auto" },
+              { label: t("apps.books.columns.single"), value: "single" },
+              { label: t("apps.books.columns.double"), value: "double" },
+            ],
+          },
+        ],
+      },
+      {
+        type: "submenu",
+        label: t("apps.books.menu.chineseScript"),
+        items: [
+          {
+            type: "radioGroup",
+            value: settings.chineseScript,
+            onValueChange: (value) =>
+              updateSettings({
+                chineseScript:
+                  value as BooksReaderSettings["chineseScript"],
+              }),
+            options: [
+              {
+                label: t("apps.books.chineseScript.original"),
+                value: "original",
+              },
+              {
+                label: t("apps.books.chineseScript.simplified"),
+                value: "simplified",
+              },
+              {
+                label: t("apps.books.chineseScript.traditional"),
+                value: "traditional",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "submenu",
+        label: t("apps.books.menu.theme"),
+        items: [
+          {
+            type: "radioGroup",
+            value: settings.themeOverride,
+            onValueChange: (value) =>
+              updateSettings({
+                themeOverride:
+                  value as BooksReaderSettings["themeOverride"],
+              }),
+            options: [
+              { label: t("apps.books.theme.auto"), value: "auto" },
+              { label: t("apps.books.theme.light"), value: "light" },
+              { label: t("apps.books.theme.sepia"), value: "sepia" },
+              { label: t("apps.books.theme.dark"), value: "dark" },
+            ],
+          },
+        ],
+      },
+    ],
+  };
 
   const chapters = navigationState.chapters;
   const canNavigateReader = isReading && navigationState.isReady;
@@ -260,6 +263,16 @@ export function BooksMenuBar({
       },
     ],
   };
+  const menus = [fileMenu, viewMenu, goMenu].map<MenuDescriptor>((menu) =>
+    isCompactMenu
+      ? {
+          ...menu,
+          items: flattenBooksMenuSubmenus(menu.items),
+          contentClassName:
+            "w-72 max-w-[calc(100vw-1rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain touch-pan-y",
+        }
+      : menu
+  );
 
   return (
     <AppMenuBarShell
@@ -274,7 +287,7 @@ export function BooksMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      <AppMenuBarMenus menus={[fileMenu, viewMenu, goMenu]} />
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/books/components/BooksMenuBar.tsx
+++ b/src/apps/books/components/BooksMenuBar.tsx
@@ -10,7 +10,7 @@ import {
   BOOK_FONTS,
   type BookFontOption,
 } from "../utils/booksReader";
-import { flattenBooksMenuSubmenus } from "../utils/booksMenuLayout";
+import { buildBooksMenuLayout } from "../utils/booksMenuLayout";
 import {
   BOOKS_FONT_SIZE_MAX,
   BOOKS_FONT_SIZE_MIN,
@@ -263,16 +263,12 @@ export function BooksMenuBar({
       },
     ],
   };
-  const menus = [fileMenu, viewMenu, goMenu].map<MenuDescriptor>((menu) =>
-    isCompactMenu
-      ? {
-          ...menu,
-          items: flattenBooksMenuSubmenus(menu.items),
-          contentClassName:
-            "w-72 max-w-[calc(100vw-1rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain touch-pan-y",
-        }
-      : menu
-  );
+  const menus = buildBooksMenuLayout({
+    fileMenu,
+    viewMenu,
+    goMenu,
+    isCompact: isCompactMenu,
+  });
 
   return (
     <AppMenuBarShell

--- a/src/apps/books/utils/booksMenuLayout.ts
+++ b/src/apps/books/utils/booksMenuLayout.ts
@@ -1,0 +1,78 @@
+import type { MenuItemDescriptor } from "@/components/shared/menubar/AppMenuBarMenus";
+
+function disableMenuItem(item: MenuItemDescriptor): MenuItemDescriptor {
+  switch (item.type) {
+    case "separator":
+      return item;
+    case "radioGroup":
+      return {
+        ...item,
+        options: item.options.map((option) => ({
+          ...option,
+          disabled: true,
+        })),
+      };
+    case "submenu":
+      return {
+        ...item,
+        disabled: true,
+        items: item.items.map(disableMenuItem),
+      };
+    case "action":
+    case "checkbox":
+    case "label":
+      return { ...item, disabled: true };
+  }
+}
+
+function appendWithoutDuplicateSeparators(
+  result: MenuItemDescriptor[],
+  item: MenuItemDescriptor
+) {
+  if (
+    item.type === "separator" &&
+    (result.length === 0 || result.at(-1)?.type === "separator")
+  ) {
+    return;
+  }
+  result.push(item);
+}
+
+/**
+ * Turn flyout submenus into labeled sections for compact viewports.
+ * Disabled submenu state is copied to every child so flattening never enables
+ * an action that the nested desktop menu would block.
+ */
+export function flattenBooksMenuSubmenus(
+  items: MenuItemDescriptor[]
+): MenuItemDescriptor[] {
+  const result: MenuItemDescriptor[] = [];
+
+  for (const item of items) {
+    if (item.type !== "submenu") {
+      appendWithoutDuplicateSeparators(result, item);
+      continue;
+    }
+
+    appendWithoutDuplicateSeparators(result, { type: "separator" });
+    appendWithoutDuplicateSeparators(result, {
+      type: "label",
+      label: item.label,
+      disabled: item.disabled,
+    });
+
+    const children = flattenBooksMenuSubmenus(item.items);
+    for (const child of children) {
+      appendWithoutDuplicateSeparators(
+        result,
+        item.disabled ? disableMenuItem(child) : child
+      );
+    }
+  }
+
+  while (result.at(-1)?.type === "separator") {
+    result.pop();
+  }
+
+  return result;
+}

--- a/src/apps/books/utils/booksMenuLayout.ts
+++ b/src/apps/books/utils/booksMenuLayout.ts
@@ -1,4 +1,10 @@
-import type { MenuItemDescriptor } from "@/components/shared/menubar/AppMenuBarMenus";
+import type {
+  MenuDescriptor,
+  MenuItemDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
+
+const COMPACT_GO_MENU_CLASS =
+  "w-72 max-w-[calc(100vw-1rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain touch-pan-y";
 
 function disableMenuItem(item: MenuItemDescriptor): MenuItemDescriptor {
   switch (item.type) {
@@ -75,4 +81,28 @@ export function flattenBooksMenuSubmenus(
   }
 
   return result;
+}
+
+export function buildBooksMenuLayout({
+  fileMenu,
+  viewMenu,
+  goMenu,
+  isCompact,
+}: {
+  fileMenu: MenuDescriptor;
+  viewMenu: MenuDescriptor;
+  goMenu: MenuDescriptor;
+  isCompact: boolean;
+}): MenuDescriptor[] {
+  return [
+    fileMenu,
+    viewMenu,
+    isCompact
+      ? {
+          ...goMenu,
+          items: flattenBooksMenuSubmenus(goMenu.items),
+          contentClassName: COMPACT_GO_MENU_CLASS,
+        }
+      : goMenu,
+  ];
 }

--- a/src/apps/books/utils/booksMenuLayout.ts
+++ b/src/apps/books/utils/booksMenuLayout.ts
@@ -26,7 +26,6 @@ function disableMenuItem(item: MenuItemDescriptor): MenuItemDescriptor {
       };
     case "action":
     case "checkbox":
-    case "label":
       return { ...item, disabled: true };
   }
 }
@@ -45,7 +44,7 @@ function appendWithoutDuplicateSeparators(
 }
 
 /**
- * Turn flyout submenus into labeled sections for compact viewports.
+ * Inline flyout contents for compact viewports.
  * Disabled submenu state is copied to every child so flattening never enables
  * an action that the nested desktop menu would block.
  */
@@ -61,11 +60,6 @@ export function flattenBooksMenuSubmenus(
     }
 
     appendWithoutDuplicateSeparators(result, { type: "separator" });
-    appendWithoutDuplicateSeparators(result, {
-      type: "label",
-      label: item.label,
-      disabled: item.disabled,
-    });
 
     const children = flattenBooksMenuSubmenus(item.items);
     for (const child of children) {

--- a/src/components/shared/menubar/AppMenuBarMenus.tsx
+++ b/src/components/shared/menubar/AppMenuBarMenus.tsx
@@ -5,7 +5,6 @@ import {
   MenubarContent,
   MenubarItem,
   MenubarCheckboxItem,
-  MenubarLabel,
   MenubarSeparator,
   MenubarShortcut,
   MenubarSub,
@@ -59,13 +58,6 @@ export type MenuItemDescriptor =
       value: string;
       onValueChange: (value: string) => void;
       options: MenuRadioOptionDescriptor[];
-    }
-  | {
-      type: "label";
-      label: ReactNode;
-      disabled?: boolean;
-      /** Extra classes merged onto the shared label class. */
-      className?: string;
     }
   | {
       type: "submenu";
@@ -138,20 +130,6 @@ function renderItems(items: MenuItemDescriptor[]) {
               </MenubarRadioItem>
             ))}
           </MenubarRadioGroup>
-        );
-      case "label":
-        return (
-          <MenubarLabel
-            key={index}
-            aria-disabled={item.disabled}
-            className={cn(
-              "flex h-6 items-center px-3 text-md font-semibold opacity-70",
-              item.disabled && "opacity-40",
-              item.className
-            )}
-          >
-            {item.label}
-          </MenubarLabel>
         );
       case "submenu":
         return (

--- a/src/components/shared/menubar/AppMenuBarMenus.tsx
+++ b/src/components/shared/menubar/AppMenuBarMenus.tsx
@@ -5,6 +5,7 @@ import {
   MenubarContent,
   MenubarItem,
   MenubarCheckboxItem,
+  MenubarLabel,
   MenubarSeparator,
   MenubarShortcut,
   MenubarSub,
@@ -60,6 +61,13 @@ export type MenuItemDescriptor =
       options: MenuRadioOptionDescriptor[];
     }
   | {
+      type: "label";
+      label: ReactNode;
+      disabled?: boolean;
+      /** Extra classes merged onto the shared label class. */
+      className?: string;
+    }
+  | {
       type: "submenu";
       label: ReactNode;
       items: MenuItemDescriptor[];
@@ -73,6 +81,8 @@ export type MenuItemDescriptor =
 export type MenuDescriptor = {
   label: ReactNode;
   items: MenuItemDescriptor[];
+  /** Extra classes merged onto the menu content container. */
+  contentClassName?: string;
 };
 
 function renderItems(items: MenuItemDescriptor[]) {
@@ -129,6 +139,20 @@ function renderItems(items: MenuItemDescriptor[]) {
             ))}
           </MenubarRadioGroup>
         );
+      case "label":
+        return (
+          <MenubarLabel
+            key={index}
+            aria-disabled={item.disabled}
+            className={cn(
+              "flex h-6 items-center px-3 text-md font-semibold opacity-70",
+              item.disabled && "opacity-40",
+              item.className
+            )}
+          >
+            {item.label}
+          </MenubarLabel>
+        );
       case "submenu":
         return (
           <MenubarSub key={index}>
@@ -165,7 +189,11 @@ export function AppMenuBarMenus({ menus }: { menus: MenuDescriptor[] }) {
           <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
             {menu.label}
           </MenubarTrigger>
-          <MenubarContent align="start" sideOffset={1} className="px-0">
+          <MenubarContent
+            align="start"
+            sideOffset={1}
+            className={cn("px-0", menu.contentClassName)}
+          >
             {renderItems(menu.items)}
           </MenubarContent>
         </MenubarMenu>

--- a/tests/test-books-menu-layout.test.ts
+++ b/tests/test-books-menu-layout.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import type { MenuItemDescriptor } from "../src/components/shared/menubar/AppMenuBarMenus";
+import { flattenBooksMenuSubmenus } from "../src/apps/books/utils/booksMenuLayout";
+
+const noop = () => {};
+
+describe("Books compact menu layout", () => {
+  test("flattens flyouts into separated, labeled sections", () => {
+    const items: MenuItemDescriptor[] = [
+      {
+        type: "submenu",
+        label: "Font",
+        items: [
+          {
+            type: "radioGroup",
+            value: "serif",
+            onValueChange: noop,
+            options: [
+              { label: "Serif", value: "serif" },
+              { label: "Sans Serif", value: "sans" },
+            ],
+          },
+        ],
+      },
+      {
+        type: "submenu",
+        label: "Text Size",
+        items: [
+          {
+            type: "action",
+            label: "Larger",
+            onClick: noop,
+          },
+        ],
+      },
+    ];
+
+    const flattened = flattenBooksMenuSubmenus(items);
+
+    expect(flattened.map((item) => item.type)).toEqual([
+      "label",
+      "radioGroup",
+      "separator",
+      "label",
+      "action",
+    ]);
+    expect(flattened.some((item) => item.type === "submenu")).toBe(false);
+  });
+
+  test("does not duplicate an existing separator before a section", () => {
+    const flattened = flattenBooksMenuSubmenus([
+      { type: "action", label: "Next Page", onClick: noop },
+      { type: "separator" },
+      {
+        type: "submenu",
+        label: "Chapters",
+        items: [{ type: "action", label: "Chapter 1", onClick: noop }],
+      },
+    ]);
+
+    expect(flattened.map((item) => item.type)).toEqual([
+      "action",
+      "separator",
+      "label",
+      "action",
+    ]);
+  });
+
+  test("keeps every item in a disabled submenu disabled", () => {
+    const items: MenuItemDescriptor[] = [
+      {
+        type: "submenu",
+        label: "Chapters",
+        disabled: true,
+        items: [
+          {
+            type: "radioGroup",
+            value: "",
+            onValueChange: noop,
+            options: [{ label: "Chapter 1", value: "0" }],
+          },
+          {
+            type: "checkbox",
+            label: "Bookmark",
+            checked: false,
+            onChange: noop,
+          },
+        ],
+      },
+    ];
+
+    const flattened = flattenBooksMenuSubmenus(items);
+    const label = flattened.find((item) => item.type === "label");
+    const radioGroup = flattened.find((item) => item.type === "radioGroup");
+    const checkbox = flattened.find((item) => item.type === "checkbox");
+
+    expect(label?.disabled).toBe(true);
+    expect(radioGroup?.options.every((option) => option.disabled)).toBe(true);
+    expect(checkbox?.disabled).toBe(true);
+
+    const originalRadioGroup = items[0].type === "submenu" && items[0].items[0];
+    expect(
+      originalRadioGroup &&
+        originalRadioGroup.type === "radioGroup" &&
+        originalRadioGroup.options[0].disabled
+    ).toBeUndefined();
+  });
+});

--- a/tests/test-books-menu-layout.test.ts
+++ b/tests/test-books-menu-layout.test.ts
@@ -66,7 +66,6 @@ describe("Books compact menu layout", () => {
     expect(compactMenus[2].items.map((item) => item.type)).toEqual([
       "action",
       "separator",
-      "label",
       "radioGroup",
     ]);
     expect(
@@ -76,7 +75,7 @@ describe("Books compact menu layout", () => {
     expect(desktopMenus[2]).toBe(goMenu);
   });
 
-  test("flattens multiple flyouts into separated, labeled sections", () => {
+  test("flattens multiple flyouts without their headers", () => {
     const items: MenuItemDescriptor[] = [
       {
         type: "submenu",
@@ -109,10 +108,8 @@ describe("Books compact menu layout", () => {
     const flattened = flattenBooksMenuSubmenus(items);
 
     expect(flattened.map((item) => item.type)).toEqual([
-      "label",
       "radioGroup",
       "separator",
-      "label",
       "action",
     ]);
     expect(flattened.some((item) => item.type === "submenu")).toBe(false);
@@ -132,7 +129,6 @@ describe("Books compact menu layout", () => {
     expect(flattened.map((item) => item.type)).toEqual([
       "action",
       "separator",
-      "label",
       "action",
     ]);
   });
@@ -161,11 +157,9 @@ describe("Books compact menu layout", () => {
     ];
 
     const flattened = flattenBooksMenuSubmenus(items);
-    const label = flattened.find((item) => item.type === "label");
     const radioGroup = flattened.find((item) => item.type === "radioGroup");
     const checkbox = flattened.find((item) => item.type === "checkbox");
 
-    expect(label?.disabled).toBe(true);
     expect(radioGroup?.options.every((option) => option.disabled)).toBe(true);
     expect(checkbox?.disabled).toBe(true);
 

--- a/tests/test-books-menu-layout.test.ts
+++ b/tests/test-books-menu-layout.test.ts
@@ -1,34 +1,105 @@
 import { describe, expect, test } from "bun:test";
-import type { MenuItemDescriptor } from "../src/components/shared/menubar/AppMenuBarMenus";
-import { flattenBooksMenuSubmenus } from "../src/apps/books/utils/booksMenuLayout";
+import type {
+  MenuDescriptor,
+  MenuItemDescriptor,
+} from "../src/components/shared/menubar/AppMenuBarMenus";
+import {
+  buildBooksMenuLayout,
+  flattenBooksMenuSubmenus,
+} from "../src/apps/books/utils/booksMenuLayout";
 
 const noop = () => {};
 
 describe("Books compact menu layout", () => {
-  test("flattens flyouts into separated, labeled sections", () => {
+  test("flattens and scrolls only the Go menu", () => {
+    const fileMenu: MenuDescriptor = {
+      label: "File",
+      items: [{ type: "action", label: "Close", onClick: noop }],
+    };
+    const viewMenu: MenuDescriptor = {
+      label: "View",
+      items: [
+        {
+          type: "submenu",
+          label: "Font",
+          items: [{ type: "action", label: "Serif", onClick: noop }],
+        },
+      ],
+    };
+    const goMenu: MenuDescriptor = {
+      label: "Go",
+      items: [
+        { type: "action", label: "Next Page", onClick: noop },
+        { type: "separator" },
+        {
+          type: "submenu",
+          label: "Chapters",
+          items: [
+            {
+              type: "radioGroup",
+              value: "0",
+              onValueChange: noop,
+              options: [{ label: "Chapter 1", value: "0" }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const compactMenus = buildBooksMenuLayout({
+      fileMenu,
+      viewMenu,
+      goMenu,
+      isCompact: true,
+    });
+    const desktopMenus = buildBooksMenuLayout({
+      fileMenu,
+      viewMenu,
+      goMenu,
+      isCompact: false,
+    });
+
+    expect(compactMenus[0]).toBe(fileMenu);
+    expect(compactMenus[1]).toBe(viewMenu);
+    expect(compactMenus[1].items[0].type).toBe("submenu");
+    expect(compactMenus[2]).not.toBe(goMenu);
+    expect(compactMenus[2].items.map((item) => item.type)).toEqual([
+      "action",
+      "separator",
+      "label",
+      "radioGroup",
+    ]);
+    expect(
+      compactMenus[2].items.some((item) => item.type === "submenu")
+    ).toBe(false);
+    expect(compactMenus[2].contentClassName).toContain("overflow-y-auto");
+    expect(desktopMenus[2]).toBe(goMenu);
+  });
+
+  test("flattens multiple flyouts into separated, labeled sections", () => {
     const items: MenuItemDescriptor[] = [
       {
         type: "submenu",
-        label: "Font",
+        label: "Part",
         items: [
           {
             type: "radioGroup",
-            value: "serif",
+            value: "1",
             onValueChange: noop,
             options: [
-              { label: "Serif", value: "serif" },
-              { label: "Sans Serif", value: "sans" },
+              { label: "Part 1", value: "1" },
+              { label: "Part 2", value: "2" },
             ],
           },
         ],
       },
       {
         type: "submenu",
-        label: "Text Size",
+        label: "Appendix",
         items: [
           {
             type: "action",
-            label: "Larger",
+            label: "Notes",
             onClick: noop,
           },
         ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- flatten only the Books Go chapter flyout on compact viewports
- show chapter choices directly without a Chapters header
- constrain the compact Go menu to the viewport and allow vertical scrolling
- keep File and View menus unchanged at every width
- preserve nested desktop Go menus and disabled chapter state
- merge the latest `main`, including the Books vertical text layout changes

## Testing
- Pending post-merge targeted unit, build, and narrow-viewport verification
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2068-c0d0-720d-9b0a-b7ddfdffe903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2068-c0d0-720d-9b0a-b7ddfdffe903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

