### PR TITLE
feat(books): allow swipe to flip pages in the reader

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -116,6 +116,7 @@ import {
   BOOKS_EDGE_TAP_RATIO,
   resolveBooksEdgeTapDirection,
 } from "../utils/booksEdgeTap";
+import { resolveBooksSwipeDirection } from "../utils/booksSwipe";
 
 const booksLog = createClientLogger("BooksReader");
 
@@ -1841,9 +1842,10 @@ export const BooksReaderPane = forwardRef<
   );
   const clearEdgeHover = useCallback(() => setHoverSide(null), []);
 
-  // Handle page-turn taps inside the EPUB iframe instead of covering its text
-  // with parent-document buttons. A live selection or interactive target wins,
-  // so dragging / long-pressing near an edge remains selectable.
+  // Handle page-turn taps and swipes inside the EPUB iframe instead of
+  // covering its text with parent-document buttons. A live selection or
+  // interactive target wins, so dragging / long-pressing near an edge
+  // remains selectable.
   useEffect(() => {
     if (!isReady) return;
     const rendition = getRendition();
@@ -1852,7 +1854,7 @@ export const BooksReaderPane = forwardRef<
     const attachedDocuments = new WeakSet<Document>();
     const cleanups: Array<() => void> = [];
 
-    const attachEdgeTapListener = (contents: Contents) => {
+    const attachPageTurnListeners = (contents: Contents) => {
       const document = contents.document;
       const contentWindow = contents.window;
       if (!document || !contentWindow || attachedDocuments.has(document)) {
@@ -1860,17 +1862,21 @@ export const BooksReaderPane = forwardRef<
       }
       attachedDocuments.add(document);
 
+      const readSelectionState = () => {
+        try {
+          const selection = contentWindow.getSelection();
+          return (
+            !!selection && selection.rangeCount > 0 && !selection.isCollapsed
+          );
+        } catch {
+          return false;
+        }
+      };
+
       const handleClick = (event: MouseEvent) => {
         if (event.defaultPrevented || event.button !== 0) return;
 
-        let hasSelection = false;
-        try {
-          const selection = contentWindow.getSelection();
-          hasSelection =
-            !!selection && selection.rangeCount > 0 && !selection.isCollapsed;
-        } catch {
-          hasSelection = false;
-        }
+        const hasSelection = readSelectionState();
 
         const target =
           event.target &&
@@ -1934,6 +1940,65 @@ export const BooksReaderPane = forwardRef<
       document.addEventListener("click", handleClick);
       cleanups.push(() => document.removeEventListener("click", handleClick));
 
+      // Swipe-to-flip: a mostly-horizontal single-finger swipe anywhere on
+      // the page turns it, mirroring the edge taps (vertical text reverses
+      // the physical direction). Long-press selection drags carry a live
+      // selection by the time the finger lifts, so they never flip.
+      let swipeStart: { x: number; y: number } | null = null;
+
+      const handleTouchStart = (event: TouchEvent) => {
+        if (event.touches.length !== 1) {
+          swipeStart = null;
+          return;
+        }
+        const touch = event.touches[0];
+        swipeStart = { x: touch.clientX, y: touch.clientY };
+      };
+
+      const handleTouchMove = (event: TouchEvent) => {
+        if (event.touches.length !== 1) swipeStart = null;
+      };
+
+      const handleTouchCancel = () => {
+        swipeStart = null;
+      };
+
+      const handleTouchEnd = (event: TouchEvent) => {
+        const start = swipeStart;
+        swipeStart = null;
+        if (!start || event.changedTouches.length !== 1) return;
+        const touch = event.changedTouches[0];
+        const direction = resolveBooksSwipeDirection({
+          deltaX: touch.clientX - start.x,
+          deltaY: touch.clientY - start.y,
+          isVerticalText:
+            resolveEffectiveTextLayout(
+              textLayoutSettingRef.current,
+              bookLanguageRef.current
+            ) === "vertical",
+          hasSelection: readSelectionState(),
+        });
+        if (!direction) return;
+        turnPage(direction);
+      };
+
+      document.addEventListener("touchstart", handleTouchStart, {
+        passive: true,
+      });
+      document.addEventListener("touchmove", handleTouchMove, {
+        passive: true,
+      });
+      document.addEventListener("touchend", handleTouchEnd, { passive: true });
+      document.addEventListener("touchcancel", handleTouchCancel, {
+        passive: true,
+      });
+      cleanups.push(() => {
+        document.removeEventListener("touchstart", handleTouchStart);
+        document.removeEventListener("touchmove", handleTouchMove);
+        document.removeEventListener("touchend", handleTouchEnd);
+        document.removeEventListener("touchcancel", handleTouchCancel);
+      });
+
       // Parent mousemoves stop at the iframe boundary, so hover tracking for
       // the edge chevrons needs an in-document listener converting to host
       // coordinates (same mapping as the click handler above).
@@ -1964,7 +2029,7 @@ export const BooksReaderPane = forwardRef<
             ? [renditionContents]
             : []
       ) as Contents[];
-      contentsList.forEach(attachEdgeTapListener);
+      contentsList.forEach(attachPageTurnListeners);
     };
 
     const handleRendered = () => attachToCurrentContents();

--- a/src/apps/books/utils/booksSwipe.ts
+++ b/src/apps/books/utils/booksSwipe.ts
@@ -1,0 +1,39 @@
+import type { BooksPageTurnDirection } from "./booksEdgeTap";
+
+/** Minimum horizontal travel (px) before a touch drag counts as a swipe. */
+export const BOOKS_SWIPE_MIN_DISTANCE = 48;
+/** Horizontal travel must beat vertical travel by this factor. */
+export const BOOKS_SWIPE_AXIS_DOMINANCE = 1.2;
+
+interface ResolveBooksSwipeDirectionOptions {
+  deltaX: number;
+  deltaY: number;
+  isVerticalText: boolean;
+  hasSelection: boolean;
+}
+
+/**
+ * Resolve a horizontal touch swipe inside the EPUB page into a page turn.
+ * Swiping left pulls in the following page for horizontal text; vertical
+ * (right-to-left page progression) text reverses the mapping — same physics
+ * as the edge taps. A live text selection always wins over navigation.
+ */
+export function resolveBooksSwipeDirection({
+  deltaX,
+  deltaY,
+  isVerticalText,
+  hasSelection,
+}: ResolveBooksSwipeDirectionOptions): BooksPageTurnDirection | null {
+  if (hasSelection || !Number.isFinite(deltaX) || !Number.isFinite(deltaY)) {
+    return null;
+  }
+
+  const absX = Math.abs(deltaX);
+  if (absX < BOOKS_SWIPE_MIN_DISTANCE) return null;
+  if (absX < Math.abs(deltaY) * BOOKS_SWIPE_AXIS_DOMINANCE) return null;
+
+  if (deltaX < 0) {
+    return isVerticalText ? "prev" : "next";
+  }
+  return isVerticalText ? "next" : "prev";
+}

--- a/tests/test-books-swipe.test.ts
+++ b/tests/test-books-swipe.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BOOKS_SWIPE_AXIS_DOMINANCE,
+  BOOKS_SWIPE_MIN_DISTANCE,
+  resolveBooksSwipeDirection,
+} from "../src/apps/books/utils/booksSwipe";
+
+const base = {
+  deltaY: 0,
+  isVerticalText: false,
+  hasSelection: false,
+};
+
+describe("Books swipe navigation", () => {
+  test("turns horizontal pages on mostly-horizontal swipes", () => {
+    expect(resolveBooksSwipeDirection({ ...base, deltaX: -120 })).toBe("next");
+    expect(resolveBooksSwipeDirection({ ...base, deltaX: 120 })).toBe("prev");
+    expect(BOOKS_SWIPE_MIN_DISTANCE).toBe(48);
+  });
+
+  test("ignores short drags below the distance threshold", () => {
+    expect(
+      resolveBooksSwipeDirection({
+        ...base,
+        deltaX: -(BOOKS_SWIPE_MIN_DISTANCE - 1),
+      })
+    ).toBeNull();
+    expect(
+      resolveBooksSwipeDirection({ ...base, deltaX: BOOKS_SWIPE_MIN_DISTANCE })
+    ).toBe("prev");
+  });
+
+  test("ignores vertical-dominant gestures (scroll-like drags)", () => {
+    expect(
+      resolveBooksSwipeDirection({ ...base, deltaX: -80, deltaY: 90 })
+    ).toBeNull();
+    expect(
+      resolveBooksSwipeDirection({ ...base, deltaX: -80, deltaY: 30 })
+    ).toBe("next");
+    expect(BOOKS_SWIPE_AXIS_DOMINANCE).toBe(1.2);
+  });
+
+  test("reverses physical direction for vertical text", () => {
+    expect(
+      resolveBooksSwipeDirection({ ...base, deltaX: -120, isVerticalText: true })
+    ).toBe("prev");
+    expect(
+      resolveBooksSwipeDirection({ ...base, deltaX: 120, isVerticalText: true })
+    ).toBe("next");
+  });
+
+  test("never turns while text is selected", () => {
+    expect(
+      resolveBooksSwipeDirection({ ...base, deltaX: -120, hasSelection: true })
+    ).toBeNull();
+    expect(
+      resolveBooksSwipeDirection({ ...base, deltaX: 120, hasSelection: true })
+    ).toBeNull();
+  });
+
+  test("wires touch swipes inside EPUB documents", async () => {
+    const source = await Bun.file(
+      "src/apps/books/components/BooksReaderPane.tsx"
+    ).text();
+
+    expect(source).toContain("resolveBooksSwipeDirection({");
+    expect(source).toContain(
+      'document.addEventListener("touchstart", handleTouchStart'
+    );
+    expect(source).toContain(
+      'document.addEventListener("touchend", handleTouchEnd'
+    );
+    // Selection state is re-read at touchend so long-press selection drags
+    // never turn the page.
+    expect(source).toContain("hasSelection: readSelectionState()");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Books app metadata already advertises "swipe to flip through the book", but the reader only supported edge taps and arrow keys. This adds touch swipe-to-flip inside the EPUB iframe:

- New `src/apps/books/utils/booksSwipe.ts` — pure `resolveBooksSwipeDirection` helper: a mostly-horizontal swipe of at least 48px turns the page; vertical-dominant (scroll-like) drags and live text selections never flip.
- `BooksReaderPane.tsx` wires single-finger `touchstart`/`touchmove`/`touchend`/`touchcancel` listeners into the same in-iframe attach path as the edge taps (touch events inside the EPUB iframe never reach the parent document). Selection state is re-read at `touchend` so long-press selection drags win over navigation, matching the edge-tap behavior.
- Direction mapping mirrors edge taps: swipe left → next page for horizontal text; vertical (right-to-left page progression) text reverses the physical direction.
- Multi-finger touches cancel the gesture, and page turns go through the existing `turnPage` (flip animation + lock + can-turn checks).

## Testing

- ✅ `bun test tests/test-books-swipe.test.ts tests/test-books-edge-tap.test.ts` (new suite: direction mapping, thresholds, vertical text, selection guard, iframe wiring)
- ✅ `bun test tests/test-books-*.test.ts(x)` related Books wiring suites (60 pass)
- ✅ `bun run test:registration`
- ✅ `bun run typecheck`
- ✅ `bun run build`
- ⚠️ `bunx eslint src/apps/books/components/BooksReaderPane.tsx` reports 1 pre-existing error + 1 pre-existing warning (present before this change, verified via `git stash`); the new files lint clean.

GUI testing skipped per repo manual-testing guidelines (touch-only gesture; covered by unit + wiring tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f26f0-e9ee-7dbc-a87b-26f521ddca70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f26f0-e9ee-7dbc-a87b-26f521ddca70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

