### PR TITLE
Quiet Aqua slider track lighting and use neutral rgba recess

### DIFF
--- a/src/styles/themes/aqua.css
+++ b/src/styles/themes/aqua.css
@@ -2576,41 +2576,36 @@
   margin: 0 auto;
 }
 
-/* Slider track — same recessed glossy channel as the switch track so sliders
-   and switches read as one cohesive set. The top white shine highlight + base
-   gradient mirror `.os-switch` (unchecked). The shine runs across the track's
-   short axis: top→down for a horizontal track. */
+/* Slider track — a quiet recessed channel. Unlike the taller switch track, the
+   thin slider channel gets no top shine layer (it reads as glare at 6px) —
+   just a neutral translucent recess (black/white rgba only, no gray tints so
+   the underlying surface shows through) with a soft inner shadow and a faint
+   bottom lip. */
 :root[data-os-theme="macosx"] .os-slider-track {
   background: linear-gradient(
-        to bottom,
-        rgba(255, 255, 255, 0.55) 0%,
-        rgba(255, 255, 255, 0.18) 60%,
-        rgba(255, 255, 255, 0) 100%
-      )
-      top / 100% 50% no-repeat,
-    linear-gradient(rgba(188, 188, 188, 0.34), rgba(255, 255, 255, 0.3)) !important;
+    to bottom,
+    rgba(0, 0, 0, 0.12),
+    rgba(0, 0, 0, 0.04)
+  ) !important;
   border: 1px solid rgba(0, 0, 0, 0.22);
   border-radius: 9999px;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2),
-    inset 0 -1px 1px rgba(255, 255, 255, 0.35),
-    0 1px 0 rgba(255, 255, 255, 0.5);
+    inset 0 -1px 1px rgba(255, 255, 255, 0.2),
+    0 1px 0 rgba(255, 255, 255, 0.25);
   position: relative;
 }
 
-/* Vertical track — rotate the shine + bevel to the short (horizontal) axis so
-   the highlight sits on the leading (left) edge and reads correctly. */
+/* Vertical track — rotate the recess + bevel to the short (horizontal) axis so
+   the shadow sits on the leading (left) edge and reads correctly. */
 :root[data-os-theme="macosx"] .os-slider-track[data-orientation="vertical"] {
   background: linear-gradient(
-        to right,
-        rgba(255, 255, 255, 0.55) 0%,
-        rgba(255, 255, 255, 0.18) 60%,
-        rgba(255, 255, 255, 0) 100%
-      )
-      left / 50% 100% no-repeat,
-    linear-gradient(to right, rgba(188, 188, 188, 0.34), rgba(255, 255, 255, 0.3)) !important;
+    to right,
+    rgba(0, 0, 0, 0.12),
+    rgba(0, 0, 0, 0.04)
+  ) !important;
   box-shadow: inset 1px 0 2px rgba(0, 0, 0, 0.2),
-    inset -1px 0 1px rgba(255, 255, 255, 0.35),
-    1px 0 0 rgba(255, 255, 255, 0.5);
+    inset -1px 0 1px rgba(255, 255, 255, 0.2),
+    1px 0 0 rgba(255, 255, 255, 0.25);
 }
 
 /* Filled portion of the track uses the same glossy accent gradient as the
@@ -2620,8 +2615,8 @@
 :root[data-os-theme="macosx"] .os-slider-range {
   background: linear-gradient(
         to bottom,
-        rgba(255, 255, 255, 0.55) 0%,
-        rgba(255, 255, 255, 0.18) 60%,
+        rgba(255, 255, 255, 0.35) 0%,
+        rgba(255, 255, 255, 0.1) 60%,
         rgba(255, 255, 255, 0) 100%
       )
       top / 100% 50% no-repeat,
@@ -2633,8 +2628,7 @@
         rgba(33, 160, 196, 0.625)
       )
     ) !important;
-  box-shadow: inset 0 -1px 1px rgba(0, 0, 0, 0.18),
-    0 1px 1px var(--os-accent-button-edge, rgba(0, 78, 187, 0.4));
+  box-shadow: inset 0 -1px 1px rgba(0, 0, 0, 0.18);
 }
 
 /* Vertical filled range — the shine + bevel run across the short (horizontal)
@@ -2642,8 +2636,8 @@
 :root[data-os-theme="macosx"] .os-slider-range[data-orientation="vertical"] {
   background: linear-gradient(
         to right,
-        rgba(255, 255, 255, 0.55) 0%,
-        rgba(255, 255, 255, 0.18) 60%,
+        rgba(255, 255, 255, 0.35) 0%,
+        rgba(255, 255, 255, 0.1) 60%,
         rgba(255, 255, 255, 0) 100%
       )
       left / 50% 100% no-repeat,
@@ -2656,8 +2650,7 @@
         rgba(33, 160, 196, 0.625)
       )
     ) !important;
-  box-shadow: inset -1px 0 1px rgba(0, 0, 0, 0.18),
-    1px 0 1px var(--os-accent-button-edge, rgba(0, 78, 187, 0.4));
+  box-shadow: inset -1px 0 1px rgba(0, 0, 0, 0.18);
 }
 
 /* Slider tick/label text - preserve explicit sizes */

--- a/src/styles/themes/dark-aqua.css
+++ b/src/styles/themes/dark-aqua.css
@@ -1045,32 +1045,29 @@
   box-shadow: inset -1px 0 1px rgba(0, 0, 0, 0.4);
 }
 
-/* Slider track (dark) — match the dark switch track so the recessed channel
-   reads dark in dark mode instead of falling back to the light Aqua track. */
+/* Slider track (dark) — quiet neutral recess matching the light-mode track
+   treatment: no top shine layer, black/white rgba only (no gray rgb tints) so
+   the underlying dark surface shows through. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-slider-track {
   background: linear-gradient(
-        to bottom,
-        rgba(255, 255, 255, 0.12),
-        rgba(255, 255, 255, 0.03)
-      )
-      top / 100% 50% no-repeat,
-    linear-gradient(to bottom, rgba(34, 34, 38, 0.42), rgba(72, 72, 78, 0.42)) !important;
+    to bottom,
+    rgba(0, 0, 0, 0.4),
+    rgba(0, 0, 0, 0.2)
+  ) !important;
   border-color: rgba(255, 255, 255, 0.14);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.5),
     inset 0 -1px 1px rgba(255, 255, 255, 0.06),
     0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
-/* Vertical slider track (dark) — rotate the shine + bevel to the short axis. */
+/* Vertical slider track (dark) — rotate the recess + bevel to the short axis. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .os-slider-track[data-orientation="vertical"] {
   background: linear-gradient(
-        to right,
-        rgba(255, 255, 255, 0.12),
-        rgba(255, 255, 255, 0.03)
-      )
-      left / 50% 100% no-repeat,
-    linear-gradient(to right, rgba(34, 34, 38, 0.42), rgba(72, 72, 78, 0.42)) !important;
+    to right,
+    rgba(0, 0, 0, 0.4),
+    rgba(0, 0, 0, 0.2)
+  ) !important;
   box-shadow: inset 1px 0 2px rgba(0, 0, 0, 0.5),
     inset -1px 0 1px rgba(255, 255, 255, 0.06),
     1px 0 0 rgba(255, 255, 255, 0.05);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Aqua slider track previously reused the switch's glossy treatment: a heavy top white-shine layer (`rgba(255,255,255,0.55)` over half the channel), a bright white outer lip, and a gray-tinted base gradient (`rgba(188,188,188,…)`). On the thin 6px slider channel this read as excess glare, and the gray tint muddied the track on translucent/glass surfaces.

- Light mode track (`src/styles/themes/aqua.css`): removed the top shine layer and gray base; the empty channel is now a quiet recess built only from neutral black/white rgba (`rgba(0,0,0,0.12) → 0.04` gradient + softened bevel highlights), so the underlying surface shows through.
- Filled range: toned the accent gloss shine down from `0.55/0.18` to `0.35/0.1` and dropped the outer accent-edge glow.
- Dark mode track (`src/styles/themes/dark-aqua.css`): same treatment — removed the shine layer and gray rgb tints (`rgba(34,34,38,…)`/`rgba(72,72,78,…)`) in favor of a neutral `rgba(0,0,0,0.4) → 0.2` recess.
- Horizontal and vertical orientations both updated; switch styles untouched.

## Screenshots

Light mode, horizontal (Books Customize panel):
![Horizontal sliders in light Aqua](https://cursor.com/artifacts/c/art-d036fdd6-0882-427d-92e6-a21f6835e146)

Dark mode, horizontal:
![Horizontal sliders in dark Aqua](https://cursor.com/artifacts/c/art-598b9166-d131-47ed-9e1c-75f8618f74ad)

Light mode, vertical (Sound mixer):
![Vertical sliders in light Aqua](https://cursor.com/artifacts/c/art-7f068941-0986-42eb-b261-a1c2ca0ff065)

Dark mode, vertical:
![Vertical sliders in dark Aqua](https://cursor.com/artifacts/c/art-550feac3-a21b-49fd-b042-c2ef988acf16)

## Testing

- Verified in the running app (`bun run dev`) via browser screenshots: horizontal sliders (Books Customize) and vertical sliders (Control Panels → Sound) in both Aqua light and dark modes, with wallpaper accent active.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2320-8127-7ece-8ef3-3515175ecbc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2320-8127-7ece-8ef3-3515175ecbc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

