### PR TITLE
Fix Books line spacing in horizontal reading; raise floor to 1.5

### DIFF
--- a/src/apps/books/components/BooksCustomizePanel.tsx
+++ b/src/apps/books/components/BooksCustomizePanel.tsx
@@ -114,22 +114,22 @@ export function BooksCustomizePanel({
   const { t, i18n } = useTranslation();
   const uiLanguage = i18n.resolvedLanguage ?? i18n.language ?? "en";
 
+  const autoPalette = getReadingPalette(osIsDark ? "dark" : "light");
   const themeSwatches: {
     id: BooksThemeOverride;
     label: string;
     background: string;
     text: string;
+    /** The Auto swatch is a plain solid dot; presets preview their text color. */
+    showGlyph: boolean;
   }[] = [
     {
       id: "auto" as const,
       label: t("apps.books.theme.auto"),
-      // Split swatch: follows the OS light/dark setting.
-      background: `linear-gradient(135deg, ${
-        getReadingPalette("light").background
-      } 50%, ${getReadingPalette("dark").background} 50%)`,
-      text: osIsDark
-        ? getReadingPalette("dark").text
-        : getReadingPalette("light").text,
+      // Solid swatch that follows the OS light/dark setting.
+      background: autoPalette.background,
+      text: autoPalette.text,
+      showGlyph: false,
     },
     ...BOOK_THEME_PRESET_IDS.map((id) => {
       const palette = getReadingPalette(id);
@@ -138,6 +138,7 @@ export function BooksCustomizePanel({
         label: t(`apps.books.theme.${id}`),
         background: palette.background,
         text: palette.text,
+        showGlyph: true,
       };
     }),
   ];
@@ -303,7 +304,7 @@ export function BooksCustomizePanel({
                 )}
                 style={{ background: swatch.background, color: swatch.text }}
               >
-                A
+                {swatch.showGlyph ? "A" : null}
               </button>
             );
           })}

--- a/src/apps/books/utils/booksReader.ts
+++ b/src/apps/books/utils/booksReader.ts
@@ -1,6 +1,7 @@
-import type {
-  BooksReaderSettings,
-  BooksThemeOverride,
+import {
+  clampBooksLineHeight,
+  type BooksReaderSettings,
+  type BooksThemeOverride,
 } from "@/stores/useBooksStore";
 import { detectLanguageFromLocale } from "@/lib/languageConfig";
 
@@ -431,10 +432,10 @@ export function buildEpubTheme(
   const fontStack = getBookFontCssStack(settings.fontId, language);
   const fontFamily = fontStack ? `${fontStack} !important` : null;
   const isVerticalText = settings.textLayout === "vertical";
-  const lineHeight =
-    isVerticalText
-      ? Math.max(settings.lineHeight, VERTICAL_BOOK_LINE_HEIGHT_MIN)
-      : settings.lineHeight;
+  const baseLineHeight = clampBooksLineHeight(settings.lineHeight);
+  const lineHeight = isVerticalText
+    ? Math.max(baseLineHeight, VERTICAL_BOOK_LINE_HEIGHT_MIN)
+    : baseLineHeight;
   const lineHeightRule = {
     "line-height": `${lineHeight} !important`,
   };
@@ -443,6 +444,10 @@ export function buildEpubTheme(
   // In vertical mode they fight the top-to-bottom inline flow and CJK line
   // breaking, so preserve only the column-break controls. Vertical columns
   // also need a wider line-height floor than horizontal prose.
+  //
+  // The line-height rule is part of the reading flow in BOTH modes: applying
+  // it only on `body` is not enough, because publisher rules on `p`/`li`/`div`
+  // beat inherited values, leaving the Line Spacing setting without effect.
   const readingFlow: Record<string, string> =
     isVerticalText
       ? {
@@ -451,6 +456,7 @@ export function buildEpubTheme(
           widows: "2",
         }
       : {
+          ...lineHeightRule,
           "text-align": "left !important",
           "-webkit-hyphens": "auto !important",
           hyphens: "auto !important",
@@ -497,7 +503,7 @@ export function buildEpubTheme(
     "*:not(a)": { color: `${palette.text} !important` },
     // Force colors so dark/sepia modes are legible regardless of publisher CSS.
     p: withFont(flowText),
-    div: withFont(isVerticalText ? lineHeightRule : {}),
+    div: withFont(lineHeightRule),
     span: withFont({}),
     li: withFont(flowText),
     // Headings keep their original alignment (often intentionally centered) but

--- a/src/stores/useBooksStore.ts
+++ b/src/stores/useBooksStore.ts
@@ -81,9 +81,17 @@ export const BOOKS_FONT_SIZE_MIN = 70;
 export const BOOKS_FONT_SIZE_MAX = 180;
 export const BOOKS_FONT_SIZE_STEP = 10;
 
-export const BOOKS_LINE_HEIGHT_MIN = 1.1;
+export const BOOKS_LINE_HEIGHT_MIN = 1.5;
 export const BOOKS_LINE_HEIGHT_MAX = 2.4;
 export const BOOKS_LINE_HEIGHT_STEP = 0.05;
+
+export function clampBooksLineHeight(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_BOOKS_SETTINGS.lineHeight;
+  return Math.min(
+    BOOKS_LINE_HEIGHT_MAX,
+    Math.max(BOOKS_LINE_HEIGHT_MIN, value)
+  );
+}
 
 export const BOOKS_GUTTER_MIN = 0;
 export const BOOKS_GUTTER_MAX = 96;
@@ -210,15 +218,18 @@ export const useBooksStore = create<BooksStoreState>()(
     {
       name: "ryos:books",
       storage: createJSONStorage(() => localStorage),
-      version: 5,
+      version: 6,
       migrate: (persistedState) => {
         const state = (persistedState ?? {}) as Partial<BooksStoreState>;
+        const settings = {
+          ...DEFAULT_BOOKS_SETTINGS,
+          ...(state.settings ?? {}),
+        };
+        // v6 raised the line-height floor from 1.1 to 1.5.
+        settings.lineHeight = clampBooksLineHeight(settings.lineHeight);
         return {
           ...state,
-          settings: {
-            ...DEFAULT_BOOKS_SETTINGS,
-            ...(state.settings ?? {}),
-          },
+          settings,
         } as BooksStoreState;
       },
       partialize: (state) => ({

--- a/src/sync/codecs.ts
+++ b/src/sync/codecs.ts
@@ -43,6 +43,7 @@ import {
   BOOKS_GUTTER_MIN,
   BOOKS_SPEECH_RATE_MAX,
   BOOKS_SPEECH_RATE_MIN,
+  clampBooksLineHeight,
   isBooksThemeOverride,
   useBooksStore,
   type BookProgress,
@@ -1627,12 +1628,10 @@ function applyBooksSettings(ops: AppliedSyncOp[]): void {
         }
         break;
       case BOOKS_SETTINGS_KEYS.lineHeight:
-        if (
-          typeof op.v === "number" &&
-          Number.isFinite(op.v) &&
-          op.v > 0
-        ) {
-          updates = { ...updates, lineHeight: op.v };
+        // Clamp instead of reject: devices on older app versions may still
+        // sync values below the raised 1.5 floor.
+        if (typeof op.v === "number" && Number.isFinite(op.v) && op.v > 0) {
+          updates = { ...updates, lineHeight: clampBooksLineHeight(op.v) };
         }
         break;
       case BOOKS_SETTINGS_KEYS.gutterPx:

--- a/tests/test-books-reader-fonts.test.ts
+++ b/tests/test-books-reader-fonts.test.ts
@@ -384,6 +384,29 @@ describe("Books reader CJK serif fonts", () => {
     expect(verticalTheme.body.orphans).toBe("2");
   });
 
+  test("applies line spacing to paragraph-level elements in horizontal reading", () => {
+    const spaciousTheme = buildEpubTheme(
+      { ...settings, lineHeight: 2.2 },
+      palette
+    );
+
+    // Publisher CSS on p/div/li beats values inherited from body, so the
+    // Line Spacing setting must be applied directly at paragraph level too.
+    expect(spaciousTheme.body["line-height"]).toBe("2.2 !important");
+    expect(spaciousTheme.p["line-height"]).toBe("2.2 !important");
+    expect(spaciousTheme.div["line-height"]).toBe("2.2 !important");
+    expect(spaciousTheme.li["line-height"]).toBe("2.2 !important");
+  });
+
+  test("clamps line spacing to the supported range", () => {
+    const tooTight = buildEpubTheme({ ...settings, lineHeight: 1.1 }, palette);
+    const tooLoose = buildEpubTheme({ ...settings, lineHeight: 9 }, palette);
+
+    expect(tooTight.body["line-height"]).toBe("1.5 !important");
+    expect(tooTight.p["line-height"]).toBe("1.5 !important");
+    expect(tooLoose.body["line-height"]).toBe("2.4 !important");
+  });
+
   test("gives vertical columns a readable minimum line height", () => {
     const verticalTheme = buildEpubTheme(
       { ...settings, textLayout: "vertical" },

--- a/tests/test-sync-v2-codecs.test.ts
+++ b/tests/test-sync-v2-codecs.test.ts
@@ -481,6 +481,15 @@ describe("books settings codec", () => {
     });
   });
 
+  test("apply clamps line spacing from older app versions into range", async () => {
+    await SYNC_CODECS["books-settings"].apply(
+      [{ k: "books-settings/lineHeight", v: 1.1, t }],
+      ctx
+    );
+
+    expect(useBooksStore.getState().settings.lineHeight).toBe(1.5);
+  });
+
   test("apply ignores malformed values and tombstones", async () => {
     await SYNC_CODECS["books-settings"].apply(
       [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

The Line Spacing slider in the Books Customize panel had no visible effect in the normal horizontal reading layout (vertical layout worked). `buildEpubTheme` only applied `line-height` on `body` in horizontal mode, and paragraph-level publisher CSS beats values inherited from `body`, so the setting never reached the text. Vertical mode worked because it already applied the rule directly on `p`/`div`/`li`.

### Fix

- Apply the `line-height` rule to paragraph-level elements (`p`, `li`, `div`) in horizontal reading mode too, mirroring the already-working vertical path (`src/apps/books/utils/booksReader.ts`).
- Restrict line spacing to start from 1.5: `BOOKS_LINE_HEIGHT_MIN` raised from 1.1 to 1.5, with a new `clampBooksLineHeight` helper used by the theme builder and the sync codec (older devices may still sync sub-1.5 values, which are now clamped instead of applied).
- Persist migration v5 → v6 clamps previously stored line-height values into the new range.
- Polish: the Auto color swatch in the Customize panel is now a fully solid fill (following the OS light/dark palette) with no "A" glyph, replacing the split-circle + "A" look.

### Verification

Reproduced on `main` first — dragging Line Spacing to max in horizontal mode changed nothing:

![Before fix: horizontal at max spacing, unchanged](https://cursor.com/artifacts/c/art-bf6e8c52-e3c2-4fc1-a944-0adce084a225)

After the fix, spacing visibly responds in horizontal mode and the slider bottoms out at 1.50:

![After fix: minimum line spacing 1.50](https://cursor.com/artifacts/c/art-19bc5e5c-4532-4bd0-880a-1765b09fa684)
![After fix: maximum line spacing 2.40](https://cursor.com/artifacts/c/art-b2d1915d-b9a8-4b17-ade2-189f7249d347)

Auto color swatch, now a plain solid dot (shown unselected next to the "A" presets, and selected with the ring while switching the page back to the light palette):

![Auto swatch solid, unselected, dark theme active](https://cursor.com/artifacts/c/art-bef8b2a3-009d-4e3b-99b2-b1340ab97782)
![Auto swatch selected, light palette applied](https://cursor.com/artifacts/c/art-c7fe83b1-1797-430f-b35e-b81c254dfa2b)

### Testing

- Reproduced the bug in-browser on `main`, then verified the fix: spacing now visibly changes in horizontal mode and the slider bottoms out at 1.50.
- Verified the Auto swatch renders as a solid circle with no glyph and still selects/applies the Auto theme.
- New unit tests: horizontal themes carry `line-height` on `body`/`p`/`div`/`li`, values clamp to [1.5, 2.4], and the sync codec clamps out-of-range synced values.
- ✅ `bun test tests/test-books-reader-fonts.test.ts tests/test-sync-v2-codecs.test.ts tests/test-books-vertical-text.test.ts` (63 pass)
- ✅ `bunx tsc --noEmit`
- ✅ `bunx eslint` on changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f20b9-46b2-714f-9118-4ed6856f210c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f20b9-46b2-714f-9118-4ed6856f210c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

