### PR TITLE
Expand the Books speech bar hit zone

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -1639,8 +1639,8 @@ export const BooksReaderPane = forwardRef<
         transition={{ duration: 0.22, ease: "easeOut" }}
       >
         <div
-          className="pointer-events-auto flex items-end justify-center"
-          style={{ minWidth: 72, minHeight: 28 }}
+          className="pointer-events-auto flex w-full items-end justify-center"
+          style={{ height: SPEECH_BAR_EXPANDED.height }}
           onPointerEnter={(event) =>
             handleSpeechBarPointerEnter(event.pointerType)
           }

--- a/tests/test-books-speech-bar-visibility.test.tsx
+++ b/tests/test-books-speech-bar-visibility.test.tsx
@@ -110,4 +110,14 @@ describe("Books speech bar visibility", () => {
     });
     expect(getVisibility().isOpen).toBe(false);
   });
+
+  test("wires the full-width bottom strip at the expanded bar height", async () => {
+    const readerSource = await Bun.file(
+      "src/apps/books/components/BooksReaderPane.tsx"
+    ).text();
+
+    expect(readerSource).toMatch(
+      /className="pointer-events-auto flex w-full items-end justify-center"\s+style=\{\{ height: SPEECH_BAR_EXPANDED\.height \}\}/
+    );
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make the entire bottom Books reader strip a full-width hover and tap target
- size the target to the expanded speech bar height while preserving the centered bar layout
- add a wiring guard for the hit-zone dimensions

## Testing
- `bun test tests/test-books-speech.test.ts tests/test-books-speech-pause.test.tsx tests/test-books-speech-cut-flip-wiring.test.tsx tests/test-books-speech-bar-visibility.test.tsx` (60 passed)
- `bun run test:registration`
- `bun run build`
- `bunx eslint tests/test-books-speech-bar-visibility.test.tsx`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2318-8d34-7bb5-a2d1-d119edec2a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2318-8d34-7bb5-a2d1-d119edec2a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

