### PR TITLE
Books: show overlay controls (rewind/pause/skip/stop) while read-aloud is playing

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { useTranslation } from "react-i18next";
+import { FastForward, Pause, Play, Rewind, Stop } from "@phosphor-icons/react";
 import ePub, { type Book, type NavItem, type Rendition } from "epubjs";
 import { cn } from "@/lib/utils";
 import { useResizeObserverWithRef } from "@/hooks/useResizeObserver";
@@ -119,6 +120,10 @@ const FOOTER_HEIGHT = 30;
 // Width at which auto column mode switches to a two-page spread. epub.js
 // defaults to 800; a lower value shows two columns on narrower windows.
 const SPREAD_MIN_WIDTH = 560;
+
+// Shared style for the read-aloud overlay control buttons.
+const SPEECH_OVERLAY_BUTTON_CLASS =
+  "flex h-7 w-7 items-center justify-center rounded-full transition-colors hover:bg-white/20 disabled:opacity-40 disabled:hover:bg-transparent";
 
 // Open transition timings. Keep the page reveal slightly after the cover zoom
 // settles so the two never fight (which reads as a "pop"). Shared with the
@@ -1289,8 +1294,11 @@ export const BooksReaderPane = forwardRef<
   );
   const {
     isSpeaking,
+    isPaused,
     startSpeaking,
     stopSpeaking,
+    pauseSpeaking,
+    resumeSpeaking,
     handleRelocated: handleSpeechRelocated,
   } = useBooksSpeech({
     getRendition: () => renditionRef.current,
@@ -1421,6 +1429,82 @@ export const BooksReaderPane = forwardRef<
           {Math.round(progressPct * 100)}%
         </span>
       </div>
+
+      {/* Read-aloud overlay: simple floating controls shown while speech is
+          active. Rewind/skip turn pages (speech restarts on the new page via
+          the relocated handler); pause/resume keeps the current sentence. */}
+      <AnimatePresence>
+        {isSpeaking && (
+          <motion.div
+            className="pointer-events-none absolute inset-x-0 z-30 flex justify-center"
+            style={{ bottom: FOOTER_HEIGHT + 8 }}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 10 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+          >
+            <div
+              className={cn(
+                "pointer-events-auto flex items-center gap-0.5 rounded-full border px-1.5 py-1 shadow-lg backdrop-blur-md",
+                palette.isDark
+                  ? "border-white/15 bg-white/10 text-white"
+                  : "border-black/10 bg-black/60 text-white"
+              )}
+            >
+              <button
+                type="button"
+                aria-label={t("apps.books.speech.rewind")}
+                title={t("apps.books.speech.rewind")}
+                onClick={() => turnPage("prev")}
+                disabled={!navigationState.canGoPreviousPage}
+                className={SPEECH_OVERLAY_BUTTON_CLASS}
+              >
+                <Rewind weight="fill" size={16} />
+              </button>
+              <button
+                type="button"
+                aria-label={
+                  isPaused
+                    ? t("apps.books.speech.resume")
+                    : t("apps.books.speech.pause")
+                }
+                title={
+                  isPaused
+                    ? t("apps.books.speech.resume")
+                    : t("apps.books.speech.pause")
+                }
+                onClick={isPaused ? resumeSpeaking : pauseSpeaking}
+                className={SPEECH_OVERLAY_BUTTON_CLASS}
+              >
+                {isPaused ? (
+                  <Play weight="fill" size={16} />
+                ) : (
+                  <Pause weight="fill" size={16} />
+                )}
+              </button>
+              <button
+                type="button"
+                aria-label={t("apps.books.speech.skip")}
+                title={t("apps.books.speech.skip")}
+                onClick={() => turnPage("next")}
+                disabled={!navigationState.canGoNextPage}
+                className={SPEECH_OVERLAY_BUTTON_CLASS}
+              >
+                <FastForward weight="fill" size={16} />
+              </button>
+              <button
+                type="button"
+                aria-label={t("apps.books.speech.stop")}
+                title={t("apps.books.speech.stop")}
+                onClick={stopSpeaking}
+                className={SPEECH_OVERLAY_BUTTON_CLASS}
+              >
+                <Stop weight="fill" size={16} />
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* Page-turn animation. epub.js only ever has the single current page
           rendered, so a true two-page slide (or a curl showing the outgoing

--- a/src/apps/books/hooks/useBooksSpeech.ts
+++ b/src/apps/books/hooks/useBooksSpeech.ts
@@ -55,8 +55,12 @@ interface UseBooksSpeechOptions {
 
 export interface UseBooksSpeechResult {
   isSpeaking: boolean;
+  /** True while read-aloud is active but paused (resumable). */
+  isPaused: boolean;
   startSpeaking: () => void;
   stopSpeaking: () => void;
+  pauseSpeaking: () => void;
+  resumeSpeaking: () => void;
   /** Call from the rendition's `relocated` handler. */
   handleRelocated: () => void;
 }
@@ -77,10 +81,16 @@ export function useBooksSpeech({
   advancePage,
 }: UseBooksSpeechOptions): UseBooksSpeechResult {
   const [isSpeaking, setIsSpeaking] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
   // Bumping the session invalidates every pending utterance callback/timer.
   const sessionRef = useRef(0);
   // True while the user wants read-aloud (also across auto page turns).
   const wantsSpeechRef = useRef(false);
+  // Mirrors isPaused for callbacks that must not depend on render state.
+  const isPausedRef = useRef(false);
+  // Chunks (and index) of the in-flight page so pause can resume mid-page.
+  const currentChunksRef = useRef<BooksSpeechChunk[] | null>(null);
+  const currentChunkIndexRef = useRef(0);
   // Consecutive auto-skipped pages with no speakable text.
   const emptyPageStreakRef = useRef(0);
   // Consecutive chunks that ended only via the hard timeout (no engine event).
@@ -120,11 +130,15 @@ export function useBooksSpeech({
   const stopSpeaking = useCallback(() => {
     sessionRef.current += 1;
     wantsSpeechRef.current = false;
+    isPausedRef.current = false;
     activeUtteranceRef.current = null;
+    currentChunksRef.current = null;
+    currentChunkIndexRef.current = 0;
     clearTimers();
     clearHighlight();
     getBrowserSpeechSynthesis()?.cancel();
     setIsSpeaking(false);
+    setIsPaused(false);
   }, [clearHighlight, clearTimers]);
 
   const getCurrentStartCfi = useCallback((): string | null => {
@@ -149,6 +163,10 @@ export function useBooksSpeech({
   const finishPage = useCallback(
     (session: number, attempt = 0) => {
       if (session !== sessionRef.current) return;
+      // Off the chunked page now — a pause during the turn resumes from the
+      // freshly visible page instead of stale ranges.
+      currentChunksRef.current = null;
+      currentChunkIndexRef.current = 0;
       clearHighlight();
       if (
         !optionsRef.current.canAdvancePage() ||
@@ -193,6 +211,9 @@ export function useBooksSpeech({
         stopSpeaking();
         return;
       }
+
+      currentChunksRef.current = chunks;
+      currentChunkIndexRef.current = index;
 
       clearHighlight();
       highlightedDocRef.current =
@@ -323,11 +344,11 @@ export function useBooksSpeech({
     [finishPage, speakChunk, stopSpeaking]
   );
 
-  // Restart speech once the engine has actually gone idle. Speaking while a
+  // Run `speak` once the engine has actually gone idle. Speaking while a
   // cancelled utterance is still winding down queues the new chunk behind
   // stale audio on some engines (Safari), drifting speech behind the screen.
-  const speakVisiblePageWhenIdle = useCallback(
-    (session: number, polls = 0) => {
+  const speakWhenSynthIdle = useCallback(
+    (session: number, speak: () => void, polls = 0) => {
       if (session !== sessionRef.current) return;
       const synth = getBrowserSpeechSynthesis();
       if (!synth) {
@@ -337,20 +358,27 @@ export function useBooksSpeech({
       if ((synth.speaking || synth.pending) && polls < MAX_ENSURE_IDLE_POLLS) {
         synth.cancel();
         const timeoutId = window.setTimeout(
-          () => speakVisiblePageWhenIdle(session, polls + 1),
+          () => speakWhenSynthIdle(session, speak, polls + 1),
           ENSURE_IDLE_POLL_MS
         );
         timersRef.current.push(timeoutId);
         return;
       }
-      speakVisiblePage(session);
+      speak();
     },
-    [speakVisiblePage, stopSpeaking]
+    [stopSpeaking]
+  );
+
+  const speakVisiblePageWhenIdle = useCallback(
+    (session: number) =>
+      speakWhenSynthIdle(session, () => speakVisiblePage(session)),
+    [speakVisiblePage, speakWhenSynthIdle]
   );
 
   const startSpeaking = useCallback(() => {
     const session = ++sessionRef.current;
     wantsSpeechRef.current = true;
+    isPausedRef.current = false;
     emptyPageStreakRef.current = 0;
     timeoutEndingStreakRef.current = 0;
     clearTimers();
@@ -359,21 +387,62 @@ export function useBooksSpeech({
     if (!synth) return;
     synth.cancel();
     setIsSpeaking(true);
+    setIsPaused(false);
     // Warm the voice list (async on some engines); utterance.lang still lets
     // the engine pick a fallback voice before the list loads.
     synth.getVoices();
     speakVisiblePage(session);
   }, [clearHighlight, clearTimers, speakVisiblePage]);
 
+  // Pause is implemented as cancel + remember-the-chunk rather than
+  // synth.pause(): pause() is unreliable on several engines (Chrome can stall
+  // permanently, some backends ignore it), and a paused engine would also trip
+  // the utterance watchdog/timeout machinery. Resuming re-speaks the current
+  // sentence from its start, which reads naturally.
+  const pauseSpeaking = useCallback(() => {
+    if (!wantsSpeechRef.current || isPausedRef.current) return;
+    // Invalidate pending utterance callbacks/timers without dropping the
+    // remembered chunk position.
+    sessionRef.current += 1;
+    isPausedRef.current = true;
+    activeUtteranceRef.current = null;
+    clearTimers();
+    getBrowserSpeechSynthesis()?.cancel();
+    // Keep the highlight so the reader can see where speech will resume.
+    setIsPaused(true);
+  }, [clearTimers]);
+
+  const resumeSpeaking = useCallback(() => {
+    if (!wantsSpeechRef.current || !isPausedRef.current) return;
+    const session = ++sessionRef.current;
+    isPausedRef.current = false;
+    timeoutEndingStreakRef.current = 0;
+    setIsPaused(false);
+    const chunks = currentChunksRef.current;
+    const index = currentChunkIndexRef.current;
+    speakWhenSynthIdle(session, () => {
+      if (chunks && chunks[index]) {
+        speakChunk(session, chunks, index);
+      } else {
+        speakVisiblePage(session);
+      }
+    });
+  }, [speakChunk, speakVisiblePage, speakWhenSynthIdle]);
+
   const handleRelocated = useCallback(() => {
     if (!wantsSpeechRef.current) return;
     // Invalidate in-flight utterances (manual page turns / chapter jumps /
-    // reflows) and restart from the freshly visible page.
+    // reflows) and restart from the freshly visible page. A page change while
+    // paused (e.g. overlay rewind/skip) resumes playback on the new page.
     const session = ++sessionRef.current;
+    isPausedRef.current = false;
     activeUtteranceRef.current = null;
+    currentChunksRef.current = null;
+    currentChunkIndexRef.current = 0;
     clearTimers();
     clearHighlight();
     getBrowserSpeechSynthesis()?.cancel();
+    setIsPaused(false);
     const timeoutId = window.setTimeout(() => {
       speakVisiblePageWhenIdle(session);
     }, RESUME_AFTER_RELOCATE_MS);
@@ -383,5 +452,13 @@ export function useBooksSpeech({
   // Stop speech (and drop highlights) when the reader unmounts / book closes.
   useEffect(() => () => stopSpeaking(), [stopSpeaking]);
 
-  return { isSpeaking, startSpeaking, stopSpeaking, handleRelocated };
+  return {
+    isSpeaking,
+    isPaused,
+    startSpeaking,
+    stopSpeaking,
+    pauseSpeaking,
+    resumeSpeaking,
+    handleRelocated,
+  };
 }

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -676,6 +676,13 @@
         "listView": "Listendarstellung",
         "percentRead": "{{percent}}%"
       },
+      "speech": {
+        "pause": "Pause",
+        "resume": "Fortsetzen",
+        "rewind": "Zurückspulen",
+        "skip": "Überspringen",
+        "stop": "Stopp"
+      },
       "speechRate": {
         "fast": "Schnell",
         "normal": "Normal",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -4555,6 +4555,13 @@
         "fast": "Fast",
         "veryFast": "Very Fast"
       },
+      "speech": {
+        "rewind": "Rewind",
+        "pause": "Pause",
+        "resume": "Resume",
+        "skip": "Skip",
+        "stop": "Stop"
+      },
       "columns": {
         "auto": "Auto",
         "single": "Single",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -678,6 +678,13 @@
         "listView": "Visualización como lista",
         "percentRead": "{{percent}}%"
       },
+      "speech": {
+        "pause": "Pausa",
+        "resume": "Reanudar",
+        "rewind": "Retroceder",
+        "skip": "Omitir",
+        "stop": "Detener"
+      },
       "speechRate": {
         "fast": "Rápida",
         "normal": "Normal",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -678,6 +678,13 @@
         "listView": "Présentation par liste",
         "percentRead": "{{percent}} %"
       },
+      "speech": {
+        "pause": "Pause",
+        "resume": "Reprendre",
+        "rewind": "Retour arrière",
+        "skip": "Passer",
+        "stop": "Arrêter"
+      },
       "speechRate": {
         "fast": "Rapide",
         "normal": "Normale",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -678,6 +678,13 @@
         "listView": "Vista a elenco",
         "percentRead": "{{percent}}%"
       },
+      "speech": {
+        "pause": "Pausa",
+        "resume": "Riprendi",
+        "rewind": "Riavvolgi",
+        "skip": "Salta",
+        "stop": "Interrompi"
+      },
       "speechRate": {
         "fast": "Veloce",
         "normal": "Normale",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -676,6 +676,13 @@
         "listView": "リスト表示",
         "percentRead": "{{percent}}%"
       },
+      "speech": {
+        "pause": "一時停止",
+        "resume": "再開",
+        "rewind": "早戻し",
+        "skip": "スキップ",
+        "stop": "停止"
+      },
       "speechRate": {
         "fast": "速い",
         "normal": "標準",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -676,6 +676,13 @@
         "listView": "목록 보기",
         "percentRead": "{{percent}}%"
       },
+      "speech": {
+        "pause": "일시 정지",
+        "resume": "재개",
+        "rewind": "되감기",
+        "skip": "건너뛰기",
+        "stop": "중단"
+      },
       "speechRate": {
         "fast": "빠름",
         "normal": "보통",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -678,6 +678,13 @@
         "listView": "Visualização por Lista",
         "percentRead": "{{percent}}%"
       },
+      "speech": {
+        "pause": "Pausar",
+        "resume": "Retomar",
+        "rewind": "Retroceder",
+        "skip": "Pular",
+        "stop": "Parar"
+      },
       "speechRate": {
         "fast": "Rápida",
         "normal": "Normal",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -680,6 +680,13 @@
         "listView": "Список",
         "percentRead": "{{percent}}%"
       },
+      "speech": {
+        "pause": "Пауза",
+        "resume": "Продолжить",
+        "rewind": "Перемотать назад",
+        "skip": "Пропустить",
+        "stop": "Остановить"
+      },
       "speechRate": {
         "fast": "Быстро",
         "normal": "Обычная",

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -676,6 +676,13 @@
         "listView": "列表视图",
         "percentRead": "{{percent}}%"
       },
+      "speech": {
+        "pause": "暂停",
+        "resume": "继续",
+        "rewind": "倒回",
+        "skip": "跳过",
+        "stop": "停止"
+      },
       "speechRate": {
         "fast": "快",
         "normal": "正常",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -676,6 +676,13 @@
         "listView": "列表顯示方式",
         "percentRead": "{{percent}}%"
       },
+      "speech": {
+        "pause": "暫停",
+        "resume": "繼續",
+        "rewind": "倒轉",
+        "skip": "跳過",
+        "stop": "停止"
+      },
       "speechRate": {
         "fast": "快",
         "normal": "正常",

--- a/tests/test-books-speech-pause.test.tsx
+++ b/tests/test-books-speech-pause.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Wiring tests for the Books read-aloud pause/resume controls
+ * (useBooksSpeech): pausing cancels the engine but keeps the position,
+ * resuming re-speaks the interrupted sentence, and page relocation while
+ * paused resumes playback on the new page.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+if (typeof document === "undefined") {
+  GlobalRegistrator.register();
+}
+
+class FakeUtterance {
+  text: string;
+  lang = "";
+  rate = 1;
+  voice: unknown = null;
+  onstart: (() => void) | null = null;
+  onend: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(text: string) {
+    this.text = text;
+  }
+}
+(globalThis as { SpeechSynthesisUtterance?: unknown }).SpeechSynthesisUtterance =
+  FakeUtterance;
+
+const spoken: FakeUtterance[] = [];
+const synth = {
+  speaking: false,
+  pending: false,
+  paused: false,
+  cancelCalls: 0,
+  speak(utterance: FakeUtterance) {
+    spoken.push(utterance);
+    this.speaking = true;
+    utterance.onstart?.();
+  },
+  cancel() {
+    this.cancelCalls += 1;
+    this.speaking = false;
+    this.pending = false;
+  },
+  resume() {},
+  pause() {},
+  getVoices: () => [],
+};
+Object.defineProperty(globalThis.window, "speechSynthesis", {
+  value: synth,
+  configurable: true,
+});
+
+function finishCurrentUtterance() {
+  const utterance = spoken[spoken.length - 1];
+  synth.speaking = false;
+  utterance?.onend?.();
+}
+
+const { useBooksSpeech } = await import(
+  "../src/apps/books/hooks/useBooksSpeech"
+);
+type SpeechResult = ReturnType<typeof useBooksSpeech>;
+
+// Rendition stub: one "page" whose start/end CFIs resolve to the boundaries
+// of a single paragraph, so the chunker yields one chunk per sentence.
+function getPageTextNode(): Text {
+  return document.querySelector("#page p")!.firstChild as Text;
+}
+const rendition = {
+  currentLocation: () => ({
+    start: { cfi: "cfi-start" },
+    end: { cfi: "cfi-end" },
+  }),
+  getRange: (cfi: string) => {
+    const node = getPageTextNode();
+    const range = document.createRange();
+    const offset = cfi === "cfi-start" ? 0 : node.data.length;
+    range.setStart(node, offset);
+    range.setEnd(node, offset);
+    return range;
+  },
+};
+
+let latest: SpeechResult | null = null;
+function SpeechProbe() {
+  latest = useBooksSpeech({
+    getRendition: () => rendition,
+    getSpeechLanguage: () => "en-US",
+    getSpeechRate: () => 1,
+    canAdvancePage: () => false,
+    advancePage: () => {},
+  });
+  return null;
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+let container: HTMLElement | null = null;
+let root: Root | null = null;
+
+beforeEach(async () => {
+  document.body.innerHTML =
+    '<div id="page"><p>First sentence. Second sentence.</p></div>';
+  spoken.length = 0;
+  synth.speaking = false;
+  synth.pending = false;
+  synth.cancelCalls = 0;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  root.render(React.createElement(SpeechProbe));
+  await waitFor(() => latest !== null);
+});
+
+afterEach(async () => {
+  root?.unmount();
+  root = null;
+  container?.remove();
+  container = null;
+  latest = null;
+  // Drain React's scheduler before happy-dom is unregistered.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+afterAll(() => {
+  if (GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.unregister();
+  }
+});
+
+describe("useBooksSpeech pause/resume", () => {
+  test("pause cancels the engine and resume re-speaks the interrupted sentence", async () => {
+    latest!.startSpeaking();
+    await waitFor(() => spoken.length === 1);
+    expect(spoken[0].text).toBe("First sentence.");
+    await waitFor(() => latest!.isSpeaking);
+    expect(latest!.isPaused).toBe(false);
+
+    finishCurrentUtterance();
+    await waitFor(() => spoken.length === 2);
+    expect(spoken[1].text).toBe("Second sentence.");
+
+    const cancelsBeforePause = synth.cancelCalls;
+    latest!.pauseSpeaking();
+    await waitFor(() => latest!.isPaused);
+    expect(latest!.isSpeaking).toBe(true);
+    expect(synth.cancelCalls).toBeGreaterThan(cancelsBeforePause);
+    expect(spoken.length).toBe(2);
+
+    latest!.resumeSpeaking();
+    await waitFor(() => spoken.length === 3);
+    expect(spoken[2].text).toBe("Second sentence.");
+    await waitFor(() => !latest!.isPaused);
+    expect(latest!.isSpeaking).toBe(true);
+
+    latest!.stopSpeaking();
+    await waitFor(() => !latest!.isSpeaking);
+    expect(latest!.isPaused).toBe(false);
+  });
+
+  test("relocating while paused clears the pause and restarts on the visible page", async () => {
+    latest!.startSpeaking();
+    await waitFor(() => spoken.length === 1);
+
+    latest!.pauseSpeaking();
+    await waitFor(() => latest!.isPaused);
+
+    // Simulate a page turn (e.g. overlay rewind/skip) while paused.
+    latest!.handleRelocated();
+    await waitFor(() => !latest!.isPaused);
+    // Speech restarts from the freshly visible page after the settle delay.
+    await waitFor(() => spoken.length === 2);
+    expect(spoken[1].text).toBe("First sentence.");
+    expect(latest!.isSpeaking).toBe(true);
+
+    latest!.stopSpeaking();
+    await waitFor(() => !latest!.isSpeaking);
+  });
+
+  test("pausing mid-first-sentence resumes from that sentence's start", async () => {
+    latest!.startSpeaking();
+    await waitFor(() => spoken.length === 1);
+
+    latest!.pauseSpeaking();
+    await waitFor(() => latest!.isPaused);
+
+    latest!.resumeSpeaking();
+    await waitFor(() => spoken.length === 2);
+    expect(spoken[1].text).toBe("First sentence.");
+
+    latest!.stopSpeaking();
+    await waitFor(() => !latest!.isSpeaking);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While read-aloud speech is active in the Books reader, a simple floating overlay now appears above the progress footer with four controls:

- **Rewind** — turns to the previous page (speech restarts there via the existing `relocated` handling)
- **Pause / Resume** — pauses speech and resumes from the start of the interrupted sentence
- **Skip** — turns to the next page
- **Stop** — ends read-aloud and dismisses the overlay

### Implementation notes

- `useBooksSpeech` gains `isPaused` / `pauseSpeaking` / `resumeSpeaking`. Pause is implemented as cancel + remember-the-current-chunk rather than `speechSynthesis.pause()`, which is unreliable on several engines (Chrome can stall permanently) and would trip the hook's utterance watchdog/timeout machinery. Resume re-speaks the interrupted sentence from its start; a page change while paused (e.g. overlay rewind/skip) resumes playback on the new page.
- The overlay lives in `BooksReaderPane`, follows the reading palette (dark/light pill), animates in/out with `motion`, and disables rewind/skip at book boundaries.
- New strings live under `apps.books.speech.*` and were synced + machine-translated across all 10 non-English locales (audit passes).
- Added `tests/test-books-speech-pause.test.tsx` covering pause/resume wiring with a mocked speech engine.

## Testing

- ✅ `bun test tests/test-books-speech-pause.test.tsx tests/test-books-speech.test.ts tests/test-books-menu-layout.test.ts tests/test-books-vertical-text.test.ts`
- ✅ `bun run test:registration`
- ✅ `bun run build`
- ✅ `bun run i18n:sync:dry-run` / `bun run i18n:audit`
- ✅ `bunx eslint` on touched files (only the pre-existing `react-refresh/only-export-components` warning in `BooksReaderPane.tsx`)

GUI-driven testing skipped per repo guidelines (AGENTS.md: skip computer use unless explicitly requested).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2158-4c20-7a2e-80e1-e1a1ee5e5182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2158-4c20-7a2e-80e1-e1a1ee5e5182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

