### PR TITLE
Match Aqua Glass pane radius on no-titlebar windows

### DIFF
--- a/src/components/layout/window-frame/WindowFrame.tsx
+++ b/src/components/layout/window-frame/WindowFrame.tsx
@@ -392,6 +392,9 @@ export function WindowFrame({
                     isBrushedMetal &&
                       isMacOSTheme &&
                       "window-material-brushedmetal",
+                    isNoTitlebar &&
+                      isMacOSTheme &&
+                      "window-material-notitlebar",
                     isGlassRegular && "window-material-glass"
                   )}
                   style={{

--- a/src/styles/themes/aqua-glass.css
+++ b/src/styles/themes/aqua-glass.css
@@ -249,6 +249,15 @@
   border-radius: var(--os-glass-r-metal) !important;
 }
 
+/* No-titlebar (immersive) windows — Maps, Photo Booth, Books, Karaoke,
+   Infinite Mac/PC — keep their own surface treatment but adopt the same
+   larger glass pane radius as default-material windows. Without this they
+   fall back to the smaller base `rounded-os` radius. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window.window-material-notitlebar {
+  border-radius: var(--os-glass-r-lg) !important;
+}
+
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]
   .window-material-brushedmetal::before {
   background: var(--os-color-window-bg) !important;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the Aqua Glass theme, windows using the `notitlebar` material (Maps, Photo Booth, Books, Karaoke, Infinite Mac/PC) still rendered with the smaller base `rounded-os` radius (`--os-metrics-radius` ≈ 9.4px round / 13.3px squircle), while default-material glass windows use the larger glass pane radius `--os-glass-r-lg` (15.6px round / 22.1px squircle).

## Fix

- `WindowFrame.tsx` now tags macOS no-titlebar windows with a `window-material-notitlebar` class (parallel to the existing `window-material-brushedmetal` / `window-material-glass` classes).
- `aqua-glass.css` gives `.window.window-material-notitlebar` the same `--os-glass-r-lg` radius as default-material glass panes. The window element already has `overflow-hidden`, so full-bleed content clips to the new radius, and the existing squircle `@supports` block already covers these windows via their `.rounded-os` class.

No CSS outside the Aqua Glass scope targets the new class, so classic Aqua and other themes are unchanged.

## Testing

- ✅ `bun run build`
- ✅ `bunx eslint src/components/layout/window-frame/WindowFrame.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f25c9-e7c5-7ebf-b8c6-c9e4401a8666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f25c9-e7c5-7ebf-b8c6-c9e4401a8666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

