### PR TITLE
Keep Books speech controls open after touch

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -51,6 +51,7 @@ import {
 } from "../utils/booksTextLayout";
 import { BOOKS_SPEECH_HIGHLIGHT_CSS } from "../utils/booksSpeech";
 import { useBooksSpeech } from "../hooks/useBooksSpeech";
+import { useBooksSpeechBarVisibility } from "../hooks/useBooksSpeechBarVisibility";
 import { ryOSLocaleToSpeechLanguage } from "@/utils/browserSpeech";
 import { useBookCover } from "../utils/useBookCover";
 import { BookCover } from "./BookCover";
@@ -136,8 +137,6 @@ const SPREAD_MIN_WIDTH = 560;
 // Shared style for the read-aloud overlay control buttons.
 const SPEECH_OVERLAY_BUTTON_CLASS =
   "flex h-7 w-7 shrink-0 items-center justify-center rounded-full transition-colors disabled:opacity-40 disabled:hover:bg-transparent";
-/** Idle delay before the read-aloud bar shrinks back to the home-indicator pill. */
-const SPEECH_BAR_COLLAPSE_MS = 1800;
 const SPEECH_BAR_COLLAPSED = { width: 72, height: 5 } as const;
 const SPEECH_BAR_EXPANDED = { width: 130, height: 36 } as const;
 
@@ -1478,56 +1477,15 @@ export const BooksReaderPane = forwardRef<
   // Read-aloud bar: stays expanded while playing; idle / paused collapses to
   // the home-indicator pill (hover or tap grows it again).
   const isSpeechPlaying = isSpeaking && !isPaused;
-  const isSpeechPlayingRef = useRef(isSpeechPlaying);
-  isSpeechPlayingRef.current = isSpeechPlaying;
-  const [speechBarExpanded, setSpeechBarExpanded] = useState(false);
-  const speechBarOpen = isSpeechPlaying || speechBarExpanded;
-  const speechBarPointerInsideRef = useRef(false);
-  const speechBarCollapseTimerRef = useRef<number | null>(null);
-  const clearSpeechBarCollapseTimer = useCallback(() => {
-    if (speechBarCollapseTimerRef.current !== null) {
-      window.clearTimeout(speechBarCollapseTimerRef.current);
-      speechBarCollapseTimerRef.current = null;
-    }
-  }, []);
-  const collapseSpeechBar = useCallback(() => {
-    clearSpeechBarCollapseTimer();
-    setSpeechBarExpanded(false);
-  }, [clearSpeechBarCollapseTimer]);
-  const expandSpeechBar = useCallback(() => {
-    clearSpeechBarCollapseTimer();
-    setSpeechBarExpanded(true);
-  }, [clearSpeechBarCollapseTimer]);
-  const scheduleSpeechBarCollapse = useCallback(
-    (delayMs = SPEECH_BAR_COLLAPSE_MS) => {
-      // Keep the full bar up for the entire playing session.
-      if (isSpeechPlayingRef.current) return;
-      clearSpeechBarCollapseTimer();
-      speechBarCollapseTimerRef.current = window.setTimeout(() => {
-        speechBarCollapseTimerRef.current = null;
-        if (speechBarPointerInsideRef.current || isSpeechPlayingRef.current) {
-          return;
-        }
-        setSpeechBarExpanded(false);
-      }, delayMs);
-    },
-    [clearSpeechBarCollapseTimer]
-  );
-  useEffect(() => {
-    if (isSpeechPlaying) {
-      expandSpeechBar();
-      return;
-    }
-    // Idle or paused: drop to the indicator unless the pointer is still over
-    // the bar (so resume / play stays one click away).
-    if (!speechBarPointerInsideRef.current) {
-      collapseSpeechBar();
-    }
-  }, [isSpeechPlaying, expandSpeechBar, collapseSpeechBar]);
-  useEffect(
-    () => () => clearSpeechBarCollapseTimer(),
-    [clearSpeechBarCollapseTimer]
-  );
+  const {
+    isOpen: speechBarOpen,
+    handlePointerEnter: handleSpeechBarPointerEnter,
+    handlePointerLeave: handleSpeechBarPointerLeave,
+    handlePointerDown: handleSpeechBarPointerDown,
+    handleFocus: handleSpeechBarFocus,
+    handleBlur: handleSpeechBarBlur,
+    revealTemporarily: revealSpeechBarTemporarily,
+  } = useBooksSpeechBarVisibility({ isPlaying: isSpeechPlaying });
 
   useImperativeHandle(
     ref,
@@ -1673,22 +1631,22 @@ export const BooksReaderPane = forwardRef<
         <div
           className="pointer-events-auto flex items-end justify-center"
           style={{ minWidth: 72, minHeight: 28 }}
-          onPointerEnter={() => {
-            speechBarPointerInsideRef.current = true;
-            expandSpeechBar();
-          }}
-          onPointerLeave={() => {
-            speechBarPointerInsideRef.current = false;
-            scheduleSpeechBarCollapse(160);
-          }}
-          onFocusCapture={expandSpeechBar}
+          onPointerEnter={(event) =>
+            handleSpeechBarPointerEnter(event.pointerType)
+          }
+          onPointerLeave={(event) =>
+            handleSpeechBarPointerLeave(event.pointerType)
+          }
+          onPointerDown={(event) =>
+            handleSpeechBarPointerDown(event.pointerType)
+          }
+          onFocusCapture={handleSpeechBarFocus}
           onBlurCapture={(event) => {
             const next = event.relatedTarget;
             if (next instanceof Node && event.currentTarget.contains(next)) {
               return;
             }
-            speechBarPointerInsideRef.current = false;
-            scheduleSpeechBarCollapse(160);
+            handleSpeechBarBlur();
           }}
         >
           <motion.div
@@ -1729,9 +1687,7 @@ export const BooksReaderPane = forwardRef<
             }}
             onClick={() => {
               if (speechBarOpen) return;
-              expandSpeechBar();
-              // Touch has no sustained hover; auto-shrink after idle.
-              scheduleSpeechBarCollapse();
+              revealSpeechBarTemporarily();
             }}
           >
             <motion.div

--- a/src/apps/books/hooks/useBooksSpeechBarVisibility.ts
+++ b/src/apps/books/hooks/useBooksSpeechBarVisibility.ts
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const BOOKS_SPEECH_BAR_TOUCH_OPEN_MS = 3000;
+
+const BOOKS_SPEECH_BAR_POINTER_EXIT_MS = 160;
+const HOVER_POINTER_TYPE = "mouse";
+
+interface UseBooksSpeechBarVisibilityOptions {
+  isPlaying: boolean;
+}
+
+interface BooksSpeechBarVisibility {
+  isOpen: boolean;
+  handlePointerEnter: (pointerType: string) => void;
+  handlePointerLeave: (pointerType: string) => void;
+  handlePointerDown: (pointerType: string) => void;
+  handleFocus: () => void;
+  handleBlur: () => void;
+  revealTemporarily: () => void;
+}
+
+export function useBooksSpeechBarVisibility({
+  isPlaying,
+}: UseBooksSpeechBarVisibilityOptions): BooksSpeechBarVisibility {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const isPlayingRef = useRef(isPlaying);
+  const isMouseInsideRef = useRef(false);
+  const hasFocusInsideRef = useRef(false);
+  const hasTemporaryTouchHoldRef = useRef(false);
+  const collapseTimerRef = useRef<number | null>(null);
+  isPlayingRef.current = isPlaying;
+
+  const clearCollapseTimer = useCallback(() => {
+    if (collapseTimerRef.current === null) return;
+    window.clearTimeout(collapseTimerRef.current);
+    collapseTimerRef.current = null;
+  }, []);
+
+  const collapse = useCallback(() => {
+    clearCollapseTimer();
+    hasTemporaryTouchHoldRef.current = false;
+    setIsExpanded(false);
+  }, [clearCollapseTimer]);
+
+  const expand = useCallback(() => {
+    clearCollapseTimer();
+    hasTemporaryTouchHoldRef.current = false;
+    setIsExpanded(true);
+  }, [clearCollapseTimer]);
+
+  const scheduleCollapse = useCallback(
+    (delayMs: number) => {
+      clearCollapseTimer();
+      hasTemporaryTouchHoldRef.current = false;
+      collapseTimerRef.current = window.setTimeout(() => {
+        collapseTimerRef.current = null;
+        if (
+          isPlayingRef.current ||
+          isMouseInsideRef.current ||
+          hasFocusInsideRef.current
+        ) {
+          return;
+        }
+        setIsExpanded(false);
+      }, delayMs);
+    },
+    [clearCollapseTimer]
+  );
+
+  const revealTemporarily = useCallback(() => {
+    clearCollapseTimer();
+    hasTemporaryTouchHoldRef.current = true;
+    setIsExpanded(true);
+    collapseTimerRef.current = window.setTimeout(() => {
+      collapseTimerRef.current = null;
+      hasTemporaryTouchHoldRef.current = false;
+      if (
+        isPlayingRef.current ||
+        isMouseInsideRef.current ||
+        hasFocusInsideRef.current
+      ) {
+        return;
+      }
+      setIsExpanded(false);
+    }, BOOKS_SPEECH_BAR_TOUCH_OPEN_MS);
+  }, [clearCollapseTimer]);
+
+  const handlePointerEnter = useCallback(
+    (pointerType: string) => {
+      if (pointerType !== HOVER_POINTER_TYPE) return;
+      isMouseInsideRef.current = true;
+      expand();
+    },
+    [expand]
+  );
+
+  const handlePointerLeave = useCallback(
+    (pointerType: string) => {
+      if (pointerType !== HOVER_POINTER_TYPE) return;
+      isMouseInsideRef.current = false;
+      scheduleCollapse(BOOKS_SPEECH_BAR_POINTER_EXIT_MS);
+    },
+    [scheduleCollapse]
+  );
+
+  const handlePointerDown = useCallback(
+    (pointerType: string) => {
+      if (pointerType === HOVER_POINTER_TYPE) return;
+      revealTemporarily();
+    },
+    [revealTemporarily]
+  );
+
+  const handleFocus = useCallback(() => {
+    hasFocusInsideRef.current = true;
+    expand();
+  }, [expand]);
+
+  const handleBlur = useCallback(() => {
+    hasFocusInsideRef.current = false;
+    scheduleCollapse(BOOKS_SPEECH_BAR_POINTER_EXIT_MS);
+  }, [scheduleCollapse]);
+
+  useEffect(() => {
+    if (isPlaying) {
+      expand();
+      return;
+    }
+    if (
+      !isMouseInsideRef.current &&
+      !hasFocusInsideRef.current &&
+      !hasTemporaryTouchHoldRef.current
+    ) {
+      collapse();
+    }
+  }, [collapse, expand, isPlaying]);
+
+  useEffect(
+    () => () => {
+      clearCollapseTimer();
+    },
+    [clearCollapseTimer]
+  );
+
+  return {
+    isOpen: isPlaying || isExpanded,
+    handlePointerEnter,
+    handlePointerLeave,
+    handlePointerDown,
+    handleFocus,
+    handleBlur,
+    revealTemporarily,
+  };
+}

--- a/tests/test-books-speech-bar-visibility.test.tsx
+++ b/tests/test-books-speech-bar-visibility.test.tsx
@@ -1,0 +1,113 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  BOOKS_SPEECH_BAR_TOUCH_OPEN_MS,
+  useBooksSpeechBarVisibility,
+} from "../src/apps/books/hooks/useBooksSpeechBarVisibility";
+
+if (typeof document === "undefined") {
+  GlobalRegistrator.register();
+}
+
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+  configurable: true,
+  value: true,
+});
+
+type SpeechBarVisibility = ReturnType<typeof useBooksSpeechBarVisibility>;
+
+let visibility: SpeechBarVisibility | null = null;
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+function SpeechBarProbe() {
+  visibility = useBooksSpeechBarVisibility({ isPlaying: false });
+  return React.createElement("div", {
+    "data-open": visibility.isOpen ? "true" : "false",
+  });
+}
+
+function getVisibility(): SpeechBarVisibility {
+  if (!visibility) throw new Error("Speech bar visibility hook is not ready");
+  return visibility;
+}
+
+beforeEach(async () => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(React.createElement(SpeechBarProbe));
+  });
+  jest.useFakeTimers();
+});
+
+afterEach(async () => {
+  jest.useRealTimers();
+  await act(async () => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+  visibility = null;
+});
+
+afterAll(() => {
+  if (GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.unregister();
+  }
+});
+
+describe("Books speech bar visibility", () => {
+  test("keeps a touch-opened bar visible for three seconds", () => {
+    act(() => {
+      getVisibility().handlePointerEnter("touch");
+    });
+    expect(getVisibility().isOpen).toBe(false);
+
+    act(() => {
+      getVisibility().handlePointerDown("touch");
+      getVisibility().handlePointerLeave("touch");
+    });
+    expect(getVisibility().isOpen).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(BOOKS_SPEECH_BAR_TOUCH_OPEN_MS - 1);
+    });
+    expect(getVisibility().isOpen).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(getVisibility().isOpen).toBe(false);
+  });
+
+  test("still follows mouse hover without the touch hold", () => {
+    act(() => {
+      getVisibility().handlePointerEnter("mouse");
+    });
+    expect(getVisibility().isOpen).toBe(true);
+
+    act(() => {
+      getVisibility().handlePointerLeave("mouse");
+      jest.advanceTimersByTime(159);
+    });
+    expect(getVisibility().isOpen).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(getVisibility().isOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep the collapsed Books read-aloud controls open for three seconds after touch
- ignore synthetic touch enter/leave events so mouse hover timing cannot shorten the touch hold
- preserve playing, focus, and mouse-hover behavior in a dedicated visibility hook
- add focused touch and mouse timing coverage

## Testing
- `bun test tests/test-books-speech.test.ts tests/test-books-speech-pause.test.tsx tests/test-books-speech-cut-flip-wiring.test.tsx tests/test-books-speech-bar-visibility.test.tsx` (59 passed)
- `bun run test:registration`
- `bun run build`
- `bunx eslint src/apps/books/hooks/useBooksSpeechBarVisibility.ts tests/test-books-speech-bar-visibility.test.tsx`

Targeted linting of `BooksReaderPane.tsx` still reports its pre-existing unsupported `aria-expanded`/`toolbar` pairing and fast-refresh warning; the same findings reproduce from `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2318-8d34-7bb5-a2d1-d119edec2a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2318-8d34-7bb5-a2d1-d119edec2a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

