### PR TITLE
Bold pronunciation ruby at 700 weight in rounded lyrics fonts

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2176,9 +2176,14 @@ ruby.lyrics-furigana rp {
   display: none;
 }
 
-/* Bold furigana for serif and sans-serif lyrics fonts */
+/* Bold pronunciation ruby (furigana, pinyin, romaji, etc.) for serif, sans-serif, and rounded lyrics fonts */
+/* :root[data-os-theme] variants outrank the theme-prefixed "normal" rule above in every theme */
 .font-lyrics-serif rt.lyrics-furigana-rt,
-.font-lyrics-sans rt.lyrics-furigana-rt {
+.font-lyrics-sans rt.lyrics-furigana-rt,
+.font-lyrics-rounded rt.lyrics-furigana-rt,
+.font-lyrics-gold-glow rt.lyrics-furigana-rt,
+:root[data-os-theme] .font-lyrics-rounded rt.lyrics-furigana-rt,
+:root[data-os-theme] .font-lyrics-gold-glow rt.lyrics-furigana-rt {
   font-weight: 700 !important;
 }
 

--- a/src/styles/themes/aqua.css
+++ b/src/styles/themes/aqua.css
@@ -1713,7 +1713,7 @@
     system-ui, -apple-system, sans-serif !important;
 }
 
-/* Bold furigana for serif and sans-serif lyrics fonts on macOS theme */
+/* Bold pronunciation ruby (furigana, pinyin, romaji, etc.) for lyrics fonts on macOS theme */
 :root[data-os-theme="macosx"] .ipod-force-font .font-lyrics-serif rt.lyrics-furigana-rt,
 :root[data-os-theme="macosx"] .ipod-force-font .font-lyrics-sans rt.lyrics-furigana-rt,
 :root[data-os-theme="macosx"] .karaoke-force-font .font-lyrics-serif rt.lyrics-furigana-rt,
@@ -1721,7 +1721,11 @@
 :root[data-os-theme="macosx"] .ipod-force-font .font-lyrics-serif-red rt.lyrics-furigana-rt,
 :root[data-os-theme="macosx"] .karaoke-force-font .font-lyrics-serif-red rt.lyrics-furigana-rt,
 :root[data-os-theme="macosx"] .ipod-force-font .font-lyrics-gradient rt.lyrics-furigana-rt,
-:root[data-os-theme="macosx"] .karaoke-force-font .font-lyrics-gradient rt.lyrics-furigana-rt {
+:root[data-os-theme="macosx"] .karaoke-force-font .font-lyrics-gradient rt.lyrics-furigana-rt,
+:root[data-os-theme="macosx"] .ipod-force-font .font-lyrics-rounded rt.lyrics-furigana-rt,
+:root[data-os-theme="macosx"] .karaoke-force-font .font-lyrics-rounded rt.lyrics-furigana-rt,
+:root[data-os-theme="macosx"] .ipod-force-font .font-lyrics-gold-glow rt.lyrics-furigana-rt,
+:root[data-os-theme="macosx"] .karaoke-force-font .font-lyrics-gold-glow rt.lyrics-furigana-rt {
   font-weight: 700 !important;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pronunciation ruby annotations (furigana, pinyin, romaji, soramimi — all rendered as `rt.lyrics-furigana-rt`) now render at font-weight 700 in the Rounded and Glow (rounded-family) lyrics fonts, matching the 700-weight base lyric text. Previously only serif/sans fonts bolded the ruby (and only Korean ruby was bolded in rounded), so furigana/pinyin annotations looked thin against the bold rounded lyrics in Karaoke, iPod, fullscreen, and desktop lyrics wallpaper contexts.

## Changes

- `src/index.css`: added `.font-lyrics-rounded` and `.font-lyrics-gold-glow` to the bold-ruby rule, plus `:root[data-os-theme]` variants so the rule outranks the theme-prefixed `font-weight: normal !important` base rule in every OS theme (including outside `*-force-font` wrappers, e.g. desktop lyrics wallpaper).
- `src/styles/themes/aqua.css`: added rounded/gold-glow entries to the existing macOS-theme bold-ruby selector list for `.ipod-force-font` / `.karaoke-force-font` contexts, consistent with the serif/sans/gradient entries.

## Testing

- ✅ `bun run build` — compiles; verified the new selectors are present in the emitted `dist/assets/index-*.css`.
- Skipped GUI verification per AGENTS.md (computer-use testing only on explicit request); the change is two CSS selector-list additions with specificity chosen to beat the existing `font-weight: normal !important` base rule (0-4-1 vs 0-3-1).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f23e3-3f56-7c0a-84d2-3e54a1c527c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f23e3-3f56-7c0a-84d2-3e54a1c527c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

