### PR TITLE
Add vertical text layout to Books

### DIFF
--- a/src/apps/books/components/BooksMenuBar.tsx
+++ b/src/apps/books/components/BooksMenuBar.tsx
@@ -153,6 +153,28 @@ export function BooksMenuBar({
         },
         {
           type: "submenu",
+          label: t("apps.books.menu.textLayout"),
+          items: [
+            {
+              type: "radioGroup",
+              value: settings.textLayout,
+              onValueChange: (value) => {
+                if (value === "book" || value === "vertical") {
+                  updateSettings({ textLayout: value });
+                }
+              },
+              options: [
+                { label: t("apps.books.textLayout.book"), value: "book" },
+                {
+                  label: t("apps.books.textLayout.vertical"),
+                  value: "vertical",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "submenu",
           label: t("apps.books.menu.chineseScript"),
           items: [
             {

--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -30,6 +30,10 @@ import {
   createChineseScriptConversionSession,
   resolveChineseScriptReadingLanguage,
 } from "../utils/chineseScriptConverter";
+import {
+  applyEpubTextLayout,
+  resolveEpubPageDirection,
+} from "../utils/booksTextLayout";
 import { useBookCover } from "../utils/useBookCover";
 import { BookCover } from "./BookCover";
 import type {
@@ -292,6 +296,12 @@ export const BooksReaderPane = forwardRef<
   const bookRef = useRef<Book | null>(null);
   const renditionRef = useRef<Rendition | null>(null);
   const bookLanguageRef = useRef<string | null>(null);
+  const publisherPageDirectionRef = useRef<"ltr" | "rtl">("ltr");
+  const textLayoutRef = useRef(settings.textLayout);
+  textLayoutRef.current = settings.textLayout;
+  const appliedTextLayoutRef = useRef<BooksReaderSettings["textLayout"] | null>(
+    null
+  );
   const chineseScriptRef = useRef(settings.chineseScript);
   chineseScriptRef.current = settings.chineseScript;
   const chineseScriptSessionRef = useRef(
@@ -398,6 +408,7 @@ export const BooksReaderPane = forwardRef<
   }, [appendDebugEvent, entry.path]);
 
   const palette = resolveReadingPalette(settings.themeOverride, osIsDark);
+  const isVerticalText = settings.textLayout === "vertical";
 
   // Measure the zoom-in geometry before first paint so the cover overlay starts
   // exactly on top of the clicked shelf book and grows to full-bleed. Runs once
@@ -467,6 +478,8 @@ export const BooksReaderPane = forwardRef<
     setCoverVisible(true);
     setLoadError(null);
     bookLanguageRef.current = null;
+    publisherPageDirectionRef.current = "ltr";
+    appliedTextLayoutRef.current = null;
     activeSectionHrefRef.current = undefined;
     setNavigationState(createInitialBooksNavigationState());
     appendDebugEvent("open:start", {
@@ -684,15 +697,24 @@ export const BooksReaderPane = forwardRef<
         await watch("epubjs:bookReady", book.ready);
         const readyBook = book as unknown as {
           container?: { packagePath?: string };
-          package?: { metadata?: { language?: string } };
+          package?: { metadata?: { direction?: unknown; language?: string } };
         };
         const bookLanguage =
           readyBook.package?.metadata?.language?.trim() || null;
         bookLanguageRef.current = bookLanguage;
+        publisherPageDirectionRef.current = resolveEpubPageDirection(
+          "book",
+          readyBook.package?.metadata?.direction
+        );
         const readingLanguage = resolveChineseScriptReadingLanguage(
           chineseScriptRef.current,
           bookLanguage ?? uiLanguage
         );
+        book.spine.hooks.content.register((document: Document) => {
+          const textLayout = textLayoutRef.current;
+          applyEpubTextLayout(document, textLayout);
+          appliedTextLayoutRef.current = textLayout;
+        });
         appendDebugEvent("epubjs:bookReady:success", {
           packagePath: readyBook.container?.packagePath,
           metadata: readyBook.package?.metadata,
@@ -725,7 +747,12 @@ export const BooksReaderPane = forwardRef<
             width: host.clientWidth,
             height: host.clientHeight,
             spread: columnModeToSpread(settings.columnMode),
+            textLayout: textLayoutRef.current,
           });
+          const pageDirection = resolveEpubPageDirection(
+            textLayoutRef.current,
+            publisherPageDirectionRef.current
+          );
           const nextRendition = activeBook.renderTo(host, {
             width: host.clientWidth || "100%",
             height: host.clientHeight || "100%",
@@ -733,14 +760,23 @@ export const BooksReaderPane = forwardRef<
             spread: columnModeToSpread(settings.columnMode),
             minSpreadWidth: SPREAD_MIN_WIDTH,
             manager: "default",
+            defaultDirection: pageDirection,
           });
           rendition = nextRendition;
           renditionRef.current = nextRendition;
           appendDebugEvent(`${renderStep}:success`);
 
-          nextRendition.on("started", () =>
-            appendDebugEvent("epubjs:rendition:started")
-          );
+          nextRendition.on("started", () => {
+            const direction = resolveEpubPageDirection(
+              textLayoutRef.current,
+              publisherPageDirectionRef.current
+            );
+            nextRendition.direction(direction);
+            appendDebugEvent("epubjs:rendition:started", {
+              direction,
+              textLayout: textLayoutRef.current,
+            });
+          });
           nextRendition.on("attached", () =>
             appendDebugEvent("epubjs:rendition:attached")
           );
@@ -797,6 +833,9 @@ export const BooksReaderPane = forwardRef<
 
               const document = contents.document;
               if (!document) return;
+              const textLayout = textLayoutRef.current;
+              applyEpubTextLayout(document, textLayout);
+              appliedTextLayoutRef.current = textLayout;
 
               // `hyphens: auto` and locale-specific CJK glyph forms depend on the
               // content language. Prefer EPUB metadata, then the ryOS UI locale.
@@ -1087,6 +1126,52 @@ export const BooksReaderPane = forwardRef<
     };
   }, [appendDebugEvent, isReady, settings.chineseScript]);
 
+  // Apply vertical text to source and rendered section documents, then let
+  // epub.js clear and redisplay the current CFI with the matching page axis.
+  useEffect(() => {
+    const rendition = renditionRef.current;
+    const book = bookRef.current;
+    if (
+      !isReady ||
+      !rendition ||
+      !book ||
+      appliedTextLayoutRef.current === settings.textLayout
+    ) {
+      return;
+    }
+
+    book.spine.each((section: { document?: Document }) => {
+      if (section.document) {
+        applyEpubTextLayout(section.document, settings.textLayout);
+      }
+    });
+
+    const renditionContents = rendition.getContents() as unknown;
+    const contentsList = (
+      Array.isArray(renditionContents)
+        ? renditionContents
+        : renditionContents
+          ? [renditionContents]
+          : []
+    ) as Array<{ document?: Document }>;
+    for (const contents of contentsList) {
+      if (contents.document) {
+        applyEpubTextLayout(contents.document, settings.textLayout);
+      }
+    }
+
+    appliedTextLayoutRef.current = settings.textLayout;
+    const direction = resolveEpubPageDirection(
+      settings.textLayout,
+      publisherPageDirectionRef.current
+    );
+    rendition.direction(direction);
+    appendDebugEvent("reader:textLayout:applied", {
+      direction,
+      textLayout: settings.textLayout,
+    });
+  }, [appendDebugEvent, isReady, settings.textLayout]);
+
   // Apply theme (colors, font family, line height) live.
   useEffect(() => {
     if (!isReady || !renditionRef.current) return;
@@ -1103,6 +1188,7 @@ export const BooksReaderPane = forwardRef<
     settings.fontId,
     settings.themeOverride,
     settings.chineseScript,
+    settings.textLayout,
     settings.lineHeight,
     osIsDark,
     uiLanguage,
@@ -1177,10 +1263,14 @@ export const BooksReaderPane = forwardRef<
 
   const handleKey = useCallback(
     (event: KeyboardEvent) => {
-      if (event.key === "ArrowRight" || event.key === "PageDown") {
+      if (event.key === "PageDown") {
         turnPage("next");
-      } else if (event.key === "ArrowLeft" || event.key === "PageUp") {
+      } else if (event.key === "PageUp") {
         turnPage("prev");
+      } else if (event.key === "ArrowRight") {
+        turnPage(textLayoutRef.current === "vertical" ? "prev" : "next");
+      } else if (event.key === "ArrowLeft") {
+        turnPage(textLayoutRef.current === "vertical" ? "next" : "prev");
       }
     },
     [turnPage]
@@ -1228,19 +1318,25 @@ export const BooksReaderPane = forwardRef<
       {/* Click zones for page turning (aligned with the render host) */}
       <button
         type="button"
-        aria-label="Previous page"
-        onClick={() => turnPage("prev")}
-        disabled={atStart}
+        aria-label={isVerticalText ? "Next page" : "Previous page"}
+        onClick={() => turnPage(isVerticalText ? "next" : "prev")}
+        disabled={isVerticalText ? atEnd : atStart}
         style={{ top: TOP_CLEARANCE, bottom: FOOTER_HEIGHT }}
-        className="absolute left-0 z-10 w-[22%] cursor-w-resize disabled:cursor-default"
+        className={cn(
+          "absolute left-0 z-10 w-[22%] disabled:cursor-default",
+          isVerticalText ? "cursor-e-resize" : "cursor-w-resize"
+        )}
       />
       <button
         type="button"
-        aria-label="Next page"
-        onClick={() => turnPage("next")}
-        disabled={atEnd}
+        aria-label={isVerticalText ? "Previous page" : "Next page"}
+        onClick={() => turnPage(isVerticalText ? "prev" : "next")}
+        disabled={isVerticalText ? atStart : atEnd}
         style={{ top: TOP_CLEARANCE, bottom: FOOTER_HEIGHT }}
-        className="absolute right-0 z-10 w-[22%] cursor-e-resize disabled:cursor-default"
+        className={cn(
+          "absolute right-0 z-10 w-[22%] disabled:cursor-default",
+          isVerticalText ? "cursor-w-resize" : "cursor-e-resize"
+        )}
       />
 
       {/* Reading-progress footer — right-aligned percentage, no bar. */}
@@ -1280,17 +1376,22 @@ export const BooksReaderPane = forwardRef<
                 backgroundColor: palette.background,
                 // Subtle fold shading along the sheet's leading edge.
                 backgroundImage:
-                  flip.dir === "next"
+                  flip.dir === (isVerticalText ? "prev" : "next")
                     ? "linear-gradient(to right, rgba(0,0,0,0) 86%, rgba(0,0,0,0.08))"
                     : "linear-gradient(to left, rgba(0,0,0,0) 86%, rgba(0,0,0,0.08))",
                 // Drop shadow cast onto the page being revealed.
                 boxShadow:
-                  flip.dir === "next"
+                  flip.dir === (isVerticalText ? "prev" : "next")
                     ? "10px 0 26px rgba(0,0,0,0.28)"
                     : "-10px 0 26px rgba(0,0,0,0.28)",
               }}
               initial={{ x: "0%" }}
-              animate={{ x: flip.dir === "next" ? "-100%" : "100%" }}
+              animate={{
+                x:
+                  flip.dir === (isVerticalText ? "prev" : "next")
+                    ? "-100%"
+                    : "100%",
+              }}
               exit={{ opacity: 0, transition: { duration: 0.1 } }}
               transition={{ duration: 0.42, ease: [0.4, 0, 0.2, 1] }}
               onAnimationComplete={() => {

--- a/src/apps/books/utils/booksReader.ts
+++ b/src/apps/books/utils/booksReader.ts
@@ -377,20 +377,25 @@ export function buildEpubTheme(
   const fontStack = getBookFontCssStack(settings.fontId, language);
   const fontFamily = fontStack ? `${fontStack} !important` : null;
 
-  // Left-align with automatic hyphenation reads far better than justified text
-  // in a narrow column (justify opens up ugly rivers of whitespace). Applied
-  // with !important so it overrides publisher `text-align: justify`. orphans/
-  // widows reduce stranded single lines at column breaks.
-  const readingFlow: Record<string, string> = {
-    "text-align": "left !important",
-    "-webkit-hyphens": "auto !important",
-    hyphens: "auto !important",
-    "-webkit-hyphenate-limit-before": "3",
-    "-webkit-hyphenate-limit-after": "3",
-    "hyphenate-limit-chars": "6 3 3 !important",
-    orphans: "2",
-    widows: "2",
-  };
+  // Physical left alignment and hyphenation are horizontal-reading choices.
+  // In vertical mode they fight the top-to-bottom inline flow and CJK line
+  // breaking, so preserve only the column-break controls.
+  const readingFlow: Record<string, string> =
+    settings.textLayout === "vertical"
+      ? {
+          orphans: "2",
+          widows: "2",
+        }
+      : {
+          "text-align": "left !important",
+          "-webkit-hyphens": "auto !important",
+          hyphens: "auto !important",
+          "-webkit-hyphenate-limit-before": "3",
+          "-webkit-hyphenate-limit-after": "3",
+          "hyphenate-limit-chars": "6 3 3 !important",
+          orphans: "2",
+          widows: "2",
+        };
 
   const bodyRules: Record<string, string> = {
     background: `${palette.background} !important`,
@@ -415,8 +420,8 @@ export function buildEpubTheme(
     color: `${palette.text} !important`,
   };
 
-  // Paragraph/list rules also force left-align + hyphenation so publisher CSS
-  // on `p`/`li` (commonly `text-align: justify`) can't win the cascade.
+  // Paragraph/list rules also apply the active reading-flow policy so
+  // publisher CSS on `p`/`li` cannot reintroduce horizontal-only formatting.
   const flowText: Record<string, string> = { ...textColor, ...readingFlow };
 
   return {

--- a/src/apps/books/utils/booksTextLayout.ts
+++ b/src/apps/books/utils/booksTextLayout.ts
@@ -1,0 +1,89 @@
+import type { BooksTextLayout } from "@/stores/useBooksStore";
+
+type TrackedStyleProperty =
+  | "writing-mode"
+  | "-webkit-writing-mode"
+  | "text-orientation"
+  | "direction";
+
+const TRACKED_STYLE_PROPERTIES: readonly TrackedStyleProperty[] = [
+  "writing-mode",
+  "-webkit-writing-mode",
+  "text-orientation",
+  "direction",
+];
+const OVERRIDE_MARKER = "data-ryos-text-layout-override";
+const ORIGINAL_STYLE_PREFIX = "data-ryos-text-layout-original";
+
+function originalStyleAttribute(
+  property: TrackedStyleProperty,
+  part: "value" | "priority"
+): string {
+  return `${ORIGINAL_STYLE_PREFIX}-${property.replaceAll("-", "_")}-${part}`;
+}
+
+function rememberPublisherStyles(root: HTMLElement): void {
+  if (root.getAttribute(OVERRIDE_MARKER) === "true") return;
+
+  for (const property of TRACKED_STYLE_PROPERTIES) {
+    root.setAttribute(
+      originalStyleAttribute(property, "value"),
+      root.style.getPropertyValue(property)
+    );
+    root.setAttribute(
+      originalStyleAttribute(property, "priority"),
+      root.style.getPropertyPriority(property)
+    );
+  }
+  root.setAttribute(OVERRIDE_MARKER, "true");
+}
+
+function restorePublisherStyles(root: HTMLElement): void {
+  if (root.getAttribute(OVERRIDE_MARKER) !== "true") return;
+
+  for (const property of TRACKED_STYLE_PROPERTIES) {
+    const value = root.getAttribute(originalStyleAttribute(property, "value"));
+    const priority =
+      root.getAttribute(originalStyleAttribute(property, "priority")) ?? "";
+
+    if (value) {
+      root.style.setProperty(property, value, priority);
+    } else {
+      root.style.removeProperty(property);
+    }
+    root.removeAttribute(originalStyleAttribute(property, "value"));
+    root.removeAttribute(originalStyleAttribute(property, "priority"));
+  }
+  root.removeAttribute(OVERRIDE_MARKER);
+}
+
+/**
+ * Set the principal writing mode before epub.js measures a section. epub.js
+ * detects vertical pagination from the EPUB document's root element.
+ */
+export function applyEpubTextLayout(
+  document: Document,
+  textLayout: BooksTextLayout
+): void {
+  const root = document.documentElement;
+  if (!root) return;
+
+  if (textLayout === "book") {
+    restorePublisherStyles(root);
+    return;
+  }
+
+  rememberPublisherStyles(root);
+  root.style.setProperty("writing-mode", "vertical-rl", "important");
+  root.style.setProperty("-webkit-writing-mode", "vertical-rl", "important");
+  root.style.setProperty("text-orientation", "mixed", "important");
+  root.style.setProperty("direction", "ltr", "important");
+}
+
+export function resolveEpubPageDirection(
+  textLayout: BooksTextLayout,
+  publisherDirection: unknown
+): "ltr" | "rtl" {
+  if (textLayout === "vertical") return "rtl";
+  return publisherDirection === "rtl" ? "rtl" : "ltr";
+}

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -598,6 +598,10 @@
         "double": "Zweiseitig",
         "single": "Einseitig"
       },
+      "textLayout": {
+        "book": "Buchstandard",
+        "vertical": "Vertikal"
+      },
       "contextMenu": {
         "delete": "Löschen",
         "moveToBottom": "Nach ganz unten",
@@ -648,6 +652,7 @@
         "textSizeDecrease": "Kleiner",
         "textSizeIncrease": "Größer",
         "textSizeReset": "Standardgröße",
+        "textLayout": "Textrichtung",
         "theme": "Design"
       },
       "name": "Bücher",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -4532,6 +4532,7 @@
         "textSizeDecrease": "Smaller",
         "textSizeReset": "Default Size",
         "columns": "Columns",
+        "textLayout": "Text Direction",
         "chineseScript": "Chinese Script",
         "theme": "Theme",
         "booksHelp": "Books Help",
@@ -4541,6 +4542,10 @@
         "auto": "Auto",
         "single": "Single",
         "double": "Double"
+      },
+      "textLayout": {
+        "book": "Book Default",
+        "vertical": "Vertical"
       },
       "chineseScript": {
         "original": "Original",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -600,6 +600,10 @@
         "double": "Doble",
         "single": "Sencillo"
       },
+      "textLayout": {
+        "book": "Predeterminado del libro",
+        "vertical": "Vertical"
+      },
       "contextMenu": {
         "delete": "Eliminar",
         "moveToBottom": "Mover al final",
@@ -650,6 +654,7 @@
         "textSizeDecrease": "Más pequeño",
         "textSizeIncrease": "Más grande",
         "textSizeReset": "Tamaño predeterminado",
+        "textLayout": "Dirección del texto",
         "theme": "Tema"
       },
       "name": "Libros",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -600,6 +600,10 @@
         "double": "Double",
         "single": "Simple"
       },
+      "textLayout": {
+        "book": "Réglage du livre",
+        "vertical": "Vertical"
+      },
       "contextMenu": {
         "delete": "Supprimer",
         "moveToBottom": "Placer tout en bas",
@@ -650,6 +654,7 @@
         "textSizeDecrease": "Plus petite",
         "textSizeIncrease": "Plus grande",
         "textSizeReset": "Taille par défaut",
+        "textLayout": "Sens du texte",
         "theme": "Thème"
       },
       "name": "Livres",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -600,6 +600,10 @@
         "double": "Doppia",
         "single": "Singola"
       },
+      "textLayout": {
+        "book": "Predefinito del libro",
+        "vertical": "Verticale"
+      },
       "contextMenu": {
         "delete": "Elimina",
         "moveToBottom": "Sposta in fondo",
@@ -650,6 +654,7 @@
         "textSizeDecrease": "Più piccolo",
         "textSizeIncrease": "Più grande",
         "textSizeReset": "Dimensioni predefinite",
+        "textLayout": "Direzione del testo",
         "theme": "Tema"
       },
       "name": "Libri",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -598,6 +598,10 @@
         "double": "見開き",
         "single": "1ページ"
       },
+      "textLayout": {
+        "book": "本の設定",
+        "vertical": "縦書き"
+      },
       "contextMenu": {
         "delete": "削除",
         "moveToBottom": "最下部へ移動",
@@ -648,6 +652,7 @@
         "textSizeDecrease": "小さく",
         "textSizeIncrease": "大きく",
         "textSizeReset": "デフォルトサイズ",
+        "textLayout": "文字方向",
         "theme": "テーマ"
       },
       "name": "ブック",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -598,6 +598,10 @@
         "double": "두 페이지",
         "single": "한 페이지"
       },
+      "textLayout": {
+        "book": "책 기본값",
+        "vertical": "세로쓰기"
+      },
       "contextMenu": {
         "delete": "삭제",
         "moveToBottom": "맨 아래로 이동",
@@ -648,6 +652,7 @@
         "textSizeDecrease": "작게",
         "textSizeIncrease": "크게",
         "textSizeReset": "기본 크기",
+        "textLayout": "글자 방향",
         "theme": "테마"
       },
       "name": "도서",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -600,6 +600,10 @@
         "double": "Duplo",
         "single": "Simples"
       },
+      "textLayout": {
+        "book": "Padrão do livro",
+        "vertical": "Vertical"
+      },
       "contextMenu": {
         "delete": "Apagar",
         "moveToBottom": "Mover para o final",
@@ -650,6 +654,7 @@
         "textSizeDecrease": "Menor",
         "textSizeIncrease": "Maior",
         "textSizeReset": "Tamanho Padrão",
+        "textLayout": "Direção do texto",
         "theme": "Tema"
       },
       "name": "Livros",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -602,6 +602,10 @@
         "double": "Две страницы",
         "single": "Одна страница"
       },
+      "textLayout": {
+        "book": "Как в книге",
+        "vertical": "Вертикально"
+      },
       "contextMenu": {
         "delete": "Удалить",
         "moveToBottom": "Переместить в конец",
@@ -652,6 +656,7 @@
         "textSizeDecrease": "Меньше",
         "textSizeIncrease": "Больше",
         "textSizeReset": "Размер по умолчанию",
+        "textLayout": "Направление текста",
         "theme": "Тема"
       },
       "name": "Книги",

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -598,6 +598,10 @@
         "double": "双页",
         "single": "单页"
       },
+      "textLayout": {
+        "book": "书籍默认",
+        "vertical": "竖排"
+      },
       "contextMenu": {
         "delete": "删除",
         "moveToBottom": "移至底端",
@@ -648,6 +652,7 @@
         "textSizeDecrease": "缩小",
         "textSizeIncrease": "放大",
         "textSizeReset": "默认大小",
+        "textLayout": "文字方向",
         "theme": "主题"
       },
       "name": "书籍",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -598,6 +598,10 @@
         "double": "雙頁",
         "single": "單頁"
       },
+      "textLayout": {
+        "book": "書籍預設",
+        "vertical": "直排"
+      },
       "contextMenu": {
         "delete": "刪除",
         "moveToBottom": "移至底端",
@@ -648,6 +652,7 @@
         "textSizeDecrease": "縮小",
         "textSizeIncrease": "放大",
         "textSizeReset": "預設大小",
+        "textLayout": "文字方向",
         "theme": "主題"
       },
       "name": "書籍",

--- a/src/stores/useBooksStore.ts
+++ b/src/stores/useBooksStore.ts
@@ -4,6 +4,7 @@ import { persist, createJSONStorage } from "zustand/middleware";
 export type BooksColumnMode = "auto" | "single" | "double";
 export type BooksThemeOverride = "auto" | "light" | "sepia" | "dark";
 export type BooksChineseScript = "original" | "simplified" | "traditional";
+export type BooksTextLayout = "book" | "vertical";
 export type BooksShelfView = "grid" | "list";
 
 export interface BookProgress {
@@ -25,6 +26,8 @@ export interface BooksReaderSettings {
   themeOverride: BooksThemeOverride;
   /** Optional live conversion for Chinese text in the rendered EPUB. */
   chineseScript: BooksChineseScript;
+  /** Text flow override. "book" preserves the EPUB's own writing mode. */
+  textLayout: BooksTextLayout;
   /** Line height multiplier. */
   lineHeight: number;
 }
@@ -35,6 +38,7 @@ export const DEFAULT_BOOKS_SETTINGS: BooksReaderSettings = {
   columnMode: "auto",
   themeOverride: "auto",
   chineseScript: "original",
+  textLayout: "book",
   lineHeight: 1.5,
 };
 
@@ -158,7 +162,7 @@ export const useBooksStore = create<BooksStoreState>()(
     {
       name: "ryos:books",
       storage: createJSONStorage(() => localStorage),
-      version: 3,
+      version: 4,
       migrate: (persistedState) => {
         const state = (persistedState ?? {}) as Partial<BooksStoreState>;
         return {

--- a/src/sync/codecs.ts
+++ b/src/sync/codecs.ts
@@ -1548,6 +1548,7 @@ const BOOKS_SETTINGS_KEYS = {
   columnMode: "books-settings/columnMode",
   themeOverride: "books-settings/themeOverride",
   chineseScript: "books-settings/chineseScript",
+  textLayout: "books-settings/textLayout",
   lineHeight: "books-settings/lineHeight",
 } as const satisfies Record<keyof BooksReaderSettings, string>;
 
@@ -1565,6 +1566,7 @@ function collectBooksSettings(
   add(BOOKS_SETTINGS_KEYS.columnMode, settings.columnMode);
   add(BOOKS_SETTINGS_KEYS.themeOverride, settings.themeOverride);
   add(BOOKS_SETTINGS_KEYS.chineseScript, settings.chineseScript);
+  add(BOOKS_SETTINGS_KEYS.textLayout, settings.textLayout);
   add(BOOKS_SETTINGS_KEYS.lineHeight, settings.lineHeight);
   return docs;
 }
@@ -1615,6 +1617,11 @@ function applyBooksSettings(ops: AppliedSyncOp[]): void {
           updates = { ...updates, chineseScript: op.v };
         }
         break;
+      case BOOKS_SETTINGS_KEYS.textLayout:
+        if (op.v === "book" || op.v === "vertical") {
+          updates = { ...updates, textLayout: op.v };
+        }
+        break;
       case BOOKS_SETTINGS_KEYS.lineHeight:
         if (
           typeof op.v === "number" &&
@@ -1657,6 +1664,9 @@ const booksSettingsCodec: SyncCodec = {
       }
       if (state.settings.chineseScript !== prev.settings.chineseScript) {
         keys.push(BOOKS_SETTINGS_KEYS.chineseScript);
+      }
+      if (state.settings.textLayout !== prev.settings.textLayout) {
+        keys.push(BOOKS_SETTINGS_KEYS.textLayout);
       }
       if (state.settings.lineHeight !== prev.settings.lineHeight) {
         keys.push(BOOKS_SETTINGS_KEYS.lineHeight);

--- a/tests/test-books-reader-fonts.test.ts
+++ b/tests/test-books-reader-fonts.test.ts
@@ -39,6 +39,7 @@ const settings = {
   columnMode: "auto" as const,
   themeOverride: "light" as const,
   chineseScript: "original" as const,
+  textLayout: "book" as const,
   lineHeight: 1.5,
 };
 
@@ -367,6 +368,20 @@ describe("Books reader CJK serif fonts", () => {
       "zh-CN"
     );
     expect(originalTheme.body["font-family"]).toBeUndefined();
+  });
+
+  test("does not force horizontal alignment or hyphenation in vertical text", () => {
+    const verticalTheme = buildEpubTheme(
+      { ...settings, textLayout: "vertical" },
+      palette,
+      "ja"
+    );
+
+    expect(verticalTheme.body["text-align"]).toBeUndefined();
+    expect(verticalTheme.body.hyphens).toBeUndefined();
+    expect(verticalTheme.p["text-align"]).toBeUndefined();
+    expect(verticalTheme.p.hyphens).toBeUndefined();
+    expect(verticalTheme.body.orphans).toBe("2");
   });
 
   test("loads Noto CJK serif families inside isolated EPUB iframes", () => {

--- a/tests/test-books-vertical-text.test.ts
+++ b/tests/test-books-vertical-text.test.ts
@@ -1,0 +1,68 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import {
+  applyEpubTextLayout,
+  resolveEpubPageDirection,
+} from "../src/apps/books/utils/booksTextLayout";
+
+beforeAll(() => {
+  if (typeof document === "undefined") {
+    GlobalRegistrator.register();
+  }
+});
+
+afterAll(() => {
+  if (GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.unregister();
+  }
+});
+
+function createBookDocument(): Document {
+  return document.implementation.createHTMLDocument("Vertical book");
+}
+
+describe("Books vertical text layout", () => {
+  test("sets the principal writing mode for epub.js pagination", () => {
+    const bookDocument = createBookDocument();
+
+    applyEpubTextLayout(bookDocument, "vertical");
+
+    const rootStyle = bookDocument.documentElement.style;
+    expect(rootStyle.getPropertyValue("writing-mode")).toBe("vertical-rl");
+    expect(rootStyle.getPropertyPriority("writing-mode")).toBe("important");
+    expect(rootStyle.getPropertyValue("-webkit-writing-mode")).toBe(
+      "vertical-rl"
+    );
+    expect(rootStyle.getPropertyValue("text-orientation")).toBe("mixed");
+    expect(rootStyle.getPropertyValue("direction")).toBe("ltr");
+  });
+
+  test("restores the publisher's root styles when returning to book default", () => {
+    const bookDocument = createBookDocument();
+    const root = bookDocument.documentElement;
+    root.style.setProperty("writing-mode", "vertical-lr");
+    root.style.setProperty("text-orientation", "upright");
+    root.style.setProperty("direction", "rtl");
+
+    applyEpubTextLayout(bookDocument, "vertical");
+    applyEpubTextLayout(bookDocument, "book");
+
+    expect(root.style.getPropertyValue("writing-mode")).toBe("vertical-lr");
+    expect(root.style.getPropertyValue("text-orientation")).toBe("upright");
+    expect(root.style.getPropertyValue("direction")).toBe("rtl");
+    expect(root.hasAttribute("data-ryos-text-layout-override")).toBe(false);
+  });
+
+  test("uses RTL page progression only for the vertical override", () => {
+    expect(resolveEpubPageDirection("vertical", "ltr")).toBe("rtl");
+    expect(resolveEpubPageDirection("book", "rtl")).toBe("rtl");
+    expect(resolveEpubPageDirection("book", "ltr")).toBe("ltr");
+    expect(resolveEpubPageDirection("book", "unexpected")).toBe("ltr");
+  });
+});

--- a/tests/test-sync-v2-codecs.test.ts
+++ b/tests/test-sync-v2-codecs.test.ts
@@ -429,6 +429,7 @@ describe("books settings codec", () => {
       columnMode: "double",
       themeOverride: "sepia",
       chineseScript: "traditional",
+      textLayout: "vertical",
       lineHeight: 1.8,
     });
 
@@ -442,6 +443,7 @@ describe("books settings codec", () => {
       "books-settings/columnMode": "double",
       "books-settings/themeOverride": "sepia",
       "books-settings/chineseScript": "traditional",
+      "books-settings/textLayout": "vertical",
       "books-settings/lineHeight": 1.8,
     });
   });
@@ -454,6 +456,7 @@ describe("books settings codec", () => {
         { k: "books-settings/columnMode", v: "single", t },
         { k: "books-settings/themeOverride", v: "dark", t },
         { k: "books-settings/chineseScript", v: "simplified", t },
+        { k: "books-settings/textLayout", v: "vertical", t },
         { k: "books-settings/lineHeight", v: 1.7, t },
       ],
       ctx
@@ -465,6 +468,7 @@ describe("books settings codec", () => {
       columnMode: "single",
       themeOverride: "dark",
       chineseScript: "simplified",
+      textLayout: "vertical",
       lineHeight: 1.7,
     });
   });
@@ -477,6 +481,7 @@ describe("books settings codec", () => {
         { k: "books-settings/columnMode", v: "triple", t },
         { k: "books-settings/themeOverride", v: "blue", t },
         { k: "books-settings/chineseScript", v: "translated", t },
+        { k: "books-settings/textLayout", v: "diagonal", t },
         { k: "books-settings/lineHeight", v: -1, t },
         { k: "books-settings/fontId", del: true, t },
       ],
@@ -496,11 +501,13 @@ describe("books settings codec", () => {
       useBooksStore.getState().updateSettings({
         fontSizePct: 120,
         themeOverride: "sepia",
+        textLayout: "vertical",
       });
       expect(changes).toEqual([
         [
           "books-settings/fontSizePct",
           "books-settings/themeOverride",
+          "books-settings/textLayout",
         ],
       ]);
     } finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a localized Book Default / Vertical text direction setting to Books
- apply `vertical-rl` on each EPUB root before epub.js pagination, force RTL page progression, and reverse edge/arrow navigation in vertical mode
- restore publisher styles when disabled and persist/sync the preference

## Walkthrough
![Books vertical text setting and rendered vertical columns](https://cursor.com/artifacts/c/art-3c320511-3153-4822-bef7-eee1cb7777f4)

## Testing
- `bun test tests/test-books-vertical-text.test.ts tests/test-books-reader-fonts.test.ts` (21 passed)
- `bun test tests/test-sync-v2-codecs.test.ts` (38 passed)
- automated Chromium flow opened Meditations, toggled Vertical, verified `vertical-rl` + top-to-bottom inline direction + RTL page zones, then restored Book Default
- `bun run i18n:sync:dry-run && bun run i18n:audit`
- `bun run test:registration`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f206c-733a-71fd-9170-eb9eb75ce685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f206c-733a-71fd-9170-eb9eb75ce685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

