### PR TITLE
Fix Books read-aloud: default speed, stalled auto page turns, and spoken-text desync

### DIFF
--- a/src/apps/books/components/BooksMenuBar.tsx
+++ b/src/apps/books/components/BooksMenuBar.tsx
@@ -16,6 +16,7 @@ import {
   BOOKS_FONT_SIZE_MIN,
   BOOKS_FONT_SIZE_STEP,
   BOOKS_SPEECH_RATE_OPTIONS,
+  normalizeBooksSpeechRate,
   type BooksReaderSettings,
 } from "@/stores/useBooksStore";
 import type { BooksNavigationState } from "./BooksReaderPane";
@@ -267,7 +268,7 @@ export function BooksMenuBar({
         items: [
           {
             type: "radioGroup",
-            value: String(settings.speechRate),
+            value: String(normalizeBooksSpeechRate(settings.speechRate)),
             onValueChange: (value) => {
               const rate = Number(value);
               if (Number.isFinite(rate) && rate > 0) {

--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -13,7 +13,10 @@ import ePub, { type Book, type NavItem, type Rendition } from "epubjs";
 import { cn } from "@/lib/utils";
 import { useResizeObserverWithRef } from "@/hooks/useResizeObserver";
 import { readBookBlobContent } from "@/services/vfs/FileContentRepository";
-import type { BooksReaderSettings } from "@/stores/useBooksStore";
+import {
+  normalizeBooksSpeechRate,
+  type BooksReaderSettings,
+} from "@/stores/useBooksStore";
 import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import {
   buildEpubTheme,
@@ -1289,7 +1292,7 @@ export const BooksReaderPane = forwardRef<
   } = useBooksSpeech({
     getRendition: () => renditionRef.current,
     getSpeechLanguage,
-    getSpeechRate: () => speechRateRef.current,
+    getSpeechRate: () => normalizeBooksSpeechRate(speechRateRef.current),
     canAdvancePage: () => navigationStateRef.current.canGoNextPage,
     advancePage: () => turnPage("next"),
   });

--- a/src/apps/books/hooks/useBooksSpeech.ts
+++ b/src/apps/books/hooks/useBooksSpeech.ts
@@ -8,6 +8,7 @@ import {
   clearSpeechHighlight,
   collectSpeechChunksFromRange,
   getVisiblePageRange,
+  isRangeOnVisiblePage,
   type BooksSpeechChunk,
   type SpeechRenditionLike,
 } from "../utils/booksSpeech";
@@ -15,14 +16,33 @@ import {
 /** Safety net for stuck utterances (broken/voiceless synth engines). */
 const UTTERANCE_TIMEOUT_BASE_MS = 10_000;
 const UTTERANCE_TIMEOUT_PER_CHAR_MS = 150;
+/** Poll the engine state to detect utterances whose end event never fires
+ * (Chrome GC bug, speech-dispatcher backends, some mobile engines). */
+const WATCHDOG_INTERVAL_MS = 250;
+/** Consecutive idle polls (after speech started) that count as "finished". */
+const WATCHDOG_IDLE_POLLS = 2;
+/** Stop if this many chunks in a row only "finish" via the hard timeout —
+ * the engine is claiming to speak forever without delivering audio events. */
+const MAX_TIMEOUT_ENDINGS = 3;
 /** Re-attempt an auto page turn swallowed by the flip-animation lock. */
 const ADVANCE_RETRY_MS = 700;
 const MAX_ADVANCE_ATTEMPTS = 6;
+/** epub.js reports locations asynchronously (queue + rAF + DOM mapping), so a
+ * completed page turn can surface its `relocated` event well after the turn.
+ * How many extra retry windows to keep waiting when the location has already
+ * changed before advancing again (which would skip pages). */
+const MAX_RELOCATE_WAIT_CHECKS = 10;
 /** Stop after this many consecutive pages with nothing to speak
  * (e.g. an image-only book) instead of silently paging to the end. */
 const MAX_EMPTY_PAGE_STREAK = 10;
 /** Let epub.js settle the new page before re-extracting visible text. */
 const RESUME_AFTER_RELOCATE_MS = 120;
+/** Cancel-and-wait polling until the engine goes idle before restarting
+ * speech after a relocation. Some engines (notably Safari) keep playing a
+ * cancelled utterance for a moment; speaking over it queues the new chunk
+ * behind stale audio and read-aloud drifts pages behind the screen. */
+const ENSURE_IDLE_POLL_MS = 150;
+const MAX_ENSURE_IDLE_POLLS = 40;
 
 interface UseBooksSpeechOptions {
   getRendition: () => SpeechRenditionLike | null;
@@ -63,6 +83,12 @@ export function useBooksSpeech({
   const wantsSpeechRef = useRef(false);
   // Consecutive auto-skipped pages with no speakable text.
   const emptyPageStreakRef = useRef(0);
+  // Consecutive chunks that ended only via the hard timeout (no engine event).
+  const timeoutEndingStreakRef = useRef(0);
+  // Strong reference to the in-flight utterance. Chrome garbage-collects
+  // otherwise-unreferenced utterances mid-speech, silently dropping their
+  // end/error events — which used to strand read-aloud at the page end.
+  const activeUtteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
   const highlightedDocRef = useRef<Document | null>(null);
   const timersRef = useRef<number[]>([]);
 
@@ -94,16 +120,32 @@ export function useBooksSpeech({
   const stopSpeaking = useCallback(() => {
     sessionRef.current += 1;
     wantsSpeechRef.current = false;
+    activeUtteranceRef.current = null;
     clearTimers();
     clearHighlight();
     getBrowserSpeechSynthesis()?.cancel();
     setIsSpeaking(false);
   }, [clearHighlight, clearTimers]);
 
+  const getCurrentStartCfi = useCallback((): string | null => {
+    try {
+      const rendition = optionsRef.current.getRendition();
+      const location = rendition?.currentLocation() as {
+        start?: { cfi?: string };
+      } | null;
+      return location?.start?.cfi ?? null;
+    } catch {
+      return null;
+    }
+  }, []);
+
   // Reached the end of the visible page: auto-turn to the next page (the
   // resulting `relocated` event resumes speech there) or stop at book end.
   // Retries because rapid successive turns (several unspeakable pages in a
-  // row) can be swallowed by the reader's flip-animation lock.
+  // row) can be swallowed by the reader's flip-animation lock — but only
+  // re-advances when the location genuinely didn't change, because epub.js
+  // may deliver `relocated` for a completed turn later than the retry timer
+  // (advancing again then would skip pages).
   const finishPage = useCallback(
     (session: number, attempt = 0) => {
       if (session !== sessionRef.current) return;
@@ -115,14 +157,27 @@ export function useBooksSpeech({
         stopSpeaking();
         return;
       }
+      const beforeCfi = getCurrentStartCfi();
       optionsRef.current.advancePage();
-      const timeoutId = window.setTimeout(() => {
-        // Still the same session means no `relocated` arrived — retry.
-        if (session === sessionRef.current) finishPage(session, attempt + 1);
-      }, ADVANCE_RETRY_MS);
-      timersRef.current.push(timeoutId);
+      const waitForRelocate = (checksLeft: number) => {
+        const timeoutId = window.setTimeout(() => {
+          // A `relocated` event would have bumped the session and resumed.
+          if (session !== sessionRef.current) return;
+          const nowCfi = getCurrentStartCfi();
+          if (beforeCfi && nowCfi && nowCfi !== beforeCfi) {
+            // The page did turn; epub.js just hasn't emitted `relocated`
+            // yet. Keep waiting instead of turning again.
+            if (checksLeft > 0) waitForRelocate(checksLeft - 1);
+            else stopSpeaking();
+            return;
+          }
+          finishPage(session, attempt + 1);
+        }, ADVANCE_RETRY_MS);
+        timersRef.current.push(timeoutId);
+      };
+      waitForRelocate(MAX_RELOCATE_WAIT_CHECKS);
     },
-    [clearHighlight, stopSpeaking]
+    [clearHighlight, getCurrentStartCfi, stopSpeaking]
   );
 
   const speakChunk = useCallback(
@@ -151,13 +206,31 @@ export function useBooksSpeech({
       utterance.rate = rate;
       const voice = pickSpeechVoiceForLanguage(synth.getVoices(), lang);
       if (voice) utterance.voice = voice;
+      activeUtteranceRef.current = utterance;
 
       let settled = false;
-      const settle = (ok: boolean) => {
+      let started = false;
+      let idlePolls = 0;
+      const settle = (ok: boolean, viaTimeout = false) => {
         if (settled) return;
         settled = true;
         window.clearTimeout(timeoutId);
+        window.clearInterval(watchdogId);
+        if (activeUtteranceRef.current === utterance) {
+          activeUtteranceRef.current = null;
+        }
         if (session !== sessionRef.current) return;
+        if (viaTimeout) {
+          timeoutEndingStreakRef.current += 1;
+          if (timeoutEndingStreakRef.current >= MAX_TIMEOUT_ENDINGS) {
+            // The engine repeatedly claims to speak but never reports any
+            // progress — stop instead of silently paging through the book.
+            stopSpeaking();
+            return;
+          }
+        } else {
+          timeoutEndingStreakRef.current = 0;
+        }
         if (!ok) {
           // Engine failure (no voices, synthesis error) — stop cleanly rather
           // than racing through highlights and page turns with no audio.
@@ -167,13 +240,41 @@ export function useBooksSpeech({
         speakChunk(session, chunks, index + 1);
       };
 
+      utterance.onstart = () => {
+        started = true;
+      };
       utterance.onend = () => settle(true);
       utterance.onerror = () => settle(false);
-      // Scale with text length and rate so slow voices never get cut off.
+
+      // Some engines never deliver end events (and Chrome can GC-drop them
+      // even with the utterance referenced), so poll the engine: once speech
+      // has started, an idle engine means the utterance finished.
+      const watchdogId = window.setInterval(() => {
+        if (settled || session !== sessionRef.current) {
+          window.clearInterval(watchdogId);
+          return;
+        }
+        const busy = synth.speaking || synth.pending;
+        if (!started) {
+          if (synth.speaking) started = true;
+          return;
+        }
+        if (busy) {
+          idlePolls = 0;
+          return;
+        }
+        idlePolls += 1;
+        if (idlePolls >= WATCHDOG_IDLE_POLLS) settle(true);
+      }, WATCHDOG_INTERVAL_MS);
+
+      // Hard cap, scaled with text length and rate so slow voices never get
+      // cut off. If speech had started, a missing end event is treated as
+      // completion (keep reading) rather than a failure.
       const timeoutId = window.setTimeout(
-        () => settle(false),
+        () => settle(started, true),
         UTTERANCE_TIMEOUT_BASE_MS +
-          (chunk.text.length * UTTERANCE_TIMEOUT_PER_CHAR_MS) / Math.max(rate, 0.5)
+          (chunk.text.length * UTTERANCE_TIMEOUT_PER_CHAR_MS) /
+            Math.max(rate, 0.5)
       );
       timersRef.current.push(timeoutId);
 
@@ -198,6 +299,10 @@ export function useBooksSpeech({
       try {
         const range = getVisiblePageRange(rendition);
         chunks = range ? collectSpeechChunksFromRange(range) : [];
+        // The CFI-derived range can overshoot the page (e.g. when the end
+        // boundary is unresolvable and the range extends to the section end).
+        // Trust layout geometry: only speak chunks actually on screen.
+        chunks = chunks.filter((chunk) => isRangeOnVisiblePage(chunk.range));
       } catch {
         chunks = [];
       }
@@ -218,10 +323,36 @@ export function useBooksSpeech({
     [finishPage, speakChunk, stopSpeaking]
   );
 
+  // Restart speech once the engine has actually gone idle. Speaking while a
+  // cancelled utterance is still winding down queues the new chunk behind
+  // stale audio on some engines (Safari), drifting speech behind the screen.
+  const speakVisiblePageWhenIdle = useCallback(
+    (session: number, polls = 0) => {
+      if (session !== sessionRef.current) return;
+      const synth = getBrowserSpeechSynthesis();
+      if (!synth) {
+        stopSpeaking();
+        return;
+      }
+      if ((synth.speaking || synth.pending) && polls < MAX_ENSURE_IDLE_POLLS) {
+        synth.cancel();
+        const timeoutId = window.setTimeout(
+          () => speakVisiblePageWhenIdle(session, polls + 1),
+          ENSURE_IDLE_POLL_MS
+        );
+        timersRef.current.push(timeoutId);
+        return;
+      }
+      speakVisiblePage(session);
+    },
+    [speakVisiblePage, stopSpeaking]
+  );
+
   const startSpeaking = useCallback(() => {
     const session = ++sessionRef.current;
     wantsSpeechRef.current = true;
     emptyPageStreakRef.current = 0;
+    timeoutEndingStreakRef.current = 0;
     clearTimers();
     clearHighlight();
     const synth = getBrowserSpeechSynthesis();
@@ -239,14 +370,15 @@ export function useBooksSpeech({
     // Invalidate in-flight utterances (manual page turns / chapter jumps /
     // reflows) and restart from the freshly visible page.
     const session = ++sessionRef.current;
+    activeUtteranceRef.current = null;
     clearTimers();
     clearHighlight();
     getBrowserSpeechSynthesis()?.cancel();
     const timeoutId = window.setTimeout(() => {
-      speakVisiblePage(session);
+      speakVisiblePageWhenIdle(session);
     }, RESUME_AFTER_RELOCATE_MS);
     timersRef.current.push(timeoutId);
-  }, [clearHighlight, clearTimers, speakVisiblePage]);
+  }, [clearHighlight, clearTimers, speakVisiblePageWhenIdle]);
 
   // Stop speech (and drop highlights) when the reader unmounts / book closes.
   useEffect(() => () => stopSpeaking(), [stopSpeaking]);

--- a/src/apps/books/utils/booksSpeech.ts
+++ b/src/apps/books/utils/booksSpeech.ts
@@ -474,6 +474,71 @@ export function getVisiblePageRange(
   return range.collapsed ? null : range;
 }
 
+const OVERFLOW_CLIP_RE = /hidden|clip|auto|scroll/;
+
+/**
+ * Whether any part of the range is actually visible in the paginated reader.
+ *
+ * The CFI-derived page range can overshoot what is on screen (epub.js maps
+ * locations asynchronously, and an unresolvable end boundary falls back to
+ * the end of the section), which made read-aloud drift ahead of the visible
+ * page. Layout geometry is authoritative: project the range's rect into the
+ * embedding document and clip it against the scroll container that hides
+ * off-page columns. Lenient (returns true) when geometry is unavailable,
+ * e.g. outside an iframe or in non-layout DOM environments.
+ */
+export function isRangeOnVisiblePage(range: Range): boolean {
+  const doc = range.startContainer.ownerDocument;
+  const win = doc?.defaultView;
+  const frame = win?.frameElement as HTMLElement | null | undefined;
+  if (!doc || !win || !frame) return true;
+
+  let rect: DOMRect;
+  try {
+    rect = range.getBoundingClientRect();
+  } catch {
+    return true;
+  }
+  // Zero-size rects carry no layout information — don't skip the chunk.
+  if (rect.width === 0 && rect.height === 0) return true;
+
+  const parentWin = frame.ownerDocument.defaultView;
+  if (!parentWin || typeof parentWin.getComputedStyle !== "function") {
+    return true;
+  }
+
+  // Range rect in the embedding document's coordinate space. (The epub.js
+  // iframe spans the whole section; its container scrolls/clips per page.)
+  const frameRect = frame.getBoundingClientRect();
+  let left = frameRect.left + rect.left;
+  let top = frameRect.top + rect.top;
+  let right = left + rect.width;
+  let bottom = top + rect.height;
+
+  for (let el = frame.parentElement; el; el = el.parentElement) {
+    let clips = false;
+    try {
+      const style = parentWin.getComputedStyle(el);
+      clips = OVERFLOW_CLIP_RE.test(
+        `${style.overflow} ${style.overflowX} ${style.overflowY}`
+      );
+    } catch {
+      clips = false;
+    }
+    if (!clips) continue;
+    const clipRect = el.getBoundingClientRect();
+    left = Math.max(left, clipRect.left);
+    top = Math.max(top, clipRect.top);
+    right = Math.min(right, clipRect.right);
+    bottom = Math.min(bottom, clipRect.bottom);
+  }
+  right = Math.min(right, parentWin.innerWidth);
+  bottom = Math.min(bottom, parentWin.innerHeight);
+  left = Math.max(left, 0);
+  top = Math.max(top, 0);
+  return right - left > 1 && bottom - top > 1;
+}
+
 // ---------------------------------------------------------------------------
 // Highlighting
 // ---------------------------------------------------------------------------

--- a/src/stores/useBooksStore.ts
+++ b/src/stores/useBooksStore.ts
@@ -49,6 +49,23 @@ export const BOOKS_SPEECH_RATE_MIN = 0.5;
 export const BOOKS_SPEECH_RATE_MAX = 2;
 export const BOOKS_SPEECH_RATE_OPTIONS = [0.8, 1, 1.2, 1.5] as const;
 
+/**
+ * Coerce a persisted/synced speech rate to a safe utterance rate. Guards
+ * against `undefined`/NaN (e.g. pre-v5 persisted settings that predate the
+ * field): assigning a non-finite rate to SpeechSynthesisUtterance throws.
+ */
+export function normalizeBooksSpeechRate(rate: unknown): number {
+  if (
+    typeof rate !== "number" ||
+    !Number.isFinite(rate) ||
+    rate < BOOKS_SPEECH_RATE_MIN ||
+    rate > BOOKS_SPEECH_RATE_MAX
+  ) {
+    return DEFAULT_BOOKS_SETTINGS.speechRate;
+  }
+  return rate;
+}
+
 export const BOOKS_FONT_SIZE_MIN = 70;
 export const BOOKS_FONT_SIZE_MAX = 180;
 export const BOOKS_FONT_SIZE_STEP = 10;
@@ -169,7 +186,9 @@ export const useBooksStore = create<BooksStoreState>()(
     {
       name: "ryos:books",
       storage: createJSONStorage(() => localStorage),
-      version: 4,
+      // v5: backfill `settings.speechRate` (added in v4 without a version
+      // bump, so persisted settings were missing it after the shallow merge).
+      version: 5,
       migrate: (persistedState) => {
         const state = (persistedState ?? {}) as Partial<BooksStoreState>;
         return {

--- a/tests/test-books-speech.test.ts
+++ b/tests/test-books-speech.test.ts
@@ -12,10 +12,17 @@ import {
   getVisiblePageRange,
   applySpeechHighlight,
   clearSpeechHighlight,
+  isRangeOnVisiblePage,
   splitTextIntoSentences,
   splitTextIntoSpeechSegments,
   type SpeechRenditionLike,
 } from "../src/apps/books/utils/booksSpeech";
+import {
+  BOOKS_SPEECH_RATE_MAX,
+  BOOKS_SPEECH_RATE_MIN,
+  DEFAULT_BOOKS_SETTINGS,
+  normalizeBooksSpeechRate,
+} from "../src/stores/useBooksStore";
 
 beforeAll(() => {
   if (typeof document === "undefined") {
@@ -235,6 +242,45 @@ describe("getVisiblePageRange", () => {
       getRange: () => null,
     };
     expect(getVisiblePageRange(rendition)).toBeNull();
+  });
+});
+
+describe("normalizeBooksSpeechRate", () => {
+  test("defaults to normal speed", () => {
+    expect(DEFAULT_BOOKS_SETTINGS.speechRate).toBe(1);
+  });
+
+  test("passes through valid rates", () => {
+    expect(normalizeBooksSpeechRate(0.8)).toBe(0.8);
+    expect(normalizeBooksSpeechRate(1)).toBe(1);
+    expect(normalizeBooksSpeechRate(1.5)).toBe(1.5);
+    expect(normalizeBooksSpeechRate(BOOKS_SPEECH_RATE_MIN)).toBe(
+      BOOKS_SPEECH_RATE_MIN
+    );
+    expect(normalizeBooksSpeechRate(BOOKS_SPEECH_RATE_MAX)).toBe(
+      BOOKS_SPEECH_RATE_MAX
+    );
+  });
+
+  test("coerces missing/invalid rates to the default (normal)", () => {
+    // Pre-v5 persisted settings lack speechRate entirely; assigning a
+    // non-finite rate to SpeechSynthesisUtterance throws in Chrome.
+    expect(normalizeBooksSpeechRate(undefined)).toBe(1);
+    expect(normalizeBooksSpeechRate(null)).toBe(1);
+    expect(normalizeBooksSpeechRate(Number.NaN)).toBe(1);
+    expect(normalizeBooksSpeechRate("1.2")).toBe(1);
+    expect(normalizeBooksSpeechRate(0)).toBe(1);
+    expect(normalizeBooksSpeechRate(99)).toBe(1);
+  });
+});
+
+describe("isRangeOnVisiblePage", () => {
+  test("is lenient outside an iframe (no layout geometry)", () => {
+    const doc = createBookDocument("<p>Alpha beta.</p>");
+    const chunks = collectSpeechChunksFromRange(rangeOver(doc));
+    expect(chunks.length).toBeGreaterThan(0);
+    // happy-dom documents aren't framed; the filter must not drop chunks.
+    expect(isRangeOnVisiblePage(chunks[0].range)).toBe(true);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up fixes for the Books read-aloud feature (#1723) addressing three reported issues.

## 1. Speed didn't default to Normal
`speechRate` shipped without a store version bump, so existing users' persisted settings shallow-merged over the defaults and left `speechRate` **undefined** — the Speech Rate menu showed nothing selected, and assigning the non-finite rate to `SpeechSynthesisUtterance.rate` throws a `TypeError` in Chrome (verified), breaking speech outright for pre-existing profiles.
- Bumped `ryos:books` persist version to 5 (the existing migrate backfills defaults).
- Added `normalizeBooksSpeechRate()` and use it at both consumers (utterance rate, menu radio) so invalid/missing rates always resolve to 1 (Normal).

![Speech Rate menu shows Normal checked after migrating a v4 (pre-speechRate) store](https://cursor.com/artifacts/c/art-dab4ab3f-c0bf-4aa1-8343-a6f67d48d91b)

## 2. Auto page turn didn't work
Advancing pages depends on the utterance's `end` event, and real engines drop it routinely (Chrome GC-collects unreferenced utterances mid-speech; reproduced with a real speech-dispatcher engine where `onend` never fired — read-aloud stalled at the first page end and stopped). Fixes in `useBooksSpeech`:
- Hold a strong reference to the in-flight utterance (Chrome GC bug).
- Added an engine watchdog that polls `speechSynthesis.speaking/pending`; once speech has started, an idle engine counts as chunk completion, so the chain (and page turns) continue even when `onend` is dropped.
- Hard timeout now treats a started-but-unreported chunk as completed instead of aborting, with a 3-strike limit so a truly broken engine still stops instead of silently paging through the book.

![Read-aloud progressed pages deep into Book I with every end event dropped](https://cursor.com/artifacts/c/art-d7910249-286d-4cd0-b9bd-d569f2a68bd7)

## 3. Spoken text a few pages off after manual turns
Three compounding causes, all fixed:
- **Overshoot:** when the end CFI can't be resolved, the page range falls back to the end of the section, so speech ran pages past the screen. Chunks are now filtered by actual layout geometry (`isRangeOnVisiblePage` projects the chunk rect through the iframe and clips it against the scroll container), making the visible page authoritative.
- **Stale-audio queueing:** engines like Safari keep playing a cancelled utterance briefly; speaking during that window queues the new page's audio behind the old page's. After a relocation, speech now restarts only once the engine is actually idle (cancel-and-poll).
- **Double-advance:** the auto-turn retry re-advanced when epub.js delivered `relocated` late, skipping pages. The retry now checks the current start CFI and keeps waiting when the page already turned.

![Highlight (spoken sentence) on the visible page after rapid manual page turns with a Safari-like cancel wind-down](https://cursor.com/artifacts/c/art-f5a430f3-8d4d-473d-866e-bbab560bed66)

## Testing
- ✅ `bun test tests/test-books-speech.test.ts` (23 pass; new coverage for `normalizeBooksSpeechRate` + `isRangeOnVisiblePage` leniency)
- ✅ `bun test tests/test-books-menu-layout.test.ts tests/test-calculator-speech.test.ts tests/test-sync-v2-codecs.test.ts`
- ✅ `bun run build`
- ✅ Headless-Chrome E2E (Playwright) with a v4-persisted store and a mock engine that drops all `end` events: store migrates to v5 with `speechRate: 1`, "Normal" checked in the menu, read-aloud crossed 7 pages / 63 utterances unattended, and every utterance's highlight verified geometrically on-screen (12/12 and 6/6) across rapid manual flips, including a Safari-like cancel wind-down mock.
- ✅ Lint: no new errors vs `main` (pre-existing warnings unchanged).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f209a-02c2-756f-b24a-9c4591924513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f209a-02c2-756f-b24a-9c4591924513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

