### PR TITLE
Books: swap stop button for Customize when playback is off

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -9,7 +9,14 @@ import {
 } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { useTranslation } from "react-i18next";
-import { FastForward, Pause, Play, Rewind, Stop } from "@phosphor-icons/react";
+import {
+  FastForward,
+  Pause,
+  Play,
+  Rewind,
+  Stop,
+  TextAa,
+} from "@phosphor-icons/react";
 import ePub, { type Book, type NavItem, type Rendition } from "epubjs";
 import { cn } from "@/lib/utils";
 import { useResizeObserverWithRef } from "@/hooks/useResizeObserver";
@@ -77,6 +84,8 @@ interface BooksReaderPaneProps {
   onSpeechStateChange?: (isSpeaking: boolean) => void;
   /** EPUB metadata language once known (drives CJK-only menus / features). */
   onBookLanguageChange?: (language: string | null) => void;
+  /** Opens the reading-appearance Customize panel (playback bar shortcut). */
+  onShowCustomize?: () => void;
 }
 
 const clamp01 = (value: number): number =>
@@ -321,6 +330,7 @@ export const BooksReaderPane = forwardRef<
     onNavigationStateChange,
     onSpeechStateChange,
     onBookLanguageChange,
+    onShowCustomize,
   },
   ref
 ) {
@@ -1755,17 +1765,30 @@ export const BooksReaderPane = forwardRef<
               >
                 <FastForward weight="fill" size={16} />
               </button>
-              <button
-                type="button"
-                aria-label={t("apps.books.speech.stop")}
-                title={t("apps.books.speech.stop")}
-                onClick={stopSpeaking}
-                disabled={!isSpeaking}
-                className={speechOverlayButtonClass}
-                tabIndex={speechBarOpen ? 0 : -1}
-              >
-                <Stop weight="fill" size={16} />
-              </button>
+              {/* Playback off → the stop slot becomes a Customize shortcut. */}
+              {isSpeaking ? (
+                <button
+                  type="button"
+                  aria-label={t("apps.books.speech.stop")}
+                  title={t("apps.books.speech.stop")}
+                  onClick={stopSpeaking}
+                  className={speechOverlayButtonClass}
+                  tabIndex={speechBarOpen ? 0 : -1}
+                >
+                  <Stop weight="fill" size={16} />
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  aria-label={t("apps.books.customize.title")}
+                  title={t("apps.books.customize.title")}
+                  onClick={onShowCustomize}
+                  className={speechOverlayButtonClass}
+                  tabIndex={speechBarOpen ? 0 : -1}
+                >
+                  <TextAa weight="bold" size={16} />
+                </button>
+              )}
             </motion.div>
           </motion.div>
         </div>

--- a/src/apps/books/components/books-app/BooksAppComponent.tsx
+++ b/src/apps/books/components/books-app/BooksAppComponent.tsx
@@ -211,6 +211,7 @@ export function BooksAppComponent({
             onNavigationStateChange={handleReaderNavigationStateChange}
             onSpeechStateChange={handleSpeechStateChange}
             onBookLanguageChange={handleBookLanguageChange}
+            onShowCustomize={() => setIsCustomizeOpen(true)}
           />
         ) : (
           <BooksShelfView


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the Books read-aloud playback bar, the stop button was disabled (dimmed and inert) whenever playback was off. This swaps that slot: when nothing is playing, the bar now shows a Customize button (`TextAa` icon) that opens the reading-appearance Customize panel; the Stop button returns while speech is active (playing or paused).

- `BooksReaderPane.tsx`: renders Stop while `isSpeaking`, otherwise a Customize shortcut wired to a new `onShowCustomize` prop; reuses the existing `apps.books.customize.title` locale key for the label/tooltip.
- `BooksAppComponent.tsx`: passes `onShowCustomize` down to open the existing Customize panel.

## Testing

- ✅ `bun run build` (tsc + Vite)
- ✅ `bunx eslint` on the two modified files (only pre-existing warnings/errors: `react-refresh/only-export-components`, `aria-expanded` on `role="toolbar"`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2332-43e1-796f-988e-1ffa00ddf2e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2332-43e1-796f-988e-1ffa00ddf2e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

