### PR TITLE
Fix Preview empty state centering

### DIFF
--- a/src/apps/preview/components/PreviewAppComponent.tsx
+++ b/src/apps/preview/components/PreviewAppComponent.tsx
@@ -247,7 +247,7 @@ export function PreviewAppComponent({
     >
       <div
         className={cn(
-          "relative h-full overflow-auto font-os-ui text-os-text-primary",
+          "relative h-full w-full overflow-auto font-os-ui text-os-text-primary",
           isAquaGlass ? "bg-transparent" : "bg-os-panel-bg",
         )}
         onDragOver={(event) => event.preventDefault()}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Preview app's empty state ("Open a document") rendered hugging the left edge of the window instead of centered.

The content pane wrapper in `PreviewAppComponent` only had `h-full`, but `WindowFrame`'s `.window-body` is a flex row container on `md:` screens, so the wrapper shrank to its content width (~177px) instead of filling the window.

## Fix

Add `w-full` to the content pane wrapper so it fills the window body, letting the empty state (and other centered states like loading/error/unsupported) center correctly.

## Before / After

| Before | After |
|---|---|
| ![Empty state off-center (left-aligned)](https://cursor.com/artifacts/c/art-a15c280d-e4c4-4bba-a669-a19d54232dcc) | ![Empty state centered](https://cursor.com/artifacts/c/art-90110303-da0c-44e2-804d-437876d36836) |

## Testing

- Verified in the browser (macOS Aqua theme) that the empty state now centers both horizontally and vertically; measured via DevTools that the pane fills the full `.window-body` width.
- `bunx tsc --noEmit` and `bunx eslint` on the changed file pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f25de-5f2b-7b24-8152-72c87f5f03dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f25de-5f2b-7b24-8152-72c87f5f03dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

