### PR TITLE
Add Books Customize panel for reading appearance

### DIFF
--- a/src/apps/books/components/BooksCustomizePanel.tsx
+++ b/src/apps/books/components/BooksCustomizePanel.tsx
@@ -46,7 +46,7 @@ function Row({
     <div className="flex min-h-7 items-center gap-2">
       <span
         title={label}
-        className="w-20 shrink-0 truncate text-[11px] text-os-text-secondary"
+        className="w-[72px] shrink-0 truncate text-[11px] text-os-text-secondary"
       >
         {label}
       </span>
@@ -156,7 +156,7 @@ export function BooksCustomizePanel({
         compact
           ? "inset-x-0 bottom-0 max-h-[75%] rounded-t-[10px] border-t border-os-window pb-4 shadow-[0_-6px_24px_rgba(0,0,0,0.25)]"
           : cn(
-              "right-3 top-10 w-[300px] max-w-[calc(100%-1.5rem)]",
+              "right-3 top-10 w-[320px] max-w-[calc(100%-1.5rem)]",
               "max-h-[calc(100%-3.5rem)] rounded-os shadow-os-window",
               "border-[length:var(--os-metrics-border-width)] border-os-window",
               "os-theme-win98:shadow-none"

--- a/src/apps/books/components/BooksCustomizePanel.tsx
+++ b/src/apps/books/components/BooksCustomizePanel.tsx
@@ -1,0 +1,315 @@
+import type { ReactNode } from "react";
+import { motion } from "motion/react";
+import { useTranslation } from "react-i18next";
+import { X } from "@phosphor-icons/react";
+import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
+import {
+  BOOKS_FONT_SIZE_MAX,
+  BOOKS_FONT_SIZE_MIN,
+  BOOKS_GUTTER_MAX,
+  BOOKS_GUTTER_MIN,
+  BOOKS_GUTTER_STEP,
+  BOOKS_LINE_HEIGHT_MAX,
+  BOOKS_LINE_HEIGHT_MIN,
+  BOOKS_LINE_HEIGHT_STEP,
+  type BooksReaderSettings,
+  type BooksThemeOverride,
+} from "@/stores/useBooksStore";
+import {
+  BOOK_FONTS,
+  BOOK_THEME_PRESET_IDS,
+  getBookFontCssStack,
+  getReadingPalette,
+} from "../utils/booksReader";
+
+interface BooksCustomizePanelProps {
+  settings: BooksReaderSettings;
+  updateSettings: (partial: Partial<BooksReaderSettings>) => void;
+  osIsDark: boolean;
+  onClose: () => void;
+}
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <span className="text-[11px] font-medium text-os-text-secondary">
+      {children}
+    </span>
+  );
+}
+
+function SegmentedControl<T extends string>({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+}: {
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (value: T) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className="flex w-full overflow-hidden rounded-[6px] border border-os-input-border"
+    >
+      {options.map((option, index) => (
+        <button
+          key={option.value}
+          type="button"
+          role="radio"
+          aria-checked={value === option.value}
+          onClick={() => onChange(option.value)}
+          className={cn(
+            "min-w-0 flex-1 truncate px-2 py-1 text-[11px] transition-colors",
+            index > 0 && "border-l border-os-input-border",
+            value === option.value
+              ? "bg-os-selection-bg text-os-selection-text"
+              : "hover:bg-black/5 os-dark:hover:bg-white/10"
+          )}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function SliderRow({
+  label,
+  valueText,
+  min,
+  max,
+  step,
+  value,
+  onChange,
+}: {
+  label: string;
+  valueText: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <section className="flex flex-col gap-1.5">
+      <div className="flex items-baseline justify-between">
+        <SectionLabel>{label}</SectionLabel>
+        <span className="text-[11px] tabular-nums text-os-text-secondary">
+          {valueText}
+        </span>
+      </div>
+      <Slider
+        aria-label={label}
+        min={min}
+        max={max}
+        step={step}
+        value={[value]}
+        onValueChange={([next]) => onChange(next)}
+      />
+    </section>
+  );
+}
+
+/**
+ * Floating reading-appearance panel (View ▸ Theme ▸ Customize…): sliders for
+ * text size / line spacing / margins, quick toggles for text direction and
+ * columns, font chips, and the full set of reading color presets.
+ */
+export function BooksCustomizePanel({
+  settings,
+  updateSettings,
+  osIsDark,
+  onClose,
+}: BooksCustomizePanelProps) {
+  const { t, i18n } = useTranslation();
+  const uiLanguage = i18n.resolvedLanguage ?? i18n.language ?? "en";
+
+  const themeSwatches: {
+    id: BooksThemeOverride;
+    label: string;
+    background: string;
+    text: string;
+  }[] = [
+    {
+      id: "auto" as const,
+      label: t("apps.books.theme.auto"),
+      // Split swatch: follows the OS light/dark setting.
+      background: `linear-gradient(135deg, ${
+        getReadingPalette("light").background
+      } 50%, ${getReadingPalette("dark").background} 50%)`,
+      text: osIsDark
+        ? getReadingPalette("dark").text
+        : getReadingPalette("light").text,
+    },
+    ...BOOK_THEME_PRESET_IDS.map((id) => {
+      const palette = getReadingPalette(id);
+      return {
+        id: id as BooksThemeOverride,
+        label: t(`apps.books.theme.${id}`),
+        background: palette.background,
+        text: palette.text,
+      };
+    }),
+  ];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -6, scale: 0.98 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: -6, scale: 0.98 }}
+      transition={{ duration: 0.18, ease: "easeOut" }}
+      role="dialog"
+      aria-label={t("apps.books.customize.title")}
+      className={cn(
+        "absolute right-3 top-10 z-[60] flex w-[276px] max-w-[calc(100%-1.5rem)] flex-col gap-3",
+        "max-h-[calc(100%-3.5rem)] overflow-y-auto overscroll-contain p-3",
+        "rounded-os bg-os-window-bg font-os-ui text-os-text-primary shadow-os-window",
+        "border-[length:var(--os-metrics-border-width)] border-os-window",
+        "os-theme-win98:shadow-none"
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-[12px] font-semibold">
+          {t("apps.books.customize.title")}
+        </span>
+        <button
+          type="button"
+          aria-label={t("common.menu.close")}
+          onClick={onClose}
+          className="flex h-5 w-5 items-center justify-center rounded text-os-text-secondary transition-colors hover:bg-black/10 hover:text-os-text-primary os-dark:hover:bg-white/15"
+        >
+          <X size={12} weight="bold" />
+        </button>
+      </div>
+
+      <SliderRow
+        label={t("apps.books.menu.textSize")}
+        valueText={`${settings.fontSizePct}%`}
+        min={BOOKS_FONT_SIZE_MIN}
+        max={BOOKS_FONT_SIZE_MAX}
+        step={5}
+        value={settings.fontSizePct}
+        onChange={(value) => updateSettings({ fontSizePct: value })}
+      />
+
+      <SliderRow
+        label={t("apps.books.customize.lineSpacing")}
+        valueText={`${settings.lineHeight.toFixed(2)}×`}
+        min={BOOKS_LINE_HEIGHT_MIN}
+        max={BOOKS_LINE_HEIGHT_MAX}
+        step={BOOKS_LINE_HEIGHT_STEP}
+        value={settings.lineHeight}
+        onChange={(value) =>
+          updateSettings({ lineHeight: Math.round(value * 100) / 100 })
+        }
+      />
+
+      <SliderRow
+        label={t("apps.books.customize.margins")}
+        valueText={`${settings.gutterPx}px`}
+        min={BOOKS_GUTTER_MIN}
+        max={BOOKS_GUTTER_MAX}
+        step={BOOKS_GUTTER_STEP}
+        value={settings.gutterPx}
+        onChange={(value) => updateSettings({ gutterPx: value })}
+      />
+
+      <section className="flex flex-col gap-1.5">
+        <SectionLabel>{t("apps.books.menu.textLayout")}</SectionLabel>
+        <SegmentedControl
+          ariaLabel={t("apps.books.menu.textLayout")}
+          value={settings.textLayout}
+          options={[
+            {
+              value: "book" as const,
+              label: t("apps.books.textLayout.horizontal"),
+            },
+            {
+              value: "vertical" as const,
+              label: t("apps.books.textLayout.vertical"),
+            },
+          ]}
+          onChange={(value) => updateSettings({ textLayout: value })}
+        />
+      </section>
+
+      <section className="flex flex-col gap-1.5">
+        <SectionLabel>{t("apps.books.menu.columns")}</SectionLabel>
+        <SegmentedControl
+          ariaLabel={t("apps.books.menu.columns")}
+          value={settings.columnMode}
+          options={[
+            { value: "auto" as const, label: t("apps.books.columns.auto") },
+            {
+              value: "single" as const,
+              label: t("apps.books.columns.single"),
+            },
+            {
+              value: "double" as const,
+              label: t("apps.books.columns.double"),
+            },
+          ]}
+          onChange={(value) => updateSettings({ columnMode: value })}
+        />
+      </section>
+
+      <section className="flex flex-col gap-1.5">
+        <SectionLabel>{t("apps.books.menu.font")}</SectionLabel>
+        <div className="grid grid-cols-2 gap-1.5">
+          {BOOK_FONTS.map((font) => {
+            const stack = getBookFontCssStack(font.id, uiLanguage);
+            const selected = settings.fontId === font.id;
+            return (
+              <button
+                key={font.id}
+                type="button"
+                aria-pressed={selected}
+                onClick={() => updateSettings({ fontId: font.id })}
+                className={cn(
+                  "truncate rounded-[6px] border px-2 py-1.5 text-[12px] transition-colors",
+                  selected
+                    ? "border-transparent bg-os-selection-bg text-os-selection-text"
+                    : "border-os-input-border hover:bg-black/5 os-dark:hover:bg-white/10"
+                )}
+                style={{ fontFamily: stack ?? undefined }}
+              >
+                {font.label}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-1.5">
+        <SectionLabel>{t("apps.books.customize.colors")}</SectionLabel>
+        <div className="grid grid-cols-5 gap-1.5">
+          {themeSwatches.map((swatch) => {
+            const selected = settings.themeOverride === swatch.id;
+            return (
+              <button
+                key={swatch.id}
+                type="button"
+                title={swatch.label}
+                aria-label={swatch.label}
+                aria-pressed={selected}
+                onClick={() => updateSettings({ themeOverride: swatch.id })}
+                className={cn(
+                  "flex aspect-square w-full items-center justify-center rounded-full border border-black/20 text-[13px] font-medium transition-shadow os-dark:border-white/25",
+                  selected &&
+                    "ring-2 ring-[color:var(--os-color-selection-bg)] ring-offset-1 ring-offset-[color:var(--os-color-window-bg)]"
+                )}
+                style={{ background: swatch.background, color: swatch.text }}
+              >
+                A
+              </button>
+            );
+          })}
+        </div>
+      </section>
+    </motion.div>
+  );
+}

--- a/src/apps/books/components/BooksCustomizePanel.tsx
+++ b/src/apps/books/components/BooksCustomizePanel.tsx
@@ -27,18 +27,40 @@ interface BooksCustomizePanelProps {
   settings: BooksReaderSettings;
   updateSettings: (partial: Partial<BooksReaderSettings>) => void;
   osIsDark: boolean;
+  /** Bottom-sheet layout for narrow windows / mobile. */
+  compact: boolean;
   onClose: () => void;
 }
 
-function SectionLabel({ children }: { children: ReactNode }) {
+/** Uniform "label — control — value" row so every setting reads the same. */
+function Row({
+  label,
+  value,
+  children,
+}: {
+  label: string;
+  value?: string;
+  children: ReactNode;
+}) {
   return (
-    <span className="text-[11px] font-medium text-os-text-secondary">
-      {children}
-    </span>
+    <div className="flex min-h-7 items-center gap-2">
+      <span
+        title={label}
+        className="w-20 shrink-0 truncate text-[11px] text-os-text-secondary"
+      >
+        {label}
+      </span>
+      <div className="flex min-w-0 flex-1 items-center">{children}</div>
+      {value !== undefined && (
+        <span className="w-11 shrink-0 text-right text-[11px] tabular-nums text-os-text-secondary">
+          {value}
+        </span>
+      )}
+    </div>
   );
 }
 
-function SegmentedControl<T extends string>({
+function Segmented<T extends string>({
   value,
   options,
   onChange,
@@ -53,9 +75,9 @@ function SegmentedControl<T extends string>({
     <div
       role="radiogroup"
       aria-label={ariaLabel}
-      className="flex w-full overflow-hidden rounded-[6px] border border-os-input-border"
+      className="flex w-full rounded-[6px] bg-black/[0.07] p-0.5 os-dark:bg-white/10"
     >
-      {options.map((option, index) => (
+      {options.map((option) => (
         <button
           key={option.value}
           type="button"
@@ -63,8 +85,7 @@ function SegmentedControl<T extends string>({
           aria-checked={value === option.value}
           onClick={() => onChange(option.value)}
           className={cn(
-            "min-w-0 flex-1 truncate px-2 py-1 text-[11px] transition-colors",
-            index > 0 && "border-l border-os-input-border",
+            "min-w-0 flex-1 truncate rounded-[5px] px-2 py-1 text-[11px] transition-colors",
             value === option.value
               ? "bg-os-selection-bg text-os-selection-text"
               : "hover:bg-black/5 os-dark:hover:bg-white/10"
@@ -77,52 +98,17 @@ function SegmentedControl<T extends string>({
   );
 }
 
-function SliderRow({
-  label,
-  valueText,
-  min,
-  max,
-  step,
-  value,
-  onChange,
-}: {
-  label: string;
-  valueText: string;
-  min: number;
-  max: number;
-  step: number;
-  value: number;
-  onChange: (value: number) => void;
-}) {
-  return (
-    <section className="flex flex-col gap-1.5">
-      <div className="flex items-baseline justify-between">
-        <SectionLabel>{label}</SectionLabel>
-        <span className="text-[11px] tabular-nums text-os-text-secondary">
-          {valueText}
-        </span>
-      </div>
-      <Slider
-        aria-label={label}
-        min={min}
-        max={max}
-        step={step}
-        value={[value]}
-        onValueChange={([next]) => onChange(next)}
-      />
-    </section>
-  );
-}
-
 /**
  * Floating reading-appearance panel (View ▸ Theme ▸ Customize…): sliders for
  * text size / line spacing / margins, quick toggles for text direction and
- * columns, font chips, and the full set of reading color presets.
+ * columns, font chips, and the full set of reading color presets. Renders as
+ * a top-right card on wide windows and a bottom sheet on narrow ones.
  */
 export function BooksCustomizePanel({
   settings,
   updateSettings,
   osIsDark,
+  compact,
   onClose,
 }: BooksCustomizePanelProps) {
   const { t, i18n } = useTranslation();
@@ -158,21 +144,26 @@ export function BooksCustomizePanel({
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: -6, scale: 0.98 }}
-      animate={{ opacity: 1, y: 0, scale: 1 }}
-      exit={{ opacity: 0, y: -6, scale: 0.98 }}
-      transition={{ duration: 0.18, ease: "easeOut" }}
+      initial={compact ? { y: "100%" } : { opacity: 0, y: -6, scale: 0.98 }}
+      animate={compact ? { y: 0 } : { opacity: 1, y: 0, scale: 1 }}
+      exit={compact ? { y: "100%" } : { opacity: 0, y: -6, scale: 0.98 }}
+      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
       role="dialog"
       aria-label={t("apps.books.customize.title")}
       className={cn(
-        "absolute right-3 top-10 z-[60] flex w-[276px] max-w-[calc(100%-1.5rem)] flex-col gap-3",
-        "max-h-[calc(100%-3.5rem)] overflow-y-auto overscroll-contain p-3",
-        "rounded-os bg-os-window-bg font-os-ui text-os-text-primary shadow-os-window",
-        "border-[length:var(--os-metrics-border-width)] border-os-window",
-        "os-theme-win98:shadow-none"
+        "absolute z-[60] flex flex-col gap-2 overflow-y-auto overscroll-contain p-3",
+        "bg-os-window-bg font-os-ui text-os-text-primary",
+        compact
+          ? "inset-x-0 bottom-0 max-h-[75%] rounded-t-[10px] border-t border-os-window pb-4 shadow-[0_-6px_24px_rgba(0,0,0,0.25)]"
+          : cn(
+              "right-3 top-10 w-[300px] max-w-[calc(100%-1.5rem)]",
+              "max-h-[calc(100%-3.5rem)] rounded-os shadow-os-window",
+              "border-[length:var(--os-metrics-border-width)] border-os-window",
+              "os-theme-win98:shadow-none"
+            )
       )}
     >
-      <div className="flex items-center justify-between">
+      <div className="mb-0.5 flex items-center justify-between">
         <span className="text-[12px] font-semibold">
           {t("apps.books.customize.title")}
         </span>
@@ -186,41 +177,52 @@ export function BooksCustomizePanel({
         </button>
       </div>
 
-      <SliderRow
+      <Row
         label={t("apps.books.menu.textSize")}
-        valueText={`${settings.fontSizePct}%`}
-        min={BOOKS_FONT_SIZE_MIN}
-        max={BOOKS_FONT_SIZE_MAX}
-        step={5}
-        value={settings.fontSizePct}
-        onChange={(value) => updateSettings({ fontSizePct: value })}
-      />
+        value={`${settings.fontSizePct}%`}
+      >
+        <Slider
+          aria-label={t("apps.books.menu.textSize")}
+          min={BOOKS_FONT_SIZE_MIN}
+          max={BOOKS_FONT_SIZE_MAX}
+          step={5}
+          value={[settings.fontSizePct]}
+          onValueChange={([next]) => updateSettings({ fontSizePct: next })}
+        />
+      </Row>
 
-      <SliderRow
+      <Row
         label={t("apps.books.customize.lineSpacing")}
-        valueText={`${settings.lineHeight.toFixed(2)}×`}
-        min={BOOKS_LINE_HEIGHT_MIN}
-        max={BOOKS_LINE_HEIGHT_MAX}
-        step={BOOKS_LINE_HEIGHT_STEP}
-        value={settings.lineHeight}
-        onChange={(value) =>
-          updateSettings({ lineHeight: Math.round(value * 100) / 100 })
-        }
-      />
+        value={settings.lineHeight.toFixed(2)}
+      >
+        <Slider
+          aria-label={t("apps.books.customize.lineSpacing")}
+          min={BOOKS_LINE_HEIGHT_MIN}
+          max={BOOKS_LINE_HEIGHT_MAX}
+          step={BOOKS_LINE_HEIGHT_STEP}
+          value={[settings.lineHeight]}
+          onValueChange={([next]) =>
+            updateSettings({ lineHeight: Math.round(next * 100) / 100 })
+          }
+        />
+      </Row>
 
-      <SliderRow
+      <Row
         label={t("apps.books.customize.margins")}
-        valueText={`${settings.gutterPx}px`}
-        min={BOOKS_GUTTER_MIN}
-        max={BOOKS_GUTTER_MAX}
-        step={BOOKS_GUTTER_STEP}
-        value={settings.gutterPx}
-        onChange={(value) => updateSettings({ gutterPx: value })}
-      />
+        value={`${settings.gutterPx}px`}
+      >
+        <Slider
+          aria-label={t("apps.books.customize.margins")}
+          min={BOOKS_GUTTER_MIN}
+          max={BOOKS_GUTTER_MAX}
+          step={BOOKS_GUTTER_STEP}
+          value={[settings.gutterPx]}
+          onValueChange={([next]) => updateSettings({ gutterPx: next })}
+        />
+      </Row>
 
-      <section className="flex flex-col gap-1.5">
-        <SectionLabel>{t("apps.books.menu.textLayout")}</SectionLabel>
-        <SegmentedControl
+      <Row label={t("apps.books.menu.textLayout")}>
+        <Segmented
           ariaLabel={t("apps.books.menu.textLayout")}
           value={settings.textLayout}
           options={[
@@ -235,11 +237,10 @@ export function BooksCustomizePanel({
           ]}
           onChange={(value) => updateSettings({ textLayout: value })}
         />
-      </section>
+      </Row>
 
-      <section className="flex flex-col gap-1.5">
-        <SectionLabel>{t("apps.books.menu.columns")}</SectionLabel>
-        <SegmentedControl
+      <Row label={t("apps.books.menu.columns")}>
+        <Segmented
           ariaLabel={t("apps.books.menu.columns")}
           value={settings.columnMode}
           options={[
@@ -255,11 +256,10 @@ export function BooksCustomizePanel({
           ]}
           onChange={(value) => updateSettings({ columnMode: value })}
         />
-      </section>
+      </Row>
 
-      <section className="flex flex-col gap-1.5">
-        <SectionLabel>{t("apps.books.menu.font")}</SectionLabel>
-        <div className="grid grid-cols-2 gap-1.5">
+      <Row label={t("apps.books.menu.font")}>
+        <div className="flex w-full gap-1 overflow-x-auto pb-0.5 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {BOOK_FONTS.map((font) => {
             const stack = getBookFontCssStack(font.id, uiLanguage);
             const selected = settings.fontId === font.id;
@@ -270,10 +270,10 @@ export function BooksCustomizePanel({
                 aria-pressed={selected}
                 onClick={() => updateSettings({ fontId: font.id })}
                 className={cn(
-                  "truncate rounded-[6px] border px-2 py-1.5 text-[12px] transition-colors",
+                  "shrink-0 whitespace-nowrap rounded-full px-2.5 py-1 text-[11px] transition-colors",
                   selected
-                    ? "border-transparent bg-os-selection-bg text-os-selection-text"
-                    : "border-os-input-border hover:bg-black/5 os-dark:hover:bg-white/10"
+                    ? "bg-os-selection-bg text-os-selection-text"
+                    : "bg-black/[0.07] hover:bg-black/15 os-dark:bg-white/10 os-dark:hover:bg-white/20"
                 )}
                 style={{ fontFamily: stack ?? undefined }}
               >
@@ -282,11 +282,10 @@ export function BooksCustomizePanel({
             );
           })}
         </div>
-      </section>
+      </Row>
 
-      <section className="flex flex-col gap-1.5">
-        <SectionLabel>{t("apps.books.customize.colors")}</SectionLabel>
-        <div className="grid grid-cols-5 gap-1.5">
+      <Row label={t("apps.books.customize.colors")}>
+        <div className="flex w-full flex-wrap gap-1.5">
           {themeSwatches.map((swatch) => {
             const selected = settings.themeOverride === swatch.id;
             return (
@@ -298,7 +297,7 @@ export function BooksCustomizePanel({
                 aria-pressed={selected}
                 onClick={() => updateSettings({ themeOverride: swatch.id })}
                 className={cn(
-                  "flex aspect-square w-full items-center justify-center rounded-full border border-black/20 text-[13px] font-medium transition-shadow os-dark:border-white/25",
+                  "flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-black/20 text-[12px] font-medium transition-shadow os-dark:border-white/25",
                   selected &&
                     "ring-2 ring-[color:var(--os-color-selection-bg)] ring-offset-1 ring-offset-[color:var(--os-color-window-bg)]"
                 )}
@@ -309,7 +308,7 @@ export function BooksCustomizePanel({
             );
           })}
         </div>
-      </section>
+      </Row>
     </motion.div>
   );
 }

--- a/src/apps/books/components/BooksMenuBar.tsx
+++ b/src/apps/books/components/BooksMenuBar.tsx
@@ -25,6 +25,7 @@ interface BooksMenuBarProps {
   onShowAbout: () => void;
   onImport: () => void;
   onBackToShelf: () => void;
+  onShowCustomize: () => void;
   isReading: boolean;
   settings: BooksReaderSettings;
   updateSettings: (partial: Partial<BooksReaderSettings>) => void;
@@ -40,6 +41,7 @@ export function BooksMenuBar({
   onShowAbout,
   onImport,
   onBackToShelf,
+  onShowCustomize,
   isReading,
   settings,
   updateSettings,
@@ -223,6 +225,12 @@ export function BooksMenuBar({
                 { label: t("apps.books.theme.sepia"), value: "sepia" },
                 { label: t("apps.books.theme.dark"), value: "dark" },
               ],
+            },
+            { type: "separator" },
+            {
+              type: "action",
+              label: t("apps.books.menu.customizeTheme"),
+              onClick: onShowCustomize,
             },
           ],
         },

--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -13,7 +13,10 @@ import ePub, { type Book, type NavItem, type Rendition } from "epubjs";
 import { cn } from "@/lib/utils";
 import { useResizeObserverWithRef } from "@/hooks/useResizeObserver";
 import { readBookBlobContent } from "@/services/vfs/FileContentRepository";
-import type { BooksReaderSettings } from "@/stores/useBooksStore";
+import {
+  clampBooksGutter,
+  type BooksReaderSettings,
+} from "@/stores/useBooksStore";
 import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import {
   buildEpubTheme,
@@ -101,10 +104,11 @@ type BooksDebugSnapshot = Record<string, unknown>;
 const TOP_CLEARANCE = 36;
 // Footer that holds the reading-progress bar.
 const FOOTER_HEIGHT = 30;
-// Horizontal gutter around the text column. Applied as a left/right inset on the
-// epub.js render host (rather than body padding) so epub.js's paginated column
-// math stays correct — it computes columns from the host width.
-const SIDE_CLEARANCE = 24;
+// The horizontal gutter around the text column comes from
+// `settings.gutterPx` (user-adjustable in the Customize panel). It is applied
+// as a left/right inset on the epub.js render host (rather than body padding)
+// so epub.js's paginated column math stays correct — it computes columns from
+// the host width.
 // Width at which auto column mode switches to a two-page spread. epub.js
 // defaults to 800; a lower value shows two columns on narrower windows.
 const SPREAD_MIN_WIDTH = 560;
@@ -409,6 +413,7 @@ export const BooksReaderPane = forwardRef<
 
   const palette = resolveReadingPalette(settings.themeOverride, osIsDark);
   const isVerticalText = settings.textLayout === "vertical";
+  const sideClearance = clampBooksGutter(settings.gutterPx);
 
   // Measure the zoom-in geometry before first paint so the cover overlay starts
   // exactly on top of the clicked shelf book and grows to full-bleed. Runs once
@@ -1310,8 +1315,8 @@ export const BooksReaderPane = forwardRef<
         style={{
           top: TOP_CLEARANCE,
           bottom: FOOTER_HEIGHT,
-          left: SIDE_CLEARANCE,
-          right: SIDE_CLEARANCE,
+          left: sideClearance,
+          right: sideClearance,
         }}
       />
 

--- a/src/apps/books/components/books-app/BooksAppComponent.tsx
+++ b/src/apps/books/components/books-app/BooksAppComponent.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from "react";
+import { AnimatePresence } from "motion/react";
 import { SquaresFour } from "@phosphor-icons/react";
 import type { AppProps, BooksInitialData } from "@/apps/base/types";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
@@ -14,6 +15,7 @@ import {
   type BooksReaderPaneHandle,
 } from "../BooksReaderPane";
 import { BookCloseZoom } from "../BookCloseZoom";
+import { BooksCustomizePanel } from "../BooksCustomizePanel";
 
 export function BooksAppComponent({
   isWindowOpen,
@@ -61,6 +63,7 @@ export function BooksAppComponent({
   // Positioning box for the transient closing-zoom overlay.
   const contentRef = useRef<HTMLDivElement>(null);
   const readerRef = useRef<BooksReaderPaneHandle>(null);
+  const [isCustomizeOpen, setIsCustomizeOpen] = useState(false);
   const [readerNavigationState, setReaderNavigationState] =
     useState<BooksNavigationState>(createInitialBooksNavigationState);
   const handleReaderNavigationStateChange = useCallback(
@@ -75,6 +78,7 @@ export function BooksAppComponent({
       onShowAbout={() => setIsAboutDialogOpen(true)}
       onImport={handleImport}
       onBackToShelf={closeBook}
+      onShowCustomize={() => setIsCustomizeOpen(true)}
       isReading={viewMode === "reader"}
       settings={settings}
       updateSettings={updateSettings}
@@ -197,6 +201,17 @@ export function BooksAppComponent({
             onMoveToBottom={moveBookToBottom}
           />
         )}
+        {/* Floating reading-appearance customization panel (View ▸ Theme ▸ Customize…). */}
+        <AnimatePresence>
+          {isCustomizeOpen && (
+            <BooksCustomizePanel
+              settings={settings}
+              updateSettings={updateSettings}
+              osIsDark={isDarkMode}
+              onClose={() => setIsCustomizeOpen(false)}
+            />
+          )}
+        </AnimatePresence>
         {/* Reverse zoom: full-bleed cover shrinks back onto the shelf book. */}
         {viewMode === "shelf" && closingBook && (
           <BookCloseZoom

--- a/src/apps/books/components/books-app/BooksAppComponent.tsx
+++ b/src/apps/books/components/books-app/BooksAppComponent.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from "react";
 import { AnimatePresence } from "motion/react";
 import { SquaresFour } from "@phosphor-icons/react";
 import type { AppProps, BooksInitialData } from "@/apps/base/types";
+import { useResizeObserverWithRef } from "@/hooks/useResizeObserver";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { appMetadata } from "../../metadata";
@@ -64,6 +65,12 @@ export function BooksAppComponent({
   const contentRef = useRef<HTMLDivElement>(null);
   const readerRef = useRef<BooksReaderPaneHandle>(null);
   const [isCustomizeOpen, setIsCustomizeOpen] = useState(false);
+  // Narrow windows (mobile / small desktop windows) get a bottom-sheet
+  // Customize panel instead of the floating top-right card.
+  const [isCompactPanel, setIsCompactPanel] = useState(false);
+  useResizeObserverWithRef(contentRef, (entry) => {
+    setIsCompactPanel(entry.contentRect.width < 500);
+  });
   const [readerNavigationState, setReaderNavigationState] =
     useState<BooksNavigationState>(createInitialBooksNavigationState);
   const handleReaderNavigationStateChange = useCallback(
@@ -208,6 +215,7 @@ export function BooksAppComponent({
               settings={settings}
               updateSettings={updateSettings}
               osIsDark={isDarkMode}
+              compact={isCompactPanel}
               onClose={() => setIsCustomizeOpen(false)}
             />
           )}

--- a/src/apps/books/utils/booksReader.ts
+++ b/src/apps/books/utils/booksReader.ts
@@ -133,11 +133,19 @@ export interface ReadingPalette {
   isDark: boolean;
 }
 
-const PALETTES: Record<Exclude<BooksThemeOverride, "auto">, ReadingPalette> = {
+export type BooksThemePresetId = Exclude<BooksThemeOverride, "auto">;
+
+const PALETTES: Record<BooksThemePresetId, ReadingPalette> = {
   light: {
     background: "#fdfdfb",
     text: "#1c1c1c",
     link: "#1d4ed8",
+    isDark: false,
+  },
+  paper: {
+    background: "#f9f4e9",
+    text: "#33302a",
+    link: "#2456c4",
     isDark: false,
   },
   sepia: {
@@ -146,13 +154,57 @@ const PALETTES: Record<Exclude<BooksThemeOverride, "auto">, ReadingPalette> = {
     link: "#8a5a2b",
     isDark: false,
   },
+  gray: {
+    background: "#e4e4e4",
+    text: "#262626",
+    link: "#1d4ed8",
+    isDark: false,
+  },
+  green: {
+    background: "#dcead9",
+    text: "#243428",
+    link: "#1e6b46",
+    isDark: false,
+  },
   dark: {
     background: "#1b1b1d",
     text: "#d6d6d6",
     link: "#7fabff",
     isDark: true,
   },
+  night: {
+    background: "#141e2e",
+    text: "#c2cbdb",
+    link: "#8ab4ff",
+    isDark: true,
+  },
+  black: {
+    background: "#000000",
+    text: "#b3b3b3",
+    link: "#7fabff",
+    isDark: true,
+  },
 };
+
+/**
+ * Reading color presets in display order (light pages first, then dark), used
+ * by the Customize panel's color swatches.
+ */
+export const BOOK_THEME_PRESET_IDS: readonly BooksThemePresetId[] = [
+  "light",
+  "paper",
+  "sepia",
+  "gray",
+  "green",
+  "dark",
+  "night",
+  "black",
+];
+
+/** Palette for a specific (non-auto) reading theme preset. */
+export function getReadingPalette(preset: BooksThemePresetId): ReadingPalette {
+  return PALETTES[preset];
+}
 
 /** Resolve the active reading palette from settings + OS dark mode. */
 export function resolveReadingPalette(
@@ -162,7 +214,7 @@ export function resolveReadingPalette(
   if (themeOverride === "auto") {
     return osIsDark ? PALETTES.dark : PALETTES.light;
   }
-  return PALETTES[themeOverride];
+  return PALETTES[themeOverride] ?? (osIsDark ? PALETTES.dark : PALETTES.light);
 }
 
 /**

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -598,14 +598,16 @@
         "double": "Zweiseitig",
         "single": "Einseitig"
       },
-      "textLayout": {
-        "book": "Buchstandard",
-        "vertical": "Vertikal"
-      },
       "contextMenu": {
         "delete": "Löschen",
         "moveToBottom": "Nach ganz unten",
         "moveToTop": "Nach ganz oben"
+      },
+      "customize": {
+        "colors": "Farben",
+        "lineSpacing": "Zeilenabstand",
+        "margins": "Seitenränder",
+        "title": "Anpassen"
       },
       "description": "EPUB-Bücher lesen",
       "help": {
@@ -644,15 +646,16 @@
         "chapters": "Kapitel",
         "chineseScript": "Chinesische Schrift",
         "columns": "Spalten",
+        "customizeTheme": "Anpassen…",
         "font": "Schrift",
         "import": "Importieren …",
         "nextPage": "Nächste Seite",
         "previousPage": "Vorherige Seite",
+        "textLayout": "Textrichtung",
         "textSize": "Textgröße",
         "textSizeDecrease": "Kleiner",
         "textSizeIncrease": "Größer",
         "textSizeReset": "Standardgröße",
-        "textLayout": "Textrichtung",
         "theme": "Design"
       },
       "name": "Bücher",
@@ -669,10 +672,20 @@
         "listView": "Listendarstellung",
         "percentRead": "{{percent}}%"
       },
+      "textLayout": {
+        "book": "Buchstandard",
+        "horizontal": "Horizontal",
+        "vertical": "Vertikal"
+      },
       "theme": {
         "auto": "Automatisch",
+        "black": "Schwarz",
         "dark": "Dunkel",
+        "gray": "Grau",
+        "green": "Grün",
         "light": "Hell",
+        "night": "Nacht",
+        "paper": "Papier",
         "sepia": "Sepia"
       },
       "title": "Bücher",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -4535,8 +4535,15 @@
         "textLayout": "Text Direction",
         "chineseScript": "Chinese Script",
         "theme": "Theme",
+        "customizeTheme": "Customize…",
         "booksHelp": "Books Help",
         "aboutBooks": "About Books"
+      },
+      "customize": {
+        "title": "Customize",
+        "lineSpacing": "Line Spacing",
+        "margins": "Margins",
+        "colors": "Colors"
       },
       "columns": {
         "auto": "Auto",
@@ -4545,6 +4552,7 @@
       },
       "textLayout": {
         "book": "Book Default",
+        "horizontal": "Horizontal",
         "vertical": "Vertical"
       },
       "chineseScript": {
@@ -4555,8 +4563,13 @@
       "theme": {
         "auto": "Auto",
         "light": "Light",
+        "paper": "Paper",
         "sepia": "Sepia",
-        "dark": "Dark"
+        "gray": "Gray",
+        "green": "Green",
+        "dark": "Dark",
+        "night": "Night",
+        "black": "Black"
       },
       "shelf": {
         "import": "Add Book",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -600,14 +600,16 @@
         "double": "Doble",
         "single": "Sencillo"
       },
-      "textLayout": {
-        "book": "Predeterminado del libro",
-        "vertical": "Vertical"
-      },
       "contextMenu": {
         "delete": "Eliminar",
         "moveToBottom": "Mover al final",
         "moveToTop": "Mover al principio"
+      },
+      "customize": {
+        "colors": "Colores",
+        "lineSpacing": "Interlineado",
+        "margins": "Márgenes",
+        "title": "Personalizar"
       },
       "description": "Leer libros EPUB",
       "help": {
@@ -646,15 +648,16 @@
         "chapters": "Capítulos",
         "chineseScript": "Escritura china",
         "columns": "Columnas",
+        "customizeTheme": "Personalizar…",
         "font": "Tipo de letra",
         "import": "Importar EPUB…",
         "nextPage": "Página siguiente",
         "previousPage": "Página anterior",
+        "textLayout": "Dirección del texto",
         "textSize": "Tamaño del texto",
         "textSizeDecrease": "Más pequeño",
         "textSizeIncrease": "Más grande",
         "textSizeReset": "Tamaño predeterminado",
-        "textLayout": "Dirección del texto",
         "theme": "Tema"
       },
       "name": "Libros",
@@ -671,10 +674,20 @@
         "listView": "Visualización como lista",
         "percentRead": "{{percent}}%"
       },
+      "textLayout": {
+        "book": "Predeterminado del libro",
+        "horizontal": "Horizontal",
+        "vertical": "Vertical"
+      },
       "theme": {
         "auto": "Automático",
+        "black": "Negro",
         "dark": "Oscuro",
+        "gray": "Gris",
+        "green": "Verde",
         "light": "Claro",
+        "night": "Noche",
+        "paper": "Papel",
         "sepia": "Sepia"
       },
       "title": "Libros",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -600,14 +600,16 @@
         "double": "Double",
         "single": "Simple"
       },
-      "textLayout": {
-        "book": "Réglage du livre",
-        "vertical": "Vertical"
-      },
       "contextMenu": {
         "delete": "Supprimer",
         "moveToBottom": "Placer tout en bas",
         "moveToTop": "Placer tout en haut"
+      },
+      "customize": {
+        "colors": "Couleurs",
+        "lineSpacing": "Interligne",
+        "margins": "Marges",
+        "title": "Personnaliser"
       },
       "description": "Lire des livres EPUB",
       "help": {
@@ -646,15 +648,16 @@
         "chapters": "Chapitres",
         "chineseScript": "Écriture chinoise",
         "columns": "Colonnes",
+        "customizeTheme": "Personnaliser…",
         "font": "Police",
         "import": "Importer un EPUB…",
         "nextPage": "Page suivante",
         "previousPage": "Page précédente",
+        "textLayout": "Sens du texte",
         "textSize": "Taille du texte",
         "textSizeDecrease": "Plus petite",
         "textSizeIncrease": "Plus grande",
         "textSizeReset": "Taille par défaut",
-        "textLayout": "Sens du texte",
         "theme": "Thème"
       },
       "name": "Livres",
@@ -671,10 +674,20 @@
         "listView": "Présentation par liste",
         "percentRead": "{{percent}} %"
       },
+      "textLayout": {
+        "book": "Réglage du livre",
+        "horizontal": "Horizontal",
+        "vertical": "Vertical"
+      },
       "theme": {
         "auto": "Auto",
+        "black": "Noir",
         "dark": "Sombre",
+        "gray": "Gris",
+        "green": "Vert",
         "light": "Clair",
+        "night": "Nuit",
+        "paper": "Papier",
         "sepia": "Sépia"
       },
       "title": "Livres",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -600,14 +600,16 @@
         "double": "Doppia",
         "single": "Singola"
       },
-      "textLayout": {
-        "book": "Predefinito del libro",
-        "vertical": "Verticale"
-      },
       "contextMenu": {
         "delete": "Elimina",
         "moveToBottom": "Sposta in fondo",
         "moveToTop": "Sposta in cima"
+      },
+      "customize": {
+        "colors": "Colori",
+        "lineSpacing": "Interlinea",
+        "margins": "Margini",
+        "title": "Personalizza"
       },
       "description": "Leggi libri EPUB",
       "help": {
@@ -646,15 +648,16 @@
         "chapters": "Capitoli",
         "chineseScript": "Scrittura cinese",
         "columns": "Colonne",
+        "customizeTheme": "Personalizza…",
         "font": "Font",
         "import": "Importa EPUB…",
         "nextPage": "Pagina successiva",
         "previousPage": "Pagina precedente",
+        "textLayout": "Direzione del testo",
         "textSize": "Dimensione testo",
         "textSizeDecrease": "Più piccolo",
         "textSizeIncrease": "Più grande",
         "textSizeReset": "Dimensioni predefinite",
-        "textLayout": "Direzione del testo",
         "theme": "Tema"
       },
       "name": "Libri",
@@ -671,10 +674,20 @@
         "listView": "Vista a elenco",
         "percentRead": "{{percent}}%"
       },
+      "textLayout": {
+        "book": "Predefinito del libro",
+        "horizontal": "Orizzontale",
+        "vertical": "Verticale"
+      },
       "theme": {
         "auto": "Automatico",
+        "black": "Nero",
         "dark": "Scuro",
+        "gray": "Grigio",
+        "green": "Verde",
         "light": "Chiaro",
+        "night": "Notte",
+        "paper": "Carta",
         "sepia": "Seppia"
       },
       "title": "Libri",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -598,14 +598,16 @@
         "double": "見開き",
         "single": "1ページ"
       },
-      "textLayout": {
-        "book": "本の設定",
-        "vertical": "縦書き"
-      },
       "contextMenu": {
         "delete": "削除",
         "moveToBottom": "最下部へ移動",
         "moveToTop": "最上部へ移動"
+      },
+      "customize": {
+        "colors": "カラー",
+        "lineSpacing": "行間",
+        "margins": "余白",
+        "title": "カスタマイズ"
       },
       "description": "EPUB形式の本を読む",
       "help": {
@@ -644,15 +646,16 @@
         "chapters": "章",
         "chineseScript": "中国語の字体",
         "columns": "段組み",
+        "customizeTheme": "カスタマイズ…",
         "font": "フォント",
         "import": "EPUBを読み込む…",
         "nextPage": "次のページ",
         "previousPage": "前のページ",
+        "textLayout": "文字方向",
         "textSize": "テキストサイズ",
         "textSizeDecrease": "小さく",
         "textSizeIncrease": "大きく",
         "textSizeReset": "デフォルトサイズ",
-        "textLayout": "文字方向",
         "theme": "テーマ"
       },
       "name": "ブック",
@@ -669,10 +672,20 @@
         "listView": "リスト表示",
         "percentRead": "{{percent}}%"
       },
+      "textLayout": {
+        "book": "本の設定",
+        "horizontal": "横書き",
+        "vertical": "縦書き"
+      },
       "theme": {
         "auto": "自動",
+        "black": "ブラック",
         "dark": "ダーク",
+        "gray": "グレー",
+        "green": "グリーン",
         "light": "ライト",
+        "night": "ナイト",
+        "paper": "ペーパー",
         "sepia": "セピア"
       },
       "title": "ブック",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -598,14 +598,16 @@
         "double": "두 페이지",
         "single": "한 페이지"
       },
-      "textLayout": {
-        "book": "책 기본값",
-        "vertical": "세로쓰기"
-      },
       "contextMenu": {
         "delete": "삭제",
         "moveToBottom": "맨 아래로 이동",
         "moveToTop": "맨 위로 이동"
+      },
+      "customize": {
+        "colors": "색상",
+        "lineSpacing": "줄 간격",
+        "margins": "여백",
+        "title": "사용자화"
       },
       "description": "EPUB 도서 읽기",
       "help": {
@@ -644,15 +646,16 @@
         "chapters": "장",
         "chineseScript": "중국어 문자",
         "columns": "단",
+        "customizeTheme": "사용자화…",
         "font": "서체",
         "import": "EPUB 가져오기…",
         "nextPage": "다음 페이지",
         "previousPage": "이전 페이지",
+        "textLayout": "글자 방향",
         "textSize": "텍스트 크기",
         "textSizeDecrease": "작게",
         "textSizeIncrease": "크게",
         "textSizeReset": "기본 크기",
-        "textLayout": "글자 방향",
         "theme": "테마"
       },
       "name": "도서",
@@ -669,10 +672,20 @@
         "listView": "목록 보기",
         "percentRead": "{{percent}}%"
       },
+      "textLayout": {
+        "book": "책 기본값",
+        "horizontal": "가로",
+        "vertical": "세로쓰기"
+      },
       "theme": {
         "auto": "자동",
+        "black": "검은색",
         "dark": "다크",
+        "gray": "회색",
+        "green": "초록색",
         "light": "라이트",
+        "night": "야간",
+        "paper": "종이",
         "sepia": "세피아"
       },
       "title": "도서",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -600,14 +600,16 @@
         "double": "Duplo",
         "single": "Simples"
       },
-      "textLayout": {
-        "book": "Padrão do livro",
-        "vertical": "Vertical"
-      },
       "contextMenu": {
         "delete": "Apagar",
         "moveToBottom": "Mover para o final",
         "moveToTop": "Mover para o topo"
+      },
+      "customize": {
+        "colors": "Cores",
+        "lineSpacing": "Espaçamento entre Linhas",
+        "margins": "Margens",
+        "title": "Personalizar"
       },
       "description": "Ler livros EPUB",
       "help": {
@@ -646,15 +648,16 @@
         "chapters": "Capítulos",
         "chineseScript": "Escrita Chinesa",
         "columns": "Colunas",
+        "customizeTheme": "Personalizar…",
         "font": "Fonte",
         "import": "Importar EPUB…",
         "nextPage": "Página Seguinte",
         "previousPage": "Página Anterior",
+        "textLayout": "Direção do texto",
         "textSize": "Tamanho do Texto",
         "textSizeDecrease": "Menor",
         "textSizeIncrease": "Maior",
         "textSizeReset": "Tamanho Padrão",
-        "textLayout": "Direção do texto",
         "theme": "Tema"
       },
       "name": "Livros",
@@ -671,10 +674,20 @@
         "listView": "Visualização por Lista",
         "percentRead": "{{percent}}%"
       },
+      "textLayout": {
+        "book": "Padrão do livro",
+        "horizontal": "Horizontal",
+        "vertical": "Vertical"
+      },
       "theme": {
         "auto": "Automático",
+        "black": "Preto",
         "dark": "Escuro",
+        "gray": "Cinza",
+        "green": "Verde",
         "light": "Claro",
+        "night": "Noite",
+        "paper": "Papel",
         "sepia": "Sépia"
       },
       "title": "Livros",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -602,14 +602,16 @@
         "double": "Две страницы",
         "single": "Одна страница"
       },
-      "textLayout": {
-        "book": "Как в книге",
-        "vertical": "Вертикально"
-      },
       "contextMenu": {
         "delete": "Удалить",
         "moveToBottom": "Переместить в конец",
         "moveToTop": "Переместить в начало"
+      },
+      "customize": {
+        "colors": "Цвета",
+        "lineSpacing": "Межстрочный интервал",
+        "margins": "Поля",
+        "title": "Настройка"
       },
       "description": "Читайте книги EPUB",
       "help": {
@@ -648,15 +650,16 @@
         "chapters": "Главы",
         "chineseScript": "Китайское письмо",
         "columns": "Колонки",
+        "customizeTheme": "Настроить…",
         "font": "Шрифт",
         "import": "Импортировать EPUB…",
         "nextPage": "Следующая страница",
         "previousPage": "Предыдущая страница",
+        "textLayout": "Направление текста",
         "textSize": "Размер текста",
         "textSizeDecrease": "Меньше",
         "textSizeIncrease": "Больше",
         "textSizeReset": "Размер по умолчанию",
-        "textLayout": "Направление текста",
         "theme": "Тема"
       },
       "name": "Книги",
@@ -673,10 +676,20 @@
         "listView": "Список",
         "percentRead": "{{percent}}%"
       },
+      "textLayout": {
+        "book": "Как в книге",
+        "horizontal": "Горизонтально",
+        "vertical": "Вертикально"
+      },
       "theme": {
         "auto": "Авто",
+        "black": "Черный",
         "dark": "Темная",
+        "gray": "Серый",
+        "green": "Зеленый",
         "light": "Светлая",
+        "night": "Ночь",
+        "paper": "Бумага",
         "sepia": "Сепия"
       },
       "title": "Книги",

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -598,14 +598,16 @@
         "double": "双页",
         "single": "单页"
       },
-      "textLayout": {
-        "book": "书籍默认",
-        "vertical": "竖排"
-      },
       "contextMenu": {
         "delete": "删除",
         "moveToBottom": "移至底端",
         "moveToTop": "移至顶端"
+      },
+      "customize": {
+        "colors": "颜色",
+        "lineSpacing": "行间距",
+        "margins": "页边距",
+        "title": "自定"
       },
       "description": "阅读 EPUB 书籍",
       "help": {
@@ -644,15 +646,16 @@
         "chapters": "章节",
         "chineseScript": "简繁转换",
         "columns": "分栏",
+        "customizeTheme": "自定…",
         "font": "字体",
         "import": "导入 EPUB…",
         "nextPage": "下一页",
         "previousPage": "上一页",
+        "textLayout": "文字方向",
         "textSize": "文字大小",
         "textSizeDecrease": "缩小",
         "textSizeIncrease": "放大",
         "textSizeReset": "默认大小",
-        "textLayout": "文字方向",
         "theme": "主题"
       },
       "name": "书籍",
@@ -669,10 +672,20 @@
         "listView": "列表视图",
         "percentRead": "{{percent}}%"
       },
+      "textLayout": {
+        "book": "书籍默认",
+        "horizontal": "水平",
+        "vertical": "竖排"
+      },
       "theme": {
         "auto": "自动",
+        "black": "黑色",
         "dark": "深色",
+        "gray": "灰色",
+        "green": "绿色",
         "light": "浅色",
+        "night": "夜间",
+        "paper": "纸张",
         "sepia": "棕褐色"
       },
       "title": "书籍",
@@ -699,7 +712,7 @@
           "currency": "货币",
           "energy": "能量",
           "length": "长度",
-        "mass": "重量与质量",
+          "mass": "重量与质量",
           "pressure": "压力",
           "speed": "速度",
           "temperature": "温度",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -598,14 +598,16 @@
         "double": "雙頁",
         "single": "單頁"
       },
-      "textLayout": {
-        "book": "書籍預設",
-        "vertical": "直排"
-      },
       "contextMenu": {
         "delete": "刪除",
         "moveToBottom": "移至底端",
         "moveToTop": "移至頂端"
+      },
+      "customize": {
+        "colors": "顏色",
+        "lineSpacing": "行距",
+        "margins": "邊界",
+        "title": "自訂"
       },
       "description": "閱讀 EPUB 書籍",
       "help": {
@@ -644,15 +646,16 @@
         "chapters": "章節",
         "chineseScript": "簡繁轉換",
         "columns": "直欄",
+        "customizeTheme": "自訂…",
         "font": "字體",
         "import": "匯入 EPUB⋯",
         "nextPage": "下一頁",
         "previousPage": "上一頁",
+        "textLayout": "文字方向",
         "textSize": "文字大小",
         "textSizeDecrease": "縮小",
         "textSizeIncrease": "放大",
         "textSizeReset": "預設大小",
-        "textLayout": "文字方向",
         "theme": "主題"
       },
       "name": "書籍",
@@ -669,10 +672,20 @@
         "listView": "列表顯示方式",
         "percentRead": "{{percent}}%"
       },
+      "textLayout": {
+        "book": "書籍預設",
+        "horizontal": "橫排",
+        "vertical": "直排"
+      },
       "theme": {
         "auto": "自動",
+        "black": "黑色",
         "dark": "深色",
+        "gray": "灰色",
+        "green": "綠色",
         "light": "淺色",
+        "night": "夜間",
+        "paper": "紙張",
         "sepia": "深褐色"
       },
       "title": "書籍",

--- a/src/stores/useBooksStore.ts
+++ b/src/stores/useBooksStore.ts
@@ -2,7 +2,32 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 
 export type BooksColumnMode = "auto" | "single" | "double";
-export type BooksThemeOverride = "auto" | "light" | "sepia" | "dark";
+export type BooksThemeOverride =
+  | "auto"
+  | "light"
+  | "paper"
+  | "sepia"
+  | "gray"
+  | "green"
+  | "dark"
+  | "night"
+  | "black";
+export const BOOKS_THEME_OVERRIDES: readonly BooksThemeOverride[] = [
+  "auto",
+  "light",
+  "paper",
+  "sepia",
+  "gray",
+  "green",
+  "dark",
+  "night",
+  "black",
+];
+export function isBooksThemeOverride(
+  value: unknown
+): value is BooksThemeOverride {
+  return (BOOKS_THEME_OVERRIDES as readonly unknown[]).includes(value);
+}
 export type BooksChineseScript = "original" | "simplified" | "traditional";
 export type BooksTextLayout = "book" | "vertical";
 export type BooksShelfView = "grid" | "list";
@@ -30,6 +55,8 @@ export interface BooksReaderSettings {
   textLayout: BooksTextLayout;
   /** Line height multiplier. */
   lineHeight: number;
+  /** Horizontal gutter (px) around the text column. */
+  gutterPx: number;
 }
 
 export const DEFAULT_BOOKS_SETTINGS: BooksReaderSettings = {
@@ -40,11 +67,25 @@ export const DEFAULT_BOOKS_SETTINGS: BooksReaderSettings = {
   chineseScript: "original",
   textLayout: "book",
   lineHeight: 1.5,
+  gutterPx: 24,
 };
 
 export const BOOKS_FONT_SIZE_MIN = 70;
 export const BOOKS_FONT_SIZE_MAX = 180;
 export const BOOKS_FONT_SIZE_STEP = 10;
+
+export const BOOKS_LINE_HEIGHT_MIN = 1.1;
+export const BOOKS_LINE_HEIGHT_MAX = 2.4;
+export const BOOKS_LINE_HEIGHT_STEP = 0.05;
+
+export const BOOKS_GUTTER_MIN = 0;
+export const BOOKS_GUTTER_MAX = 96;
+export const BOOKS_GUTTER_STEP = 4;
+
+export function clampBooksGutter(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_BOOKS_SETTINGS.gutterPx;
+  return Math.min(BOOKS_GUTTER_MAX, Math.max(BOOKS_GUTTER_MIN, value));
+}
 
 interface BooksStoreState {
   progressByPath: Record<string, BookProgress>;
@@ -162,7 +203,7 @@ export const useBooksStore = create<BooksStoreState>()(
     {
       name: "ryos:books",
       storage: createJSONStorage(() => localStorage),
-      version: 4,
+      version: 5,
       migrate: (persistedState) => {
         const state = (persistedState ?? {}) as Partial<BooksStoreState>;
         return {

--- a/src/sync/codecs.ts
+++ b/src/sync/codecs.ts
@@ -39,6 +39,9 @@ import { useMapsStore } from "@/stores/useMapsStore";
 import {
   BOOKS_FONT_SIZE_MAX,
   BOOKS_FONT_SIZE_MIN,
+  BOOKS_GUTTER_MAX,
+  BOOKS_GUTTER_MIN,
+  isBooksThemeOverride,
   useBooksStore,
   type BookProgress,
   type BooksReaderSettings,
@@ -1550,6 +1553,7 @@ const BOOKS_SETTINGS_KEYS = {
   chineseScript: "books-settings/chineseScript",
   textLayout: "books-settings/textLayout",
   lineHeight: "books-settings/lineHeight",
+  gutterPx: "books-settings/gutterPx",
 } as const satisfies Record<keyof BooksReaderSettings, string>;
 
 function collectBooksSettings(
@@ -1568,6 +1572,7 @@ function collectBooksSettings(
   add(BOOKS_SETTINGS_KEYS.chineseScript, settings.chineseScript);
   add(BOOKS_SETTINGS_KEYS.textLayout, settings.textLayout);
   add(BOOKS_SETTINGS_KEYS.lineHeight, settings.lineHeight);
+  add(BOOKS_SETTINGS_KEYS.gutterPx, settings.gutterPx);
   return docs;
 }
 
@@ -1599,12 +1604,7 @@ function applyBooksSettings(ops: AppliedSyncOp[]): void {
         }
         break;
       case BOOKS_SETTINGS_KEYS.themeOverride:
-        if (
-          op.v === "auto" ||
-          op.v === "light" ||
-          op.v === "sepia" ||
-          op.v === "dark"
-        ) {
+        if (isBooksThemeOverride(op.v)) {
           updates = { ...updates, themeOverride: op.v };
         }
         break;
@@ -1629,6 +1629,16 @@ function applyBooksSettings(ops: AppliedSyncOp[]): void {
           op.v > 0
         ) {
           updates = { ...updates, lineHeight: op.v };
+        }
+        break;
+      case BOOKS_SETTINGS_KEYS.gutterPx:
+        if (
+          typeof op.v === "number" &&
+          Number.isFinite(op.v) &&
+          op.v >= BOOKS_GUTTER_MIN &&
+          op.v <= BOOKS_GUTTER_MAX
+        ) {
+          updates = { ...updates, gutterPx: op.v };
         }
         break;
     }
@@ -1670,6 +1680,9 @@ const booksSettingsCodec: SyncCodec = {
       }
       if (state.settings.lineHeight !== prev.settings.lineHeight) {
         keys.push(BOOKS_SETTINGS_KEYS.lineHeight);
+      }
+      if (state.settings.gutterPx !== prev.settings.gutterPx) {
+        keys.push(BOOKS_SETTINGS_KEYS.gutterPx);
       }
       if (keys.length === 0 || !useBooksStore.persist.hasHydrated()) return;
       onChange(keys);

--- a/tests/test-sync-v2-codecs.test.ts
+++ b/tests/test-sync-v2-codecs.test.ts
@@ -431,6 +431,7 @@ describe("books settings codec", () => {
       chineseScript: "traditional",
       textLayout: "vertical",
       lineHeight: 1.8,
+      gutterPx: 32,
     });
 
     const docs = SYNC_CODECS["books-settings"].collect(ctx) as Map<
@@ -445,6 +446,7 @@ describe("books settings codec", () => {
       "books-settings/chineseScript": "traditional",
       "books-settings/textLayout": "vertical",
       "books-settings/lineHeight": 1.8,
+      "books-settings/gutterPx": 32,
     });
   });
 
@@ -454,10 +456,11 @@ describe("books settings codec", () => {
         { k: "books-settings/fontId", v: "sans", t },
         { k: "books-settings/fontSizePct", v: 140, t },
         { k: "books-settings/columnMode", v: "single", t },
-        { k: "books-settings/themeOverride", v: "dark", t },
+        { k: "books-settings/themeOverride", v: "night", t },
         { k: "books-settings/chineseScript", v: "simplified", t },
         { k: "books-settings/textLayout", v: "vertical", t },
         { k: "books-settings/lineHeight", v: 1.7, t },
+        { k: "books-settings/gutterPx", v: 48, t },
       ],
       ctx
     );
@@ -466,10 +469,11 @@ describe("books settings codec", () => {
       fontId: "sans",
       fontSizePct: 140,
       columnMode: "single",
-      themeOverride: "dark",
+      themeOverride: "night",
       chineseScript: "simplified",
       textLayout: "vertical",
       lineHeight: 1.7,
+      gutterPx: 48,
     });
   });
 
@@ -479,10 +483,11 @@ describe("books settings codec", () => {
         { k: "books-settings/fontId", v: "", t },
         { k: "books-settings/fontSizePct", v: 1_000, t },
         { k: "books-settings/columnMode", v: "triple", t },
-        { k: "books-settings/themeOverride", v: "blue", t },
+        { k: "books-settings/themeOverride", v: "neon", t },
         { k: "books-settings/chineseScript", v: "translated", t },
         { k: "books-settings/textLayout", v: "diagonal", t },
         { k: "books-settings/lineHeight", v: -1, t },
+        { k: "books-settings/gutterPx", v: 1_000, t },
         { k: "books-settings/fontId", del: true, t },
       ],
       ctx
@@ -502,12 +507,14 @@ describe("books settings codec", () => {
         fontSizePct: 120,
         themeOverride: "sepia",
         textLayout: "vertical",
+        gutterPx: 40,
       });
       expect(changes).toEqual([
         [
           "books-settings/fontSizePct",
           "books-settings/themeOverride",
           "books-settings/textLayout",
+          "books-settings/gutterPx",
         ],
       ]);
     } finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **View ▸ Theme ▸ Customize…** option to the Books app that opens a reading-appearance panel:

- **Sliders** for Text Size (70–180%), Line Spacing (1.10–2.40×), and Margins (0–96px side gutters — new `gutterPx` reader setting driving the epub.js render-host insets)
- **Quick toggles** for text direction (Horizontal / Vertical) and columns (Auto / Single / Double)
- **Font chips** for all reading fonts, each previewed in its own typeface
- **Expanded color presets**: Auto, Light, Paper, Sepia, Gray, Green, Dark, Night, Black (5 new palettes beyond the existing Light/Sepia/Dark)

The panel uses a simple uniform layout — label on the left, control in the middle, value on the right — with flat pill segments, a horizontally scrollable font chip row, and a wrapped swatch grid. On wide windows it floats top-right; when the Books window is narrower than 500px (mobile / small windows) it becomes a full-width bottom sheet sliding up from the bottom.

![Simplified Customize panel, desktop card](https://cursor.com/artifacts/c/art-a57aa9e1-dd8d-4aba-a5b3-252c18008070)
![Bottom-sheet layout on a narrow window](https://cursor.com/artifacts/c/art-cd2f949a-3fa0-4203-b618-227d1c1ab38e)

## Implementation

- `useBooksStore`: new `gutterPx` setting (default 24), extended `BooksThemeOverride` union + `isBooksThemeOverride` guard, slider range constants, persist version bump 4 → 5
- `booksReader.ts`: new reading palettes, `BOOK_THEME_PRESET_IDS`, `getReadingPalette`; `resolveReadingPalette` falls back to auto for unknown ids
- `BooksCustomizePanel.tsx`: new panel using OS theme tokens; `compact` prop switches to the bottom-sheet layout, driven by a resize observer on the Books window content in `BooksAppComponent`
- `BooksReaderPane`: side gutters now come from `settings.gutterPx` (clamped); the existing resize observer reflows epub.js live
- Sync: `books-settings/gutterPx` key with clamped validation; theme validation accepts the new presets
- i18n: new strings added and machine-translated across all 11 locales

## Testing

- `bun test tests/test-sync-v2-codecs.test.ts tests/test-books-reader-fonts.test.ts tests/test-books-menu-layout.test.ts tests/test-books-vertical-text.test.ts` — 64 pass
- `bun run build`, `bun run lint` (identical issue count to baseline), `bun run i18n:sync:dry-run`, `bun run i18n:audit` — all pass
- Manual browser verification of both layouts: panel opens from View ▸ Theme ▸ Customize…, sliders reflow the book live, direction/columns/font/color toggles apply immediately, bottom sheet appears when the window is narrowed below 500px and all controls remain usable, panel closes via X
- Note: the Meditations title page rendering dark text under dark presets is pre-existing (reproduces with the built-in Dark theme on `main`); regular body text is correctly light under the new Night/Black presets

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f20b9-46b2-714f-9118-4ed6856f210c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f20b9-46b2-714f-9118-4ed6856f210c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

