### PR TITLE
Improve Books page-turn gestures and curl feedback

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -1418,7 +1418,7 @@ export const BooksReaderPane = forwardRef<
         tiltDeg: gesture?.tiltDeg ?? 0,
         dragProgress: gesture?.progress ?? 0,
         viewportWidth:
-          gesture?.viewportWidth ?? viewportRef.current?.clientWidth ?? 0,
+          viewportRef.current?.clientWidth ?? gesture?.viewportWidth ?? 0,
       });
 
       let action: Promise<unknown> | unknown;

--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -1,5 +1,6 @@
 import {
   forwardRef,
+  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
@@ -99,6 +100,7 @@ interface FlipState {
   originY: number;
   tiltDeg: number;
   dragProgress: number;
+  viewportWidth: number;
 }
 
 interface ActivePageTurnGesture {
@@ -1415,6 +1417,8 @@ export const BooksReaderPane = forwardRef<
         originY: gesture?.originY ?? 0.5,
         tiltDeg: gesture?.tiltDeg ?? 0,
         dragProgress: gesture?.progress ?? 0,
+        viewportWidth:
+          gesture?.viewportWidth ?? viewportRef.current?.clientWidth ?? 0,
       });
 
       let action: Promise<unknown> | unknown;
@@ -1619,6 +1623,24 @@ export const BooksReaderPane = forwardRef<
     [cancelPageTurnGesture]
   );
 
+  const handleReaderPointerLeave = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!event.currentTarget.hasPointerCapture(event.pointerId)) {
+        cancelPageTurnGesture(event.pointerId);
+      }
+    },
+    [cancelPageTurnGesture]
+  );
+
+  const handleReaderClickCapture = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      if (!consumeGestureClick("reader")) return;
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    [consumeGestureClick]
+  );
+
   useImperativeHandle(
     ref,
     () => ({
@@ -1685,6 +1707,8 @@ export const BooksReaderPane = forwardRef<
       onPointerMove={handleReaderPointerMove}
       onPointerUp={handleReaderPointerUp}
       onPointerCancel={handleReaderPointerCancel}
+      onPointerLeave={handleReaderPointerLeave}
+      onClickCapture={handleReaderClickCapture}
     >
       {/* The epub.js render target, inset below the top clearance, above the
           progress footer, and with side gutters for a comfortable measure. */}
@@ -1931,7 +1955,10 @@ export const BooksReaderPane = forwardRef<
                 transformPerspective: 1400,
               }}
               initial={{
-                x: "0%",
+                x: prefersReducedMotion
+                  ? 0
+                  : (flip.dir === "next" ? -1 : 1) *
+                    Math.min(14, flip.dragProgress * 14),
                 rotateY: prefersReducedMotion
                   ? 0
                   : (flip.dir === "next" ? -1 : 1) *
@@ -1940,10 +1967,10 @@ export const BooksReaderPane = forwardRef<
               }}
               animate={{
                 x: prefersReducedMotion
-                  ? "0%"
-                  : flip.dir === "next"
-                    ? "-104%"
-                    : "104%",
+                  ? 0
+                  : (flip.dir === "next" ? -1 : 1) *
+                    Math.max(320, flip.viewportWidth) *
+                    1.04,
                 opacity: prefersReducedMotion ? 0 : 1,
                 rotateY: prefersReducedMotion
                   ? 0

--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -103,7 +103,7 @@ interface FlipState {
 
 interface ActivePageTurnGesture {
   pointerId: number;
-  pointerType: string;
+  source: "reader" | "content";
   start: PageTurnGesturePoint;
   viewportWidth: number;
   viewportHeight: number;
@@ -112,6 +112,7 @@ interface ActivePageTurnGesture {
 interface PageTurnPointerSample extends PageTurnGesturePoint {
   pointerId: number;
   pointerType: string;
+  source: "reader" | "content";
   viewportWidth: number;
   viewportHeight: number;
 }
@@ -121,7 +122,12 @@ interface PageTurnGestureHandlers {
   move: (sample: PageTurnPointerSample) => boolean;
   end: (sample: PageTurnPointerSample) => boolean;
   cancel: (pointerId: number) => void;
-  consumeClick: () => boolean;
+  consumeClick: (source: PageTurnPointerSample["source"]) => boolean;
+}
+
+interface PointerCaptureTarget extends EventTarget {
+  setPointerCapture: (pointerId: number) => void;
+  releasePointerCapture: (pointerId: number) => void;
 }
 
 type BooksDebugLevel = "info" | "warn" | "error";
@@ -163,6 +169,16 @@ function measureActivePageTurnGesture(
     viewportWidth: active.viewportWidth,
     viewportHeight: active.viewportHeight,
   });
+}
+
+function canCapturePointer(
+  target: EventTarget | null
+): target is PointerCaptureTarget {
+  return (
+    target !== null &&
+    typeof Reflect.get(target, "setPointerCapture") === "function" &&
+    typeof Reflect.get(target, "releasePointerCapture") === "function"
+  );
 }
 
 export function createInitialBooksNavigationState(): BooksNavigationState {
@@ -345,11 +361,15 @@ export const BooksReaderPane = forwardRef<
     createChineseScriptConversionSession()
   );
   const flipLockRef = useRef(false);
+  const flipOperationIdRef = useRef(0);
   const flipNavigationCompleteRef = useRef(true);
   const flipAnimationCompleteRef = useRef(true);
   const activePageTurnGestureRef = useRef<ActivePageTurnGesture | null>(null);
   const pageTurnGestureHandlersRef = useRef<PageTurnGestureHandlers | null>(null);
-  const suppressGestureClickUntilRef = useRef(0);
+  const suppressedGestureClickRef = useRef<{
+    source: PageTurnPointerSample["source"];
+    until: number;
+  } | null>(null);
   const onProgressRef = useRef(onProgress);
   onProgressRef.current = onProgress;
   const initialCfiRef = useRef(initialCfi);
@@ -518,6 +538,7 @@ export const BooksReaderPane = forwardRef<
     let book: Book | null = null;
     let rendition: Rendition | null = null;
     let displayedContentFontsReady: Promise<FontFaceSet> | undefined;
+    const pageTurnCleanupByDocument = new WeakMap<Document, () => void>();
     setIsReady(false);
     setCoverVisible(true);
     setLoadError(null);
@@ -863,6 +884,7 @@ export const BooksReaderPane = forwardRef<
               ): PageTurnPointerSample => ({
                 pointerId: event.pointerId,
                 pointerType: event.pointerType,
+                source: "content",
                 x: event.clientX,
                 y: event.clientY,
                 time: event.timeStamp,
@@ -873,6 +895,8 @@ export const BooksReaderPane = forwardRef<
                   contentWindow?.innerHeight ??
                   document.documentElement.clientHeight,
               });
+              let capturedPointerId: number | null = null;
+              let pointerCaptureTarget: PointerCaptureTarget | null = null;
               const onContentPointerDown = (event: PointerEvent) => {
                 if (
                   !event.isPrimary ||
@@ -880,9 +904,20 @@ export const BooksReaderPane = forwardRef<
                 ) {
                   return;
                 }
-                pageTurnGestureHandlersRef.current?.start(
-                  getPointerSample(event)
-                );
+                if (
+                  pageTurnGestureHandlersRef.current?.start(
+                    getPointerSample(event)
+                  ) &&
+                  canCapturePointer(event.target)
+                ) {
+                  try {
+                    event.target.setPointerCapture(event.pointerId);
+                    capturedPointerId = event.pointerId;
+                    pointerCaptureTarget = event.target;
+                  } catch {
+                    // Pointer capture is optional in older embedded WebViews.
+                  }
+                }
               };
               const onContentPointerMove = (event: PointerEvent) => {
                 if (
@@ -901,17 +936,46 @@ export const BooksReaderPane = forwardRef<
                 ) {
                   event.preventDefault();
                 }
+                if (
+                  capturedPointerId === event.pointerId &&
+                  pointerCaptureTarget
+                ) {
+                  try {
+                    pointerCaptureTarget.releasePointerCapture(event.pointerId);
+                  } catch {
+                    // Ignore when the browser already released capture.
+                  }
+                  capturedPointerId = null;
+                  pointerCaptureTarget = null;
+                }
               };
               const onContentPointerCancel = (event: PointerEvent) => {
                 pageTurnGestureHandlersRef.current?.cancel(event.pointerId);
+                capturedPointerId = null;
+                pointerCaptureTarget = null;
+              };
+              const onContentLostPointerCapture = (event: PointerEvent) => {
+                if (capturedPointerId !== event.pointerId) return;
+                pageTurnGestureHandlersRef.current?.cancel(event.pointerId);
+                capturedPointerId = null;
+                pointerCaptureTarget = null;
+              };
+              const onContentBlur = () => {
+                if (capturedPointerId === null) return;
+                pageTurnGestureHandlersRef.current?.cancel(capturedPointerId);
+                capturedPointerId = null;
+                pointerCaptureTarget = null;
               };
               const onContentClick = (event: MouseEvent) => {
-                if (pageTurnGestureHandlersRef.current?.consumeClick()) {
+                if (
+                  pageTurnGestureHandlersRef.current?.consumeClick("content")
+                ) {
                   event.preventDefault();
                   event.stopImmediatePropagation();
                 }
               };
               const removePageTurnListeners = () => {
+                onContentBlur();
                 document.removeEventListener(
                   "pointerdown",
                   onContentPointerDown
@@ -925,7 +989,21 @@ export const BooksReaderPane = forwardRef<
                   "pointercancel",
                   onContentPointerCancel
                 );
+                document.removeEventListener(
+                  "lostpointercapture",
+                  onContentLostPointerCapture
+                );
                 document.removeEventListener("click", onContentClick, true);
+                contentWindow?.removeEventListener("blur", onContentBlur);
+                contentWindow?.removeEventListener(
+                  "pagehide",
+                  removePageTurnListeners
+                );
+                contentWindow?.removeEventListener(
+                  "unload",
+                  removePageTurnListeners
+                );
+                pageTurnCleanupByDocument.delete(document);
               };
               document.documentElement.style.touchAction = "pinch-zoom";
               if (document.body) document.body.style.touchAction = "pinch-zoom";
@@ -938,12 +1016,23 @@ export const BooksReaderPane = forwardRef<
                 "pointercancel",
                 onContentPointerCancel
               );
+              document.addEventListener(
+                "lostpointercapture",
+                onContentLostPointerCapture
+              );
               document.addEventListener("click", onContentClick, true);
+              contentWindow?.addEventListener("blur", onContentBlur);
+              contentWindow?.addEventListener(
+                "pagehide",
+                removePageTurnListeners,
+                { once: true }
+              );
               contentWindow?.addEventListener(
                 "unload",
                 removePageTurnListeners,
                 { once: true }
               );
+              pageTurnCleanupByDocument.set(document, removePageTurnListeners);
 
               // `hyphens: auto` and locale-specific CJK glyph forms depend on the
               // content language. Prefer EPUB metadata, then the ryOS UI locale.
@@ -999,6 +1088,13 @@ export const BooksReaderPane = forwardRef<
                   "warn"
                 );
               }
+            }
+          );
+          nextRendition.hooks.unloaded.register(
+            (view: { contents?: { document?: Document } }) => {
+              const contentDocument = view.contents?.document;
+              if (!contentDocument) return;
+              pageTurnCleanupByDocument.get(contentDocument)?.();
             }
           );
 
@@ -1290,8 +1386,9 @@ export const BooksReaderPane = forwardRef<
     { debounce: 80 }
   );
 
-  const completeFlipWhenReady = useCallback(() => {
+  const completeFlipWhenReady = useCallback((operationId: number) => {
     if (
+      flipOperationIdRef.current !== operationId ||
       !flipNavigationCompleteRef.current ||
       !flipAnimationCompleteRef.current
     ) {
@@ -1309,11 +1406,12 @@ export const BooksReaderPane = forwardRef<
       if (!canTurnPage(dir, state)) return;
 
       flipLockRef.current = true;
+      const operationId = ++flipOperationIdRef.current;
       flipNavigationCompleteRef.current = false;
       flipAnimationCompleteRef.current = false;
       setFlip({
         dir,
-        id: Date.now(),
+        id: operationId,
         originY: gesture?.originY ?? 0.5,
         tiltDeg: gesture?.tiltDeg ?? 0,
         dragProgress: gesture?.progress ?? 0,
@@ -1323,9 +1421,10 @@ export const BooksReaderPane = forwardRef<
       try {
         action = dir === "next" ? rendition.next() : rendition.prev();
       } catch (error) {
+        if (flipOperationIdRef.current !== operationId) return;
         flipNavigationCompleteRef.current = true;
         flipAnimationCompleteRef.current = true;
-        completeFlipWhenReady();
+        completeFlipWhenReady(operationId);
         appendDebugEvent("epubjs:pageTurn:failed", error, "error");
         return;
       }
@@ -1335,8 +1434,9 @@ export const BooksReaderPane = forwardRef<
           appendDebugEvent("epubjs:pageTurn:failed", error, "error")
         )
         .finally(() => {
+          if (flipOperationIdRef.current !== operationId) return;
           flipNavigationCompleteRef.current = true;
-          completeFlipWhenReady();
+          completeFlipWhenReady(operationId);
         });
     },
     [appendDebugEvent, completeFlipWhenReady]
@@ -1360,7 +1460,7 @@ export const BooksReaderPane = forwardRef<
 
       activePageTurnGestureRef.current = {
         pointerId: sample.pointerId,
-        pointerType: sample.pointerType,
+        source: sample.source,
         start: { x: sample.x, y: sample.y, time: sample.time },
         viewportWidth: sample.viewportWidth,
         viewportHeight: sample.viewportHeight,
@@ -1402,7 +1502,10 @@ export const BooksReaderPane = forwardRef<
       setPageTurnGesture(null);
 
       if (consumed) {
-        suppressGestureClickUntilRef.current = Date.now() + 500;
+        suppressedGestureClickRef.current = {
+          source: active.source,
+          until: Date.now() + 120,
+        };
       }
 
       if (
@@ -1423,11 +1526,21 @@ export const BooksReaderPane = forwardRef<
     setPageTurnGesture(null);
   }, []);
 
-  const consumeGestureClick = useCallback((): boolean => {
-    if (Date.now() > suppressGestureClickUntilRef.current) return false;
-    suppressGestureClickUntilRef.current = 0;
-    return true;
-  }, []);
+  const consumeGestureClick = useCallback(
+    (source: PageTurnPointerSample["source"]): boolean => {
+      const suppressedClick = suppressedGestureClickRef.current;
+      if (
+        !suppressedClick ||
+        suppressedClick.source !== source ||
+        Date.now() > suppressedClick.until
+      ) {
+        return false;
+      }
+      suppressedGestureClickRef.current = null;
+      return true;
+    },
+    []
+  );
 
   pageTurnGestureHandlersRef.current = {
     start: beginPageTurnGesture,
@@ -1445,6 +1558,7 @@ export const BooksReaderPane = forwardRef<
       return {
         pointerId: event.pointerId,
         pointerType: event.pointerType,
+        source: "reader",
         x: event.clientX - rect.left,
         y: event.clientY - rect.top,
         time: event.timeStamp,
@@ -1463,13 +1577,7 @@ export const BooksReaderPane = forwardRef<
       ) {
         return;
       }
-      if (beginPageTurnGesture(getReaderPointerSample(event))) {
-        try {
-          event.currentTarget.setPointerCapture(event.pointerId);
-        } catch {
-          // Pointer capture is best-effort (some embedded WebViews omit it).
-        }
-      }
+      beginPageTurnGesture(getReaderPointerSample(event));
     },
     [beginPageTurnGesture, getReaderPointerSample]
   );
@@ -1478,6 +1586,13 @@ export const BooksReaderPane = forwardRef<
     (event: ReactPointerEvent<HTMLDivElement>) => {
       if (movePageTurnGesture(getReaderPointerSample(event))) {
         event.preventDefault();
+        try {
+          if (!event.currentTarget.hasPointerCapture(event.pointerId)) {
+            event.currentTarget.setPointerCapture(event.pointerId);
+          }
+        } catch {
+          // Pointer capture is best-effort (some embedded WebViews omit it).
+        }
       }
     },
     [getReaderPointerSample, movePageTurnGesture]
@@ -1512,6 +1627,7 @@ export const BooksReaderPane = forwardRef<
       goToChapter: (href: string) => {
         const rendition = renditionRef.current;
         if (!rendition || !href) return;
+        flipOperationIdRef.current += 1;
         flipLockRef.current = false;
         flipNavigationCompleteRef.current = true;
         flipAnimationCompleteRef.current = true;
@@ -1607,7 +1723,7 @@ export const BooksReaderPane = forwardRef<
         aria-label="Previous page"
         aria-disabled={atStart}
         onClick={() => {
-          if (!consumeGestureClick()) turnPage("prev");
+          if (!consumeGestureClick("reader")) turnPage("prev");
         }}
         style={{ top: TOP_CLEARANCE, bottom: FOOTER_HEIGHT }}
         className={cn(
@@ -1620,7 +1736,7 @@ export const BooksReaderPane = forwardRef<
         aria-label="Next page"
         aria-disabled={atEnd}
         onClick={() => {
-          if (!consumeGestureClick()) turnPage("next");
+          if (!consumeGestureClick("reader")) turnPage("next");
         }}
         style={{ top: TOP_CLEARANCE, bottom: FOOTER_HEIGHT }}
         className={cn(
@@ -1680,12 +1796,16 @@ export const BooksReaderPane = forwardRef<
                 opacity: 0.12 + pageTurnGesture.progress * 0.58,
                 scaleX: 0.2 + pageTurnGesture.progress * 0.8,
               }}
-              transition={{
-                type: "spring",
-                stiffness: 500,
-                damping: 42,
-                mass: 0.25,
-              }}
+              transition={
+                prefersReducedMotion
+                  ? { duration: 0 }
+                  : {
+                      type: "spring",
+                      stiffness: 500,
+                      damping: 42,
+                      mass: 0.25,
+                    }
+              }
             />
             <motion.div
               className={cn(
@@ -1745,12 +1865,16 @@ export const BooksReaderPane = forwardRef<
                 scaleX: 0.45,
                 transition: { duration: prefersReducedMotion ? 0 : 0.14 },
               }}
-              transition={{
-                type: "spring",
-                stiffness: 520,
-                damping: 40,
-                mass: 0.28,
-              }}
+              transition={
+                prefersReducedMotion
+                  ? { duration: 0 }
+                  : {
+                      type: "spring",
+                      stiffness: 520,
+                      damping: 40,
+                      mass: 0.28,
+                    }
+              }
             >
               <div
                 className={cn(
@@ -1807,10 +1931,7 @@ export const BooksReaderPane = forwardRef<
                 transformPerspective: 1400,
               }}
               initial={{
-                x: `${
-                  (flip.dir === "next" ? -1 : 1) *
-                  Math.min(14, flip.dragProgress * 18)
-                }%`,
+                x: "0%",
                 rotateY: prefersReducedMotion
                   ? 0
                   : (flip.dir === "next" ? -1 : 1) *
@@ -1818,7 +1939,12 @@ export const BooksReaderPane = forwardRef<
                 rotateZ: prefersReducedMotion ? 0 : flip.tiltDeg * 0.28,
               }}
               animate={{
-                x: flip.dir === "next" ? "-104%" : "104%",
+                x: prefersReducedMotion
+                  ? "0%"
+                  : flip.dir === "next"
+                    ? "-104%"
+                    : "104%",
+                opacity: prefersReducedMotion ? 0 : 1,
                 rotateY: prefersReducedMotion
                   ? 0
                   : flip.dir === "next"
@@ -1833,15 +1959,16 @@ export const BooksReaderPane = forwardRef<
               }}
               transition={{
                 duration: prefersReducedMotion
-                  ? 0.12
+                  ? 0.08
                   : flip.dragProgress > 0
                     ? 0.34
                     : 0.42,
                 ease: [0.32, 0.72, 0, 1],
               }}
               onAnimationComplete={() => {
+                if (flipOperationIdRef.current !== flip.id) return;
                 flipAnimationCompleteRef.current = true;
-                completeFlipWhenReady();
+                completeFlipWhenReady(flip.id);
               }}
             >
               <div

--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -1,5 +1,6 @@
 import {
   forwardRef,
+  type PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -7,7 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { AnimatePresence, motion } from "motion/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useTranslation } from "react-i18next";
 import ePub, { type Book, type NavItem, type Rendition } from "epubjs";
 import { cn } from "@/lib/utils";
@@ -25,6 +26,14 @@ import {
   resolveEpubDisplayFallbackTarget,
   resolveReadingPalette,
 } from "../utils/booksReader";
+import {
+  canTurnPage,
+  isPageTurnGestureStartAllowed,
+  measurePageTurnGesture,
+  shouldCommitPageTurn,
+  type PageTurnGestureMetrics,
+  type PageTurnGesturePoint,
+} from "../utils/pageTurnGesture";
 import {
   applyChineseScriptToDocument,
   createChineseScriptConversionSession,
@@ -87,6 +96,32 @@ interface ZoomRect {
 interface FlipState {
   dir: "next" | "prev";
   id: number;
+  originY: number;
+  tiltDeg: number;
+  dragProgress: number;
+}
+
+interface ActivePageTurnGesture {
+  pointerId: number;
+  pointerType: string;
+  start: PageTurnGesturePoint;
+  viewportWidth: number;
+  viewportHeight: number;
+}
+
+interface PageTurnPointerSample extends PageTurnGesturePoint {
+  pointerId: number;
+  pointerType: string;
+  viewportWidth: number;
+  viewportHeight: number;
+}
+
+interface PageTurnGestureHandlers {
+  start: (sample: PageTurnPointerSample) => boolean;
+  move: (sample: PageTurnPointerSample) => boolean;
+  end: (sample: PageTurnPointerSample) => boolean;
+  cancel: (pointerId: number) => void;
+  consumeClick: () => boolean;
 }
 
 type BooksDebugLevel = "info" | "warn" | "error";
@@ -117,6 +152,18 @@ const DEFAULT_BOOK_ASSET_BY_PATH: Record<string, string> = {
   "/Books/Meditations - Marcus Aurelius.epub":
     "/assets/books/meditations-marcus-aurelius.epub",
 };
+
+function measureActivePageTurnGesture(
+  active: ActivePageTurnGesture,
+  current: PageTurnGesturePoint
+): PageTurnGestureMetrics {
+  return measurePageTurnGesture({
+    start: active.start,
+    current,
+    viewportWidth: active.viewportWidth,
+    viewportHeight: active.viewportHeight,
+  });
+}
 
 export function createInitialBooksNavigationState(): BooksNavigationState {
   return {
@@ -298,6 +345,11 @@ export const BooksReaderPane = forwardRef<
     createChineseScriptConversionSession()
   );
   const flipLockRef = useRef(false);
+  const flipNavigationCompleteRef = useRef(true);
+  const flipAnimationCompleteRef = useRef(true);
+  const activePageTurnGestureRef = useRef<ActivePageTurnGesture | null>(null);
+  const pageTurnGestureHandlersRef = useRef<PageTurnGestureHandlers | null>(null);
+  const suppressGestureClickUntilRef = useRef(0);
   const onProgressRef = useRef(onProgress);
   onProgressRef.current = onProgress;
   const initialCfiRef = useRef(initialCfi);
@@ -307,6 +359,7 @@ export const BooksReaderPane = forwardRef<
   const uiLanguage = i18n.resolvedLanguage ?? i18n.language ?? "en";
   const uiLanguageRef = useRef(uiLanguage);
   uiLanguageRef.current = uiLanguage;
+  const prefersReducedMotion = useReducedMotion();
   const [isReady, setIsReady] = useState(false);
   const [coverVisible, setCoverVisible] = useState(true);
   // Set when the EPUB can't be opened (missing blob or display failure) so the
@@ -318,6 +371,8 @@ export const BooksReaderPane = forwardRef<
     null
   );
   const [flip, setFlip] = useState<FlipState | null>(null);
+  const [pageTurnGesture, setPageTurnGesture] =
+    useState<PageTurnGestureMetrics | null>(null);
   const [atStart, setAtStart] = useState(true);
   const [atEnd, setAtEnd] = useState(false);
   const [navigationState, setNavigationState] = useState(
@@ -798,6 +853,98 @@ export const BooksReaderPane = forwardRef<
               const document = contents.document;
               if (!document) return;
 
+              // epub.js renders into an iframe, so pointer events do not bubble
+              // to the reader shell. Forward them through a stable ref and keep
+              // pinch zoom available while reserving one-finger drags for page
+              // turns.
+              const contentWindow = document.defaultView;
+              const getPointerSample = (
+                event: PointerEvent
+              ): PageTurnPointerSample => ({
+                pointerId: event.pointerId,
+                pointerType: event.pointerType,
+                x: event.clientX,
+                y: event.clientY,
+                time: event.timeStamp,
+                viewportWidth:
+                  contentWindow?.innerWidth ??
+                  document.documentElement.clientWidth,
+                viewportHeight:
+                  contentWindow?.innerHeight ??
+                  document.documentElement.clientHeight,
+              });
+              const onContentPointerDown = (event: PointerEvent) => {
+                if (
+                  !event.isPrimary ||
+                  (event.pointerType === "mouse" && event.button !== 0)
+                ) {
+                  return;
+                }
+                pageTurnGestureHandlersRef.current?.start(
+                  getPointerSample(event)
+                );
+              };
+              const onContentPointerMove = (event: PointerEvent) => {
+                if (
+                  pageTurnGestureHandlersRef.current?.move(
+                    getPointerSample(event)
+                  )
+                ) {
+                  event.preventDefault();
+                }
+              };
+              const onContentPointerUp = (event: PointerEvent) => {
+                if (
+                  pageTurnGestureHandlersRef.current?.end(
+                    getPointerSample(event)
+                  )
+                ) {
+                  event.preventDefault();
+                }
+              };
+              const onContentPointerCancel = (event: PointerEvent) => {
+                pageTurnGestureHandlersRef.current?.cancel(event.pointerId);
+              };
+              const onContentClick = (event: MouseEvent) => {
+                if (pageTurnGestureHandlersRef.current?.consumeClick()) {
+                  event.preventDefault();
+                  event.stopImmediatePropagation();
+                }
+              };
+              const removePageTurnListeners = () => {
+                document.removeEventListener(
+                  "pointerdown",
+                  onContentPointerDown
+                );
+                document.removeEventListener(
+                  "pointermove",
+                  onContentPointerMove
+                );
+                document.removeEventListener("pointerup", onContentPointerUp);
+                document.removeEventListener(
+                  "pointercancel",
+                  onContentPointerCancel
+                );
+                document.removeEventListener("click", onContentClick, true);
+              };
+              document.documentElement.style.touchAction = "pinch-zoom";
+              if (document.body) document.body.style.touchAction = "pinch-zoom";
+              document.addEventListener("pointerdown", onContentPointerDown);
+              document.addEventListener("pointermove", onContentPointerMove, {
+                passive: false,
+              });
+              document.addEventListener("pointerup", onContentPointerUp);
+              document.addEventListener(
+                "pointercancel",
+                onContentPointerCancel
+              );
+              document.addEventListener("click", onContentClick, true);
+              contentWindow?.addEventListener(
+                "unload",
+                removePageTurnListeners,
+                { once: true }
+              );
+
               // `hyphens: auto` and locale-specific CJK glyph forms depend on the
               // content language. Prefer EPUB metadata, then the ryOS UI locale.
               try {
@@ -1143,19 +1290,219 @@ export const BooksReaderPane = forwardRef<
     { debounce: 80 }
   );
 
-  const turnPage = useCallback((dir: "next" | "prev") => {
-    const rendition = renditionRef.current;
-    if (!rendition || flipLockRef.current) return;
-    const state = navigationStateRef.current;
-    if (dir === "prev" && !state.canGoPreviousPage) return;
-    if (dir === "next" && !state.canGoNextPage) return;
-    flipLockRef.current = true;
-    setFlip({ dir, id: Date.now() });
-    const action = dir === "next" ? rendition.next() : rendition.prev();
-    Promise.resolve(action).finally(() => {
-      // flip animation onComplete releases the lock
-    });
+  const completeFlipWhenReady = useCallback(() => {
+    if (
+      !flipNavigationCompleteRef.current ||
+      !flipAnimationCompleteRef.current
+    ) {
+      return;
+    }
+    flipLockRef.current = false;
+    setFlip(null);
   }, []);
+
+  const turnPage = useCallback(
+    (dir: "next" | "prev", gesture?: PageTurnGestureMetrics) => {
+      const rendition = renditionRef.current;
+      if (!rendition || flipLockRef.current) return;
+      const state = navigationStateRef.current;
+      if (!canTurnPage(dir, state)) return;
+
+      flipLockRef.current = true;
+      flipNavigationCompleteRef.current = false;
+      flipAnimationCompleteRef.current = false;
+      setFlip({
+        dir,
+        id: Date.now(),
+        originY: gesture?.originY ?? 0.5,
+        tiltDeg: gesture?.tiltDeg ?? 0,
+        dragProgress: gesture?.progress ?? 0,
+      });
+
+      let action: Promise<unknown> | unknown;
+      try {
+        action = dir === "next" ? rendition.next() : rendition.prev();
+      } catch (error) {
+        flipNavigationCompleteRef.current = true;
+        flipAnimationCompleteRef.current = true;
+        completeFlipWhenReady();
+        appendDebugEvent("epubjs:pageTurn:failed", error, "error");
+        return;
+      }
+
+      Promise.resolve(action)
+        .catch((error) =>
+          appendDebugEvent("epubjs:pageTurn:failed", error, "error")
+        )
+        .finally(() => {
+          flipNavigationCompleteRef.current = true;
+          completeFlipWhenReady();
+        });
+    },
+    [appendDebugEvent, completeFlipWhenReady]
+  );
+
+  const beginPageTurnGesture = useCallback(
+    (sample: PageTurnPointerSample): boolean => {
+      const state = navigationStateRef.current;
+      if (
+        flipLockRef.current ||
+        !state.isReady ||
+        (!state.canGoPreviousPage && !state.canGoNextPage) ||
+        !isPageTurnGestureStartAllowed({
+          pointerType: sample.pointerType,
+          startX: sample.x,
+          viewportWidth: sample.viewportWidth,
+        })
+      ) {
+        return false;
+      }
+
+      activePageTurnGestureRef.current = {
+        pointerId: sample.pointerId,
+        pointerType: sample.pointerType,
+        start: { x: sample.x, y: sample.y, time: sample.time },
+        viewportWidth: sample.viewportWidth,
+        viewportHeight: sample.viewportHeight,
+      };
+      return true;
+    },
+    []
+  );
+
+  const movePageTurnGesture = useCallback(
+    (sample: PageTurnPointerSample): boolean => {
+      const active = activePageTurnGestureRef.current;
+      if (!active || active.pointerId !== sample.pointerId) return false;
+
+      const metrics = measureActivePageTurnGesture(active, sample);
+      if (
+        !metrics.isIntentional ||
+        !metrics.direction ||
+        !canTurnPage(metrics.direction, navigationStateRef.current)
+      ) {
+        setPageTurnGesture(null);
+        return false;
+      }
+
+      setPageTurnGesture(metrics);
+      return true;
+    },
+    []
+  );
+
+  const endPageTurnGesture = useCallback(
+    (sample: PageTurnPointerSample): boolean => {
+      const active = activePageTurnGestureRef.current;
+      if (!active || active.pointerId !== sample.pointerId) return false;
+      activePageTurnGestureRef.current = null;
+
+      const metrics = measureActivePageTurnGesture(active, sample);
+      const consumed = metrics.isIntentional;
+      setPageTurnGesture(null);
+
+      if (consumed) {
+        suppressGestureClickUntilRef.current = Date.now() + 500;
+      }
+
+      if (
+        metrics.direction &&
+        shouldCommitPageTurn(metrics, navigationStateRef.current)
+      ) {
+        turnPage(metrics.direction, metrics);
+      }
+
+      return consumed;
+    },
+    [turnPage]
+  );
+
+  const cancelPageTurnGesture = useCallback((pointerId: number) => {
+    if (activePageTurnGestureRef.current?.pointerId !== pointerId) return;
+    activePageTurnGestureRef.current = null;
+    setPageTurnGesture(null);
+  }, []);
+
+  const consumeGestureClick = useCallback((): boolean => {
+    if (Date.now() > suppressGestureClickUntilRef.current) return false;
+    suppressGestureClickUntilRef.current = 0;
+    return true;
+  }, []);
+
+  pageTurnGestureHandlersRef.current = {
+    start: beginPageTurnGesture,
+    move: movePageTurnGesture,
+    end: endPageTurnGesture,
+    cancel: cancelPageTurnGesture,
+    consumeClick: consumeGestureClick,
+  };
+
+  const getReaderPointerSample = useCallback(
+    (
+      event: ReactPointerEvent<HTMLDivElement>
+    ): PageTurnPointerSample => {
+      const rect = event.currentTarget.getBoundingClientRect();
+      return {
+        pointerId: event.pointerId,
+        pointerType: event.pointerType,
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top,
+        time: event.timeStamp,
+        viewportWidth: rect.width,
+        viewportHeight: rect.height,
+      };
+    },
+    []
+  );
+
+  const handleReaderPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (
+        !event.isPrimary ||
+        (event.pointerType === "mouse" && event.button !== 0)
+      ) {
+        return;
+      }
+      if (beginPageTurnGesture(getReaderPointerSample(event))) {
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+          // Pointer capture is best-effort (some embedded WebViews omit it).
+        }
+      }
+    },
+    [beginPageTurnGesture, getReaderPointerSample]
+  );
+
+  const handleReaderPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (movePageTurnGesture(getReaderPointerSample(event))) {
+        event.preventDefault();
+      }
+    },
+    [getReaderPointerSample, movePageTurnGesture]
+  );
+
+  const handleReaderPointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (endPageTurnGesture(getReaderPointerSample(event))) {
+        event.preventDefault();
+      }
+      try {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      } catch {
+        // Ignore when capture was not established.
+      }
+    },
+    [endPageTurnGesture, getReaderPointerSample]
+  );
+
+  const handleReaderPointerCancel = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      cancelPageTurnGesture(event.pointerId);
+    },
+    [cancelPageTurnGesture]
+  );
 
   useImperativeHandle(
     ref,
@@ -1166,6 +1513,10 @@ export const BooksReaderPane = forwardRef<
         const rendition = renditionRef.current;
         if (!rendition || !href) return;
         flipLockRef.current = false;
+        flipNavigationCompleteRef.current = true;
+        flipAnimationCompleteRef.current = true;
+        activePageTurnGestureRef.current = null;
+        setPageTurnGesture(null);
         setFlip(null);
         Promise.resolve(rendition.display(href)).catch((error) =>
           appendDebugEvent("epubjs:chapterDisplay:failed", error, "error")
@@ -1210,7 +1561,14 @@ export const BooksReaderPane = forwardRef<
       ref={viewportRef}
       tabIndex={0}
       className="relative h-full w-full overflow-hidden outline-none"
-      style={{ backgroundColor: palette.background }}
+      style={{
+        backgroundColor: palette.background,
+        touchAction: "pinch-zoom",
+      }}
+      onPointerDown={handleReaderPointerDown}
+      onPointerMove={handleReaderPointerMove}
+      onPointerUp={handleReaderPointerUp}
+      onPointerCancel={handleReaderPointerCancel}
     >
       {/* The epub.js render target, inset below the top clearance, above the
           progress footer, and with side gutters for a comfortable measure. */}
@@ -1225,22 +1583,50 @@ export const BooksReaderPane = forwardRef<
         }}
       />
 
+      {/* A quiet page-edge vignette gives the flat EPUB iframe some depth. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute z-[5]"
+        style={{
+          top: TOP_CLEARANCE,
+          bottom: FOOTER_HEIGHT,
+          left: SIDE_CLEARANCE,
+          right: SIDE_CLEARANCE,
+          background: palette.isDark
+            ? "linear-gradient(to right, rgba(0,0,0,0.18), transparent 4%, transparent 96%, rgba(0,0,0,0.18))"
+            : "linear-gradient(to right, rgba(58,45,30,0.06), transparent 4%, transparent 96%, rgba(58,45,30,0.06))",
+          boxShadow: palette.isDark
+            ? "inset 0 0 22px rgba(0,0,0,0.12)"
+            : "inset 0 0 18px rgba(76,58,36,0.035)",
+        }}
+      />
+
       {/* Click zones for page turning (aligned with the render host) */}
       <button
         type="button"
         aria-label="Previous page"
-        onClick={() => turnPage("prev")}
-        disabled={atStart}
+        aria-disabled={atStart}
+        onClick={() => {
+          if (!consumeGestureClick()) turnPage("prev");
+        }}
         style={{ top: TOP_CLEARANCE, bottom: FOOTER_HEIGHT }}
-        className="absolute left-0 z-10 w-[22%] cursor-w-resize disabled:cursor-default"
+        className={cn(
+          "absolute left-0 z-10 w-[22%]",
+          atStart ? "cursor-default" : "cursor-w-resize"
+        )}
       />
       <button
         type="button"
         aria-label="Next page"
-        onClick={() => turnPage("next")}
-        disabled={atEnd}
+        aria-disabled={atEnd}
+        onClick={() => {
+          if (!consumeGestureClick()) turnPage("next");
+        }}
         style={{ top: TOP_CLEARANCE, bottom: FOOTER_HEIGHT }}
-        className="absolute right-0 z-10 w-[22%] cursor-e-resize disabled:cursor-default"
+        className={cn(
+          "absolute right-0 z-10 w-[22%]",
+          atEnd ? "cursor-default" : "cursor-e-resize"
+        )}
       />
 
       {/* Reading-progress footer — right-aligned percentage, no bar. */}
@@ -1258,48 +1644,230 @@ export const BooksReaderPane = forwardRef<
         </span>
       </div>
 
-      {/* Page-turn animation. epub.js only ever has the single current page
-          rendered, so a true two-page slide (or a curl showing the outgoing
-          page) would require expensive DOM snapshotting (html2canvas), which is
-          too slow/janky to be worth it. Instead an opaque "page" sheet slides
-          off in the reading direction, revealing the freshly-rendered next/prev
-          page underneath — so the transition shows real content, cheaply. */}
-      <AnimatePresence
-        onExitComplete={() => {
-          flipLockRef.current = false;
-        }}
-      >
+      {/* Follow a held pointer with a light page curl before committing the
+          rendition change. The contact point controls both the crease and tilt,
+          so diagonal drags feel attached rather than forced onto a flat axis. */}
+      <AnimatePresence>
+        {!flip && pageTurnGesture?.direction && (
+          <motion.div
+            key={`gesture-${pageTurnGesture.direction}`}
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 z-20 overflow-hidden"
+            style={{ perspective: 1200 }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: prefersReducedMotion ? 0 : 0.12 }}
+          >
+            <motion.div
+              className={cn(
+                "absolute w-[28%]",
+                pageTurnGesture.direction === "next" ? "right-0" : "left-0"
+              )}
+              style={{
+                top: TOP_CLEARANCE,
+                bottom: FOOTER_HEIGHT,
+                background:
+                  pageTurnGesture.direction === "next"
+                    ? "linear-gradient(to left, rgba(0,0,0,0.12), transparent)"
+                    : "linear-gradient(to right, rgba(0,0,0,0.12), transparent)",
+                transformOrigin:
+                  pageTurnGesture.direction === "next"
+                    ? "right center"
+                    : "left center",
+              }}
+              animate={{
+                opacity: 0.12 + pageTurnGesture.progress * 0.58,
+                scaleX: 0.2 + pageTurnGesture.progress * 0.8,
+              }}
+              transition={{
+                type: "spring",
+                stiffness: 500,
+                damping: 42,
+                mass: 0.25,
+              }}
+            />
+            <motion.div
+              className={cn(
+                "absolute overflow-hidden",
+                pageTurnGesture.direction === "next" ? "right-[-2px]" : "left-[-2px]"
+              )}
+              style={{
+                top: TOP_CLEARANCE + 3,
+                bottom: FOOTER_HEIGHT + 3,
+                width: `${Math.min(
+                  34,
+                  5 + pageTurnGesture.progress * 31
+                )}%`,
+                backgroundColor: palette.background,
+                backgroundImage: `${
+                  palette.isDark
+                    ? "radial-gradient(ellipse at center, rgba(255,255,255,0.08), transparent 62%)"
+                    : "radial-gradient(ellipse at center, rgba(255,255,255,0.72), transparent 64%)"
+                }, ${
+                  pageTurnGesture.direction === "next"
+                    ? "linear-gradient(to right, rgba(0,0,0,0.02), rgba(0,0,0,0.13))"
+                    : "linear-gradient(to left, rgba(0,0,0,0.02), rgba(0,0,0,0.13))"
+                }`,
+                borderRadius:
+                  pageTurnGesture.direction === "next"
+                    ? "70% 0 0 70% / 18% 0 0 18%"
+                    : "0 70% 70% 0 / 0 18% 18% 0",
+                boxShadow:
+                  pageTurnGesture.direction === "next"
+                    ? "-10px 0 24px rgba(0,0,0,0.2)"
+                    : "10px 0 24px rgba(0,0,0,0.2)",
+                transformOrigin: `${
+                  pageTurnGesture.direction === "next" ? "right" : "left"
+                } ${pageTurnGesture.originY * 100}%`,
+                transformPerspective: 1200,
+              }}
+              initial={{ opacity: 0, scaleX: 0.35 }}
+              animate={{
+                opacity: 0.72 + pageTurnGesture.progress * 0.28,
+                x:
+                  pageTurnGesture.direction === "next"
+                    ? -pageTurnGesture.progress * 14
+                    : pageTurnGesture.progress * 14,
+                rotateY: prefersReducedMotion
+                  ? 0
+                  : pageTurnGesture.direction === "next"
+                    ? -(8 + pageTurnGesture.progress * 15)
+                    : 8 + pageTurnGesture.progress * 15,
+                rotateZ: prefersReducedMotion
+                  ? 0
+                  : pageTurnGesture.tiltDeg *
+                    (pageTurnGesture.direction === "next" ? -0.45 : 0.45),
+                scaleX: 1,
+              }}
+              exit={{
+                opacity: 0,
+                scaleX: 0.45,
+                transition: { duration: prefersReducedMotion ? 0 : 0.14 },
+              }}
+              transition={{
+                type: "spring",
+                stiffness: 520,
+                damping: 40,
+                mass: 0.28,
+              }}
+            >
+              <div
+                className={cn(
+                  "absolute inset-y-0 w-[3px]",
+                  pageTurnGesture.direction === "next" ? "left-0" : "right-0"
+                )}
+                style={{
+                  background: palette.isDark
+                    ? "linear-gradient(to right, rgba(255,255,255,0.03), rgba(0,0,0,0.32))"
+                    : "linear-gradient(to right, rgba(255,255,255,0.75), rgba(73,52,30,0.2))",
+                }}
+              />
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* epub.js keeps one live page, so the committed turn uses a paper sheet
+          while it swaps content underneath. A shaped edge, contact-point
+          lighting, and perspective make the inexpensive transition read as a
+          curl instead of a blank horizontal panel. */}
+      <AnimatePresence>
         {flip && (
           <motion.div
             key={flip.id}
-            className="pointer-events-none absolute inset-0 z-20 overflow-hidden"
+            aria-hidden="true"
+            className="absolute inset-0 z-20 overflow-hidden"
+            style={{ perspective: 1400 }}
           >
             <motion.div
-              className="absolute inset-0"
+              className="absolute inset-0 overflow-hidden"
               style={{
                 backgroundColor: palette.background,
-                // Subtle fold shading along the sheet's leading edge.
-                backgroundImage:
+                backgroundImage: `${
+                  palette.isDark
+                    ? `radial-gradient(ellipse at ${
+                        flip.dir === "next" ? "100%" : "0%"
+                      } ${flip.originY * 100}%, rgba(255,255,255,0.08), transparent 48%)`
+                    : `radial-gradient(ellipse at ${
+                        flip.dir === "next" ? "100%" : "0%"
+                      } ${flip.originY * 100}%, rgba(255,255,255,0.7), transparent 52%)`
+                }, ${
                   flip.dir === "next"
-                    ? "linear-gradient(to right, rgba(0,0,0,0) 86%, rgba(0,0,0,0.08))"
-                    : "linear-gradient(to left, rgba(0,0,0,0) 86%, rgba(0,0,0,0.08))",
-                // Drop shadow cast onto the page being revealed.
+                    ? "linear-gradient(to right, transparent 79%, rgba(59,43,25,0.1) 96%, rgba(0,0,0,0.16))"
+                    : "linear-gradient(to left, transparent 79%, rgba(59,43,25,0.1) 96%, rgba(0,0,0,0.16))"
+                }, repeating-linear-gradient(0deg, transparent 0, transparent 4px, rgba(80,60,40,0.012) 5px)`,
                 boxShadow:
                   flip.dir === "next"
-                    ? "10px 0 26px rgba(0,0,0,0.28)"
-                    : "-10px 0 26px rgba(0,0,0,0.28)",
+                    ? "12px 0 32px rgba(0,0,0,0.3)"
+                    : "-12px 0 32px rgba(0,0,0,0.3)",
+                transformOrigin: `${
+                  flip.dir === "next" ? "right" : "left"
+                } ${flip.originY * 100}%`,
+                transformPerspective: 1400,
               }}
-              initial={{ x: "0%" }}
-              animate={{ x: flip.dir === "next" ? "-100%" : "100%" }}
-              exit={{ opacity: 0, transition: { duration: 0.1 } }}
-              transition={{ duration: 0.42, ease: [0.4, 0, 0.2, 1] }}
+              initial={{
+                x: `${
+                  (flip.dir === "next" ? -1 : 1) *
+                  Math.min(14, flip.dragProgress * 18)
+                }%`,
+                rotateY: prefersReducedMotion
+                  ? 0
+                  : (flip.dir === "next" ? -1 : 1) *
+                    (1.5 + flip.dragProgress * 5),
+                rotateZ: prefersReducedMotion ? 0 : flip.tiltDeg * 0.28,
+              }}
+              animate={{
+                x: flip.dir === "next" ? "-104%" : "104%",
+                rotateY: prefersReducedMotion
+                  ? 0
+                  : flip.dir === "next"
+                    ? -8
+                    : 8,
+                rotateZ: prefersReducedMotion ? 0 : flip.tiltDeg * 0.12,
+                scaleY: prefersReducedMotion ? 1 : 0.992,
+              }}
+              exit={{
+                opacity: 0,
+                transition: { duration: prefersReducedMotion ? 0 : 0.08 },
+              }}
+              transition={{
+                duration: prefersReducedMotion
+                  ? 0.12
+                  : flip.dragProgress > 0
+                    ? 0.34
+                    : 0.42,
+                ease: [0.32, 0.72, 0, 1],
+              }}
               onAnimationComplete={() => {
-                // Release the lock as soon as the slide settles (not after the
-                // exit fade) so fast page-turning stays responsive.
-                flipLockRef.current = false;
-                setFlip(null);
+                flipAnimationCompleteRef.current = true;
+                completeFlipWhenReady();
               }}
-            />
+            >
+              <div
+                className={cn(
+                  "absolute inset-y-0 w-[7%]",
+                  flip.dir === "next" ? "right-0" : "left-0"
+                )}
+                style={{
+                  background:
+                    flip.dir === "next"
+                      ? "linear-gradient(to right, transparent, rgba(0,0,0,0.13))"
+                      : "linear-gradient(to left, transparent, rgba(0,0,0,0.13))",
+                }}
+              />
+              <div
+                className={cn(
+                  "absolute inset-y-0 w-px",
+                  flip.dir === "next" ? "right-0" : "left-0"
+                )}
+                style={{
+                  backgroundColor: palette.isDark
+                    ? "rgba(255,255,255,0.12)"
+                    : "rgba(66,46,24,0.2)",
+                }}
+              />
+            </motion.div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/apps/books/utils/pageTurnGesture.ts
+++ b/src/apps/books/utils/pageTurnGesture.ts
@@ -1,0 +1,133 @@
+export type PageTurnDirection = "next" | "prev";
+
+export interface PageTurnGesturePoint {
+  x: number;
+  y: number;
+  time: number;
+}
+
+export interface PageTurnGestureInput {
+  start: PageTurnGesturePoint;
+  current: PageTurnGesturePoint;
+  viewportWidth: number;
+  viewportHeight: number;
+}
+
+export interface PageTurnGestureMetrics {
+  direction: PageTurnDirection | null;
+  isIntentional: boolean;
+  progress: number;
+  originY: number;
+  tiltDeg: number;
+  horizontalDistance: number;
+  verticalDistance: number;
+  effectiveDistance: number;
+  horizontalVelocity: number;
+  angleFromHorizontalDeg: number;
+}
+
+export interface PageTurnAvailability {
+  canGoPreviousPage: boolean;
+  canGoNextPage: boolean;
+}
+
+const INTENT_HORIZONTAL_DISTANCE_PX = 8;
+const MAX_ANGLE_FROM_HORIZONTAL_DEG = 72;
+const COMMIT_PROGRESS = 0.16;
+const COMMIT_HORIZONTAL_DISTANCE_PX = 22;
+const FLICK_HORIZONTAL_DISTANCE_PX = 18;
+const FLICK_VELOCITY_PX_PER_MS = 0.45;
+const MOUSE_EDGE_ZONE_RATIO = 0.28;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function isPageTurnGestureStartAllowed({
+  pointerType,
+  startX,
+  viewportWidth,
+}: {
+  pointerType: string;
+  startX: number;
+  viewportWidth: number;
+}): boolean {
+  if (pointerType !== "mouse") return true;
+  if (viewportWidth <= 0) return false;
+
+  const edgeWidth = viewportWidth * MOUSE_EDGE_ZONE_RATIO;
+  return startX <= edgeWidth || startX >= viewportWidth - edgeWidth;
+}
+
+export function measurePageTurnGesture({
+  start,
+  current,
+  viewportWidth,
+  viewportHeight,
+}: PageTurnGestureInput): PageTurnGestureMetrics {
+  const deltaX = current.x - start.x;
+  const deltaY = current.y - start.y;
+  const absDx = Math.abs(deltaX);
+  const absDy = Math.abs(deltaY);
+  const direction: PageTurnDirection | null =
+    absDx >= INTENT_HORIZONTAL_DISTANCE_PX
+      ? deltaX < 0
+        ? "next"
+        : "prev"
+      : null;
+  const angleFromHorizontalDeg =
+    absDx === 0 ? 90 : (Math.atan2(absDy, absDx) * 180) / Math.PI;
+  const isIntentional =
+    direction !== null &&
+    angleFromHorizontalDeg <= MAX_ANGLE_FROM_HORIZONTAL_DEG;
+
+  // Let diagonal travel help lift the page without allowing a near-vertical
+  // drag to become a turn. This feels less rigid than using deltaX alone.
+  const effectiveDistance = isIntentional ? absDx + absDy * 0.22 : 0;
+  const travelForFullTurn = Math.max(150, viewportWidth * 0.42);
+  const elapsedMs = Math.max(1, current.time - start.time);
+
+  return {
+    direction,
+    isIntentional,
+    progress: clamp(effectiveDistance / travelForFullTurn, 0, 1),
+    originY: clamp(start.y / Math.max(1, viewportHeight), 0.08, 0.92),
+    tiltDeg: clamp((deltaY / Math.max(1, viewportHeight)) * 24, -9, 9),
+    horizontalDistance: absDx,
+    verticalDistance: absDy,
+    effectiveDistance,
+    horizontalVelocity: absDx / elapsedMs,
+    angleFromHorizontalDeg,
+  };
+}
+
+export function canTurnPage(
+  direction: PageTurnDirection,
+  availability: PageTurnAvailability,
+): boolean {
+  return direction === "next"
+    ? availability.canGoNextPage
+    : availability.canGoPreviousPage;
+}
+
+export function shouldCommitPageTurn(
+  metrics: PageTurnGestureMetrics,
+  availability: PageTurnAvailability,
+): boolean {
+  if (
+    !metrics.isIntentional ||
+    !metrics.direction ||
+    !canTurnPage(metrics.direction, availability)
+  ) {
+    return false;
+  }
+
+  const crossedDistanceThreshold =
+    metrics.progress >= COMMIT_PROGRESS &&
+    metrics.horizontalDistance >= COMMIT_HORIZONTAL_DISTANCE_PX;
+  const wasFlicked =
+    metrics.horizontalDistance >= FLICK_HORIZONTAL_DISTANCE_PX &&
+    metrics.horizontalVelocity >= FLICK_VELOCITY_PX_PER_MS;
+
+  return crossedDistanceThreshold || wasFlicked;
+}

--- a/src/apps/books/utils/pageTurnGesture.ts
+++ b/src/apps/books/utils/pageTurnGesture.ts
@@ -24,6 +24,7 @@ export interface PageTurnGestureMetrics {
   effectiveDistance: number;
   horizontalVelocity: number;
   angleFromHorizontalDeg: number;
+  viewportWidth: number;
 }
 
 export interface PageTurnAvailability {
@@ -98,6 +99,7 @@ export function measurePageTurnGesture({
     effectiveDistance,
     horizontalVelocity: absDx / elapsedMs,
     angleFromHorizontalDeg,
+    viewportWidth: Math.max(0, viewportWidth),
   };
 }
 

--- a/tests/test-books-page-turn-gesture.test.ts
+++ b/tests/test-books-page-turn-gesture.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isPageTurnGestureStartAllowed,
+  measurePageTurnGesture,
+  shouldCommitPageTurn,
+} from "../src/apps/books/utils/pageTurnGesture";
+
+const availability = {
+  canGoPreviousPage: true,
+  canGoNextPage: true,
+};
+
+function gesture({
+  deltaX,
+  deltaY,
+  elapsedMs = 300,
+  startX = 400,
+  startY = 300,
+  viewportWidth = 800,
+  viewportHeight = 600,
+}: {
+  deltaX: number;
+  deltaY: number;
+  elapsedMs?: number;
+  startX?: number;
+  startY?: number;
+  viewportWidth?: number;
+  viewportHeight?: number;
+}) {
+  return measurePageTurnGesture({
+    start: { x: startX, y: startY, time: 0 },
+    current: {
+      x: startX + deltaX,
+      y: startY + deltaY,
+      time: elapsedMs,
+    },
+    viewportWidth,
+    viewportHeight,
+  });
+}
+
+describe("Books page-turn gesture", () => {
+  test("commits deliberate horizontal and diagonal turns", () => {
+    const horizontal = gesture({ deltaX: -70, deltaY: 4 });
+    const diagonal = gesture({ deltaX: -55, deltaY: 90 });
+
+    expect(horizontal.direction).toBe("next");
+    expect(horizontal.isIntentional).toBe(true);
+    expect(shouldCommitPageTurn(horizontal, availability)).toBe(true);
+
+    expect(diagonal.direction).toBe("next");
+    expect(diagonal.angleFromHorizontalDeg).toBeGreaterThan(45);
+    expect(diagonal.isIntentional).toBe(true);
+    expect(shouldCommitPageTurn(diagonal, availability)).toBe(true);
+  });
+
+  test("rejects near-vertical drags and short holds", () => {
+    const vertical = gesture({ deltaX: 12, deltaY: 120 });
+    const short = gesture({ deltaX: -12, deltaY: 3, elapsedMs: 500 });
+
+    expect(vertical.isIntentional).toBe(false);
+    expect(shouldCommitPageTurn(vertical, availability)).toBe(false);
+    expect(short.isIntentional).toBe(true);
+    expect(shouldCommitPageTurn(short, availability)).toBe(false);
+  });
+
+  test("commits a short fast flick", () => {
+    const flick = gesture({ deltaX: 24, deltaY: -8, elapsedMs: 35 });
+
+    expect(flick.direction).toBe("prev");
+    expect(flick.horizontalVelocity).toBeGreaterThan(0.45);
+    expect(shouldCommitPageTurn(flick, availability)).toBe(true);
+  });
+
+  test("respects the available navigation direction", () => {
+    const next = gesture({ deltaX: -80, deltaY: 20 });
+    const previous = gesture({ deltaX: 80, deltaY: -20 });
+
+    expect(
+      shouldCommitPageTurn(next, {
+        canGoPreviousPage: true,
+        canGoNextPage: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldCommitPageTurn(previous, {
+        canGoPreviousPage: false,
+        canGoNextPage: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("tracks the held edge and drag angle for the curl", () => {
+    const metrics = gesture({
+      deltaX: -80,
+      deltaY: 150,
+      startY: 120,
+    });
+
+    expect(metrics.originY).toBeCloseTo(0.2);
+    expect(metrics.tiltDeg).toBeCloseTo(6);
+    expect(metrics.progress).toBeGreaterThan(0.3);
+  });
+
+  test("allows touch anywhere but limits mouse drags to page edges", () => {
+    expect(
+      isPageTurnGestureStartAllowed({
+        pointerType: "touch",
+        startX: 400,
+        viewportWidth: 800,
+      }),
+    ).toBe(true);
+    expect(
+      isPageTurnGestureStartAllowed({
+        pointerType: "mouse",
+        startX: 400,
+        viewportWidth: 800,
+      }),
+    ).toBe(false);
+    expect(
+      isPageTurnGestureStartAllowed({
+        pointerType: "mouse",
+        startX: 100,
+        viewportWidth: 800,
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add angle-aware drag and swipe page turns inside the EPUB iframe and reader chrome
- make held gestures drive a contact-point curl with theme-aware paper shading and depth
- capture and clean up pointers across iframe lifecycles without breaking edge-zone clicks
- serialize navigation and animation completion by page-turn operation
- preserve drag displacement through the full reader sweep, respect reduced motion, and scope post-swipe click suppression
- cover diagonal intent, flicks, boundaries, and mouse edge starts with unit tests

## Testing
- `bun test tests/test-books-page-turn-gesture.test.ts tests/test-books-reader-fonts.test.ts tests/test-books-default-epub.test.ts tests/test-books-cover-load-queue.test.ts tests/test-books-cloud-blob-sync.test.ts tests/test-books-chinese-script-converter.test.ts` (38 passed)
- `bunx eslint src/apps/books/components/BooksReaderPane.tsx src/apps/books/utils/pageTurnGesture.ts tests/test-books-page-turn-gesture.test.ts` (0 errors; one existing Fast Refresh warning)
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f206b-9352-7af5-8851-b8f21db8610f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f206b-9352-7af5-8851-b8f21db8610f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

