### PR TITLE
Books: render font chips in their fonts; vertical text for legacy-tagged Japanese books

### DIFF
--- a/src/apps/books/components/BooksCustomizePanel.tsx
+++ b/src/apps/books/components/BooksCustomizePanel.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/stores/useBooksStore";
 import { useThemeStore } from "@/stores/useThemeStore";
 import {
+  applyFontPreviewStack,
   BOOK_FONTS,
   BOOK_THEME_PRESET_IDS,
   buildAccentReadingPalette,
@@ -454,13 +455,17 @@ export function BooksCustomizePanel({
                 type="button"
                 aria-pressed={selected}
                 onClick={() => updateSettings({ fontId: font.id })}
+                // Recreated every render, so React re-runs it whenever the
+                // resolved stack changes (e.g. UI language switch).
+                ref={(el) => {
+                  applyFontPreviewStack(el, stack);
+                }}
                 className={cn(
                   "shrink-0 whitespace-nowrap rounded-full px-2.5 py-1 text-[11px] transition-colors",
                   selected
                     ? "bg-os-selection-bg text-os-selection-text"
                     : "bg-black/[0.07] hover:bg-black/15 os-dark:bg-white/10 os-dark:hover:bg-white/20"
                 )}
-                style={{ fontFamily: stack ?? undefined }}
               >
                 {t(`apps.books.fonts.${font.id}`)}
               </button>

--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -44,6 +44,7 @@ import {
   resolveReadingPalette,
 } from "../utils/booksReader";
 import {
+  normalizeBookLanguage,
   resolveEffectiveChineseScript,
   resolveEffectiveTextLayout,
 } from "../utils/booksLanguage";
@@ -776,8 +777,11 @@ export const BooksReaderPane = forwardRef<
           container?: { packagePath?: string };
           package?: { metadata?: { direction?: unknown; language?: string } };
         };
-        const nextBookLanguage =
-          readyBook.package?.metadata?.language?.trim() || null;
+        // Normalize legacy tags ("jpn", "zho", …) so downstream consumers
+        // (layout gates, font stacks, TTS, lang attributes) all agree.
+        const nextBookLanguage = normalizeBookLanguage(
+          readyBook.package?.metadata?.language
+        );
         bookLanguageRef.current = nextBookLanguage;
         setBookLanguage(nextBookLanguage);
         onBookLanguageChange?.(nextBookLanguage);

--- a/src/apps/books/utils/booksLanguage.ts
+++ b/src/apps/books/utils/booksLanguage.ts
@@ -5,12 +5,43 @@ import type {
 } from "@/stores/useBooksStore";
 
 /**
+ * EPUB `dc:language` values in the wild are not always BCP-47: legacy books
+ * use ISO 639-2 codes ("jpn", "kor", "zho", "chi", "cmn") or the bare country
+ * code "jp". Map those primary subtags to BCP-47 so the language gates
+ * (vertical text, Chinese script conversion) and locale-aware font stacks
+ * recognize such books — otherwise e.g. a Japanese book tagged "jpn" never
+ * gets the vertical layout option.
+ */
+const LEGACY_PRIMARY_SUBTAG_FIXES: Record<string, string> = {
+  jpn: "ja",
+  jp: "ja",
+  kor: "ko",
+  zho: "zh",
+  chi: "zh",
+  cmn: "zh",
+};
+
+/** Normalize a raw EPUB metadata language tag; null for missing/blank. */
+export function normalizeBookLanguage(
+  language?: string | null
+): string | null {
+  if (!language) return null;
+  const trimmed = language.trim();
+  if (!trimmed) return null;
+  const subtags = trimmed.replaceAll("_", "-").split("-");
+  const fixedPrimary = LEGACY_PRIMARY_SUBTAG_FIXES[subtags[0].toLowerCase()];
+  if (!fixedPrimary) return trimmed;
+  return [fixedPrimary, ...subtags.slice(1)].join("-");
+}
+
+/**
  * EPUB metadata / BCP-47 tag resolves to Chinese (Simplified or Traditional).
  * Unknown / missing language is not treated as Chinese.
  */
 export function isChineseBookLanguage(language?: string | null): boolean {
-  if (!language) return false;
-  const resolved = detectLanguageFromLocale(language);
+  const normalized = normalizeBookLanguage(language);
+  if (!normalized) return false;
+  const resolved = detectLanguageFromLocale(normalized);
   return resolved === "zh-CN" || resolved === "zh-TW";
 }
 
@@ -19,8 +50,9 @@ export function isChineseBookLanguage(language?: string | null): boolean {
  * language is not treated as CJK (vertical text stays off).
  */
 export function isCjkBookLanguage(language?: string | null): boolean {
-  if (!language) return false;
-  const resolved = detectLanguageFromLocale(language);
+  const normalized = normalizeBookLanguage(language);
+  if (!normalized) return false;
+  const resolved = detectLanguageFromLocale(normalized);
   return (
     resolved === "zh-CN" ||
     resolved === "zh-TW" ||

--- a/src/apps/books/utils/booksReader.ts
+++ b/src/apps/books/utils/booksReader.ts
@@ -223,6 +223,26 @@ export function getBookFontCssStack(
   }
 }
 
+/**
+ * Render a font-picker control in the font it selects. Theme stylesheets
+ * force `font-family: var(--os-font-ui) !important` on every `button` (macOS
+ * Aqua, Windows platform rules), which beats a plain inline style — so the
+ * preview stack must be set as an inline declaration with `important`
+ * priority. Pass `null` (the "Original" choice) to fall back to the theme UI
+ * font.
+ */
+export function applyFontPreviewStack(
+  el: HTMLElement | null,
+  stack: string | null
+): void {
+  if (!el) return;
+  if (stack) {
+    el.style.setProperty("font-family", stack, "important");
+  } else {
+    el.style.removeProperty("font-family");
+  }
+}
+
 export interface ReadingPalette {
   background: string;
   text: string;

--- a/tests/test-books-font-preview.test.tsx
+++ b/tests/test-books-font-preview.test.tsx
@@ -1,0 +1,154 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import i18next from "i18next";
+import { I18nextProvider, initReactI18next } from "react-i18next";
+
+if (typeof document === "undefined") {
+  GlobalRegistrator.register();
+}
+
+Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+  configurable: true,
+  value: true,
+});
+
+// happy-dom has no ResizeObserver; ScrollFadeRow observes its scroll container.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    value: ResizeObserverStub,
+  });
+}
+
+const { BooksCustomizePanel } = await import(
+  "../src/apps/books/components/BooksCustomizePanel"
+);
+const { applyFontPreviewStack, BOOK_FONTS, getBookFontCssStack } = await import(
+  "../src/apps/books/utils/booksReader"
+);
+const { DEFAULT_BOOKS_SETTINGS } = await import(
+  "../src/stores/useBooksStore"
+);
+
+const i18n = i18next.createInstance();
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+beforeAll(async () => {
+  await i18n.use(initReactI18next).init({
+    lng: "en",
+    fallbackLng: "en",
+    resources: { en: { translation: {} } },
+    interpolation: { escapeValue: false },
+  });
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+afterAll(() => {
+  if (GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.unregister();
+  }
+});
+
+async function renderPanel(): Promise<HTMLDivElement> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      React.createElement(
+        I18nextProvider,
+        { i18n },
+        React.createElement(BooksCustomizePanel, {
+          settings: { ...DEFAULT_BOOKS_SETTINGS },
+          updateSettings: () => {},
+          osIsDark: false,
+          compact: false,
+          bookLanguage: null,
+          onClose: () => {},
+        })
+      )
+    );
+  });
+  return container;
+}
+
+describe("applyFontPreviewStack", () => {
+  test("sets the stack as an inline declaration with important priority", () => {
+    const el = document.createElement("button");
+    applyFontPreviewStack(el, '"EB Garamond", serif');
+
+    expect(el.style.getPropertyValue("font-family")).toBe(
+      '"EB Garamond", serif'
+    );
+    expect(el.style.getPropertyPriority("font-family")).toBe("important");
+  });
+
+  test("clears any previous stack when the font keeps publisher defaults", () => {
+    const el = document.createElement("button");
+    applyFontPreviewStack(el, '"EB Garamond", serif');
+    applyFontPreviewStack(el, null);
+
+    expect(el.style.getPropertyValue("font-family")).toBe("");
+  });
+
+  test("ignores unmount calls from React ref callbacks", () => {
+    expect(() => applyFontPreviewStack(null, '"EB Garamond", serif')).not.toThrow();
+  });
+});
+
+/** CSSOM normalizes quoting, so compare unquoted family lists. */
+function fontFamilies(stack: string): string[] {
+  return stack
+    .split(",")
+    .map((family) => family.trim().replace(/^["']|["']$/g, ""));
+}
+
+describe("BooksCustomizePanel font chips", () => {
+  test("every chip previews its own font stack with important priority", async () => {
+    const host = await renderPanel();
+    const chips = Array.from(
+      host.querySelectorAll<HTMLButtonElement>("button[aria-pressed]")
+    ).filter((chip) => chip.textContent?.startsWith("apps.books.fonts."));
+
+    expect(chips).toHaveLength(BOOK_FONTS.length);
+
+    for (const font of BOOK_FONTS) {
+      const chip = chips.find(
+        (candidate) => candidate.textContent === `apps.books.fonts.${font.id}`
+      );
+      expect(chip).toBeDefined();
+
+      const expectedStack = getBookFontCssStack(font.id, "en");
+      if (expectedStack === null) {
+        // "Original" keeps the theme UI font (no inline override).
+        expect(chip!.style.getPropertyValue("font-family")).toBe("");
+      } else {
+        expect(
+          fontFamilies(chip!.style.getPropertyValue("font-family"))
+        ).toEqual(fontFamilies(expectedStack));
+        // Theme stylesheets force `font-family: var(--os-font-ui) !important`
+        // on buttons; only an inline important declaration can beat that.
+        expect(chip!.style.getPropertyPriority("font-family")).toBe(
+          "important"
+        );
+      }
+    }
+  });
+});

--- a/tests/test-books-language-gates.test.ts
+++ b/tests/test-books-language-gates.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   isChineseBookLanguage,
   isCjkBookLanguage,
+  normalizeBookLanguage,
   resolveEffectiveChineseScript,
   resolveEffectiveTextLayout,
 } from "../src/apps/books/utils/booksLanguage";
@@ -35,6 +36,44 @@ describe("Books language gates", () => {
     expect(isCjkBookLanguage("en-US")).toBe(false);
     expect(isCjkBookLanguage("fr")).toBe(false);
     expect(isCjkBookLanguage(null)).toBe(false);
+  });
+
+  test("normalizes legacy EPUB dc:language tags to BCP-47", () => {
+    expect(normalizeBookLanguage("jpn")).toBe("ja");
+    expect(normalizeBookLanguage("JPN")).toBe("ja");
+    expect(normalizeBookLanguage("jp")).toBe("ja");
+    expect(normalizeBookLanguage("jpn-JP")).toBe("ja-JP");
+    expect(normalizeBookLanguage("kor")).toBe("ko");
+    expect(normalizeBookLanguage("zho")).toBe("zh");
+    expect(normalizeBookLanguage("chi")).toBe("zh");
+    expect(normalizeBookLanguage("cmn")).toBe("zh");
+    expect(normalizeBookLanguage("zho_TW")).toBe("zh-TW");
+    // Valid tags pass through untouched (aside from trimming).
+    expect(normalizeBookLanguage(" ja ")).toBe("ja");
+    expect(normalizeBookLanguage("zh-Hant-HK")).toBe("zh-Hant-HK");
+    expect(normalizeBookLanguage("en-US")).toBe("en-US");
+    expect(normalizeBookLanguage("")).toBe(null);
+    expect(normalizeBookLanguage("   ")).toBe(null);
+    expect(normalizeBookLanguage(null)).toBe(null);
+    expect(normalizeBookLanguage(undefined)).toBe(null);
+  });
+
+  test("recognizes Japanese books tagged with legacy language codes", () => {
+    // Real-world Japanese EPUBs (Aozora Bunko conversions, older tooling)
+    // often carry ISO 639-2 "jpn" or the bare country code "jp"; those books
+    // must still get the vertical text option, matching Chinese books.
+    expect(isCjkBookLanguage("jpn")).toBe(true);
+    expect(isCjkBookLanguage("jp")).toBe(true);
+    expect(isCjkBookLanguage("jpn-JP")).toBe(true);
+    expect(isCjkBookLanguage("kor")).toBe(true);
+    expect(isCjkBookLanguage("zho")).toBe(true);
+    expect(isCjkBookLanguage("chi")).toBe(true);
+    expect(isChineseBookLanguage("zho")).toBe(true);
+    expect(isChineseBookLanguage("zho-TW")).toBe(true);
+    expect(isChineseBookLanguage("jpn")).toBe(false);
+    expect(resolveEffectiveTextLayout("vertical", "jpn")).toBe("vertical");
+    expect(resolveEffectiveTextLayout("vertical", "jp")).toBe("vertical");
+    expect(resolveEffectiveTextLayout("vertical", "kor")).toBe("vertical");
   });
 
   test("skips simplified/traditional conversion outside Chinese books", () => {

--- a/tests/test-boot-screen-accent.test.ts
+++ b/tests/test-boot-screen-accent.test.ts
@@ -16,8 +16,11 @@ import { darkAquaThemeCss } from "./theme-css-fixtures";
 import type { OsThemeId } from "../src/themes/types";
 import { ensureTestLocalStorage } from "./setup";
 
-const actualSound = await import("../src/hooks/useSound");
-const actualReactI18next = await import("react-i18next");
+// Snapshot the real exports BEFORE mock.module runs: bun mutates the live
+// module namespace in place, so restoring from the namespace object itself
+// would re-install the mocks for every later test file in this process.
+const actualSound = { ...(await import("../src/hooks/useSound")) };
+const actualReactI18next = { ...(await import("react-i18next")) };
 
 beforeAll(() => {
   if (typeof document === "undefined") {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Font chips render their own fonts

The font selector buttons in the Books app's Customize panel are supposed to preview their font (via an inline `style={{ fontFamily: stack }}`), but they all render in the OS UI font. Theme stylesheets force `font-family: var(--os-font-ui) !important` on every `button` (macOS Aqua in `aqua.css`, Windows platform rules in `platform.css`), and a stylesheet `!important` declaration beats a normal inline style.

- Added `applyFontPreviewStack()` in `src/apps/books/utils/booksReader.ts`, which sets the preview stack as an inline declaration with `important` priority (`el.style.setProperty("font-family", stack, "important")`) — inline `!important` wins over any stylesheet rule. Passing `null` (the "Original" choice) removes the override so the chip keeps the theme UI font.
- Wired the font chips in `BooksCustomizePanel.tsx` to apply the stack through a callback ref instead of the `style` prop. The ref is recreated every render, so React re-runs it when the resolved stack changes (e.g. after a UI language switch changes the CJK fallbacks).

## Vertical text for Japanese books with legacy language tags

The vertical-text gate (`isCjkBookLanguage`) already accepts `ja`, but it feeds raw EPUB `dc:language` metadata into `detectLanguageFromLocale`, which only understands BCP-47. Real-world Japanese EPUBs (Aozora Bunko conversions, older tooling) are often tagged with ISO 639-2 `jpn` or the bare country code `jp` — those books never showed the vertical layout option, while Chinese books (usually tagged `zh*`) did.

- Added `normalizeBookLanguage()` in `src/apps/books/utils/booksLanguage.ts`, mapping legacy primary subtags (`jpn`/`jp` → `ja`, `kor` → `ko`, `zho`/`chi`/`cmn` → `zh`, preserving region subtags like `jpn-JP` → `ja-JP`) before detection. Both language gates now normalize their input.
- `BooksReaderPane.tsx` normalizes the tag at the source (`package.metadata.language`), so downstream consumers (layout gates, CJK font stacks, TTS language, iframe `lang` attributes, menu/panel props) all agree.

## Testing

- New suite `tests/test-books-font-preview.test.tsx`: unit tests for `applyFontPreviewStack` plus a happy-dom render of the real `BooksCustomizePanel` asserting every chip carries its own resolved stack as an inline `important` declaration (and that "Original" carries none).
- Extended `tests/test-books-language-gates.test.ts` with `normalizeBookLanguage` coverage and legacy-tag gate checks (`jpn`, `jp`, `jpn-JP`, `kor`, `zho`, `chi`, plus vertical layout resolution).
- ✅ `bun test tests/test-books-font-preview.test.tsx tests/test-books-language-gates.test.ts tests/test-books-vertical-text.test.ts`
- ✅ `bun test tests/test-books-reader-fonts.test.ts tests/test-books-menu-layout.test.ts tests/test-books-custom-theme.test.ts tests/test-books-chinese-script-converter.test.ts tests/test-books-speech.test.ts`
- ✅ `bun run test:registration`
- ✅ `bun run build`
- ⚠️ `bunx eslint` on changed files — only pre-existing findings in `BooksReaderPane.tsx` (verified present before this change)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2430-c209-7836-9544-4a4d66d6279d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2430-c209-7836-9544-4a4d66d6279d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

