### PR TITLE
Cut boot JS ~44% by code-splitting heavy desktop shell dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,9 +35,16 @@
     <link rel="dns-prefetch" href="https://www.youtube.com" />
     <link rel="dns-prefetch" href="https://i.ytimg.com" />
     
-    <!-- CJK fonts: Noto/Source Han Serif, Nanum Gothic, and Chiron GoRound TC -->
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;700&family=Noto+Serif+JP:wght@400;700&family=Noto+Serif+KR:wght@400;700&family=Nanum+Gothic:wght@700&display=swap" rel="stylesheet" />
-    <link href="https://cdn.jsdelivr.net/npm/chiron-go-round-tc-webfont@1.0.11/css/vf.css" rel="stylesheet" />
+    <!-- CJK fonts: Noto/Source Han Serif, Nanum Gothic, and Chiron GoRound TC.
+         Loaded async (print→all swap) so these external stylesheets never block
+         first paint; they only style CJK lyrics/reader content, which tolerates
+         a brief fallback-font swap. -->
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;700&family=Noto+Serif+JP:wght@400;700&family=Noto+Serif+KR:wght@400;700&family=Nanum+Gothic:wght@700&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
+    <link href="https://cdn.jsdelivr.net/npm/chiron-go-round-tc-webfont@1.0.11/css/vf.css" rel="stylesheet" media="print" onload="this.media='all'" />
+    <noscript>
+      <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;700&family=Noto+Serif+JP:wght@400;700&family=Noto+Serif+KR:wght@400;700&family=Nanum+Gothic:wght@700&display=swap" rel="stylesheet" />
+      <link href="https://cdn.jsdelivr.net/npm/chiron-go-round-tc-webfont@1.0.11/css/vf.css" rel="stylesheet" />
+    </noscript>
 
     <!-- Preload critical fonts (used immediately on page load) -->
     <link rel="preload" href="/fonts/ChicagoKare-Regular.woff2" as="font" type="font/woff2" crossorigin />

--- a/scripts/trace-import-chain.ts
+++ b/scripts/trace-import-chain.ts
@@ -1,0 +1,105 @@
+/**
+ * Dev utility: trace static import chains from the client entry to a target
+ * module. Helps find which import path drags a heavy module into the boot
+ * bundle. Also imported by tests/test-boot-import-graph.test.ts to guard the
+ * boot graph against regressions.
+ *
+ * Usage: bun run scripts/trace-import-chain.ts <target-substring> [entry]
+ * Example: bun run scripts/trace-import-chain.ts stores/useIpodStore
+ */
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+const SRC = path.join(ROOT, "src");
+const exts = [".ts", ".tsx", ".js", ".jsx"];
+
+function resolveImport(fromFile: string, spec: string): string | null {
+  if (spec.startsWith("@/")) spec = path.join(SRC, spec.slice(2));
+  else if (spec.startsWith(".")) spec = path.join(path.dirname(fromFile), spec);
+  else return null; // bare package import
+  if (existsSync(spec) && !spec.match(/\.(ts|tsx|js|jsx|json|css)$/)) {
+    for (const e of exts) {
+      if (existsSync(spec + e)) return spec + e;
+      if (existsSync(path.join(spec, "index" + e)))
+        return path.join(spec, "index" + e);
+    }
+    return null;
+  }
+  if (existsSync(spec)) return spec;
+  for (const e of exts) if (existsSync(spec + e)) return spec + e;
+  return null;
+}
+
+// Static imports and re-exports only; dynamic import() intentionally excluded,
+// and type-only imports are excluded since they vanish at compile time.
+const IMPORT_RE =
+  /(?:^|\n)\s*(?:import|export)\s+(?!type\b)[^"'()]*?from\s*["']([^"']+)["']|(?:^|\n)\s*import\s*["']([^"']+)["']/g;
+
+function getImports(file: string): string[] {
+  if (!file.match(/\.(ts|tsx|js|jsx)$/)) return [];
+  let text: string;
+  try {
+    text = readFileSync(file, "utf-8");
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const m of text.matchAll(IMPORT_RE)) {
+    const spec = m[1] ?? m[2];
+    if (!spec) continue;
+    const resolved = resolveImport(file, spec);
+    if (resolved) out.push(resolved);
+  }
+  return out;
+}
+
+/**
+ * BFS the static import graph from `entry`, returning the shortest chain of
+ * repo-relative file paths ending at the first module whose path contains
+ * `targetSubstring`, or null when the target is not statically reachable.
+ */
+export function findStaticImportChain(
+  targetSubstring: string,
+  entry: string = path.join(SRC, "main.tsx")
+): string[] | null {
+  const entryAbs = path.resolve(ROOT, entry);
+  const parent = new Map<string, string>();
+  const queue = [entryAbs];
+  parent.set(entryAbs, "");
+  while (queue.length) {
+    const cur = queue.shift()!;
+    if (cur.includes(targetSubstring)) {
+      const chain: string[] = [];
+      let node: string | undefined = cur;
+      while (node) {
+        chain.unshift(path.relative(ROOT, node));
+        node = parent.get(node) || undefined;
+      }
+      return chain;
+    }
+    for (const dep of getImports(cur)) {
+      if (!parent.has(dep)) {
+        parent.set(dep, cur);
+        queue.push(dep);
+      }
+    }
+  }
+  return null;
+}
+
+if (import.meta.main) {
+  const target = process.argv[2];
+  if (!target) {
+    console.error(
+      "usage: bun run scripts/trace-import-chain.ts <target-substring> [entry]"
+    );
+    process.exit(1);
+  }
+  const chain = findStaticImportChain(target, process.argv[3] ?? "src/main.tsx");
+  if (!chain) {
+    console.log(`No static chain from entry to "${target}"`);
+  } else {
+    console.log(chain.join("\n  -> "));
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { AppManager } from "./apps/base/AppManager";
 import { appRegistry } from "./config/appRegistry";
-import { useEffect, useMemo, useReducer, useCallback } from "react";
+import { Suspense, lazy, useEffect, useMemo, useReducer, useCallback } from "react";
 import { applyDisplayMode } from "./utils/displayMode";
 import { Toaster } from "./components/ui/sonner";
 import { toast } from "@/hooks/useToast";
@@ -24,12 +24,20 @@ import { ScreenSaverOverlay } from "./components/screensavers/ScreenSaverOverlay
 import { useBackgroundChatNotifications } from "./hooks/useBackgroundChatNotifications";
 import { DesktopErrorBoundary } from "@/components/errors/ErrorBoundaries";
 import { DeferredAutoCloudSync } from "@/hooks/useDeferredAutoCloudSync";
-import { AirDropListener } from "@/components/AirDropListener";
+import { DeferredAirDropListener } from "@/components/DeferredAirDropListener";
 import { WallpaperAccentRunner } from "@/hooks/WallpaperAccentRunner";
 import { DesktopCornerMask } from "@/components/layout/desktop/DesktopCornerMask";
 import { installNativeToastNotifications } from "@/utils/nativeToastNotifications";
-import { DebugLogOverlay } from "@/components/debug/DebugLogOverlay";
 import { createClientLogger } from "@/utils/logger";
+
+// Code-split: the debug overlay (console/network panels + live dashboard) is
+// a large component tree that only renders while Debug Mode is enabled, so
+// normal sessions never download or parse it.
+const DebugLogOverlay = lazy(() =>
+  import("@/components/debug/DebugLogOverlay").then((m) => ({
+    default: m.DebugLogOverlay,
+  }))
+);
 
 // Convert registry to array
 const apps: AnyApp[] = Object.values(appRegistry);
@@ -76,7 +84,10 @@ export function App() {
       setLastSeenDesktopVersion: state.setLastSeenDesktopVersion,
     })
   );
-  const displayMode = useDisplaySettingsStoreShallow((state) => state.displayMode);
+  const { displayMode, debugMode } = useDisplaySettingsStoreShallow((state) => ({
+    displayMode: state.displayMode,
+    debugMode: state.debugMode,
+  }));
   const { isWindowsTheme, isMacOSTheme, isSystem7Theme, isAquaGlass } =
     useThemeFlags();
   const isMobile = useIsMobile();
@@ -273,11 +284,15 @@ export function App() {
         <AppManager apps={apps} />
       </DesktopErrorBoundary>
       <Toaster position={toastConfig.position} offset={toastConfig.offset} />
-      <AirDropListener />
+      <DeferredAirDropListener />
       <DeferredAutoCloudSync />
       <WallpaperAccentRunner />
       <ScreenSaverOverlay />
-      <DebugLogOverlay />
+      {debugMode && (
+        <Suspense fallback={null}>
+          <DebugLogOverlay />
+        </Suspense>
+      )}
     </>
   );
 }

--- a/src/components/DeferredAirDropListener.tsx
+++ b/src/components/DeferredAirDropListener.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState, type ComponentType } from "react";
+
+/**
+ * Schedules dynamic import of the AirDrop listener after first paint (idle,
+ * max 3s wait), so `useFileSystem` (the full finder VFS stack) and the chats /
+ * files / textedit store graph it drags in are not in the App static graph.
+ * AirDrop transfers arrive over a realtime channel that is only subscribed for
+ * authenticated users, so a few seconds of deferral is unobservable.
+ */
+export function DeferredAirDropListener() {
+  const [Listener, setListener] = useState<ComponentType | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let idleId: number | undefined;
+    let timeoutId: number | undefined;
+
+    const load = () => {
+      if (cancelled) return;
+      void import("./AirDropListener").then((mod) => {
+        if (!cancelled) setListener(() => mod.AirDropListener);
+      });
+    };
+
+    const w = window;
+    if (typeof w.requestIdleCallback === "function") {
+      idleId = w.requestIdleCallback(load, { timeout: 3000 });
+    } else {
+      timeoutId = w.setTimeout(load, 0);
+    }
+
+    return () => {
+      cancelled = true;
+      if (idleId !== undefined && typeof w.cancelIdleCallback === "function") {
+        w.cancelIdleCallback(idleId);
+      }
+      if (timeoutId !== undefined) {
+        w.clearTimeout(timeoutId);
+      }
+    };
+  }, []);
+
+  if (!Listener) return null;
+  return <Listener />;
+}

--- a/src/components/layout/desktop/DesktopCoverWallpaperLayer.tsx
+++ b/src/components/layout/desktop/DesktopCoverWallpaperLayer.tsx
@@ -1,0 +1,52 @@
+import { AnimatePresence, motion } from "motion/react";
+import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
+import { usePublishNowPlayingCover } from "@/stores/useNowPlayingCoverBridge";
+
+export function CoverWallpaperLayer() {
+  const { coverUrl } = useNowPlayingCover();
+  // Publish to the lightweight bridge for boot-path consumers (menubar tone).
+  usePublishNowPlayingCover(coverUrl);
+
+  return (
+    <div className="absolute inset-0 w-full h-full z-[-10] overflow-hidden bg-neutral-950">
+      <AnimatePresence mode="popLayout">
+        {coverUrl ? (
+          <motion.div
+            key={coverUrl}
+            className="absolute inset-0 w-full h-full"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.6 }}
+          >
+            {/* Full-bleed cover: fills the entire desktop, cropping as needed. */}
+            <div
+              className="absolute inset-0 w-full h-full"
+              style={{
+                backgroundImage: `url("${coverUrl}")`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+                backgroundRepeat: "no-repeat",
+              }}
+            />
+            {/* Subtle darkening keeps desktop icons readable. */}
+            <div className="absolute inset-0 w-full h-full bg-black/25" />
+          </motion.div>
+        ) : (
+          <motion.div
+            key="cover-empty"
+            className="absolute inset-0 w-full h-full"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.6 }}
+            style={{
+              backgroundImage:
+                "linear-gradient(to bottom, #1a1a1f 0%, #0c0c10 100%)",
+            }}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
+++ b/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
@@ -1,70 +1,41 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
-import { createPortal } from "react-dom";
-import { useTranslation } from "react-i18next";
-import { AnimatePresence, motion } from "motion/react";
-import { useWallpaper } from "@/hooks/useWallpaper";
-import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
-import { useWeatherWallpaper } from "@/hooks/useWeatherWallpaper";
-import { useNowPlayingLyrics } from "@/hooks/useNowPlayingLyrics";
-import { useThemeFlags } from "@/hooks/useThemeFlags";
-import { useIsPhone } from "@/hooks/useIsPhone";
-import { useIpodPipActive } from "@/apps/ipod/hooks/useIpodPipActive";
-import { useSaveSongCoverColor } from "@/hooks/useSaveSongCoverColor";
-import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
-import { useWeatherSimulationStore } from "@/stores/useWeatherSimulationStore";
-import { SF_LAT, SF_LON } from "@/stores/useWeatherStore";
-import { WeatherShaderBackground } from "@/components/shared/WeatherShaderBackground";
-import { YouTubePlayer } from "@/components/shared/YouTubePlayer";
-import { KaraokeVisualLayers } from "@/apps/karaoke/components/karaoke-app/KaraokeVisualLayers";
-import { DisplayMode } from "@/types/lyrics";
-import { getWeatherEmoji } from "@/lib/weather/openMeteo";
-import { Emoji } from "@/components/shared/Emoji";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { LyricsDisplay } from "@/apps/ipod/components/lyrics-display/LyricsDisplay";
+import { Suspense, lazy, useEffect, useState } from "react";
 import {
   getDayNightGradientCss,
-  getWeatherGradientColors,
   getWeatherGradientCss,
   isCoverWallpaper,
   isDayNightGradientWallpaper,
   isLyricsWallpaper,
   isWeatherWallpaper,
-  weatherCodeToFamily,
-  type WeatherFamily,
 } from "@/utils/dynamicWallpaper";
+import { useWallpaper } from "@/hooks/useWallpaper";
 
 /** Recompute the day/night gradient roughly once a minute. */
 const GRADIENT_REFRESH_MS = 60 * 1000;
 
-// Mirror the Karaoke fullscreen lyric sizing so the wallpaper renders large,
-// viewport-relative lyrics (rather than the small in-app default).
-const LYRICS_WALLPAPER_GAP = "clamp(0.2rem, calc(min(10vw, 10vh) * 0.08), 1rem)";
-
-// Bottom clearance (px) so the lyrics sit above the dock / taskbar. Matches the
-// PiP + toast bottom offsets used elsewhere so the lyrics line up with the rest
-// of the desktop chrome. Aqua glass sits a little higher than classic Aqua.
-const LYRICS_DOCK_CLEARANCE_GLASS = 82;
-const LYRICS_DOCK_CLEARANCE_AQUA = 72;
-const LYRICS_DOCK_CLEARANCE_WINDOWS = 42;
-const LYRICS_DOCK_CLEARANCE_DEFAULT = 16;
-// Lift the lyrics slightly off the dock/taskbar without pushing the block too
-// high on the desktop.
-const LYRICS_EXTRA_LIFT = 48;
-// Extra clearance (px) when the iPod "pop player" (PiP) is showing: the floating
-// player is ~64px tall and sits just above the dock, so lift the lyrics past it.
-const LYRICS_PIP_CLEARANCE = 76;
-
-// Mirror listen-sync thresholds so the muted wallpaper player tracks the
-// primary iPod / Karaoke player without constant hard seeks.
-const WALLPAPER_SOFT_SYNC_THRESHOLD_SEC = 0.5;
-const WALLPAPER_HARD_SEEK_THRESHOLD_SEC = 3;
-const WALLPAPER_SEEK_JUMP_THRESHOLD_SEC = 0.75;
+// The weather / lyrics / cover layers are code-split because they pull heavy
+// dependency graphs that must not load at boot for users on other wallpapers:
+//   - weather → WeatherShaderBackground → three (~465KB chunk)
+//   - lyrics  → YouTubePlayer (react-player) + KaraokeVisualLayers (three) +
+//               LyricsDisplay (pinyin-pro / wanakana / hangul romanization) +
+//               the full iPod/Karaoke store stack
+//   - cover   → the iPod/Karaoke store stack
+// While a lazy chunk loads, a lightweight CSS-only fallback renders so the
+// desktop background never flashes.
+const WeatherGradientLayer = lazy(() =>
+  import("./DesktopWeatherWallpaperLayer").then((m) => ({
+    default: m.WeatherGradientLayer,
+  }))
+);
+const LyricsWallpaperLayer = lazy(() =>
+  import("./DesktopLyricsWallpaperLayer").then((m) => ({
+    default: m.LyricsWallpaperLayer,
+  }))
+);
+const CoverWallpaperLayer = lazy(() =>
+  import("./DesktopCoverWallpaperLayer").then((m) => ({
+    default: m.CoverWallpaperLayer,
+  }))
+);
 
 function DayNightGradientLayer() {
   const [gradient, setGradient] = useState(() => getDayNightGradientCss());
@@ -88,506 +59,20 @@ function DayNightGradientLayer() {
   );
 }
 
-// Translation key suffix per weather family for the condition label.
-const WEATHER_CONDITION_KEY: Record<WeatherFamily, string> = {
-  clear: "clear",
-  partlyCloudy: "partlyCloudy",
-  fog: "fog",
-  drizzle: "drizzle",
-  rain: "rain",
-  snow: "snow",
-  thunderstorm: "thunderstorm",
-};
-
-// Debug-mode condition simulator: a representative WMO code per family so the
-// shader renders each look. `weatherCodeToFamily` maps these back to families.
-const SIMULATABLE_WEATHER: { family: WeatherFamily; code: number }[] = [
-  { family: "clear", code: 0 },
-  { family: "partlyCloudy", code: 2 },
-  { family: "fog", code: 45 },
-  { family: "drizzle", code: 51 },
-  { family: "rain", code: 61 },
-  { family: "snow", code: 71 },
-  { family: "thunderstorm", code: 95 },
-];
-
-// Normalize the [top, mid, bottom] gradient colors (0..255) to shader-space
-// vec3 components (0..1).
-function toShaderColors(code: number | null): {
-  top: [number, number, number];
-  mid: [number, number, number];
-  bottom: [number, number, number];
-} {
-  const [top, mid, bottom] = getWeatherGradientColors(code);
-  const n = (rgb: [number, number, number]): [number, number, number] => [
-    rgb[0] / 255,
-    rgb[1] / 255,
-    rgb[2] / 255,
-  ];
-  return { top: n(top), mid: n(mid), bottom: n(bottom) };
-}
-
-// Extra bottom clearance (px) so the weather text clears the dock / taskbar,
-// mirroring PipPlayer's per-theme bottom offsets.
-const WEATHER_BOTTOM_WINDOWS = 42;
-const WEATHER_BOTTOM_DEFAULT = 16;
-// Lift the text above the iPod pop player (PiP) when it's showing.
-const WEATHER_PIP_CLEARANCE = 76;
-// macOS top-left placement: gap below the menu bar and inset from the left edge.
-const WEATHER_TOP_GAP = 20;
-const WEATHER_LEFT_INSET = 28;
-// Vertical offset so the debug condition picker clears the overlay text block.
-const WEATHER_SELECT_OFFSET = 96;
-
-function WeatherGradientLayer() {
-  const { t } = useTranslation();
-  const { weatherCode, isDay, temperature, city, lat, lon } =
-    useWeatherWallpaper();
-  const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
-  const isPhone = useIsPhone();
-  const pipActive = useIpodPipActive();
-  const debugMode = useDisplaySettingsStore((s) => s.debugMode);
-  const simulatedWeatherCode = useWeatherSimulationStore(
-    (s) => s.simulatedWeatherCode
-  );
-  const setSimulatedWeatherCode = useWeatherSimulationStore(
-    (s) => s.setSimulatedWeatherCode
-  );
-
-  // Debug simulation (when set) overrides the live condition for all weather
-  // visuals; temperature + city always stay live.
-  const effectiveCode = simulatedWeatherCode ?? weatherCode;
-
-  const [gradient, setGradient] = useState(() =>
-    getWeatherGradientCss(effectiveCode)
-  );
-  const [colors, setColors] = useState(() => toShaderColors(effectiveCode));
-
-  // Recompute on the minute timer (time-of-day) and whenever the effective
-  // weather code changes. The gradient reads the wall clock internally.
-  useEffect(() => {
-    const update = () => {
-      setGradient(getWeatherGradientCss(effectiveCode));
-      setColors(toShaderColors(effectiveCode));
-    };
-    update();
-    const id = setInterval(update, GRADIENT_REFRESH_MS);
-    return () => clearInterval(id);
-  }, [effectiveCode]);
-
-  const family = weatherCodeToFamily(effectiveCode);
-  const simulationValue =
-    simulatedWeatherCode == null
-      ? "live"
-      : weatherCodeToFamily(simulatedWeatherCode);
-
-  // macOS (Aqua / Aqua Glass): pin the text top-left, just under the menu bar.
-  // Everything else keeps the PiP-mirroring placement above the dock/taskbar:
-  // centered on phones, right-aligned on desktop, lifted above an active PiP.
-  const topLeft = isMacOSTheme;
-  const shouldCenter = !topLeft && isPhone;
-  const isRightAligned = !topLeft && !shouldCenter;
-  const overlayStyle = useMemo<CSSProperties>(() => {
-    if (topLeft) {
-      return {
-        top: `calc(env(safe-area-inset-top, 0px) + var(--os-metrics-menubar-height, 25px) + ${WEATHER_TOP_GAP}px)`,
-        left: `calc(env(safe-area-inset-left, 0px) + ${WEATHER_LEFT_INSET}px)`,
-        textAlign: "left",
-        alignItems: "flex-start",
-      };
-    }
-    const base = isWindowsTheme ? WEATHER_BOTTOM_WINDOWS : WEATHER_BOTTOM_DEFAULT;
-    const bottomPx = base + (pipActive ? WEATHER_PIP_CLEARANCE : 0);
-    const style: CSSProperties = {
-      bottom: `calc(env(safe-area-inset-bottom, 0px) + ${bottomPx}px)`,
-    };
-    if (shouldCenter) {
-      style.left = "50%";
-      style.transform = "translateX(-50%)";
-      style.textAlign = "center";
-      style.alignItems = "center";
-    } else {
-      style.right = "12px";
-      style.textAlign = "right";
-      style.alignItems = "flex-end";
-    }
-    return style;
-  }, [topLeft, isWindowsTheme, shouldCenter, pipActive]);
-
-  // The interactive debug picker is portaled to <body> so it sits above the
-  // desktop icons (the wallpaper layer is z-[-10] and otherwise unclickable)
-  // but stays BELOW application windows — matching the iPod PiP, which uses
-  // z-[1] since windows start at z-index 2+. It reuses the overlay's offsets,
-  // nudged to clear the text block.
-  const debugSelectStyle = useMemo<CSSProperties>(() => {
-    const style: CSSProperties = { position: "fixed", zIndex: 1 };
-    if (topLeft) {
-      style.top = `calc(env(safe-area-inset-top, 0px) + var(--os-metrics-menubar-height, 25px) + ${WEATHER_TOP_GAP + WEATHER_SELECT_OFFSET}px)`;
-      style.left = `calc(env(safe-area-inset-left, 0px) + ${WEATHER_LEFT_INSET}px)`;
-      return style;
-    }
-    const base = isWindowsTheme ? WEATHER_BOTTOM_WINDOWS : WEATHER_BOTTOM_DEFAULT;
-    const bottomPx =
-      base + (pipActive ? WEATHER_PIP_CLEARANCE : 0) + WEATHER_SELECT_OFFSET;
-    style.bottom = `calc(env(safe-area-inset-bottom, 0px) + ${bottomPx}px)`;
-    if (shouldCenter) {
-      style.left = "50%";
-      style.transform = "translateX(-50%)";
-    } else {
-      style.right = "12px";
-    }
-    return style;
-  }, [topLeft, isWindowsTheme, shouldCenter, pipActive]);
-
-  const hasData = effectiveCode != null && temperature != null;
-  // Localize the SF fallback (stored with city: null) at the render layer,
-  // matching the dashboard widget; real reverse-geocoded cities show as-is.
-  const isSfFallback =
-    city == null &&
-    lat != null &&
-    lon != null &&
-    Math.abs(lat - SF_LAT) < 0.01 &&
-    Math.abs(lon - SF_LON) < 0.01;
-  const displayCity =
-    city ?? (isSfFallback ? t("apps.dashboard.cities.sanFrancisco") : null);
-  const textShadow = "0 1px 4px rgba(0,0,0,0.45)";
-
+/** CSS-only weather sky shown while the shader layer's chunk loads. */
+function WeatherGradientFallback() {
   return (
-    <div className="absolute inset-0 w-full h-full z-[-10] overflow-hidden">
-      {/* Base CSS gradient fallback (also shown if WebGL is unavailable). */}
-      <div
-        className="absolute inset-0 w-full h-full"
-        style={{
-          backgroundImage: gradient,
-          transition: "background-image 3s linear",
-        }}
-      />
-      {/* Animated procedural weather sky. */}
-      <WeatherShaderBackground
-        family={family}
-        isDay={isDay}
-        topColor={colors.top}
-        midColor={colors.mid}
-        bottomColor={colors.bottom}
-        isActive
-        className="absolute inset-0 w-full h-full"
-      />
-      {/* Text overlay: city, temperature, condition. */}
-      {hasData && (
-        <div
-          className="absolute flex flex-col select-none pointer-events-none"
-          style={overlayStyle}
-        >
-          {displayCity && (
-            <span
-              className="font-medium truncate"
-              style={{
-                fontSize: 14,
-                color: "rgba(255,255,255,0.9)",
-                maxWidth: "70vw",
-                textShadow,
-                fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
-              }}
-            >
-              {displayCity}
-            </span>
-          )}
-          <span
-            className="font-light leading-none"
-            style={{
-              fontSize: 48,
-              letterSpacing: "-0.04em",
-              color: "#FFF",
-              textShadow: "0 2px 10px rgba(0,0,0,0.3)",
-              fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
-            }}
-          >
-            {temperature}°
-          </span>
-          <div
-            className="flex items-center gap-1.5"
-            style={{
-              flexDirection: isRightAligned ? "row-reverse" : "row",
-            }}
-          >
-            <Emoji
-              emoji={getWeatherEmoji(effectiveCode ?? 0, isDay)}
-              size={18}
-              style={{ filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.35))" }}
-            />
-            <span
-              className="font-medium"
-              style={{
-                fontSize: 13,
-                color: "rgba(255,255,255,0.85)",
-                textShadow,
-                fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
-              }}
-            >
-              {t(
-                `apps.dashboard.weather.conditions.${WEATHER_CONDITION_KEY[family]}`
-              )}
-            </span>
-          </div>
-        </div>
-      )}
-      {debugMode &&
-        createPortal(
-          <div
-            style={{ ...debugSelectStyle, pointerEvents: "auto" }}
-            onClick={(e) => e.stopPropagation()}
-            onPointerDown={(e) => e.stopPropagation()}
-          >
-            <Select
-              value={simulationValue}
-              onValueChange={(value) => {
-                if (value === "live") {
-                  setSimulatedWeatherCode(null);
-                  return;
-                }
-                const match = SIMULATABLE_WEATHER.find(
-                  (o) => o.family === value
-                );
-                setSimulatedWeatherCode(match ? match.code : null);
-              }}
-            >
-              <SelectTrigger className="h-7 w-[120px] text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="live">{t("common.auto")}</SelectItem>
-                {SIMULATABLE_WEATHER.map((o) => (
-                  <SelectItem key={o.family} value={o.family}>
-                    {t(
-                      `apps.dashboard.weather.conditions.${WEATHER_CONDITION_KEY[o.family]}`
-                    )}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>,
-          document.body
-        )}
-    </div>
+    <div
+      className="absolute inset-0 w-full h-full z-[-10]"
+      style={{ backgroundImage: getWeatherGradientCss(null) }}
+    />
   );
 }
 
-function LyricsWallpaperLayer() {
-  const np = useNowPlayingLyrics();
-  const videoPlayerRef = useRef<React.ComponentRef<typeof YouTubePlayer>>(null);
-  const prevElapsedRef = useRef(np.elapsedSeconds);
-  const prevTrackIdRef = useRef(np.track?.id);
-  const wallpaperPlaybackRateRef = useRef(1);
-  const { isMacOSTheme, isAquaGlass, isWinXp, isWin98 } = useThemeFlags();
-  const pipActive = useIpodPipActive();
-  // Persist the resolved cover color back to the song (and store) so the lyric
-  // highlight color matches the song palette — exactly like the Karaoke overlay.
-  const saveCoverColor = useSaveSongCoverColor(np.track);
-
-  // Reserve enough bottom space for the lyrics to clear the dock / taskbar, plus
-  // the iPod pop player (PiP) when it's active. The offset differs for Aqua vs
-  // Aqua Glass since the glass dock sits a touch higher.
-  const containerStyle = useMemo<CSSProperties>(() => {
-    const isWindowsTheme = isWinXp || isWin98;
-    const dockClearance = isMacOSTheme
-      ? isAquaGlass
-        ? LYRICS_DOCK_CLEARANCE_GLASS
-        : LYRICS_DOCK_CLEARANCE_AQUA
-      : isWindowsTheme
-        ? LYRICS_DOCK_CLEARANCE_WINDOWS
-        : LYRICS_DOCK_CLEARANCE_DEFAULT;
-    const paddingBottomPx =
-      dockClearance +
-      LYRICS_EXTRA_LIFT +
-      (pipActive ? LYRICS_PIP_CLEARANCE : 0);
-    return {
-      gap: LYRICS_WALLPAPER_GAP,
-      paddingLeft: "env(safe-area-inset-left, 0px)",
-      paddingRight: "env(safe-area-inset-right, 0px)",
-      paddingBottom: `calc(env(safe-area-inset-bottom, 0px) + ${paddingBottomPx}px)`,
-    };
-  }, [isMacOSTheme, isAquaGlass, isWinXp, isWin98, pipActive]);
-
-  const showVideoBackground =
-    np.effectiveDisplayMode === DisplayMode.Video &&
-    np.isPlaying &&
-    np.track?.url &&
-    np.track.source !== "appleMusic";
-
-  useEffect(() => {
-    if (!showVideoBackground) return;
-    const player = videoPlayerRef.current;
-    if (!player) return;
-
-    const target = np.elapsedSeconds;
-    if (np.track?.id !== prevTrackIdRef.current) {
-      prevTrackIdRef.current = np.track?.id;
-      prevElapsedRef.current = target;
-      wallpaperPlaybackRateRef.current = 1;
-    }
-
-    const prevElapsed = prevElapsedRef.current;
-    const elapsedJump = Math.abs(target - prevElapsed);
-    prevElapsedRef.current = target;
-
-    const current = player.getCurrentTime() ?? 0;
-    const drift = target - current;
-    const absDrift = Math.abs(drift);
-
-    const setPlaybackRate = (rate: number) => {
-      if (wallpaperPlaybackRateRef.current === rate) return;
-      try {
-        const internalPlayer = player.getInternalPlayer() as
-          | { playbackRate?: number }
-          | null
-          | undefined;
-        if (
-          internalPlayer &&
-          typeof internalPlayer.playbackRate !== "undefined"
-        ) {
-          internalPlayer.playbackRate = rate;
-          wallpaperPlaybackRateRef.current = rate;
-        }
-      } catch {
-        // Some players don't support playbackRate.
-      }
-    };
-
-    if (
-      elapsedJump > WALLPAPER_SEEK_JUMP_THRESHOLD_SEC ||
-      absDrift > WALLPAPER_HARD_SEEK_THRESHOLD_SEC ||
-      (!np.isPlaying && absDrift > WALLPAPER_SOFT_SYNC_THRESHOLD_SEC)
-    ) {
-      player.seekTo(target, "seconds");
-      setPlaybackRate(1);
-      return;
-    }
-
-    if (np.isPlaying && absDrift > WALLPAPER_SOFT_SYNC_THRESHOLD_SEC) {
-      setPlaybackRate(drift > 0 ? 1.05 : 0.95);
-      return;
-    }
-
-    setPlaybackRate(1);
-  }, [
-    np.elapsedSeconds,
-    np.isPlaying,
-    np.track?.id,
-    showVideoBackground,
-  ]);
-
+/** Dark backdrop shown while the lyrics / cover layer's chunk loads. */
+function DarkWallpaperFallback() {
   return (
-    <div className="absolute inset-0 w-full h-full z-[-10] overflow-hidden bg-neutral-950">
-      {showVideoBackground && (
-        <div className="absolute inset-0 w-full h-full overflow-hidden">
-          <div className="w-full h-[calc(100%+400px)] mt-[-200px]">
-            <YouTubePlayer
-              ref={videoPlayerRef}
-              url={np.track!.url}
-              playing={np.isPlaying}
-              volume={0}
-              width="100%"
-              height="100%"
-              style={{ pointerEvents: "none" }}
-              onReady={() => {
-                wallpaperPlaybackRateRef.current = 1;
-                videoPlayerRef.current?.seekTo(np.elapsedSeconds, "seconds");
-              }}
-              config={{
-                youtube: {
-                  playerVars: {
-                    controls: 0,
-                    fs: 0,
-                  },
-                },
-              }}
-            />
-          </div>
-        </div>
-      )}
-      <KaraokeVisualLayers
-        effectiveDisplayMode={np.effectiveDisplayMode}
-        visualBackgroundActive={np.visualBackgroundActive}
-        currentTrack={np.track}
-        coverUrl={np.coverUrl}
-        isPlaying={np.isPlaying}
-        layerClassName="absolute inset-0 w-full h-full"
-        coverOverlayClassName="absolute inset-0"
-        onCoverInteraction={() => {}}
-      />
-      {/* Soft darkening keeps the lyrics and desktop icons readable. */}
-      <div className="absolute inset-0 w-full h-full bg-black/30" />
-      {np.hasLyrics && (
-        <LyricsDisplay
-          lines={np.lyricsControls.lines}
-          originalLines={np.lyricsControls.originalLines}
-          currentLine={np.lyricsControls.currentLine}
-          isLoading={np.lyricsControls.isLoading}
-          error={np.lyricsControls.error}
-          visible
-          videoVisible
-          fontClassName={np.lyricsFontClassName}
-          isTranslating={np.lyricsControls.isTranslating}
-          furiganaMap={np.furiganaMap}
-          soramimiMap={np.soramimiMap}
-          currentTimeMs={np.currentTimeMs}
-          textSizeClass="fullscreen-lyrics-text"
-          gapClass="gap-0"
-          containerStyle={containerStyle}
-          coverUrl={np.coverUrl}
-          coverColor={np.track?.coverColor}
-          onCoverColorResolved={saveCoverColor}
-          showInterludeEllipsis
-        />
-      )}
-    </div>
-  );
-}
-
-function CoverWallpaperLayer() {
-  const { coverUrl } = useNowPlayingCover();
-
-  return (
-    <div className="absolute inset-0 w-full h-full z-[-10] overflow-hidden bg-neutral-950">
-      <AnimatePresence mode="popLayout">
-        {coverUrl ? (
-          <motion.div
-            key={coverUrl}
-            className="absolute inset-0 w-full h-full"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.6 }}
-          >
-            {/* Full-bleed cover: fills the entire desktop, cropping as needed. */}
-            <div
-              className="absolute inset-0 w-full h-full"
-              style={{
-                backgroundImage: `url("${coverUrl}")`,
-                backgroundSize: "cover",
-                backgroundPosition: "center",
-                backgroundRepeat: "no-repeat",
-              }}
-            />
-            {/* Subtle darkening keeps desktop icons readable. */}
-            <div className="absolute inset-0 w-full h-full bg-black/25" />
-          </motion.div>
-        ) : (
-          <motion.div
-            key="cover-empty"
-            className="absolute inset-0 w-full h-full"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.6 }}
-            style={{
-              backgroundImage:
-                "linear-gradient(to bottom, #1a1a1f 0%, #0c0c10 100%)",
-            }}
-          />
-        )}
-      </AnimatePresence>
-    </div>
+    <div className="absolute inset-0 w-full h-full z-[-10] bg-neutral-950" />
   );
 }
 
@@ -604,13 +89,25 @@ export function DesktopDynamicWallpaper() {
     return <DayNightGradientLayer />;
   }
   if (isWeatherWallpaper(currentWallpaper)) {
-    return <WeatherGradientLayer />;
+    return (
+      <Suspense fallback={<WeatherGradientFallback />}>
+        <WeatherGradientLayer />
+      </Suspense>
+    );
   }
   if (isCoverWallpaper(currentWallpaper)) {
-    return <CoverWallpaperLayer />;
+    return (
+      <Suspense fallback={<DarkWallpaperFallback />}>
+        <CoverWallpaperLayer />
+      </Suspense>
+    );
   }
   if (isLyricsWallpaper(currentWallpaper)) {
-    return <LyricsWallpaperLayer />;
+    return (
+      <Suspense fallback={<DarkWallpaperFallback />}>
+        <LyricsWallpaperLayer />
+      </Suspense>
+    );
   }
   return null;
 }

--- a/src/components/layout/desktop/DesktopLyricsWallpaperLayer.tsx
+++ b/src/components/layout/desktop/DesktopLyricsWallpaperLayer.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useMemo, useRef, type CSSProperties } from "react";
+import { useNowPlayingLyrics } from "@/hooks/useNowPlayingLyrics";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { useIpodPipActive } from "@/apps/ipod/hooks/useIpodPipActive";
+import { useSaveSongCoverColor } from "@/hooks/useSaveSongCoverColor";
+import { YouTubePlayer } from "@/components/shared/YouTubePlayer";
+import { KaraokeVisualLayers } from "@/apps/karaoke/components/karaoke-app/KaraokeVisualLayers";
+import { DisplayMode } from "@/types/lyrics";
+import { LyricsDisplay } from "@/apps/ipod/components/lyrics-display/LyricsDisplay";
+import { usePublishNowPlayingCover } from "@/stores/useNowPlayingCoverBridge";
+
+// Mirror the Karaoke fullscreen lyric sizing so the wallpaper renders large,
+// viewport-relative lyrics (rather than the small in-app default).
+const LYRICS_WALLPAPER_GAP = "clamp(0.2rem, calc(min(10vw, 10vh) * 0.08), 1rem)";
+
+// Bottom clearance (px) so the lyrics sit above the dock / taskbar. Matches the
+// PiP + toast bottom offsets used elsewhere so the lyrics line up with the rest
+// of the desktop chrome. Aqua glass sits a little higher than classic Aqua.
+const LYRICS_DOCK_CLEARANCE_GLASS = 82;
+const LYRICS_DOCK_CLEARANCE_AQUA = 72;
+const LYRICS_DOCK_CLEARANCE_WINDOWS = 42;
+const LYRICS_DOCK_CLEARANCE_DEFAULT = 16;
+// Lift the lyrics slightly off the dock/taskbar without pushing the block too
+// high on the desktop.
+const LYRICS_EXTRA_LIFT = 48;
+// Extra clearance (px) when the iPod "pop player" (PiP) is showing: the floating
+// player is ~64px tall and sits just above the dock, so lift the lyrics past it.
+const LYRICS_PIP_CLEARANCE = 76;
+
+// Mirror listen-sync thresholds so the muted wallpaper player tracks the
+// primary iPod / Karaoke player without constant hard seeks.
+const WALLPAPER_SOFT_SYNC_THRESHOLD_SEC = 0.5;
+const WALLPAPER_HARD_SEEK_THRESHOLD_SEC = 3;
+const WALLPAPER_SEEK_JUMP_THRESHOLD_SEC = 0.75;
+
+export function LyricsWallpaperLayer() {
+  const np = useNowPlayingLyrics();
+  const videoPlayerRef = useRef<React.ComponentRef<typeof YouTubePlayer>>(null);
+  const prevElapsedRef = useRef(np.elapsedSeconds);
+  const prevTrackIdRef = useRef(np.track?.id);
+  const wallpaperPlaybackRateRef = useRef(1);
+  const { isMacOSTheme, isAquaGlass, isWinXp, isWin98 } = useThemeFlags();
+  const pipActive = useIpodPipActive();
+  // Persist the resolved cover color back to the song (and store) so the lyric
+  // highlight color matches the song palette — exactly like the Karaoke overlay.
+  const saveCoverColor = useSaveSongCoverColor(np.track);
+  // Publish to the lightweight bridge for boot-path consumers (menubar tone).
+  usePublishNowPlayingCover(np.coverUrl);
+
+  // Reserve enough bottom space for the lyrics to clear the dock / taskbar, plus
+  // the iPod pop player (PiP) when it's active. The offset differs for Aqua vs
+  // Aqua Glass since the glass dock sits a touch higher.
+  const containerStyle = useMemo<CSSProperties>(() => {
+    const isWindowsTheme = isWinXp || isWin98;
+    const dockClearance = isMacOSTheme
+      ? isAquaGlass
+        ? LYRICS_DOCK_CLEARANCE_GLASS
+        : LYRICS_DOCK_CLEARANCE_AQUA
+      : isWindowsTheme
+        ? LYRICS_DOCK_CLEARANCE_WINDOWS
+        : LYRICS_DOCK_CLEARANCE_DEFAULT;
+    const paddingBottomPx =
+      dockClearance +
+      LYRICS_EXTRA_LIFT +
+      (pipActive ? LYRICS_PIP_CLEARANCE : 0);
+    return {
+      gap: LYRICS_WALLPAPER_GAP,
+      paddingLeft: "env(safe-area-inset-left, 0px)",
+      paddingRight: "env(safe-area-inset-right, 0px)",
+      paddingBottom: `calc(env(safe-area-inset-bottom, 0px) + ${paddingBottomPx}px)`,
+    };
+  }, [isMacOSTheme, isAquaGlass, isWinXp, isWin98, pipActive]);
+
+  const showVideoBackground =
+    np.effectiveDisplayMode === DisplayMode.Video &&
+    np.isPlaying &&
+    np.track?.url &&
+    np.track.source !== "appleMusic";
+
+  useEffect(() => {
+    if (!showVideoBackground) return;
+    const player = videoPlayerRef.current;
+    if (!player) return;
+
+    const target = np.elapsedSeconds;
+    if (np.track?.id !== prevTrackIdRef.current) {
+      prevTrackIdRef.current = np.track?.id;
+      prevElapsedRef.current = target;
+      wallpaperPlaybackRateRef.current = 1;
+    }
+
+    const prevElapsed = prevElapsedRef.current;
+    const elapsedJump = Math.abs(target - prevElapsed);
+    prevElapsedRef.current = target;
+
+    const current = player.getCurrentTime() ?? 0;
+    const drift = target - current;
+    const absDrift = Math.abs(drift);
+
+    const setPlaybackRate = (rate: number) => {
+      if (wallpaperPlaybackRateRef.current === rate) return;
+      try {
+        const internalPlayer = player.getInternalPlayer() as
+          | { playbackRate?: number }
+          | null
+          | undefined;
+        if (
+          internalPlayer &&
+          typeof internalPlayer.playbackRate !== "undefined"
+        ) {
+          internalPlayer.playbackRate = rate;
+          wallpaperPlaybackRateRef.current = rate;
+        }
+      } catch {
+        // Some players don't support playbackRate.
+      }
+    };
+
+    if (
+      elapsedJump > WALLPAPER_SEEK_JUMP_THRESHOLD_SEC ||
+      absDrift > WALLPAPER_HARD_SEEK_THRESHOLD_SEC ||
+      (!np.isPlaying && absDrift > WALLPAPER_SOFT_SYNC_THRESHOLD_SEC)
+    ) {
+      player.seekTo(target, "seconds");
+      setPlaybackRate(1);
+      return;
+    }
+
+    if (np.isPlaying && absDrift > WALLPAPER_SOFT_SYNC_THRESHOLD_SEC) {
+      setPlaybackRate(drift > 0 ? 1.05 : 0.95);
+      return;
+    }
+
+    setPlaybackRate(1);
+  }, [
+    np.elapsedSeconds,
+    np.isPlaying,
+    np.track?.id,
+    showVideoBackground,
+  ]);
+
+  return (
+    <div className="absolute inset-0 w-full h-full z-[-10] overflow-hidden bg-neutral-950">
+      {showVideoBackground && (
+        <div className="absolute inset-0 w-full h-full overflow-hidden">
+          <div className="w-full h-[calc(100%+400px)] mt-[-200px]">
+            <YouTubePlayer
+              ref={videoPlayerRef}
+              url={np.track!.url}
+              playing={np.isPlaying}
+              volume={0}
+              width="100%"
+              height="100%"
+              style={{ pointerEvents: "none" }}
+              onReady={() => {
+                wallpaperPlaybackRateRef.current = 1;
+                videoPlayerRef.current?.seekTo(np.elapsedSeconds, "seconds");
+              }}
+              config={{
+                youtube: {
+                  playerVars: {
+                    controls: 0,
+                    fs: 0,
+                  },
+                },
+              }}
+            />
+          </div>
+        </div>
+      )}
+      <KaraokeVisualLayers
+        effectiveDisplayMode={np.effectiveDisplayMode}
+        visualBackgroundActive={np.visualBackgroundActive}
+        currentTrack={np.track}
+        coverUrl={np.coverUrl}
+        isPlaying={np.isPlaying}
+        layerClassName="absolute inset-0 w-full h-full"
+        coverOverlayClassName="absolute inset-0"
+        onCoverInteraction={() => {}}
+      />
+      {/* Soft darkening keeps the lyrics and desktop icons readable. */}
+      <div className="absolute inset-0 w-full h-full bg-black/30" />
+      {np.hasLyrics && (
+        <LyricsDisplay
+          lines={np.lyricsControls.lines}
+          originalLines={np.lyricsControls.originalLines}
+          currentLine={np.lyricsControls.currentLine}
+          isLoading={np.lyricsControls.isLoading}
+          error={np.lyricsControls.error}
+          visible
+          videoVisible
+          fontClassName={np.lyricsFontClassName}
+          isTranslating={np.lyricsControls.isTranslating}
+          furiganaMap={np.furiganaMap}
+          soramimiMap={np.soramimiMap}
+          currentTimeMs={np.currentTimeMs}
+          textSizeClass="fullscreen-lyrics-text"
+          gapClass="gap-0"
+          containerStyle={containerStyle}
+          coverUrl={np.coverUrl}
+          coverColor={np.track?.coverColor}
+          onCoverColorResolved={saveCoverColor}
+          showInterludeEllipsis
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/desktop/DesktopWeatherWallpaperLayer.tsx
+++ b/src/components/layout/desktop/DesktopWeatherWallpaperLayer.tsx
@@ -1,0 +1,313 @@
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import { useWeatherWallpaper } from "@/hooks/useWeatherWallpaper";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { useIsPhone } from "@/hooks/useIsPhone";
+import { useIpodPipActive } from "@/apps/ipod/hooks/useIpodPipActive";
+import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
+import { useWeatherSimulationStore } from "@/stores/useWeatherSimulationStore";
+import { SF_LAT, SF_LON } from "@/stores/useWeatherStore";
+import { WeatherShaderBackground } from "@/components/shared/WeatherShaderBackground";
+import { getWeatherEmoji } from "@/lib/weather/openMeteo";
+import { Emoji } from "@/components/shared/Emoji";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  getWeatherGradientColors,
+  getWeatherGradientCss,
+  weatherCodeToFamily,
+  type WeatherFamily,
+} from "@/utils/dynamicWallpaper";
+
+/** Recompute the weather gradient roughly once a minute. */
+const GRADIENT_REFRESH_MS = 60 * 1000;
+
+// Translation key suffix per weather family for the condition label.
+const WEATHER_CONDITION_KEY: Record<WeatherFamily, string> = {
+  clear: "clear",
+  partlyCloudy: "partlyCloudy",
+  fog: "fog",
+  drizzle: "drizzle",
+  rain: "rain",
+  snow: "snow",
+  thunderstorm: "thunderstorm",
+};
+
+// Debug-mode condition simulator: a representative WMO code per family so the
+// shader renders each look. `weatherCodeToFamily` maps these back to families.
+const SIMULATABLE_WEATHER: { family: WeatherFamily; code: number }[] = [
+  { family: "clear", code: 0 },
+  { family: "partlyCloudy", code: 2 },
+  { family: "fog", code: 45 },
+  { family: "drizzle", code: 51 },
+  { family: "rain", code: 61 },
+  { family: "snow", code: 71 },
+  { family: "thunderstorm", code: 95 },
+];
+
+// Normalize the [top, mid, bottom] gradient colors (0..255) to shader-space
+// vec3 components (0..1).
+function toShaderColors(code: number | null): {
+  top: [number, number, number];
+  mid: [number, number, number];
+  bottom: [number, number, number];
+} {
+  const [top, mid, bottom] = getWeatherGradientColors(code);
+  const n = (rgb: [number, number, number]): [number, number, number] => [
+    rgb[0] / 255,
+    rgb[1] / 255,
+    rgb[2] / 255,
+  ];
+  return { top: n(top), mid: n(mid), bottom: n(bottom) };
+}
+
+// Extra bottom clearance (px) so the weather text clears the dock / taskbar,
+// mirroring PipPlayer's per-theme bottom offsets.
+const WEATHER_BOTTOM_WINDOWS = 42;
+const WEATHER_BOTTOM_DEFAULT = 16;
+// Lift the text above the iPod pop player (PiP) when it's showing.
+const WEATHER_PIP_CLEARANCE = 76;
+// macOS top-left placement: gap below the menu bar and inset from the left edge.
+const WEATHER_TOP_GAP = 20;
+const WEATHER_LEFT_INSET = 28;
+// Vertical offset so the debug condition picker clears the overlay text block.
+const WEATHER_SELECT_OFFSET = 96;
+
+export function WeatherGradientLayer() {
+  const { t } = useTranslation();
+  const { weatherCode, isDay, temperature, city, lat, lon } =
+    useWeatherWallpaper();
+  const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
+  const isPhone = useIsPhone();
+  const pipActive = useIpodPipActive();
+  const debugMode = useDisplaySettingsStore((s) => s.debugMode);
+  const simulatedWeatherCode = useWeatherSimulationStore(
+    (s) => s.simulatedWeatherCode
+  );
+  const setSimulatedWeatherCode = useWeatherSimulationStore(
+    (s) => s.setSimulatedWeatherCode
+  );
+
+  // Debug simulation (when set) overrides the live condition for all weather
+  // visuals; temperature + city always stay live.
+  const effectiveCode = simulatedWeatherCode ?? weatherCode;
+
+  const [gradient, setGradient] = useState(() =>
+    getWeatherGradientCss(effectiveCode)
+  );
+  const [colors, setColors] = useState(() => toShaderColors(effectiveCode));
+
+  // Recompute on the minute timer (time-of-day) and whenever the effective
+  // weather code changes. The gradient reads the wall clock internally.
+  useEffect(() => {
+    const update = () => {
+      setGradient(getWeatherGradientCss(effectiveCode));
+      setColors(toShaderColors(effectiveCode));
+    };
+    update();
+    const id = setInterval(update, GRADIENT_REFRESH_MS);
+    return () => clearInterval(id);
+  }, [effectiveCode]);
+
+  const family = weatherCodeToFamily(effectiveCode);
+  const simulationValue =
+    simulatedWeatherCode == null
+      ? "live"
+      : weatherCodeToFamily(simulatedWeatherCode);
+
+  // macOS (Aqua / Aqua Glass): pin the text top-left, just under the menu bar.
+  // Everything else keeps the PiP-mirroring placement above the dock/taskbar:
+  // centered on phones, right-aligned on desktop, lifted above an active PiP.
+  const topLeft = isMacOSTheme;
+  const shouldCenter = !topLeft && isPhone;
+  const isRightAligned = !topLeft && !shouldCenter;
+  const overlayStyle = useMemo<CSSProperties>(() => {
+    if (topLeft) {
+      return {
+        top: `calc(env(safe-area-inset-top, 0px) + var(--os-metrics-menubar-height, 25px) + ${WEATHER_TOP_GAP}px)`,
+        left: `calc(env(safe-area-inset-left, 0px) + ${WEATHER_LEFT_INSET}px)`,
+        textAlign: "left",
+        alignItems: "flex-start",
+      };
+    }
+    const base = isWindowsTheme ? WEATHER_BOTTOM_WINDOWS : WEATHER_BOTTOM_DEFAULT;
+    const bottomPx = base + (pipActive ? WEATHER_PIP_CLEARANCE : 0);
+    const style: CSSProperties = {
+      bottom: `calc(env(safe-area-inset-bottom, 0px) + ${bottomPx}px)`,
+    };
+    if (shouldCenter) {
+      style.left = "50%";
+      style.transform = "translateX(-50%)";
+      style.textAlign = "center";
+      style.alignItems = "center";
+    } else {
+      style.right = "12px";
+      style.textAlign = "right";
+      style.alignItems = "flex-end";
+    }
+    return style;
+  }, [topLeft, isWindowsTheme, shouldCenter, pipActive]);
+
+  // The interactive debug picker is portaled to <body> so it sits above the
+  // desktop icons (the wallpaper layer is z-[-10] and otherwise unclickable)
+  // but stays BELOW application windows — matching the iPod PiP, which uses
+  // z-[1] since windows start at z-index 2+. It reuses the overlay's offsets,
+  // nudged to clear the text block.
+  const debugSelectStyle = useMemo<CSSProperties>(() => {
+    const style: CSSProperties = { position: "fixed", zIndex: 1 };
+    if (topLeft) {
+      style.top = `calc(env(safe-area-inset-top, 0px) + var(--os-metrics-menubar-height, 25px) + ${WEATHER_TOP_GAP + WEATHER_SELECT_OFFSET}px)`;
+      style.left = `calc(env(safe-area-inset-left, 0px) + ${WEATHER_LEFT_INSET}px)`;
+      return style;
+    }
+    const base = isWindowsTheme ? WEATHER_BOTTOM_WINDOWS : WEATHER_BOTTOM_DEFAULT;
+    const bottomPx =
+      base + (pipActive ? WEATHER_PIP_CLEARANCE : 0) + WEATHER_SELECT_OFFSET;
+    style.bottom = `calc(env(safe-area-inset-bottom, 0px) + ${bottomPx}px)`;
+    if (shouldCenter) {
+      style.left = "50%";
+      style.transform = "translateX(-50%)";
+    } else {
+      style.right = "12px";
+    }
+    return style;
+  }, [topLeft, isWindowsTheme, shouldCenter, pipActive]);
+
+  const hasData = effectiveCode != null && temperature != null;
+  // Localize the SF fallback (stored with city: null) at the render layer,
+  // matching the dashboard widget; real reverse-geocoded cities show as-is.
+  const isSfFallback =
+    city == null &&
+    lat != null &&
+    lon != null &&
+    Math.abs(lat - SF_LAT) < 0.01 &&
+    Math.abs(lon - SF_LON) < 0.01;
+  const displayCity =
+    city ?? (isSfFallback ? t("apps.dashboard.cities.sanFrancisco") : null);
+  const textShadow = "0 1px 4px rgba(0,0,0,0.45)";
+
+  return (
+    <div className="absolute inset-0 w-full h-full z-[-10] overflow-hidden">
+      {/* Base CSS gradient fallback (also shown if WebGL is unavailable). */}
+      <div
+        className="absolute inset-0 w-full h-full"
+        style={{
+          backgroundImage: gradient,
+          transition: "background-image 3s linear",
+        }}
+      />
+      {/* Animated procedural weather sky. */}
+      <WeatherShaderBackground
+        family={family}
+        isDay={isDay}
+        topColor={colors.top}
+        midColor={colors.mid}
+        bottomColor={colors.bottom}
+        isActive
+        className="absolute inset-0 w-full h-full"
+      />
+      {/* Text overlay: city, temperature, condition. */}
+      {hasData && (
+        <div
+          className="absolute flex flex-col select-none pointer-events-none"
+          style={overlayStyle}
+        >
+          {displayCity && (
+            <span
+              className="font-medium truncate"
+              style={{
+                fontSize: 14,
+                color: "rgba(255,255,255,0.9)",
+                maxWidth: "70vw",
+                textShadow,
+                fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
+              }}
+            >
+              {displayCity}
+            </span>
+          )}
+          <span
+            className="font-light leading-none"
+            style={{
+              fontSize: 48,
+              letterSpacing: "-0.04em",
+              color: "#FFF",
+              textShadow: "0 2px 10px rgba(0,0,0,0.3)",
+              fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
+            }}
+          >
+            {temperature}°
+          </span>
+          <div
+            className="flex items-center gap-1.5"
+            style={{
+              flexDirection: isRightAligned ? "row-reverse" : "row",
+            }}
+          >
+            <Emoji
+              emoji={getWeatherEmoji(effectiveCode ?? 0, isDay)}
+              size={18}
+              style={{ filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.35))" }}
+            />
+            <span
+              className="font-medium"
+              style={{
+                fontSize: 13,
+                color: "rgba(255,255,255,0.85)",
+                textShadow,
+                fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
+              }}
+            >
+              {t(
+                `apps.dashboard.weather.conditions.${WEATHER_CONDITION_KEY[family]}`
+              )}
+            </span>
+          </div>
+        </div>
+      )}
+      {debugMode &&
+        createPortal(
+          <div
+            style={{ ...debugSelectStyle, pointerEvents: "auto" }}
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <Select
+              value={simulationValue}
+              onValueChange={(value) => {
+                if (value === "live") {
+                  setSimulatedWeatherCode(null);
+                  return;
+                }
+                const match = SIMULATABLE_WEATHER.find(
+                  (o) => o.family === value
+                );
+                setSimulatedWeatherCode(match ? match.code : null);
+              }}
+            >
+              <SelectTrigger className="h-7 w-[120px] text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="live">{t("common.auto")}</SelectItem>
+                {SIMULATABLE_WEATHER.map((o) => (
+                  <SelectItem key={o.family} value={o.family}>
+                    {t(
+                      `apps.dashboard.weather.conditions.${WEATHER_CONDITION_KEY[o.family]}`
+                    )}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+}

--- a/src/components/layout/desktop/useDesktop.ts
+++ b/src/components/layout/desktop/useDesktop.ts
@@ -8,7 +8,7 @@ import {
   useEffect,
 } from "react";
 import type { DragEvent, MouseEvent as ReactMouseEvent } from "react";
-import { SortType } from "@/apps/finder/components/FinderMenuBar";
+import type { SortType } from "@/apps/finder/components/FinderMenuBar";
 import { usePointerLongPress } from "@/hooks/usePointerLongPress";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useFilesStore, type FileSystemItem } from "@/stores/useFilesStore";

--- a/src/hooks/CoverWallpaperAccentRunner.tsx
+++ b/src/hooks/CoverWallpaperAccentRunner.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useThemeStore } from "@/stores/useThemeStore";
+import { useCoverPaletteResult } from "@/hooks/useCoverPalette";
+import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
+import { resolveWallpaperAccentFromPalette } from "@/themes/wallpaperAccentColor";
+
+/**
+ * Cover / lyrics wallpaper accent: tint from the now-playing album art via the
+ * same canvas palette-extraction the iPod cover-art glow uses.
+ *
+ * Lives in its own module (lazily mounted by {@link WallpaperAccentRunner})
+ * because {@link useNowPlayingCover} subscribes to the full iPod + Karaoke
+ * store stack, which should not load at boot for users on other wallpapers.
+ */
+export function CoverWallpaperAccentRunner() {
+  const setWallpaperAccentColor = useThemeStore(
+    (s) => s.setWallpaperAccentColor
+  );
+  const { coverUrl: nowPlayingCoverUrl } = useNowPlayingCover();
+  const { palette, source, coverUrl } = useCoverPaletteResult(
+    nowPlayingCoverUrl
+  );
+
+  useEffect(() => {
+    // Only act on a palette actually extracted from an image.
+    if (source !== "cover" || !coverUrl) return;
+    setWallpaperAccentColor(resolveWallpaperAccentFromPalette(palette));
+  }, [source, coverUrl, palette, setWallpaperAccentColor]);
+
+  return null;
+}

--- a/src/hooks/WallpaperAccentRunner.tsx
+++ b/src/hooks/WallpaperAccentRunner.tsx
@@ -1,15 +1,34 @@
+import { Suspense, lazy } from "react";
 import {
   useWallpaperAccent,
   useWeatherWallpaperAccent,
 } from "./useWallpaperAccent";
 
+// Code-split: the cover accent subscribes to the full iPod + Karaoke store
+// stack via useNowPlayingCover, which should only load when a cover / lyrics
+// wallpaper is actually driving the accent.
+const CoverWallpaperAccentRunner = lazy(() =>
+  import("./CoverWallpaperAccentRunner").then((m) => ({
+    default: m.CoverWallpaperAccentRunner,
+  }))
+);
+
 /** Mounts {@link useWallpaperAccent} once at the app root so the wallpaper
  * accent stays in sync with the active wallpaper regardless of open apps. */
 export function WallpaperAccentRunner() {
-  const { weatherAccentActive } = useWallpaperAccent();
-  // Only subscribe to live weather (and its geolocation/network fetch) while
-  // the weather wallpaper is actually driving the accent.
-  return weatherAccentActive ? <WeatherWallpaperAccentRunner /> : null;
+  const { weatherAccentActive, coverAccentActive } = useWallpaperAccent();
+  // Only subscribe to live weather (and its geolocation/network fetch) or the
+  // now-playing cover while that wallpaper is actually driving the accent.
+  return (
+    <>
+      {weatherAccentActive ? <WeatherWallpaperAccentRunner /> : null}
+      {coverAccentActive ? (
+        <Suspense fallback={null}>
+          <CoverWallpaperAccentRunner />
+        </Suspense>
+      ) : null}
+    </>
+  );
 }
 
 function WeatherWallpaperAccentRunner() {

--- a/src/hooks/useWallpaperAccent.ts
+++ b/src/hooks/useWallpaperAccent.ts
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useWallpaper } from "@/hooks/useWallpaper";
 import { useCoverPaletteResult } from "@/hooks/useCoverPalette";
-import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
 import { useWeatherWallpaper } from "@/hooks/useWeatherWallpaper";
 import { useWeatherSimulationStore } from "@/stores/useWeatherSimulationStore";
 import { DEFAULT_ACCENT, getAccentChrome } from "@/themes/accents";
@@ -45,11 +44,15 @@ const rgbToHex = ([r, g, b]: [number, number, number]): string =>
  * (mid) color. Video wallpapers and load/CORS failures fall back to the theme's
  * classic look.
  *
- * Returns `weatherAccentActive` so the runner can mount the weather sub-runner
- * (which pulls in live weather, and therefore geolocation) only while the
- * weather wallpaper is actually driving the accent.
+ * Returns `weatherAccentActive` / `coverAccentActive` so the runner can mount
+ * the matching sub-runner (live weather + geolocation, or the now-playing
+ * iPod/Karaoke cover stack) only while that wallpaper is actually driving the
+ * accent.
  */
-export function useWallpaperAccent(): { weatherAccentActive: boolean } {
+export function useWallpaperAccent(): {
+  weatherAccentActive: boolean;
+  coverAccentActive: boolean;
+} {
   const current = useThemeStore((s) => s.current);
   const accent = useThemeStore(
     (s) => s.accentByTheme[s.current] ?? DEFAULT_ACCENT
@@ -68,28 +71,31 @@ export function useWallpaperAccent(): { weatherAccentActive: boolean } {
   const isCover = isCoverWallpaper(currentWallpaper);
   const isLyrics = isLyricsWallpaper(currentWallpaper);
   // Cover + lyrics wallpapers both tint from the now-playing album art, exactly
-  // like the Karaoke/lyrics cover-color path.
+  // like the Karaoke/lyrics cover-color path. That sampling lives in the
+  // lazily-mounted CoverWallpaperAccentRunner (it subscribes to the iPod +
+  // Karaoke stores); this hook only handles plain image wallpapers.
   const isCoverBased = isCover || isLyrics;
 
-  const { coverUrl: nowPlayingCoverUrl } = useNowPlayingCover();
-
   // Pick the image URL fed to the canvas palette extractor:
-  //  - cover / lyrics wallpaper → the now-playing album art
   //  - image wallpapers (incl. shuffle photos) → the resolved wallpaper source
-  //  - gradient / weather / video / inactive → none (handled elsewhere/skipped)
+  //  - cover / lyrics / gradient / weather / video / inactive → none (handled
+  //    by the sub-runners or skipped)
   let sampleUrl: string | null = null;
-  if (isWallpaperAccent && !isGradient && !isWeather) {
-    if (isCoverBased) {
-      sampleUrl = nowPlayingCoverUrl;
-    } else if (!isVideoWallpaper && isConcreteWallpaperSource(wallpaperSource)) {
-      sampleUrl = wallpaperSource;
-    }
+  if (
+    isWallpaperAccent &&
+    !isGradient &&
+    !isWeather &&
+    !isCoverBased &&
+    !isVideoWallpaper &&
+    isConcreteWallpaperSource(wallpaperSource)
+  ) {
+    sampleUrl = wallpaperSource;
   }
 
   const { palette, source, coverUrl } = useCoverPaletteResult(sampleUrl);
 
   useEffect(() => {
-    if (!isWallpaperAccent || isGradient || isWeather) return;
+    if (!isWallpaperAccent || isGradient || isWeather || isCoverBased) return;
     // Only act on a palette actually extracted from an image.
     if (source !== "cover" || !coverUrl) return;
     setWallpaperAccentColor(resolveWallpaperAccentFromPalette(palette));
@@ -97,6 +103,7 @@ export function useWallpaperAccent(): { weatherAccentActive: boolean } {
     isWallpaperAccent,
     isGradient,
     isWeather,
+    isCoverBased,
     source,
     coverUrl,
     palette,
@@ -118,7 +125,10 @@ export function useWallpaperAccent(): { weatherAccentActive: boolean } {
     return () => window.clearInterval(id);
   }, [isWallpaperAccent, isGradient, setWallpaperAccentColor]);
 
-  return { weatherAccentActive: isWallpaperAccent && isWeather };
+  return {
+    weatherAccentActive: isWallpaperAccent && isWeather,
+    coverAccentActive: isWallpaperAccent && isCoverBased,
+  };
 }
 
 /**

--- a/src/hooks/useWallpaperMenubarText.ts
+++ b/src/hooks/useWallpaperMenubarText.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useWallpaper } from "@/hooks/useWallpaper";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
-import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
+import { useNowPlayingCoverBridge } from "@/stores/useNowPlayingCoverBridge";
 import { useWeatherWallpaper } from "@/hooks/useWeatherWallpaper";
 import { useWeatherSimulationStore } from "@/stores/useWeatherSimulationStore";
 import {
@@ -115,9 +115,11 @@ export function useWallpaperMenubarText(enabled: boolean): WallpaperMenubarText 
   const isCover = isCoverWallpaper(currentWallpaper);
   const isLyrics = isLyricsWallpaper(currentWallpaper);
   // Cover + lyrics wallpapers both tint from the now-playing album art, exactly
-  // like the wallpaper accent's cover-based path.
+  // like the wallpaper accent's cover-based path. The URL comes from the
+  // lightweight bridge (published by the lazily loaded cover / lyrics
+  // wallpaper layers) so this boot-path hook never pulls the iPod stores.
   const isCoverBased = isCover || isLyrics;
-  const { coverUrl: nowPlayingCoverUrl } = useNowPlayingCover();
+  const nowPlayingCoverUrl = useNowPlayingCoverBridge((s) => s.coverUrl);
   // Only subscribe to live weather (and its geolocation/fetch) while the weather
   // wallpaper is actually driving the menubar tone.
   const { weatherCode } = useWeatherWallpaper(enabled && isWeather);

--- a/src/stores/useNowPlayingCoverBridge.ts
+++ b/src/stores/useNowPlayingCoverBridge.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { create } from "zustand";
+
+/**
+ * Tiny always-loaded bridge holding the now-playing cover URL for consumers on
+ * the boot-critical path (e.g. the Aqua Glass menubar tone sampler).
+ *
+ * Reading the cover directly via `useNowPlayingCover` would statically pull the
+ * full iPod + Karaoke store stack into the entry bundle. Instead, the lazily
+ * loaded cover / lyrics wallpaper layers (the only states in which a cover can
+ * be the wallpaper) publish the URL here, and light consumers subscribe to
+ * this bridge.
+ */
+interface NowPlayingCoverBridgeState {
+  coverUrl: string | null;
+  setCoverUrl: (coverUrl: string | null) => void;
+}
+
+export const useNowPlayingCoverBridge = create<NowPlayingCoverBridgeState>(
+  (set) => ({
+    coverUrl: null,
+    setCoverUrl: (coverUrl) =>
+      set((s) => (s.coverUrl === coverUrl ? s : { coverUrl })),
+  })
+);
+
+/** Publish `coverUrl` to the bridge while mounted; clears it on unmount. */
+export function usePublishNowPlayingCover(coverUrl: string | null) {
+  const setCoverUrl = useNowPlayingCoverBridge((s) => s.setCoverUrl);
+  useEffect(() => {
+    setCoverUrl(coverUrl);
+    return () => setCoverUrl(null);
+  }, [coverUrl, setCoverUrl]);
+}

--- a/src/stores/useTextEditStore.ts
+++ b/src/stores/useTextEditStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { JSONContent } from "@tiptap/core";
+import type { JSONContent } from "@tiptap/core";
 import { useAppStore } from "@/stores/useAppStore";
 import { createIndexedDBPersistStorage } from "@/utils/indexedDBPersistStorage";
 

--- a/tests/test-boot-import-graph.test.ts
+++ b/tests/test-boot-import-graph.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { findStaticImportChain } from "../scripts/trace-import-chain";
+
+/**
+ * Boot-bundle guard: heavy modules must never be statically reachable from the
+ * client entry (`src/main.tsx`). A static chain to any of these pulls its
+ * whole dependency graph (three, react-player, romanization libs, the iPod /
+ * Karaoke / finder store stacks, …) into the entry chunk, which every visitor
+ * downloads and parses before first paint.
+ *
+ * These must only load through dynamic import() — lazy app components, the
+ * code-split dynamic wallpaper layers, or the deferred idle runners. If one of
+ * these assertions fails, the printed chain shows exactly which import to fix
+ * (usually by lazy-loading the component or importing a type with
+ * `import type`).
+ */
+const FORBIDDEN_BOOT_MODULES: Array<{ target: string; reason: string }> = [
+  {
+    target: "stores/useIpodStore",
+    reason: "iPod store (~2700 lines) — only needed for music playback",
+  },
+  {
+    target: "stores/useKaraokeStore",
+    reason: "Karaoke store — only needed for karaoke playback",
+  },
+  {
+    target: "finder/hooks/useFileSystem",
+    reason:
+      "full finder VFS hook (~1800 lines) — deferred via DeferredAirDropListener",
+  },
+  {
+    target: "shared/WeatherShaderBackground",
+    reason: "pulls the three.js chunk (~465KB) at boot",
+  },
+  {
+    target: "shared/YouTubePlayer",
+    reason: "pulls the react-player (media-player) chunk at boot",
+  },
+  {
+    target: "karaoke-app/KaraokeVisualLayers",
+    reason: "pulls three.js visual backgrounds at boot",
+  },
+  {
+    target: "lyrics-display/LyricsDisplay",
+    reason: "pulls pinyin-pro / wanakana / hangul romanization at boot",
+  },
+  {
+    target: "utils/romanization",
+    reason: "pinyin-pro / wanakana / hangul-romanization libs",
+  },
+  {
+    target: "debug/DebugLogOverlay",
+    reason: "debug-mode-only overlay — lazily mounted from App",
+  },
+  {
+    target: "hooks/useAutoCloudSync",
+    reason: "cloud sync engine — deferred via DeferredAutoCloudSync",
+  },
+];
+
+describe("boot import graph", () => {
+  for (const { target, reason } of FORBIDDEN_BOOT_MODULES) {
+    test(`src/main.tsx must not statically import ${target}`, () => {
+      const chain = findStaticImportChain(target);
+      if (chain) {
+        throw new Error(
+          `"${target}" (${reason}) is statically reachable from src/main.tsx:\n  ` +
+            chain.join("\n  -> ")
+        );
+      }
+      expect(chain).toBeNull();
+    });
+  }
+
+  test("sanity: the tracer still resolves real chains", () => {
+    // App.tsx is trivially reachable; guards against the tracer silently
+    // failing to parse imports (which would green-light everything above).
+    const chain = findStaticImportChain("src/App.tsx");
+    expect(chain).not.toBeNull();
+    expect(chain![0]).toBe("src/main.tsx");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The desktop shell statically imported several heavy modules that every visitor downloaded and parsed at boot, regardless of their wallpaper or settings:

- `DesktopDynamicWallpaper` statically pulled `WeatherShaderBackground` (**three.js, 465 kB chunk**), `YouTubePlayer` (**react-player / media-player chunk**), `KaraokeVisualLayers`, and `LyricsDisplay` (pinyin-pro / wanakana / hangul romanization) — even when the wallpaper was a static photo.
- `WallpaperAccentRunner` and the Aqua Glass menubar tone sampler (`useWallpaperMenubarText`) pulled the full **iPod + Karaoke store stack** (~2700-line store) via `useNowPlayingCover`.
- `AirDropListener` pulled the ~1800-line finder VFS hook (`useFileSystem`) and its store graph at parse time.
- `DebugLogOverlay` (1165 lines + console/network panels) parsed on every session even though it only renders in Debug Mode.
- Two external CJK webfont stylesheets in `index.html` were render-blocking.

## Changes

- Code-split the weather / lyrics / cover dynamic wallpaper layers behind `React.lazy` with CSS-only fallbacks (gradient / dark backdrop), so their chunks load only when that wallpaper is active.
- Split the cover-based wallpaper accent into a lazily mounted `CoverWallpaperAccentRunner`, and add a tiny `useNowPlayingCoverBridge` store (published by the lazy cover/lyrics layers) so the menubar tone sampler never touches the iPod stores.
- Defer the AirDrop listener to idle via `DeferredAirDropListener` (same pattern as `DeferredAutoCloudSync`).
- Lazy-load `DebugLogOverlay`, mounted only while Debug Mode is on.
- Make the CJK font stylesheets non-render-blocking (`media="print"` → `all` swap, with `<noscript>` fallback).
- Type-only imports for `@tiptap/core` `JSONContent` (`useTextEditStore`) and finder `SortType` (`useDesktop`) — keeps tiptap out of the dev-mode graph.
- Add `scripts/trace-import-chain.ts` (static import-graph tracer CLI) and `tests/test-boot-import-graph.test.ts`, a wiring test that fails with the exact offending import chain if any of these heavy modules becomes statically reachable from `src/main.tsx` again.

## Results

| Metric | Before | After |
|---|---|---|
| Entry chunk | 1,549 kB (491 kB gzip) | 909 kB (260 kB gzip) |
| Chunks fetched at boot | entry + react + ui-core + motion + zustand + **three (465 kB) + media-player (86 kB) + hangul** | entry + react + ui-core + motion + zustand |
| Boot JS total (gzip) | ~845 kB | ~475 kB (**−44%**) |

Runtime smoke tests against the production build (Playwright, `vite preview`):

- Static wallpaper boot fetches **zero** heavy chunks (no three / media-player / hangul / tiptap / audio / webamp / pusher) and the desktop renders normally.
- Switching to the weather wallpaper lazily loads the weather layer + three chunk and renders the shader sky with live data.
- Cover and lyrics wallpapers lazily load their layer chunks (`DesktopCoverWallpaperLayer`, `DesktopLyricsWallpaperLayer` + media-player + hangul) with no page errors.

![Desktop boots on a static wallpaper with no heavy chunks fetched](https://cursor.com/artifacts/c/art-b6358cc9-f713-48da-82a8-88c8ae6bbba1)
![Weather wallpaper lazily loads the three.js shader layer](https://cursor.com/artifacts/c/art-2e3e584b-fc56-4e0e-b339-a4d2a0502d34)

## Testing

- ✅ `bunx tsc -b`
- ✅ `bun run build`
- ✅ `bun run test:unit` (1811 pass / 0 fail, includes the new boot-import-graph suite)
- ✅ `bun run test:registration`
- ✅ `bunx eslint <changed files>`
- ✅ Playwright boot smoke tests on the production preview (static / weather / cover / lyrics wallpapers)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f231b-a95a-70e0-b6c7-7b727bf247b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f231b-a95a-70e0-b6c7-7b727bf247b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

