### PR TITLE
Fix Books read-aloud for sentences crossing a page boundary

### DIFF
--- a/src/apps/books/hooks/useBooksSpeech.ts
+++ b/src/apps/books/hooks/useBooksSpeech.ts
@@ -8,7 +8,10 @@ import {
   clearSpeechHighlight,
   collectSpeechChunksFromRange,
   getVisiblePageRange,
+  isRangeEndOnVisiblePage,
   isRangeOnVisiblePage,
+  rangeEndsAtOrBefore,
+  type BooksSpeechCarryOver,
   type BooksSpeechChunk,
   type SpeechRenditionLike,
 } from "../utils/booksSpeech";
@@ -43,6 +46,10 @@ const RESUME_AFTER_RELOCATE_MS = 120;
  * behind stale audio and read-aloud drifts pages behind the screen. */
 const ENSURE_IDLE_POLL_MS = 150;
 const MAX_ENSURE_IDLE_POLLS = 40;
+/** When the page auto-turns mid-utterance (a sentence cut by the page end),
+ * the tail of that sentence keeps playing across the flip — wait for its
+ * natural end rather than cancelling it. Generous cap for slow voices. */
+const MAX_NATURAL_FINISH_POLLS = 300;
 
 interface UseBooksSpeechOptions {
   getRendition: () => SpeechRenditionLike | null;
@@ -91,6 +98,16 @@ export function useBooksSpeech({
   const activeUtteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
   const highlightedDocRef = useRef<Document | null>(null);
   const timersRef = useRef<number[]>([]);
+  // Set when the page was auto-turned at a mid-sentence cut while the cut
+  // sentence is still being spoken. `relocated` consumes it to resume speech
+  // on the new page without cancelling the in-flight utterance.
+  const cutAdvanceRef = useRef<{
+    carryOver: BooksSpeechCarryOver;
+    beforeCfi: string | null;
+  } | null>(null);
+  // End position of the last chunk spoken before an auto page turn at a
+  // sentence cut, so the new page skips text that was already spoken.
+  const pendingCarryOverRef = useRef<BooksSpeechCarryOver | null>(null);
 
   const optionsRef = useRef({
     getRendition,
@@ -121,6 +138,8 @@ export function useBooksSpeech({
     sessionRef.current += 1;
     wantsSpeechRef.current = false;
     activeUtteranceRef.current = null;
+    cutAdvanceRef.current = null;
+    pendingCarryOverRef.current = null;
     clearTimers();
     clearHighlight();
     getBrowserSpeechSynthesis()?.cancel();
@@ -157,8 +176,14 @@ export function useBooksSpeech({
         stopSpeaking();
         return;
       }
-      const beforeCfi = getCurrentStartCfi();
-      optionsRef.current.advancePage();
+      // A mid-utterance cut advance already turned this page — don't turn
+      // again; just wait for its `relocated` event (which resumes speech).
+      // If that turn was swallowed, the retry below re-advances.
+      const cutAdvance = cutAdvanceRef.current;
+      const beforeCfi = cutAdvance ? cutAdvance.beforeCfi : getCurrentStartCfi();
+      if (!cutAdvance || attempt > 0) {
+        optionsRef.current.advancePage();
+      }
       const waitForRelocate = (checksLeft: number) => {
         const timeoutId = window.setTimeout(() => {
           // A `relocated` event would have bumped the session and resumed.
@@ -178,6 +203,27 @@ export function useBooksSpeech({
       waitForRelocate(MAX_RELOCATE_WAIT_CHECKS);
     },
     [clearHighlight, getCurrentStartCfi, stopSpeaking]
+  );
+
+  // Turn the page at a sentence that is cut off by the page end, while (or
+  // right after) speaking it — the sentence audio continues uninterrupted
+  // across the flip, and the recorded carry-over lets the new page skip the
+  // text that was already spoken (instead of repeating the sentence).
+  const advanceAtCut = useCallback(
+    (session: number, chunk: BooksSpeechChunk) => {
+      if (session !== sessionRef.current) return;
+      if (cutAdvanceRef.current) return;
+      if (!optionsRef.current.canAdvancePage()) return;
+      cutAdvanceRef.current = {
+        carryOver: {
+          endContainer: chunk.range.endContainer,
+          endOffset: chunk.range.endOffset,
+        },
+        beforeCfi: getCurrentStartCfi(),
+      };
+      optionsRef.current.advancePage();
+    },
+    [getCurrentStartCfi]
   );
 
   const speakChunk = useCallback(
@@ -237,6 +283,22 @@ export function useBooksSpeech({
           stopSpeaking();
           return;
         }
+        // Sentence cut off by the page end but no word boundary crossed the
+        // cut while speaking (engine without boundary events, or the cut sat
+        // at the very end): turn the page now so the next page resumes with
+        // the carry-over instead of repeating this sentence.
+        if (chunk.pageEndCutIndex !== undefined) {
+          advanceAtCut(session, chunk);
+        }
+        if (cutAdvanceRef.current) {
+          // A page turn at the cut is in flight. Anything after this chunk
+          // lives past the page boundary — the resumed speech on the new
+          // page picks it up (after the carry-over skip); finishPage just
+          // waits for `relocated` (re-advancing only if the turn was
+          // swallowed).
+          finishPage(session);
+          return;
+        }
         speakChunk(session, chunks, index + 1);
       };
 
@@ -245,6 +307,18 @@ export function useBooksSpeech({
       };
       utterance.onend = () => settle(true);
       utterance.onerror = () => settle(false);
+      const cutIndex = chunk.pageEndCutIndex;
+      if (cutIndex !== undefined && cutIndex < chunk.text.length) {
+        // The sentence continues past the visible page end. Flip the page as
+        // the spoken word crosses the cut so the text being read stays on
+        // screen; the utterance keeps playing through the flip.
+        utterance.onboundary = (event) => {
+          if (settled || session !== sessionRef.current) return;
+          if (event.charIndex >= cutIndex) {
+            advanceAtCut(session, chunk);
+          }
+        };
+      }
 
       // Some engines never deliver end events (and Chrome can GC-drop them
       // even with the utterance referenced), so poll the engine: once speech
@@ -284,7 +358,7 @@ export function useBooksSpeech({
       synth.resume();
       synth.speak(utterance);
     },
-    [clearHighlight, finishPage, stopSpeaking]
+    [advanceAtCut, clearHighlight, finishPage, stopSpeaking]
   );
 
   const speakVisiblePage = useCallback(
@@ -295,6 +369,8 @@ export function useBooksSpeech({
         stopSpeaking();
         return;
       }
+      const carryOver = pendingCarryOverRef.current;
+      pendingCarryOverRef.current = null;
       let chunks: BooksSpeechChunk[] = [];
       try {
         const range = getVisiblePageRange(rendition);
@@ -303,6 +379,26 @@ export function useBooksSpeech({
         // boundary is unresolvable and the range extends to the section end).
         // Trust layout geometry: only speak chunks actually on screen.
         chunks = chunks.filter((chunk) => isRangeOnVisiblePage(chunk.range));
+        // After an auto page turn at a cut-off sentence, skip everything
+        // that was already spoken on the previous page (the cut sentence was
+        // spoken whole across the flip) instead of repeating it.
+        if (carryOver) {
+          chunks = chunks.filter(
+            (chunk) => !rangeEndsAtOrBefore(chunk.range, carryOver)
+          );
+        }
+        // When the cut wasn't detectable from the page range itself (an
+        // unresolvable end boundary falls back to the section end), detect it
+        // geometrically: a final chunk whose end is off-screen crosses onto
+        // the next page — flip once it finishes and carry over its end.
+        const lastChunk = chunks[chunks.length - 1];
+        if (
+          lastChunk &&
+          lastChunk.pageEndCutIndex === undefined &&
+          !isRangeEndOnVisiblePage(lastChunk.range)
+        ) {
+          lastChunk.pageEndCutIndex = lastChunk.text.length;
+        }
       } catch {
         chunks = [];
       }
@@ -326,18 +422,24 @@ export function useBooksSpeech({
   // Restart speech once the engine has actually gone idle. Speaking while a
   // cancelled utterance is still winding down queues the new chunk behind
   // stale audio on some engines (Safari), drifting speech behind the screen.
+  // With `cancelWhileWaiting` false (auto page turn at a cut-off sentence),
+  // the in-flight utterance is left to finish naturally — the tail of the
+  // cut sentence plays across the flip — before speaking the new page.
   const speakVisiblePageWhenIdle = useCallback(
-    (session: number, polls = 0) => {
+    (session: number, polls = 0, cancelWhileWaiting = true) => {
       if (session !== sessionRef.current) return;
       const synth = getBrowserSpeechSynthesis();
       if (!synth) {
         stopSpeaking();
         return;
       }
-      if ((synth.speaking || synth.pending) && polls < MAX_ENSURE_IDLE_POLLS) {
-        synth.cancel();
+      const maxPolls = cancelWhileWaiting
+        ? MAX_ENSURE_IDLE_POLLS
+        : MAX_NATURAL_FINISH_POLLS;
+      if ((synth.speaking || synth.pending) && polls < maxPolls) {
+        if (cancelWhileWaiting) synth.cancel();
         const timeoutId = window.setTimeout(
-          () => speakVisiblePageWhenIdle(session, polls + 1),
+          () => speakVisiblePageWhenIdle(session, polls + 1, cancelWhileWaiting),
           ENSURE_IDLE_POLL_MS
         );
         timersRef.current.push(timeoutId);
@@ -353,6 +455,8 @@ export function useBooksSpeech({
     wantsSpeechRef.current = true;
     emptyPageStreakRef.current = 0;
     timeoutEndingStreakRef.current = 0;
+    cutAdvanceRef.current = null;
+    pendingCarryOverRef.current = null;
     clearTimers();
     clearHighlight();
     const synth = getBrowserSpeechSynthesis();
@@ -367,11 +471,25 @@ export function useBooksSpeech({
 
   const handleRelocated = useCallback(() => {
     if (!wantsSpeechRef.current) return;
+    const cutAdvance = cutAdvanceRef.current;
+    cutAdvanceRef.current = null;
+    const session = ++sessionRef.current;
+    clearTimers();
+    if (cutAdvance) {
+      // Auto page turn at a mid-sentence cut: the tail of the cut sentence
+      // is (possibly) still being spoken — keep the utterance and highlight
+      // alive across the flip, then resume past the already-spoken text.
+      pendingCarryOverRef.current = cutAdvance.carryOver;
+      const timeoutId = window.setTimeout(() => {
+        speakVisiblePageWhenIdle(session, 0, false);
+      }, RESUME_AFTER_RELOCATE_MS);
+      timersRef.current.push(timeoutId);
+      return;
+    }
     // Invalidate in-flight utterances (manual page turns / chapter jumps /
     // reflows) and restart from the freshly visible page.
-    const session = ++sessionRef.current;
+    pendingCarryOverRef.current = null;
     activeUtteranceRef.current = null;
-    clearTimers();
     clearHighlight();
     getBrowserSpeechSynthesis()?.cancel();
     const timeoutId = window.setTimeout(() => {

--- a/src/apps/books/utils/booksSpeech.ts
+++ b/src/apps/books/utils/booksSpeech.ts
@@ -10,6 +10,21 @@ export interface BooksSpeechChunk {
   text: string;
   /** Range covering the chunk inside the EPUB section document. */
   range: Range;
+  /**
+   * Set when the sentence is cut off by the end of the visible page and its
+   * text was extended past the page boundary so it can be spoken whole:
+   * offset into `text` where the visible page ends (the rest of the sentence
+   * flows onto the next page). Used to auto-turn the page as speech crosses
+   * the boundary.
+   */
+  pageEndCutIndex?: number;
+}
+
+/** Document position where the last spoken chunk ended, carried across an
+ * auto page turn so speech on the new page skips already-spoken text. */
+export interface BooksSpeechCarryOver {
+  endContainer: Node;
+  endOffset: number;
 }
 
 export interface SpeechTextSegment {
@@ -22,6 +37,10 @@ export interface SpeechTextSegment {
 /** Chunks longer than this are split at word boundaries. Keeping utterances
  * short avoids the long-standing Chrome bug where long utterances stall. */
 export const BOOKS_SPEECH_MAX_CHUNK_LENGTH = 240;
+
+/** How far past the visible page end a cut-off sentence may be extended.
+ * Generous enough to finish any sentence the chunker would speak whole. */
+const MAX_PAGE_CUT_EXTENSION = BOOKS_SPEECH_MAX_CHUNK_LENGTH * 2;
 
 const LATIN_TERMINATORS = new Set([".", "!", "?", "…"]);
 const CJK_TERMINATORS = new Set(["。", "！", "？", "；"]);
@@ -43,12 +62,8 @@ const SOFT_BREAK_CHARS = new Set([",", ";", ":", "，", "、", "：", " "]);
 
 const isWhitespace = (ch: string): boolean => /\s/.test(ch);
 
-/**
- * Split text into sentence boundaries (offsets into the input). Latin
- * terminators only break when followed by whitespace (so "3.14" stays whole);
- * CJK terminators break immediately.
- */
-export function splitTextIntoSentences(text: string): SpeechTextSegment[] {
+/** Sentence-boundary offsets into the input (see splitTextIntoSentences). */
+function findSentenceBoundaries(text: string): number[] {
   const boundaries: number[] = [];
   let i = 0;
   while (i < text.length) {
@@ -75,6 +90,16 @@ export function splitTextIntoSentences(text: string): SpeechTextSegment[] {
     }
     i++;
   }
+  return boundaries;
+}
+
+/**
+ * Split text into sentence boundaries (offsets into the input). Latin
+ * terminators only break when followed by whitespace (so "3.14" stays whole);
+ * CJK terminators break immediately.
+ */
+export function splitTextIntoSentences(text: string): SpeechTextSegment[] {
+  const boundaries = findSentenceBoundaries(text);
 
   const segments: SpeechTextSegment[] = [];
   let start = 0;
@@ -223,6 +248,11 @@ interface TextPiece {
 interface Paragraph {
   text: string;
   pieces: TextPiece[];
+  /**
+   * Offset into `text` where the visible page ends, when the paragraph was
+   * extended past the page boundary to finish a cut-off sentence.
+   */
+  pageCutOffset?: number;
 }
 
 /**
@@ -266,22 +296,62 @@ function compareBoundaryPoints(
   return 0;
 }
 
-function nodeOverlapsRange(node: Text, range: Range): boolean {
-  const length = node.data.length;
-  return (
-    // Node end after range start…
-    compareBoundaryPoints(
-      node,
-      length,
-      range.startContainer,
-      range.startOffset
-    ) > 0 &&
-    // …and node start before range end.
-    compareBoundaryPoints(node, 0, range.endContainer, range.endOffset) < 0
-  );
+/**
+ * Whether `range` ends at or before the carried-over end position of the last
+ * chunk spoken on the previous page (i.e. its text was already spoken).
+ * Lenient (returns false) across documents or for detached nodes, so a
+ * section change or re-render never skips fresh content.
+ */
+export function rangeEndsAtOrBefore(
+  range: Range,
+  carryOver: BooksSpeechCarryOver
+): boolean {
+  const { endContainer, endOffset } = carryOver;
+  if (range.endContainer.ownerDocument !== endContainer.ownerDocument) {
+    return false;
+  }
+  if (!endContainer.isConnected || !range.endContainer.isConnected) {
+    return false;
+  }
+  try {
+    return (
+      compareBoundaryPoints(
+        range.endContainer,
+        range.endOffset,
+        endContainer,
+        endOffset
+      ) <= 0
+    );
+  } catch {
+    return false;
+  }
 }
 
-/** Collect visible text grouped into paragraphs (block-level runs). */
+function getBlockAncestorOfNode(node: Node): Element | null {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return getBlockAncestor(node as Text);
+  }
+  for (
+    let el: Element | null =
+      node.nodeType === Node.ELEMENT_NODE ? (node as Element) : null;
+    el;
+    el = el.parentElement
+  ) {
+    if (BLOCK_TAGS.has(el.tagName)) return el;
+  }
+  return null;
+}
+
+/**
+ * Collect visible text grouped into paragraphs (block-level runs).
+ *
+ * When the range ends mid-sentence (a page boundary cutting a sentence in
+ * half), the final paragraph is extended past the range end — within the
+ * same block, up to the end of the cut sentence or a safety budget — and
+ * `pageCutOffset` records where the visible page actually ends. Read-aloud
+ * uses this to speak the sentence whole and turn the page at the cut instead
+ * of stopping mid-sentence.
+ */
 function collectParagraphs(range: Range): Paragraph[] {
   const container = range.commonAncestorContainer;
   const doc =
@@ -292,10 +362,17 @@ function collectParagraphs(range: Range): Paragraph[] {
 
   // TreeWalker never yields its root, so when the whole range sits inside a
   // single text node, walk from the parent element instead.
-  const walkRoot =
+  let walkRoot =
     container.nodeType === Node.TEXT_NODE
       ? container.parentNode ?? container
       : container;
+  // The remainder of a sentence cut at the range end may live outside the
+  // range's common ancestor (e.g. the range ends inside an inline element);
+  // widen the walk to the cut paragraph's block so the extension can see it.
+  const endBlock = getBlockAncestorOfNode(range.endContainer);
+  if (endBlock && endBlock !== walkRoot && endBlock.contains(walkRoot)) {
+    walkRoot = endBlock;
+  }
   const walker = doc.createTreeWalker(
     walkRoot,
     NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT
@@ -305,52 +382,182 @@ function collectParagraphs(range: Range): Paragraph[] {
   let currentPieces: TextPiece[] = [];
   let currentText = "";
   let currentBlock: Element | null = null;
+  // Offset in the current paragraph where the visible page ends; non-null
+  // while collecting past the range end to finish a cut-off sentence.
+  let cutOffset: number | null = null;
+  let done = false;
 
   const closeParagraph = () => {
     if (currentText.length > 0) {
-      paragraphs.push({ text: currentText, pieces: currentPieces });
+      const paragraph: Paragraph = { text: currentText, pieces: currentPieces };
+      if (cutOffset !== null && cutOffset < currentText.length) {
+        paragraph.pageCutOffset = cutOffset;
+      }
+      paragraphs.push(paragraph);
     }
     currentPieces = [];
     currentText = "";
+    cutOffset = null;
   };
 
-  for (
-    let node = walker.nextNode();
-    node !== null;
-    node = walker.nextNode()
-  ) {
-    if (node.nodeType === Node.ELEMENT_NODE) {
-      // Explicit line breaks split poetry/verse into speakable lines.
-      if ((node as Element).tagName === "BR") closeParagraph();
-      continue;
-    }
-    const textNode = node as Text;
-    if (!nodeOverlapsRange(textNode, range)) continue;
-    if (!isSpokenTextNode(textNode)) continue;
-
-    let start = 0;
-    let end = textNode.data.length;
-    if (range.startContainer === textNode) {
-      start = Math.max(start, range.startOffset);
-    }
-    if (range.endContainer === textNode) {
-      end = Math.min(end, range.endOffset);
-    }
-    if (end <= start) continue;
-
-    const block = getBlockAncestor(textNode);
-    if (block !== currentBlock) {
-      closeParagraph();
-      currentBlock = block;
-    }
-
+  const appendPiece = (node: Text, start: number, end: number) => {
+    if (end <= start) return;
     currentPieces.push({
-      node: textNode,
+      node,
       start,
       end,
       paragraphStart: currentText.length,
     });
-    currentText += textNode.data.slice(start, end);
+    currentText += node.data.slice(start, end);
+  };
+
+  const truncateTo = (offset: number) => {
+    if (currentText.length <= offset) return;
+    currentText = currentText.slice(0, offset);
+    const kept: TextPiece[] = [];
+    for (const piece of currentPieces) {
+      if (piece.paragraphStart >= offset) break;
+      const maxLength = offset - piece.paragraphStart;
+      const length = Math.min(piece.end - piece.start, maxLength);
+      kept.push(
+        length === piece.end - piece.start
+          ? piece
+          : { ...piece, end: piece.start + length }
+      );
+    }
+    currentPieces = kept;
+  };
+
+  // Whether the open paragraph ends mid-sentence at the cut point (real
+  // content after its last sentence boundary).
+  const paragraphCutMidSentence = (): boolean => {
+    if (currentText.length === 0) return false;
+    const boundaries = findSentenceBoundaries(currentText);
+    const lastBoundary =
+      boundaries.length > 0 ? boundaries[boundaries.length - 1] : 0;
+    return trimSegment(currentText, lastBoundary, currentText.length) !== null;
+  };
+
+  // While extending past the cut, stop once the sentence is finished (or the
+  // extension budget is exhausted). Nothing beyond the cut paragraph is
+  // collected.
+  const checkExtensionDone = () => {
+    if (cutOffset === null) return;
+    const cut = cutOffset;
+    const boundary = findSentenceBoundaries(currentText).find((b) => b >= cut);
+    if (boundary !== undefined) {
+      truncateTo(boundary);
+      done = true;
+      closeParagraph();
+      return;
+    }
+    if (currentText.length - cut > MAX_PAGE_CUT_EXTENSION) {
+      truncateTo(cut + MAX_PAGE_CUT_EXTENSION);
+      done = true;
+      closeParagraph();
+    }
+  };
+
+  for (
+    let node = walker.nextNode();
+    node !== null && !done;
+    node = walker.nextNode()
+  ) {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      // Explicit line breaks split poetry/verse into speakable lines (and
+      // end any cut-sentence extension — the line is the sentence).
+      if ((node as Element).tagName === "BR") {
+        if (cutOffset !== null) done = true;
+        closeParagraph();
+      }
+      continue;
+    }
+    const textNode = node as Text;
+    if (!isSpokenTextNode(textNode)) continue;
+    const length = textNode.data.length;
+
+    // Entirely before the range start.
+    if (
+      compareBoundaryPoints(
+        textNode,
+        length,
+        range.startContainer,
+        range.startOffset
+      ) <= 0
+    ) {
+      continue;
+    }
+
+    let start = 0;
+    if (range.startContainer === textNode) {
+      start = Math.max(start, range.startOffset);
+    }
+
+    // Visible portion of the node, clipped at the range end. A boundary
+    // point in another container never falls inside a text node, so the
+    // node is either fully before or fully after it.
+    let visibleEnd: number;
+    if (range.endContainer === textNode) {
+      visibleEnd = Math.min(length, range.endOffset);
+    } else if (
+      compareBoundaryPoints(
+        textNode,
+        0,
+        range.endContainer,
+        range.endOffset
+      ) >= 0
+    ) {
+      visibleEnd = 0;
+    } else {
+      visibleEnd = length;
+    }
+
+    const block = getBlockAncestor(textNode);
+
+    if (cutOffset !== null) {
+      // Extending a cut sentence: only within the same block.
+      if (block !== currentBlock) {
+        done = true;
+        closeParagraph();
+        continue;
+      }
+      appendPiece(textNode, 0, length);
+      checkExtensionDone();
+      continue;
+    }
+
+    if (visibleEnd <= start) {
+      // The visible range ended before this node. Extend if the open
+      // paragraph was cut mid-sentence and this node continues its block;
+      // otherwise the collection is complete.
+      if (block === currentBlock && paragraphCutMidSentence()) {
+        cutOffset = currentText.length;
+        appendPiece(textNode, 0, length);
+        checkExtensionDone();
+      } else {
+        done = true;
+        closeParagraph();
+      }
+      continue;
+    }
+
+    if (block !== currentBlock) {
+      closeParagraph();
+      currentBlock = block;
+    }
+    appendPiece(textNode, start, visibleEnd);
+
+    if (visibleEnd < length) {
+      // The visible range ends inside this node — the page cuts here.
+      if (paragraphCutMidSentence()) {
+        cutOffset = currentText.length;
+        appendPiece(textNode, visibleEnd, length);
+        checkExtensionDone();
+      } else {
+        done = true;
+        closeParagraph();
+      }
+    }
   }
   closeParagraph();
   return paragraphs;
@@ -377,15 +584,18 @@ function paragraphOffsetToPosition(
 /**
  * Split the given page range into speakable sentence chunks, each with a
  * Range for highlighting.
+ *
+ * A sentence cut in half by the end of the page is extended past the page
+ * boundary and emitted as one whole chunk with `pageEndCutIndex` marking
+ * where the visible page ends inside its text (so read-aloud can turn the
+ * page mid-utterance instead of stopping at the fragment).
  */
 export function collectSpeechChunksFromRange(range: Range): BooksSpeechChunk[] {
   const chunks: BooksSpeechChunk[] = [];
   for (const paragraph of collectParagraphs(range)) {
     for (const segment of splitTextIntoSpeechSegments(paragraph.text)) {
-      const text = paragraph.text
-        .slice(segment.start, segment.end)
-        .replace(/\s+/g, " ")
-        .trim();
+      const raw = paragraph.text.slice(segment.start, segment.end);
+      const text = raw.replace(/\s+/g, " ").trim();
       if (!text) continue;
       const startPos = paragraphOffsetToPosition(
         paragraph.pieces,
@@ -404,7 +614,21 @@ export function collectSpeechChunksFromRange(range: Range): BooksSpeechChunk[] {
         const chunkRange = doc.createRange();
         chunkRange.setStart(startPos.node, startPos.offset);
         chunkRange.setEnd(endPos.node, endPos.offset);
-        chunks.push({ text, range: chunkRange });
+        const chunk: BooksSpeechChunk = { text, range: chunkRange };
+        const cut = paragraph.pageCutOffset;
+        if (cut !== undefined && cut > segment.start && cut < segment.end) {
+          // Map the paragraph cut offset into the normalized chunk text:
+          // count the normalized length of the visible part.
+          const visible = paragraph.text
+            .slice(segment.start, cut)
+            .replace(/\s+/g, " ")
+            .replace(/^\s+/, "");
+          const cutIndex = Math.min(visible.replace(/\s+$/, "").length, text.length);
+          if (cutIndex > 0 && cutIndex < text.length) {
+            chunk.pageEndCutIndex = cutIndex;
+          }
+        }
+        chunks.push(chunk);
       } catch {
         // Skip chunks whose boundaries can't form a valid range.
       }
@@ -537,6 +761,29 @@ export function isRangeOnVisiblePage(range: Range): boolean {
   left = Math.max(left, 0);
   top = Math.max(top, 0);
   return right - left > 1 && bottom - top > 1;
+}
+
+/**
+ * Whether the end of the range (its last character) is on the visible page.
+ * Used to detect a chunk whose sentence flows past the page boundary when
+ * the page range itself couldn't be clipped (unresolvable end CFI). Lenient
+ * (returns true) when the endpoint can't be probed.
+ */
+export function isRangeEndOnVisiblePage(range: Range): boolean {
+  const { endContainer, endOffset } = range;
+  if (endContainer.nodeType !== Node.TEXT_NODE || endOffset < 1) {
+    return true;
+  }
+  const doc = endContainer.ownerDocument;
+  if (!doc) return true;
+  try {
+    const probe = doc.createRange();
+    probe.setStart(endContainer, endOffset - 1);
+    probe.setEnd(endContainer, endOffset);
+    return isRangeOnVisiblePage(probe);
+  } catch {
+    return true;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test-books-speech-cut-flip-wiring.test.tsx
+++ b/tests/test-books-speech-cut-flip-wiring.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Wiring test for read-aloud across a page boundary that cuts a sentence in
+ * half: the page must flip while the cut sentence is being spoken (at the
+ * cut), the in-flight utterance must survive the flip, and speech on the new
+ * page must continue with the next sentence instead of repeating the cut one.
+ */
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+if (typeof document === "undefined") {
+  GlobalRegistrator.register();
+}
+
+const { useBooksSpeech } = await import(
+  "../src/apps/books/hooks/useBooksSpeech"
+);
+type SpeechRenditionLike =
+  import("../src/apps/books/utils/booksSpeech").SpeechRenditionLike;
+
+class FakeUtterance {
+  text: string;
+  lang = "";
+  rate = 1;
+  voice: unknown = null;
+  onstart: (() => void) | null = null;
+  onend: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onboundary: ((event: { charIndex: number }) => void) | null = null;
+  constructor(text: string) {
+    this.text = text;
+  }
+}
+
+const spoken: FakeUtterance[] = [];
+const synth = {
+  speaking: false,
+  pending: false,
+  cancelCount: 0,
+  cancel() {
+    this.cancelCount += 1;
+    this.speaking = false;
+    this.pending = false;
+  },
+  resume() {},
+  getVoices: () => [] as SpeechSynthesisVoice[],
+  speak(utterance: FakeUtterance) {
+    spoken.push(utterance);
+    this.speaking = true;
+  },
+};
+
+(window as unknown as { speechSynthesis: unknown }).speechSynthesis = synth;
+(
+  globalThis as unknown as { SpeechSynthesisUtterance: unknown }
+).SpeechSynthesisUtterance = FakeUtterance;
+
+// One paragraph; the page boundary cuts the middle sentence after
+// "Gamma delta". Page 1 shows [0, CUT); page 2 shows [CUT, end).
+const BOOK_HTML = "<p>Alpha beta. Gamma delta epsilon zeta. Eta theta.</p>";
+const CUT = "Alpha beta. Gamma delta".length;
+
+function bookTextNode(): Text {
+  return document.querySelector("p")!.firstChild as Text;
+}
+
+function finishUtterance(utterance: FakeUtterance) {
+  synth.speaking = false;
+  utterance.onend?.();
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 3000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("Timed out waiting for speech wiring state");
+}
+
+let page = 1;
+let advanceCalls = 0;
+let controls: ReturnType<typeof useBooksSpeech> | null = null;
+
+const rendition: SpeechRenditionLike = {
+  currentLocation: () =>
+    page === 1
+      ? { start: { cfi: "epubcfi(p1-start)" }, end: { cfi: "epubcfi(p1-end)" } }
+      : {
+          start: { cfi: "epubcfi(p2-start)" },
+          end: { cfi: "epubcfi(p2-end)" },
+        },
+  getRange: (cfi: string) => {
+    const node = bookTextNode();
+    const range = document.createRange();
+    if (cfi.includes("p1-start")) range.setStart(node, 0);
+    else if (cfi.includes("p1-end") || cfi.includes("p2-start")) {
+      range.setStart(node, CUT);
+    } else range.setStart(node, node.data.length);
+    range.collapse(true);
+    return range;
+  },
+};
+
+function SpeechProbe() {
+  controls = useBooksSpeech({
+    getRendition: () => rendition,
+    getSpeechLanguage: () => "en-US",
+    getSpeechRate: () => 1,
+    canAdvancePage: () => page === 1,
+    advancePage: () => {
+      advanceCalls += 1;
+      page = 2;
+      // epub.js delivers `relocated` asynchronously after a turn.
+      setTimeout(() => controls?.handleRelocated(), 20);
+    },
+  });
+  return null;
+}
+
+let root: Root | null = null;
+
+afterEach(async () => {
+  controls?.stopSpeaking();
+  root?.unmount();
+  root = null;
+  controls = null;
+  document.body.replaceChildren();
+  // Let React's scheduler flush before happy-dom is torn down.
+  await new Promise((resolve) => setTimeout(resolve, 20));
+});
+
+afterAll(() => {
+  if (GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.unregister();
+  }
+});
+
+describe("read-aloud across a mid-sentence page boundary", () => {
+  test("flips at the cut and resumes with the next sentence (no repeat)", async () => {
+    document.body.innerHTML = BOOK_HTML;
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+    root.render(React.createElement(SpeechProbe));
+    await waitFor(() => controls !== null);
+
+    controls!.startSpeaking();
+    await waitFor(() => spoken.length === 1);
+    expect(spoken[0].text).toBe("Alpha beta.");
+    spoken[0].onstart?.();
+    finishUtterance(spoken[0]);
+
+    // The cut sentence is spoken whole (extended past the page boundary).
+    await waitFor(() => spoken.length === 2);
+    expect(spoken[1].text).toBe("Gamma delta epsilon zeta.");
+    spoken[1].onstart?.();
+
+    // Speech crosses the page cut -> the page flips immediately...
+    const cancelsBeforeFlip = synth.cancelCount;
+    spoken[1].onboundary?.({ charIndex: "Gamma delta ".length });
+    expect(advanceCalls).toBe(1);
+    expect(page).toBe(2);
+
+    // ...and the relocation does NOT cancel the in-flight utterance.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(synth.cancelCount).toBe(cancelsBeforeFlip);
+    expect(synth.speaking).toBe(true);
+
+    // The sentence tail finishes after the flip; speech resumes on the new
+    // page with the NEXT sentence instead of repeating the cut sentence.
+    finishUtterance(spoken[1]);
+    await waitFor(() => spoken.length === 3);
+    expect(spoken[2].text).toBe("Eta theta.");
+    // No extra page turns were issued for the crossing.
+    expect(advanceCalls).toBe(1);
+  }, 10000);
+});

--- a/tests/test-books-speech.test.ts
+++ b/tests/test-books-speech.test.ts
@@ -12,7 +12,9 @@ import {
   getVisiblePageRange,
   applySpeechHighlight,
   clearSpeechHighlight,
+  isRangeEndOnVisiblePage,
   isRangeOnVisiblePage,
+  rangeEndsAtOrBefore,
   splitTextIntoSentences,
   splitTextIntoSpeechSegments,
   type SpeechRenditionLike,
@@ -191,6 +193,127 @@ describe("collectSpeechChunksFromRange", () => {
     const doc = createBookDocument("<p>Spaced   \n   out. </p>");
     const chunks = collectSpeechChunksFromRange(rangeOver(doc));
     expect(chunks.map((c) => c.text)).toEqual(["Spaced out."]);
+  });
+});
+
+describe("sentences cut off by the page boundary", () => {
+  test("extends a cut sentence to its end and marks the page cut index", () => {
+    const doc = createBookDocument(
+      "<p>Alpha beta. Gamma delta epsilon zeta. Eta theta.</p>"
+    );
+    const textNode = doc.querySelector("p")!.firstChild as Text;
+    const range = doc.createRange();
+    range.setStart(textNode, 0);
+    // Page ends mid-way through the second sentence.
+    range.setEnd(textNode, "Alpha beta. Gamma delta".length);
+    const chunks = collectSpeechChunksFromRange(range);
+    expect(chunks.map((c) => c.text)).toEqual([
+      "Alpha beta.",
+      "Gamma delta epsilon zeta.",
+    ]);
+    expect(chunks[0].pageEndCutIndex).toBeUndefined();
+    // The cut falls right after "Gamma delta" within the extended sentence.
+    expect(chunks[1].pageEndCutIndex).toBe("Gamma delta".length);
+    expect(chunks[1].range.toString()).toBe("Gamma delta epsilon zeta.");
+  });
+
+  test("does not extend when the page ends at a sentence boundary", () => {
+    const doc = createBookDocument("<p>Alpha beta. Gamma delta.</p>");
+    const textNode = doc.querySelector("p")!.firstChild as Text;
+    const range = doc.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, "Alpha beta. ".length);
+    const chunks = collectSpeechChunksFromRange(range);
+    expect(chunks.map((c) => c.text)).toEqual(["Alpha beta."]);
+    expect(chunks[0].pageEndCutIndex).toBeUndefined();
+  });
+
+  test("extends a cut sentence across inline elements", () => {
+    const doc = createBookDocument(
+      "<p>He said <em>hello there</em> to me. Done.</p>"
+    );
+    const firstText = doc.querySelector("p")!.firstChild as Text;
+    const range = doc.createRange();
+    range.setStart(firstText, 0);
+    // Page ends inside the first word run, mid-sentence.
+    range.setEnd(firstText, "He sa".length);
+    const chunks = collectSpeechChunksFromRange(range);
+    expect(chunks.map((c) => c.text)).toEqual(["He said hello there to me."]);
+    expect(chunks[0].pageEndCutIndex).toBe("He sa".length);
+  });
+
+  test("does not extend past the cut paragraph into the next block", () => {
+    const doc = createBookDocument(
+      "<p>An unterminated fragment</p><p>Next paragraph.</p>"
+    );
+    const firstText = doc.querySelector("p")!.firstChild as Text;
+    const range = doc.createRange();
+    range.setStart(firstText, 0);
+    range.setEnd(firstText, "An untermi".length);
+    const chunks = collectSpeechChunksFromRange(range);
+    // The fragment finishes its own block but never leaks into the next <p>.
+    expect(chunks.map((c) => c.text)).toEqual(["An unterminated fragment"]);
+    expect(chunks[0].pageEndCutIndex).toBe("An untermi".length);
+  });
+
+  test("stops the extension at a <br> line break", () => {
+    const doc = createBookDocument("<p>Line one more<br>Line two</p>");
+    const firstText = doc.querySelector("p")!.firstChild as Text;
+    const range = doc.createRange();
+    range.setStart(firstText, 0);
+    range.setEnd(firstText, "Line one".length);
+    const chunks = collectSpeechChunksFromRange(range);
+    expect(chunks.map((c) => c.text)).toEqual(["Line one more"]);
+    expect(chunks[0].pageEndCutIndex).toBe("Line one".length);
+  });
+
+  test("mid-paragraph page start plus cut sentence keeps offsets aligned", () => {
+    const doc = createBookDocument(
+      "<p>Alpha beta. Gamma delta epsilon. Eta theta.</p>"
+    );
+    const textNode = doc.querySelector("p")!.firstChild as Text;
+    const range = doc.createRange();
+    // Page starts mid-paragraph and ends mid-sentence.
+    range.setStart(textNode, "Alpha beta. ".length);
+    range.setEnd(textNode, "Alpha beta. Gamma delta".length);
+    const chunks = collectSpeechChunksFromRange(range);
+    expect(chunks.map((c) => c.text)).toEqual(["Gamma delta epsilon."]);
+    expect(chunks[0].pageEndCutIndex).toBe("Gamma delta".length);
+    expect(chunks[0].range.toString()).toBe("Gamma delta epsilon.");
+  });
+});
+
+describe("rangeEndsAtOrBefore", () => {
+  test("identifies chunks already spoken before the carry-over point", () => {
+    const doc = createBookDocument("<p>Alpha beta. Gamma delta.</p>");
+    const chunks = collectSpeechChunksFromRange(rangeOver(doc));
+    expect(chunks.length).toBe(2);
+    const carryOver = {
+      endContainer: chunks[0].range.endContainer,
+      endOffset: chunks[0].range.endOffset,
+    };
+    expect(rangeEndsAtOrBefore(chunks[0].range, carryOver)).toBe(true);
+    expect(rangeEndsAtOrBefore(chunks[1].range, carryOver)).toBe(false);
+  });
+
+  test("is lenient across documents", () => {
+    const doc = createBookDocument("<p>Alpha beta.</p>");
+    const chunks = collectSpeechChunksFromRange(rangeOver(doc));
+    const detached = doc.implementation.createHTMLDocument("other");
+    detached.body.innerHTML = "<p>Other doc.</p>";
+    const carryOver = {
+      endContainer: detached.querySelector("p")!.firstChild as Node,
+      endOffset: 5,
+    };
+    expect(rangeEndsAtOrBefore(chunks[0].range, carryOver)).toBe(false);
+  });
+});
+
+describe("isRangeEndOnVisiblePage", () => {
+  test("is lenient outside an iframe (no layout geometry)", () => {
+    const doc = createBookDocument("<p>Alpha beta.</p>");
+    const chunks = collectSpeechChunksFromRange(rangeOver(doc));
+    expect(isRangeEndOnVisiblePage(chunks[0].range)).toBe(true);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When read-aloud reached a sentence that crosses two pages:

1. The page did not flip at the point where the sentence is cut off — speech either stopped at the fragment or ran ahead of the visible page.
2. After the page flipped, the cut-off sentence was spoken again from its beginning (including the part from the previous page) instead of continuing with the next sentence.

## Fix

**`src/apps/books/utils/booksSpeech.ts`**
- `collectParagraphs` now detects when the visible page range ends mid-sentence and extends the final paragraph past the page boundary (within the same block, up to the sentence end or a safety budget), recording `pageCutOffset` where the page actually ends.
- `collectSpeechChunksFromRange` emits the cut sentence as one whole chunk with `pageEndCutIndex` — the offset in the spoken text where the page ends.
- New `rangeEndsAtOrBefore` compares a chunk's end against a carried-over document position, and `isRangeEndOnVisiblePage` geometrically detects a chunk flowing off-page when the end CFI is unresolvable (section-end fallback).

**`src/apps/books/hooks/useBooksSpeech.ts`**
- The cut sentence is spoken whole. When the utterance's word boundary crosses `pageEndCutIndex`, the page auto-turns immediately (`advanceAtCut`) while the utterance keeps playing across the flip (with a settle-time fallback for engines without boundary events).
- The `relocated` handler recognizes this cut advance: it does not cancel the in-flight utterance or clear the highlight, waits for the sentence tail to finish naturally, then resumes on the new page.
- On resume, chunks ending at or before the carry-over position (the cut chunk's end) are skipped, so speech continues with the next sentence instead of repeating the cut one.
- `finishPage` won't double-turn when a cut advance is already in flight (re-advancing only if the turn was swallowed by the flip lock).

## Testing

- ✅ `bun test tests/test-books-speech.test.ts` — 32 pass, including 6 new cases for cut-sentence extension (cut index mapping, sentence-boundary/inline/`<br>`/next-block limits, mid-paragraph page starts) and carry-over comparisons.
- ✅ `bun test tests/test-books-speech-cut-flip-wiring.test.tsx` — new wiring test driving `useBooksSpeech` with a fake rendition/synth: verifies the sentence is spoken whole, the page flips exactly once at the cut, the utterance survives relocation, and speech resumes with the next sentence (no repeat).
- ✅ `bun run test:registration`
- ✅ `bunx tsc -b`
- ✅ `bunx eslint` on the touched files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2162-e147-71e9-ad5f-7f92c88440d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2162-e147-71e9-ad5f-7f92c88440d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

