### PR TITLE
Fix vertical book line spacing

### DIFF
--- a/src/apps/books/utils/booksReader.ts
+++ b/src/apps/books/utils/booksReader.ts
@@ -13,6 +13,8 @@ const BOOK_GENEVA_STACK =
 const BOOK_ROUNDED_STACK =
   '"ryOS VAG Rounded", "Chiron GoRound TC WS", "Hiragino Maru Gothic ProN", "Nanum Gothic", "Yuanti SC", ui-rounded, sans-serif';
 
+const VERTICAL_BOOK_LINE_HEIGHT_MIN = 1.8;
+
 const BOOK_CJK_SERIF_STACKS = {
   "zh-CN":
     '"Noto Serif SC", "Source Han Serif SC", "Noto Serif CJK SC", "Songti SC", STSong, SimSun, "Noto Serif JP", "Source Han Serif JP", "Noto Serif KR", "Source Han Serif KR"',
@@ -376,13 +378,23 @@ export function buildEpubTheme(
 ): Record<string, Record<string, string>> {
   const fontStack = getBookFontCssStack(settings.fontId, language);
   const fontFamily = fontStack ? `${fontStack} !important` : null;
+  const isVerticalText = settings.textLayout === "vertical";
+  const lineHeight =
+    isVerticalText
+      ? Math.max(settings.lineHeight, VERTICAL_BOOK_LINE_HEIGHT_MIN)
+      : settings.lineHeight;
+  const lineHeightRule = {
+    "line-height": `${lineHeight} !important`,
+  };
 
   // Physical left alignment and hyphenation are horizontal-reading choices.
   // In vertical mode they fight the top-to-bottom inline flow and CJK line
-  // breaking, so preserve only the column-break controls.
+  // breaking, so preserve only the column-break controls. Vertical columns
+  // also need a wider line-height floor than horizontal prose.
   const readingFlow: Record<string, string> =
-    settings.textLayout === "vertical"
+    isVerticalText
       ? {
+          ...lineHeightRule,
           orphans: "2",
           widows: "2",
         }
@@ -400,7 +412,7 @@ export function buildEpubTheme(
   const bodyRules: Record<string, string> = {
     background: `${palette.background} !important`,
     color: `${palette.text} !important`,
-    "line-height": `${settings.lineHeight} !important`,
+    ...lineHeightRule,
     "padding-top": "0 !important",
     "padding-bottom": "0 !important",
     ...readingFlow,
@@ -433,7 +445,7 @@ export function buildEpubTheme(
     "*:not(a)": { color: `${palette.text} !important` },
     // Force colors so dark/sepia modes are legible regardless of publisher CSS.
     p: withFont(flowText),
-    div: withFont({}),
+    div: withFont(isVerticalText ? lineHeightRule : {}),
     span: withFont({}),
     li: withFont(flowText),
     // Headings keep their original alignment (often intentionally centered) but

--- a/tests/test-books-reader-fonts.test.ts
+++ b/tests/test-books-reader-fonts.test.ts
@@ -384,6 +384,25 @@ describe("Books reader CJK serif fonts", () => {
     expect(verticalTheme.body.orphans).toBe("2");
   });
 
+  test("gives vertical columns a readable minimum line height", () => {
+    const verticalTheme = buildEpubTheme(
+      { ...settings, textLayout: "vertical" },
+      palette,
+      "zh-TW"
+    );
+    const spaciousVerticalTheme = buildEpubTheme(
+      { ...settings, textLayout: "vertical", lineHeight: 2 },
+      palette,
+      "zh-TW"
+    );
+
+    expect(verticalTheme.body["line-height"]).toBe("1.8 !important");
+    expect(verticalTheme.p["line-height"]).toBe("1.8 !important");
+    expect(verticalTheme.div["line-height"]).toBe("1.8 !important");
+    expect(verticalTheme.li["line-height"]).toBe("1.8 !important");
+    expect(spaciousVerticalTheme.body["line-height"]).toBe("2 !important");
+  });
+
   test("loads Noto CJK serif families inside isolated EPUB iframes", () => {
     const css = buildFontFaceCss("https://os.example");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- increase vertical book text to a 1.8 minimum line height
- override publisher paragraph, list, and container spacing in vertical mode
- preserve larger configured line heights and horizontal book styling

## Walkthrough
![Chinese vertical text in Serif at 1.8 line height](https://cursor.com/artifacts/c/art-febd44bf-4a97-4025-8a8c-63c7bc40b72a)

![Serif font selection in the Books reader](https://cursor.com/artifacts/c/art-e25ec7da-f84d-47ae-a8ec-deb6bf133928)

## Testing
- `bun test tests/test-books-reader-fonts.test.ts tests/test-books-vertical-text.test.ts` (22 passed)
- `bunx eslint src/apps/books/utils/booksReader.ts tests/test-books-reader-fonts.test.ts`
- `bun run build`
- imported the public-domain Chinese 《孙子兵法》 EPUB, selected Serif + Vertical, and verified readable spacing in a narrow reader window
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2086-420f-7824-9b07-be95da452f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2086-420f-7824-9b07-be95da452f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

