### PR TITLE
Fix offline PWA: send explicit Cache-Control from the standalone server

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "bun run scripts/build-app.ts",
     "build:vite": "vite build",
     "inspect:precache": "bun run scripts/inspect-precache.ts",
+    "verify:offline-pwa": "bun run scripts/verify-offline-pwa.ts",
     "measure:startup": "bun run scripts/measure-startup.ts",
     "typecheck": "tsc -b",
     "lint": "eslint .",

--- a/scripts/api-standalone-server.ts
+++ b/scripts/api-standalone-server.ts
@@ -43,6 +43,7 @@ import {
   discoverApiRouteManifest,
   type ApiRouteManifestEntry,
 } from "./api-route-manifest";
+import { getStaticCacheHeaders } from "./static-cache-policy";
 
 type QueryValue = string | string[];
 type QueryMap = Record<string, QueryValue>;
@@ -637,7 +638,15 @@ async function serveDistPath(
     return null;
   }
   const absolutePath = path.resolve(DIST_ROOT, decodedPath);
-  return await getStaticFileResponse(absolutePath, options);
+  // Explicit Cache-Control on every static response. Vercel gets these from
+  // vercel.json; here they also stop CDNs (e.g. Cloudflare in front of a
+  // Coolify deploy) from edge-caching sw.js/index.html past a deploy, which
+  // breaks service-worker installs and, with them, offline support.
+  const headers = {
+    ...getStaticCacheHeaders(decodedPath.split(path.sep).join("/")),
+    ...options?.headers,
+  };
+  return await getStaticFileResponse(absolutePath, { headers });
 }
 
 async function serveSpaIndex(): Promise<Response> {
@@ -905,10 +914,21 @@ async function bootstrap(): Promise<void> {
           return ogShareResponse;
         }
 
-        return (
-          (await handleStaticRequest(pathname)) ||
-          jsonResponse({ error: "Not found" }, 404)
-        );
+        const staticResponse = await handleStaticRequest(pathname);
+        if (staticResponse) {
+          return staticResponse;
+        }
+
+        // Never let CDNs cache static misses: after a deploy swaps the
+        // hashed bundles, a cached 404 for a new asset would keep breaking
+        // clients even once the origin can serve it.
+        return new Response(JSON.stringify({ error: "Not found" }), {
+          status: 404,
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+            "cache-control": "no-store",
+          },
+        });
       }
 
       const matched = matchRoute(pathname, routes);

--- a/scripts/static-cache-policy.ts
+++ b/scripts/static-cache-policy.ts
@@ -1,0 +1,95 @@
+/**
+ * Cache-Control policy for static files served from `dist/` by the
+ * standalone Bun server (Coolify / Docker / plain-Bun deploys).
+ *
+ * On Vercel these headers come from `vercel.json`; the standalone server must
+ * emit them itself. Without an explicit Cache-Control, CDNs in front of the
+ * origin (e.g. Cloudflare) apply their extension-based default TTL (~4h) to
+ * `.js` files — including `sw.js`. A stale edge-cached `sw.js` references
+ * hashed assets that no longer exist after a deploy, which makes the Workbox
+ * precache install fail (404 → service worker goes redundant) and breaks
+ * offline support for every client until the edge entry expires.
+ *
+ * Mirrors the `headers` section of `vercel.json`.
+ */
+
+const NO_CACHE = "no-cache, no-store, must-revalidate";
+const IMMUTABLE = "public, max-age=31536000, immutable";
+/** Vercel's default for static files: cache in the browser but revalidate. */
+const DEFAULT = "public, max-age=0, must-revalidate";
+
+/**
+ * Rollup emits content-hashed bundles directly under `assets/` (e.g.
+ * `index-DtdH3Hje.js`, `Sun.es-CFTCQksY.js`). Files in `assets/` sub-
+ * directories come from `public/assets` and are NOT hashed.
+ */
+const HASHED_BUNDLE = /^assets\/[^/]+-[A-Za-z0-9_-]{8}\.[a-z0-9]+$/;
+
+/** Content-hashed Workbox runtime emitted next to `sw.js` at the dist root. */
+const HASHED_WORKBOX = /^workbox-[a-f0-9]{8}\.js$/;
+
+const NO_CACHE_FILES = new Set([
+  "index.html",
+  "404.html",
+  "sw.js",
+  "registerSW.js",
+  "manifest.json",
+  "version.json",
+  "theme-bootstrap-config.js",
+  "app-config.js",
+  "icons/manifest.json",
+  "wallpapers/manifest.json",
+]);
+
+const IMMUTABLE_PREFIXES = [
+  "wallpapers/tiles/",
+  "wallpapers/photos/",
+  "wallpapers/thumbs/",
+  "wallpapers/videos/",
+  "icons/default/",
+  "icons/macosx/",
+  "icons/system7/",
+  "icons/win98/",
+  "icons/xp/",
+  "sounds/",
+  "patterns/",
+  "assets/games/jsdos/",
+];
+
+const IMMUTABLE_FILES = new Set(["apple-touch-icon.png", "favicon.ico"]);
+
+/**
+ * Returns the response headers (always including `Cache-Control`) for a
+ * dist-relative static file path (no leading slash, posix separators).
+ */
+export function getStaticCacheHeaders(
+  relativePath: string
+): Record<string, string> {
+  if (NO_CACHE_FILES.has(relativePath) || relativePath.startsWith("data/")) {
+    return { "Cache-Control": NO_CACHE };
+  }
+
+  if (relativePath === "wallpapers/placeholders.json") {
+    return {
+      "Cache-Control": "public, max-age=86400, stale-while-revalidate=604800",
+    };
+  }
+
+  if (relativePath.startsWith("fonts/")) {
+    return {
+      "Cache-Control": IMMUTABLE,
+      "Access-Control-Allow-Origin": "*",
+    };
+  }
+
+  if (
+    HASHED_BUNDLE.test(relativePath) ||
+    HASHED_WORKBOX.test(relativePath) ||
+    IMMUTABLE_FILES.has(relativePath) ||
+    IMMUTABLE_PREFIXES.some((prefix) => relativePath.startsWith(prefix))
+  ) {
+    return { "Cache-Control": IMMUTABLE };
+  }
+
+  return { "Cache-Control": DEFAULT };
+}

--- a/scripts/verify-offline-pwa.ts
+++ b/scripts/verify-offline-pwa.ts
@@ -1,0 +1,85 @@
+/*
+ * Verifies the PWA cold-launches offline against a running server:
+ * 1. Persistent Chromium profile: load online, wait for the service worker
+ *    to activate and finish precaching.
+ * 2. Close the browser entirely.
+ * 3. Relaunch the same profile offline, navigate, and require the desktop
+ *    shell to render. Exits non-zero when the offline launch fails.
+ *
+ * Usage: bun run verify:offline-pwa [--url=http://127.0.0.1:4173]
+ * (serve a production build first, e.g. `bun run build && bunx vite preview`)
+ */
+import { existsSync, rmSync } from "node:fs";
+import { chromium } from "playwright";
+
+const targetUrl = process.argv.find((a) => a.startsWith("--url="))?.slice(6) ??
+  "http://127.0.0.1:4173";
+const profileDir = "/tmp/pwa-offline-profile";
+rmSync(profileDir, { recursive: true, force: true });
+
+const installedChromium = chromium.executablePath();
+const executablePath = existsSync(installedChromium)
+  ? undefined
+  : ["/usr/local/bin/google-chrome", "/usr/bin/google-chrome"].find(existsSync);
+
+// ---- phase 1: online priming ----
+{
+  const context = await chromium.launchPersistentContext(profileDir, {
+    headless: true,
+    executablePath,
+    viewport: { width: 1440, height: 900 },
+  });
+  const page = await context.newPage();
+  await page.goto(targetUrl, { waitUntil: "load" });
+  await page.locator("#root > *").first().waitFor({ state: "visible", timeout: 30000 });
+  await page.evaluate(async () => {
+    await navigator.serviceWorker.ready;
+  });
+  await page.waitForTimeout(4000);
+  const cacheInfo = await page.evaluate(async () => {
+    const names = await caches.keys();
+    const out: Record<string, number> = {};
+    for (const n of names) out[n] = (await (await caches.open(n)).keys()).length;
+    return out;
+  });
+  console.log("caches after online prime:", JSON.stringify(cacheInfo));
+  await context.close();
+}
+
+// ---- phase 2: cold offline launch ----
+{
+  const context = await chromium.launchPersistentContext(profileDir, {
+    headless: true,
+    executablePath,
+    viewport: { width: 1440, height: 900 },
+    offline: true,
+  });
+  const page = await context.newPage();
+  const consoleLines: string[] = [];
+  page.on("console", (m) => consoleLines.push(`[${m.type()}] ${m.text()}`));
+  page.on("pageerror", (e) => consoleLines.push(`[pageerror] ${e.message}`));
+
+  let navOk = true;
+  try {
+    await page.goto(targetUrl, { waitUntil: "load", timeout: 30000 });
+  } catch (e) {
+    navOk = false;
+    console.log("navigation failed:", (e as Error).message.split("\n")[0]);
+  }
+
+  let rendered = false;
+  if (navOk) {
+    try {
+      await page.locator("#root > *").first().waitFor({ state: "visible", timeout: 20000 });
+      rendered = true;
+    } catch {
+      rendered = false;
+    }
+  }
+  console.log("cold offline shell rendered:", rendered);
+  console.log("== console ==");
+  for (const line of consoleLines.slice(0, 60)) console.log(line);
+  await page.screenshot({ path: "/tmp/offline-cold-after.png" });
+  await context.close();
+  process.exit(rendered ? 0 : 1);
+}

--- a/tests/test-static-cache-policy.test.ts
+++ b/tests/test-static-cache-policy.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { getStaticCacheHeaders } from "../scripts/static-cache-policy";
+
+const NO_CACHE = "no-cache, no-store, must-revalidate";
+const IMMUTABLE = "public, max-age=31536000, immutable";
+const DEFAULT = "public, max-age=0, must-revalidate";
+
+describe("standalone static cache policy", () => {
+  test("service worker and app shell are never cacheable", () => {
+    for (const file of [
+      "sw.js",
+      "registerSW.js",
+      "index.html",
+      "404.html",
+      "manifest.json",
+      "version.json",
+      "theme-bootstrap-config.js",
+      "app-config.js",
+      "icons/manifest.json",
+      "wallpapers/manifest.json",
+    ]) {
+      expect(getStaticCacheHeaders(file)["Cache-Control"]).toBe(NO_CACHE);
+    }
+  });
+
+  test("data JSON files are never cacheable", () => {
+    expect(getStaticCacheHeaders("data/filesystem.json")["Cache-Control"]).toBe(
+      NO_CACHE
+    );
+    expect(getStaticCacheHeaders("data/applets.json")["Cache-Control"]).toBe(
+      NO_CACHE
+    );
+  });
+
+  test("content-hashed bundles are immutable", () => {
+    for (const file of [
+      "assets/index-DtdH3Hje.js",
+      "assets/index-Cw_Oi01Q.css",
+      "assets/Sun.es-CFTCQksY.js",
+      "assets/mermaid-GHXKKRXX-BFc4ptNZ.js",
+      "workbox-7ddec154.js",
+    ]) {
+      expect(getStaticCacheHeaders(file)["Cache-Control"]).toBe(IMMUTABLE);
+    }
+  });
+
+  test("unhashed public files under assets/ are revalidated", () => {
+    for (const file of [
+      "assets/button.svg",
+      "assets/button-default.svg",
+      "assets/brushed-metal.jpg",
+      "assets/books/meditations-marcus-aurelius.epub",
+    ]) {
+      expect(getStaticCacheHeaders(file)["Cache-Control"]).toBe(DEFAULT);
+    }
+  });
+
+  test("static asset folders mirror vercel.json immutable caching", () => {
+    for (const file of [
+      "wallpapers/photos/foo.jpg",
+      "wallpapers/tiles/bar.png",
+      "wallpapers/thumbs/foo.jpg",
+      "wallpapers/videos/foo.mp4",
+      "icons/default/file.png",
+      "icons/macosx/file.png",
+      "sounds/click.mp3",
+      "patterns/pattern.png",
+      "assets/games/jsdos/game.zip",
+      "apple-touch-icon.png",
+      "favicon.ico",
+    ]) {
+      expect(getStaticCacheHeaders(file)["Cache-Control"]).toBe(IMMUTABLE);
+    }
+  });
+
+  test("fonts are immutable with CORS enabled", () => {
+    const headers = getStaticCacheHeaders("fonts/LucidaGrande.woff2");
+    expect(headers["Cache-Control"]).toBe(IMMUTABLE);
+    expect(headers["Access-Control-Allow-Origin"]).toBe("*");
+  });
+
+  test("wallpaper placeholders use stale-while-revalidate", () => {
+    expect(
+      getStaticCacheHeaders("wallpapers/placeholders.json")["Cache-Control"]
+    ).toBe("public, max-age=86400, stale-while-revalidate=604800");
+  });
+
+  test("docs pages and other files default to revalidation", () => {
+    expect(getStaticCacheHeaders("docs/overview.html")["Cache-Control"]).toBe(
+      DEFAULT
+    );
+    expect(getStaticCacheHeaders("emoji/smile.png")["Cache-Control"]).toBe(
+      DEFAULT
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The installed PWA stopped loading offline. Reproduced against production (`os.ryo.lu`) with Playwright: registering `/sw.js` resolves, but the worker ends up **`redundant`** and the page is left with **no service worker** and a precache stuck incomplete (131/194 entries). No service worker means no offline support at all.

Root cause: production runs the **standalone Bun server** (Coolify) behind Cloudflare, and `scripts/api-standalone-server.ts` serves every `dist/` file **without any `Cache-Control` header**. Cloudflare then applies its extension-based default TTL (~4h) to `.js` files — **including `sw.js`**:

```
$ curl -sI https://os.ryo.lu/sw.js
age: 1938
cache-control: max-age=14400        <-- injected by the CDN; origin sends none
cf-cache-status: HIT
```

After each deploy the edge keeps serving the **previous build's `sw.js`**, whose precache manifest references hashed assets that no longer exist — 6 entries 404ed at capture time (and the 404s were edge-cached too). Workbox aborts the install on any failed precache fetch, the new worker goes redundant, and every client that (re)registers during the ~4h window loses its service worker. With today's rapid deploy cadence this window was effectively permanent, so the PWA "doesn't load up from offline anymore". On Vercel this never happened because `vercel.json` marks `sw.js`/`index.html` as `no-cache, no-store, must-revalidate` — the standalone server had no equivalent.

Full capture: [prod_sw_install_failure_evidence.log](https://cursor.com/artifacts/c/art-49174236-99a2-4271-b6c5-783cb19387b2)

## Fix

- **`scripts/static-cache-policy.ts`** (new): `Cache-Control` policy for dist-relative paths, mirroring the `headers` section of `vercel.json`:
  - `no-cache, no-store, must-revalidate` for `sw.js`, `registerSW.js`, `index.html`, `404.html`, `manifest.json`, `version.json`, `theme-bootstrap-config.js`, `app-config.js`, icon/wallpaper manifests, and `data/*`
  - `public, max-age=31536000, immutable` for content-hashed bundles (`assets/*-<hash>.*`, `workbox-*.js`), fonts (plus `Access-Control-Allow-Origin: *`), wallpapers, icons, sounds, patterns, jsdos games, favicon/touch icon
  - `public, max-age=0, must-revalidate` for everything else (docs pages, unhashed public files)
- **`scripts/api-standalone-server.ts`**: every static response now goes through the policy; static 404s return `Cache-Control: no-store` so a cached 404 can't keep poisoning service-worker installs after the origin recovers.
- **`scripts/verify-offline-pwa.ts`** (new, `bun run verify:offline-pwa`): primes a persistent Chromium profile online (SW active + full precache), relaunches the browser offline, and requires the desktop shell to render.
- **`tests/test-static-cache-policy.test.ts`** (new): unit coverage for the policy.

## Post-deploy note

For immediate recovery, purge the Cloudflare cache (at least `/sw.js` and `/assets/*`) after this deploys; otherwise the stale edge entries linger for up to the remaining edge TTL. Affected clients heal automatically on their next **online** visit once the edge serves the current `sw.js`.

## Verification

![ryOS desktop rendered on a cold offline launch against the patched server](https://cursor.com/artifacts/c/art-b0cfc484-2510-48c2-bf89-984a21df62fe)

- ✅ `bun test tests/test-static-cache-policy.test.ts` (8 pass)
- ✅ `bun run test:registration`
- ✅ `bun run typecheck`, ✅ `bunx eslint` on changed files
- ✅ Headers verified via `curl -I` against `NODE_ENV=production bun run scripts/api-standalone-server.ts`: `sw.js`/`index.html`/`/` → `no-cache, no-store, must-revalidate`; hashed bundles → `immutable`; static 404 → `no-store`
- ✅ `bun run verify:offline-pwa --url=http://127.0.0.1:3100`: 194/194 precached, desktop shell renders on a cold offline relaunch
- ⚠️ `bun run test:api`: 321/326 pass — the 5 failures are pre-existing/flaky (each reproduces on unmodified `main` or passes in isolation; my change only touches non-`/api` static serving)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2545-a48a-7416-8c42-4bd9bdb571eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2545-a48a-7416-8c42-4bd9bdb571eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

