### PR TITLE
MediaCore Phase 0: guardrail regression tests

### DIFF
--- a/tests/test-listen-playback-sync-contract.test.ts
+++ b/tests/test-listen-playback-sync-contract.test.ts
@@ -1,0 +1,146 @@
+/**
+ * MediaCore Phase 0 guardrails — Listen Together playback-sync contract.
+ *
+ * Pins how `usePlaybackListenSync` maps a transport target onto
+ * `useListenSync`, and the DJ broadcast payload shape. Phase 7's
+ * generalization to a shared transport interface must keep this mapping.
+ */
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+class MemoryStorage implements Storage {
+  private readonly map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.map.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+}
+
+if (!(globalThis as { localStorage?: Storage }).localStorage) {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: new MemoryStorage(),
+    writable: true,
+  });
+}
+
+const listenSyncCalls: Array<Record<string, unknown>> = [];
+const actualListenSync = await import("../src/hooks/useListenSync");
+mock.module("@/hooks/useListenSync", () => ({
+  useListenSync: (args: Record<string, unknown>) => {
+    listenSyncCalls.push(args);
+  },
+}));
+afterAll(() => {
+  mock.module("@/hooks/useListenSync", () => actualListenSync);
+});
+
+const { usePlaybackListenSync, broadcastListenState } = await import(
+  "../src/shared/media/playbackListenSync"
+);
+
+const makeTarget = (listenRemoteOnly: boolean) => {
+  const setVirtualElapsedSeconds = () => {};
+  return {
+    currentTrackId: "track-1",
+    currentTrackMeta: { title: "Track One" },
+    isPlaying: true,
+    setIsPlaying: () => {},
+    setCurrentTrackId: () => {},
+    getActivePlayer: () => null,
+    addTrackFromId: () => {},
+    listenRemoteOnly,
+    setVirtualElapsedSeconds,
+  };
+};
+
+describe("usePlaybackListenSync mapping", () => {
+  test("DJ/solo mode applies listener playback and drops the virtual clock", () => {
+    listenSyncCalls.length = 0;
+    usePlaybackListenSync(makeTarget(false));
+
+    expect(listenSyncCalls).toHaveLength(1);
+    const call = listenSyncCalls[0];
+    expect(call.currentTrackId).toBe("track-1");
+    expect(call.applyListenerPlayback).toBe(true);
+    expect(call.setVirtualElapsedSeconds).toBeUndefined();
+  });
+
+  test("remote-only listeners do not drive the local player", () => {
+    listenSyncCalls.length = 0;
+    const target = makeTarget(true);
+    usePlaybackListenSync(target);
+
+    expect(listenSyncCalls).toHaveLength(1);
+    const call = listenSyncCalls[0];
+    expect(call.applyListenerPlayback).toBe(false);
+    expect(call.setVirtualElapsedSeconds).toBe(
+      target.setVirtualElapsedSeconds
+    );
+  });
+});
+
+describe("broadcastListenState payload", () => {
+  test("converts the active player clock to positionMs", async () => {
+    const payloads: unknown[] = [];
+    const result = await broadcastListenState({
+      getActivePlayer: () => ({ getCurrentTime: () => 61.25 }) as never,
+      syncSession: async (payload) => {
+        payloads.push(payload);
+        return { ok: true };
+      },
+      currentTrackId: "track-9",
+      currentTrackMeta: { title: "Nine" },
+      isPlaying: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(payloads).toEqual([
+      {
+        currentTrackId: "track-9",
+        currentTrackMeta: { title: "Nine" },
+        isPlaying: false,
+        positionMs: 61250,
+      },
+    ]);
+  });
+
+  test("clamps a missing or negative player clock to zero", async () => {
+    const payloads: Array<{ positionMs: number }> = [];
+    await broadcastListenState({
+      getActivePlayer: () => null,
+      syncSession: async (payload) => {
+        payloads.push(payload as { positionMs: number });
+        return { ok: true };
+      },
+      currentTrackId: null,
+      currentTrackMeta: null,
+      isPlaying: false,
+    });
+    await broadcastListenState({
+      getActivePlayer: () => ({ getCurrentTime: () => -4 }) as never,
+      syncSession: async (payload) => {
+        payloads.push(payload as { positionMs: number });
+        return { ok: true };
+      },
+      currentTrackId: null,
+      currentTrackMeta: null,
+      isPlaying: false,
+    });
+
+    expect(payloads.map((p) => p.positionMs)).toEqual([0, 0]);
+  });
+});

--- a/tests/test-media-control-schema-snapshot.test.ts
+++ b/tests/test-media-control-schema-snapshot.test.ts
@@ -1,0 +1,163 @@
+/**
+ * MediaCore Phase 0 guardrails — AI media tool schema snapshots.
+ *
+ * Pins the exact action vocabulary and parameter rules of the three media
+ * control tools (`ipodControl`, `karaokeControl`, `tvControl`) so the
+ * Phase 5 consolidation into a single `mediaControl` tool can prove it
+ * accepts everything the current tools accept.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  ipodControlSchema,
+  karaokeControlSchema,
+  tvControlSchema,
+} from "../api/chat/tools/schemas";
+import { TV_ACTIONS } from "../api/chat/tools/types";
+
+const MEDIA_ACTIONS = [
+  "toggle",
+  "play",
+  "pause",
+  "playKnown",
+  "addAndPlay",
+  "next",
+  "previous",
+] as const;
+
+/** Minimal extra params each action needs to pass refinement. */
+const validParamsFor = (action: string): Record<string, unknown> =>
+  action === "addAndPlay" ? { id: "dQw4w9WgXcQ" } : {};
+
+for (const [name, schema] of [
+  ["ipodControl", ipodControlSchema],
+  ["karaokeControl", karaokeControlSchema],
+] as const) {
+  describe(`${name} schema snapshot`, () => {
+    test("accepts exactly the pinned action vocabulary", () => {
+      for (const action of MEDIA_ACTIONS) {
+        const result = schema.safeParse({
+          action,
+          ...validParamsFor(action),
+        });
+        expect(result.success).toBe(true);
+      }
+      expect(schema.safeParse({ action: "stop" }).success).toBe(false);
+      expect(schema.safeParse({ action: "tune" }).success).toBe(false);
+    });
+
+    test("defaults the action to toggle", () => {
+      const result = schema.safeParse({});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.action).toBe("toggle");
+      }
+    });
+
+    test("addAndPlay requires id and rejects manual title/artist", () => {
+      expect(schema.safeParse({ action: "addAndPlay" }).success).toBe(false);
+      expect(
+        schema.safeParse({
+          action: "addAndPlay",
+          id: "dQw4w9WgXcQ",
+          title: "Manual",
+        }).success
+      ).toBe(false);
+      expect(
+        schema.safeParse({
+          action: "addAndPlay",
+          id: "dQw4w9WgXcQ",
+          artist: "Manual",
+        }).success
+      ).toBe(false);
+    });
+
+    test("playKnown allows id/title/artist and also bare invocation", () => {
+      expect(schema.safeParse({ action: "playKnown" }).success).toBe(true);
+      expect(
+        schema.safeParse({
+          action: "playKnown",
+          title: "Song",
+          artist: "Artist",
+        }).success
+      ).toBe(true);
+    });
+
+    test("playback-state and navigation actions reject item identifiers", () => {
+      for (const action of ["toggle", "play", "pause", "next", "previous"]) {
+        expect(schema.safeParse({ action, id: "x" }).success).toBe(false);
+        expect(schema.safeParse({ action, title: "x" }).success).toBe(false);
+      }
+    });
+
+    test("supports enableTranslation and enableFullscreen flags", () => {
+      const result = schema.safeParse({
+        action: "play",
+        enableTranslation: "zh-TW",
+        enableFullscreen: true,
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+}
+
+describe("ipodControl vs karaokeControl surface difference", () => {
+  test("only ipodControl carries the enableVideo flag", () => {
+    const ipodResult = ipodControlSchema.safeParse({
+      action: "play",
+      enableVideo: true,
+    });
+    expect(ipodResult.success).toBe(true);
+    if (ipodResult.success) {
+      expect(
+        (ipodResult.data as { enableVideo?: boolean }).enableVideo
+      ).toBe(true);
+    }
+
+    // Karaoke's schema has no enableVideo key; Zod strips it from output.
+    const karaokeResult = karaokeControlSchema.safeParse({
+      action: "play",
+      enableVideo: true,
+    });
+    expect(karaokeResult.success).toBe(true);
+    if (karaokeResult.success) {
+      expect("enableVideo" in karaokeResult.data).toBe(false);
+    }
+  });
+});
+
+describe("tvControl schema snapshot", () => {
+  test("action vocabulary is pinned", () => {
+    expect([...TV_ACTIONS]).toEqual([
+      "list",
+      "tune",
+      "createChannel",
+      "deleteChannel",
+      "addVideo",
+      "removeVideo",
+    ]);
+  });
+
+  test("accepts representative calls for every action", () => {
+    const calls: Record<(typeof TV_ACTIONS)[number], Record<string, unknown>> =
+      {
+        list: { action: "list" },
+        tune: { action: "tune", channelId: "mtv" },
+        createChannel: { action: "createChannel", prompt: "lofi beats" },
+        deleteChannel: { action: "deleteChannel", channelId: "custom-1" },
+        addVideo: {
+          action: "addVideo",
+          channelId: "custom-1",
+          videoId: "dQw4w9WgXcQ",
+        },
+        removeVideo: {
+          action: "removeVideo",
+          channelId: "custom-1",
+          removeVideoId: "dQw4w9WgXcQ",
+        },
+      };
+    for (const action of TV_ACTIONS) {
+      expect(tvControlSchema.safeParse(calls[action]).success).toBe(true);
+    }
+    expect(tvControlSchema.safeParse({ action: "play" }).success).toBe(false);
+  });
+});

--- a/tests/test-media-transport-parity.test.ts
+++ b/tests/test-media-transport-parity.test.ts
@@ -1,0 +1,432 @@
+/**
+ * MediaCore Phase 0 guardrails — transport parity.
+ *
+ * Pins the current playback-transport semantics of the four media stores
+ * (iPod, Karaoke, Videos, TV) before they are migrated onto a shared
+ * transport slice factory. Phase 1 must keep every assertion here green
+ * without modifying this file.
+ */
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+class MemoryStorage implements Storage {
+  private readonly map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.map.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+}
+
+const browserGlobals = globalThis as typeof globalThis & {
+  localStorage?: Storage;
+  navigator?: Navigator;
+};
+if (!browserGlobals.localStorage) {
+  Object.defineProperty(browserGlobals, "localStorage", {
+    configurable: true,
+    value: new MemoryStorage(),
+    writable: true,
+  });
+}
+
+const navigatorState = { onLine: true };
+Object.defineProperty(browserGlobals, "navigator", {
+  value: {
+    ...(browserGlobals.navigator ?? {}),
+    get onLine() {
+      return navigatorState.onLine;
+    },
+    userAgent: "test",
+  },
+  configurable: true,
+});
+
+const { useIpodStore } = await import("../src/stores/useIpodStore");
+const { useKaraokeStore } = await import("../src/stores/useKaraokeStore");
+const { useVideoStore } = await import("../src/stores/useVideoStore");
+const { useTvStore } = await import("../src/stores/useTvStore");
+type Track = import("../src/stores/useIpodStore").Track;
+type Video = import("../src/stores/useVideoStore").Video;
+
+const ytTrack = (n: number): Track => ({
+  id: `yt${n}`,
+  url: `https://youtu.be/yt${n}`,
+  title: `Song ${n}`,
+});
+
+const video = (n: number): Video => ({
+  id: `vid${n}`,
+  url: `https://youtu.be/vid${n}`,
+  title: `Video ${n}`,
+});
+
+/**
+ * Uniform view over each store's transport so the same lifecycle assertions
+ * run against all of them.
+ */
+interface TransportDriver {
+  name: string;
+  /** Reset the store and seed a 3-item library where applicable. */
+  seed: () => void;
+  currentId: () => string | null;
+  /** Select a different item (id from the seeded library). */
+  selectOther: () => void;
+  togglePlay: () => void;
+  setIsPlaying: (value: boolean) => void;
+  confirmPlayback: () => void;
+  flags: () => { isPlaying: boolean; playbackRequested: boolean };
+  /** Whether setIsPlaying(true) is blocked while offline. */
+  guardsOffline: boolean;
+}
+
+const seedIpodTracks = () => {
+  useIpodStore.setState({
+    tracks: [ytTrack(1), ytTrack(2), ytTrack(3)],
+    librarySource: "youtube",
+    currentSongId: "yt1",
+    isPlaying: false,
+    playbackRequested: false,
+    loopAll: true,
+    loopCurrent: false,
+    isShuffled: false,
+    playbackHistory: [],
+    historyPosition: -1,
+    elapsedTime: 0,
+    totalTime: 0,
+  });
+};
+
+const drivers: TransportDriver[] = [
+  {
+    name: "iPod",
+    seed: seedIpodTracks,
+    currentId: () => useIpodStore.getState().currentSongId,
+    selectOther: () => useIpodStore.getState().setCurrentSongId("yt2"),
+    togglePlay: () => useIpodStore.getState().togglePlay(),
+    setIsPlaying: (value) => useIpodStore.getState().setIsPlaying(value),
+    confirmPlayback: () => useIpodStore.getState().confirmPlayback(),
+    flags: () => {
+      const s = useIpodStore.getState();
+      return { isPlaying: s.isPlaying, playbackRequested: s.playbackRequested };
+    },
+    guardsOffline: true,
+  },
+  {
+    name: "Karaoke",
+    seed: () => {
+      seedIpodTracks();
+      useKaraokeStore.setState({
+        currentSongId: "yt1",
+        isPlaying: false,
+        playbackRequested: false,
+        loopAll: true,
+        loopCurrent: false,
+        isShuffled: false,
+        playbackHistory: [],
+        elapsedTime: 0,
+        totalTime: 0,
+      });
+    },
+    currentId: () => useKaraokeStore.getState().currentSongId,
+    selectOther: () => useKaraokeStore.getState().setCurrentSongId("yt2"),
+    togglePlay: () => useKaraokeStore.getState().togglePlay(),
+    setIsPlaying: (value) => useKaraokeStore.getState().setIsPlaying(value),
+    confirmPlayback: () => useKaraokeStore.getState().confirmPlayback(),
+    flags: () => {
+      const s = useKaraokeStore.getState();
+      return { isPlaying: s.isPlaying, playbackRequested: s.playbackRequested };
+    },
+    guardsOffline: true,
+  },
+  {
+    name: "Videos",
+    seed: () => {
+      useVideoStore.setState({
+        videos: [video(1), video(2), video(3)],
+        currentVideoId: "vid1",
+        isPlaying: false,
+        playbackRequested: false,
+        loopAll: true,
+        loopCurrent: false,
+        isShuffled: false,
+        playedSeconds: 0,
+        elapsedTime: 0,
+      });
+    },
+    currentId: () => useVideoStore.getState().currentVideoId,
+    selectOther: () => useVideoStore.getState().setCurrentVideoId("vid2"),
+    togglePlay: () => useVideoStore.getState().togglePlay(),
+    setIsPlaying: (value) => useVideoStore.getState().setIsPlaying(value),
+    confirmPlayback: () => useVideoStore.getState().confirmPlayback(),
+    flags: () => {
+      const s = useVideoStore.getState();
+      return { isPlaying: s.isPlaying, playbackRequested: s.playbackRequested };
+    },
+    guardsOffline: false,
+  },
+  {
+    name: "TV",
+    seed: () => {
+      useTvStore.setState({
+        currentChannelId: "ryo",
+        lastVideoIndexByChannel: {},
+        isPlaying: false,
+        playbackRequested: false,
+        playedSeconds: 0,
+      });
+    },
+    currentId: () => useTvStore.getState().currentChannelId,
+    selectOther: () => useTvStore.getState().setCurrentChannelId("mtv"),
+    togglePlay: () => useTvStore.getState().togglePlay(),
+    setIsPlaying: (value) => useTvStore.getState().setIsPlaying(value),
+    confirmPlayback: () => useTvStore.getState().confirmPlayback(),
+    flags: () => {
+      const s = useTvStore.getState();
+      return { isPlaying: s.isPlaying, playbackRequested: s.playbackRequested };
+    },
+    guardsOffline: false,
+  },
+];
+
+for (const driver of drivers) {
+  describe(`${driver.name} transport parity`, () => {
+    beforeEach(() => {
+      navigatorState.onLine = true;
+      driver.seed();
+    });
+
+    test("request → confirm → stop lifecycle", () => {
+      driver.setIsPlaying(true);
+      expect(driver.flags()).toEqual({
+        isPlaying: false,
+        playbackRequested: true,
+      });
+
+      driver.confirmPlayback();
+      expect(driver.flags()).toEqual({
+        isPlaying: true,
+        playbackRequested: true,
+      });
+
+      driver.setIsPlaying(false);
+      expect(driver.flags()).toEqual({
+        isPlaying: false,
+        playbackRequested: false,
+      });
+    });
+
+    test("stale confirmation after cancel is ignored", () => {
+      driver.setIsPlaying(true);
+      driver.setIsPlaying(false);
+      driver.confirmPlayback();
+      expect(driver.flags()).toEqual({
+        isPlaying: false,
+        playbackRequested: false,
+      });
+    });
+
+    test("togglePlay requests from stopped and stops from requested", () => {
+      driver.togglePlay();
+      expect(driver.flags()).toEqual({
+        isPlaying: false,
+        playbackRequested: true,
+      });
+
+      driver.togglePlay();
+      expect(driver.flags()).toEqual({
+        isPlaying: false,
+        playbackRequested: false,
+      });
+    });
+
+    test("selecting a different item resets confirmation but keeps the request", () => {
+      driver.setIsPlaying(true);
+      driver.confirmPlayback();
+
+      driver.selectOther();
+      expect(driver.flags()).toEqual({
+        isPlaying: false,
+        playbackRequested: true,
+      });
+    });
+
+    if (driver.guardsOffline) {
+      test("setIsPlaying(true) is a no-op while offline", () => {
+        navigatorState.onLine = false;
+        driver.setIsPlaying(true);
+        expect(driver.flags()).toEqual({
+          isPlaying: false,
+          playbackRequested: false,
+        });
+      });
+    }
+  });
+}
+
+describe("iPod YouTube next/previous navigation", () => {
+  beforeEach(() => {
+    navigatorState.onLine = true;
+    seedIpodTracks();
+  });
+
+  test("sequential next advances and requests playback", () => {
+    useIpodStore.getState().nextTrack();
+    const s = useIpodStore.getState();
+    expect(s.currentSongId).toBe("yt2");
+    expect(s.playbackRequested).toBe(true);
+    expect(s.isPlaying).toBe(false);
+    expect(s.playbackHistory).toEqual(["yt1"]);
+  });
+
+  test("next at the end with loopAll on wraps to the first track", () => {
+    useIpodStore.setState({ currentSongId: "yt3", loopAll: true });
+    useIpodStore.getState().nextTrack();
+    expect(useIpodStore.getState().currentSongId).toBe("yt1");
+    expect(useIpodStore.getState().playbackRequested).toBe(true);
+  });
+
+  test("next at the end with loopAll off stops on the last track", () => {
+    useIpodStore.setState({ currentSongId: "yt3", loopAll: false });
+    useIpodStore.getState().nextTrack();
+    const s = useIpodStore.getState();
+    expect(s.currentSongId).toBe("yt3");
+    expect(s.isPlaying).toBe(false);
+    expect(s.playbackRequested).toBe(false);
+  });
+
+  test("loopCurrent keeps next on the same track", () => {
+    useIpodStore.setState({ loopCurrent: true });
+    useIpodStore.getState().nextTrack();
+    expect(useIpodStore.getState().currentSongId).toBe("yt1");
+    expect(useIpodStore.getState().playbackRequested).toBe(true);
+  });
+
+  test("sequential previous from the first track wraps to the last", () => {
+    useIpodStore.getState().previousTrack();
+    expect(useIpodStore.getState().currentSongId).toBe("yt3");
+  });
+
+  test("shuffle previous retraces history and pops it", () => {
+    useIpodStore.setState({
+      isShuffled: true,
+      currentSongId: "yt3",
+      playbackHistory: ["yt1", "yt2"],
+    });
+    useIpodStore.getState().previousTrack();
+    expect(useIpodStore.getState().currentSongId).toBe("yt2");
+    expect(useIpodStore.getState().playbackHistory).toEqual(["yt1"]);
+  });
+
+  test("track change resets the playback clock", () => {
+    useIpodStore.setState({ elapsedTime: 42, totalTime: 200 });
+    useIpodStore.getState().nextTrack();
+    expect(useIpodStore.getState().elapsedTime).toBe(0);
+    expect(useIpodStore.getState().totalTime).toBe(0);
+  });
+});
+
+describe("Karaoke next/previous navigation (iPod library)", () => {
+  beforeEach(() => {
+    navigatorState.onLine = true;
+    seedIpodTracks();
+    useKaraokeStore.setState({
+      currentSongId: "yt1",
+      isPlaying: false,
+      playbackRequested: false,
+      loopAll: true,
+      loopCurrent: false,
+      isShuffled: false,
+      playbackHistory: [],
+    });
+  });
+
+  test("reads the current track from the iPod library", () => {
+    const track = useKaraokeStore.getState().getCurrentTrack();
+    expect(track?.id).toBe("yt1");
+    expect(useKaraokeStore.getState().getCurrentIndex()).toBe(0);
+  });
+
+  test("sequential next advances and requests playback", () => {
+    useKaraokeStore.getState().nextTrack();
+    const s = useKaraokeStore.getState();
+    expect(s.currentSongId).toBe("yt2");
+    expect(s.playbackRequested).toBe(true);
+    expect(s.isPlaying).toBe(false);
+  });
+
+  test("next at the end with loopAll off stops on the last track", () => {
+    useKaraokeStore.setState({ currentSongId: "yt3", loopAll: false });
+    useKaraokeStore.getState().nextTrack();
+    const s = useKaraokeStore.getState();
+    expect(s.currentSongId).toBe("yt3");
+    expect(s.playbackRequested).toBe(false);
+  });
+
+  test("shuffle next records history; previous retraces it", () => {
+    useKaraokeStore.setState({ isShuffled: true, currentSongId: "yt1" });
+    useKaraokeStore.getState().nextTrack();
+    expect(useKaraokeStore.getState().playbackHistory).toEqual(["yt1"]);
+
+    const middle = useKaraokeStore.getState().currentSongId;
+    expect(middle).not.toBe("yt1");
+
+    useKaraokeStore.getState().previousTrack();
+    expect(useKaraokeStore.getState().currentSongId).toBe("yt1");
+    expect(useKaraokeStore.getState().playbackHistory).toEqual([]);
+  });
+
+  test("empty iPod library stops playback and clears the selection", () => {
+    useIpodStore.setState({ tracks: [] });
+    useKaraokeStore.getState().nextTrack();
+    const s = useKaraokeStore.getState();
+    expect(s.currentSongId).toBeNull();
+    expect(s.playbackRequested).toBe(false);
+  });
+});
+
+describe("TV channel-scoped transport", () => {
+  beforeEach(() => {
+    useTvStore.setState({
+      currentChannelId: "ryo",
+      lastVideoIndexByChannel: {},
+      isPlaying: false,
+      playbackRequested: false,
+      playedSeconds: 0,
+    });
+  });
+
+  test("changing the video index on the current channel resets confirmation", () => {
+    useTvStore.getState().setIsPlaying(true);
+    useTvStore.getState().confirmPlayback();
+
+    useTvStore.getState().setVideoIndex("ryo", 3);
+    const s = useTvStore.getState();
+    expect(s.lastVideoIndexByChannel.ryo).toBe(3);
+    expect(s.isPlaying).toBe(false);
+    expect(s.playbackRequested).toBe(true);
+  });
+
+  test("changing the video index on another channel keeps playback confirmed", () => {
+    useTvStore.getState().setIsPlaying(true);
+    useTvStore.getState().confirmPlayback();
+
+    useTvStore.getState().setVideoIndex("mtv", 2);
+    const s = useTvStore.getState();
+    expect(s.isPlaying).toBe(true);
+    expect(s.playbackRequested).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> [!IMPORTANT]
> **Superseded by #1757**, which collapses all MediaCore phases into one PR against `main`. Close this PR without merging.

## Summary

Phase 0 of the MediaCore consolidation plan (`docs/proposals/media-core.md`, PR #1750): pin current behavior with regression tests before any code moves. Tests only — no production code changes.

- `tests/test-media-transport-parity.test.ts` (32 tests): a uniform `TransportDriver` runs the same lifecycle assertions against all four media stores (iPod, Karaoke, Videos, TV) — `playbackRequested → confirmPlayback → isPlaying`, stale-confirm rejection, togglePlay semantics, selection-resets-confirmation, offline guards — plus iPod/Karaoke next/previous navigation (sequential, loopAll end-stop, loopCurrent, shuffle history push/pop, clock reset) and TV channel-scoped confirmation resets. Phase 1 (transport slice factory) must keep this file green unmodified.
- `tests/test-media-control-schema-snapshot.test.ts` (15 tests): pins the exact action vocabulary and refinement rules of `ipodControl`, `karaokeControl`, and `tvControl`, including the `enableVideo` surface difference. Phase 5 (unified `mediaControl`) proves compatibility against these snapshots.
- `tests/test-listen-playback-sync-contract.test.ts` (4 tests): pins the `usePlaybackListenSync` → `useListenSync` mapping (DJ vs remote-only listener) and the `broadcastListenState` payload shape for the Phase 7 Listen Together generalization.

## Testing

- ✅ `bun test tests/test-media-transport-parity.test.ts` (32 pass)
- ✅ `bun test tests/test-media-control-schema-snapshot.test.ts` (15 pass)
- ✅ `bun test tests/test-listen-playback-sync-contract.test.ts` (4 pass)
- ✅ `bun run test:registration` (267 unit, 21 API, 1 opt-in)
- ✅ Pre-existing media suites still green in isolation: `test-confirmed-playback-state`, `test-ipod-playback-navigation`, `test-tv-control-schema`, `test-listen-sync-adapter`, `test-sync-v2-codecs`, `test-media-library-store-facade`, `test-playback-time-throttle`, `test-songs-tombstone-sync`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2808-4335-7fed-9f5b-ffbbb0bcd4b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2808-4335-7fed-9f5b-ffbbb0bcd4b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

