### PR TITLE
Blend book images into the reading background

### DIFF
--- a/src/apps/books/utils/booksReader.ts
+++ b/src/apps/books/utils/booksReader.ts
@@ -665,6 +665,39 @@ export async function reflowEpubAfterFontsSettle({
 
 export type EpubThemeRules = Record<string, Record<string, string>>;
 
+/** Elements that render book artwork (raster + inline/embedded SVG images). */
+const EPUB_IMAGE_SELECTOR = "img, svg, image";
+
+/**
+ * Image rules that blend book illustrations into the reading page.
+ *
+ * Many EPUB images (scanned photos, diagrams, ornaments) sit on an opaque
+ * white rectangle that glares against non-white reading themes. On light
+ * palettes `mix-blend-mode: multiply` melts white pixels into the page color
+ * while leaving darker content intact (multiplying by a near-white page barely
+ * changes it). Multiply against a dark page would crush the whole image toward
+ * black, so dark palettes instead dim the image — softening the white glare
+ * without inverting or destroying photographs.
+ */
+export function buildEpubImageRules(palette: ReadingPalette): EpubThemeRules {
+  if (palette.isDark) {
+    return {
+      [EPUB_IMAGE_SELECTOR]: {
+        filter: "brightness(0.8) contrast(1.05) !important",
+        "mix-blend-mode": "normal !important",
+      },
+    };
+  }
+  // A transparent reading background has no backdrop inside the iframe, so
+  // multiply simply no-ops there — safe to apply unconditionally.
+  return {
+    [EPUB_IMAGE_SELECTOR]: {
+      "mix-blend-mode": "multiply !important",
+      filter: "none !important",
+    },
+  };
+}
+
 /**
  * Serialize theme rules for epub.js `registerCss`. Unlike `themes.default(rules)`,
  * `registerCss` replaces the injected stylesheet instead of appending rules.
@@ -798,6 +831,7 @@ export function buildEpubTheme(
   const flowText: Record<string, string> = { ...textColor, ...readingFlow };
 
   return {
+    ...buildEpubImageRules(palette),
     // A transparent reading background only works when the publisher's own
     // root background can't paint over it (iframes are transparent by
     // default, but EPUB CSS often sets `html { background: … }`).

--- a/tests/test-books-custom-theme.test.ts
+++ b/tests/test-books-custom-theme.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   buildAccentReadingPalette,
   buildCustomReadingPalette,
+  buildEpubImageRules,
   buildEpubTheme,
   getReadingOverlayBackground,
   resolveReadingPalette,
@@ -129,6 +130,62 @@ describe("Books custom reading palette", () => {
     expect(theme.html.background).toBe("transparent !important");
     expect(theme.body.background).toBe("transparent !important");
     expect(theme.body.color).toBe("#1c1c1c !important");
+  });
+});
+
+describe("Books image blending", () => {
+  const IMAGE_SELECTOR = "img, svg, image";
+
+  test("light palettes multiply-blend white image backgrounds into the page", () => {
+    const palette = resolveReadingPalette(
+      { ...DEFAULT_BOOKS_SETTINGS, themeOverride: "sepia" },
+      false
+    );
+    const rules = buildEpubImageRules(palette);
+    expect(rules[IMAGE_SELECTOR]["mix-blend-mode"]).toBe(
+      "multiply !important"
+    );
+    expect(rules[IMAGE_SELECTOR].filter).toBe("none !important");
+  });
+
+  test("dark palettes dim images instead of multiplying them to black", () => {
+    const palette = resolveReadingPalette(
+      { ...DEFAULT_BOOKS_SETTINGS, themeOverride: "dark" },
+      false
+    );
+    const rules = buildEpubImageRules(palette);
+    expect(rules[IMAGE_SELECTOR]["mix-blend-mode"]).toBe("normal !important");
+    expect(rules[IMAGE_SELECTOR].filter).toContain("brightness");
+  });
+
+  test("auto theme follows OS dark mode for image treatment", () => {
+    const settings = { ...DEFAULT_BOOKS_SETTINGS, themeOverride: "auto" as const };
+    const lightRules = buildEpubImageRules(
+      resolveReadingPalette(settings, false)
+    );
+    const darkRules = buildEpubImageRules(
+      resolveReadingPalette(settings, true)
+    );
+    expect(lightRules[IMAGE_SELECTOR]["mix-blend-mode"]).toBe(
+      "multiply !important"
+    );
+    expect(darkRules[IMAGE_SELECTOR].filter).toContain("brightness");
+  });
+
+  test("buildEpubTheme includes the image rules for the active palette", () => {
+    const settings = { ...DEFAULT_BOOKS_SETTINGS, themeOverride: "paper" as const };
+    const palette = resolveReadingPalette(settings, false);
+    const theme = buildEpubTheme(settings, palette);
+    expect(theme[IMAGE_SELECTOR]).toEqual(
+      buildEpubImageRules(palette)[IMAGE_SELECTOR]
+    );
+
+    const darkSettings = { ...DEFAULT_BOOKS_SETTINGS, themeOverride: "night" as const };
+    const darkPalette = resolveReadingPalette(darkSettings, false);
+    const darkTheme = buildEpubTheme(darkSettings, darkPalette);
+    expect(darkTheme[IMAGE_SELECTOR]["mix-blend-mode"]).toBe(
+      "normal !important"
+    );
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

EPUB images that sit on an opaque white rectangle (scanned photos, plates, diagrams) glare against non-white reading themes in Books — a stark white box on sepia/paper/green pages, and a blinding rectangle in dark themes.

## Fix

`buildEpubTheme` now injects image rules (`img, svg, image`) derived from the active reading palette via a new `buildEpubImageRules` helper in `src/apps/books/utils/booksReader.ts`:

- **Light palettes**: `mix-blend-mode: multiply` — white pixels melt into the page color while darker photo/diagram content stays intact. On a transparent (Aqua Glass) background, multiply has no backdrop inside the iframe and simply no-ops, so it is safe unconditionally.
- **Dark palettes**: multiply would crush images toward black, so images are instead dimmed (`brightness(0.8) contrast(1.05)`, Apple Books-style) to soften the white glare without inverting or destroying photographs.

The rules ride the existing theme pipeline (`registerCss` + content hook), so they apply live on theme/dark-mode changes and to every section iframe.

## Verification

![Sepia theme: white image background blends into the page](https://cursor.com/artifacts/c/art-0329d0b6-6c2d-48a4-bd22-ac5814afdcb8)

![Dark theme: image dimmed instead of glaring white](https://cursor.com/artifacts/c/art-bf35e3f6-578a-40f9-8801-8dfa73db06ff)

Verified in-app with a test EPUB containing a white-background photo plate: sepia blends the white background into the page; dark mode dims the plate.

## Testing

- ✅ `bun test tests/test-books-custom-theme.test.ts tests/test-books-reader-fonts.test.ts tests/test-books-language-gates.test.ts` (51 pass, includes 4 new image-blending tests)
- ✅ `bunx eslint src/apps/books/utils/booksReader.ts tests/test-books-custom-theme.test.ts`
- ✅ `bun run typecheck`
- ✅ Manual browser verification (sepia + dark screenshots above)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2538-22a4-70aa-89f9-c1a684bb785a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2538-22a4-70aa-89f9-c1a684bb785a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

