### PR TITLE
MediaCore Phase 1: shared transport slice for the four media stores

### DIFF
--- a/src/shared/media/transport.ts
+++ b/src/shared/media/transport.ts
@@ -1,0 +1,346 @@
+/**
+ * MediaCore shared playback transport.
+ *
+ * One implementation of the transport state machine and next/previous
+ * navigation algorithm that the media apps (iPod YouTube + Apple Music,
+ * Karaoke, Videos, TV) previously each hand-rolled. Stores compose
+ * `createTransportActions` for the confirm-playback lifecycle and map
+ * `computeNextNavigation` / `computePreviousNavigation` decisions onto
+ * their own state patches (lyrics clearing, clock resets, etc.).
+ */
+import {
+  type ConfirmedPlaybackFields,
+  confirmPlayback as confirmPlaybackState,
+  requestPlayback,
+  stopPlayback,
+  togglePlayback,
+} from "./confirmedPlayback";
+
+export const PLAYBACK_HISTORY_LIMIT = 50;
+
+/** Anything with a stable string id — tracks, videos, channels. */
+export interface MediaItemRef {
+  id: string;
+}
+
+// ============================================================================
+// Transport lifecycle actions (togglePlay / setIsPlaying / confirmPlayback)
+// ============================================================================
+
+export interface TransportActions {
+  togglePlay: () => void;
+  /** Request play or stop; `true` remains pending until `confirmPlayback`. */
+  setIsPlaying: (playing: boolean) => void;
+  confirmPlayback: () => void;
+}
+
+export interface TransportActionOptions {
+  /**
+   * Block toggle/play requests while offline. Matches the historical iPod /
+   * Karaoke guards: `togglePlay` is blocked entirely, `setIsPlaying` only
+   * when requesting playback (pausing offline is always allowed).
+   */
+  guardOffline?: boolean;
+}
+
+type TransportSet<S extends ConfirmedPlaybackFields> = (
+  partial:
+    | Partial<S>
+    | ConfirmedPlaybackFields
+    | ((state: S) => Partial<S> | ConfirmedPlaybackFields)
+) => void;
+
+function isOffline(): boolean {
+  return typeof navigator !== "undefined" && !navigator.onLine;
+}
+
+export function createTransportActions<S extends ConfirmedPlaybackFields>(
+  set: TransportSet<S>,
+  options: TransportActionOptions = {}
+): TransportActions {
+  const guardOffline = options.guardOffline ?? false;
+  return {
+    togglePlay: () => {
+      if (guardOffline && isOffline()) return;
+      set((state) => togglePlayback(state));
+    },
+    setIsPlaying: (playing) => {
+      if (playing && guardOffline && isOffline()) return;
+      set(playing ? requestPlayback() : stopPlayback());
+    },
+    confirmPlayback: () => {
+      set((state) => confirmPlaybackState(state));
+    },
+  };
+}
+
+// ============================================================================
+// Library position helpers
+// ============================================================================
+
+export function findMediaIndexById(
+  items: readonly MediaItemRef[],
+  id: string | null
+): number {
+  if (!id || items.length === 0) return -1;
+  const index = items.findIndex((item) => item.id === id);
+  return index >= 0 ? index : -1;
+}
+
+// ============================================================================
+// Playback-history strategies
+// ============================================================================
+
+/**
+ * Dedupe-append (iPod semantics): moving to a track pulls any earlier
+ * occurrence of it to the end so back/forward doesn't create duplicates.
+ */
+export function dedupeAppendHistory(
+  history: readonly string[],
+  id: string,
+  maxHistory: number = PLAYBACK_HISTORY_LIMIT
+): string[] {
+  const filtered = history.filter((entry) => entry !== id);
+  return [...filtered, id].slice(-maxHistory);
+}
+
+/** Plain append (Karaoke semantics). */
+export function appendHistory(
+  history: readonly string[],
+  id: string,
+  maxHistory: number = PLAYBACK_HISTORY_LIMIT
+): string[] {
+  return [...history, id].slice(-maxHistory);
+}
+
+// ============================================================================
+// Shuffle pickers
+// ============================================================================
+
+function getUnplayedIds(
+  items: readonly MediaItemRef[],
+  history: readonly string[]
+): string[] {
+  const playedIds = new Set(history);
+  return items.reduce<string[]>((acc, item) => {
+    if (!playedIds.has(item.id)) acc.push(item.id);
+    return acc;
+  }, []);
+}
+
+/**
+ * iPod shuffle: exhaust unplayed tracks first, then avoid the most recently
+ * played ones, and never repeat the current track when avoidable.
+ */
+export function pickRandomIdAvoidingRecent(
+  items: readonly MediaItemRef[],
+  history: readonly string[],
+  currentId: string | null
+): string | null {
+  if (items.length === 0) return null;
+  if (items.length === 1) return items[0].id;
+
+  const unplayedIds = getUnplayedIds(items, history);
+  if (unplayedIds.length > 0) {
+    const availableUnplayed = unplayedIds.filter((id) => id !== currentId);
+    if (availableUnplayed.length > 0) {
+      return availableUnplayed[
+        Math.floor(Math.random() * availableUnplayed.length)
+      ];
+    }
+  }
+
+  // Avoid a window of recently played tracks (half the library, capped).
+  const avoidCount = Math.min(Math.floor(items.length / 2), 10);
+  const recentIds = new Set(history.slice(-avoidCount));
+  const availableIds = items.reduce<string[]>((acc, item) => {
+    if (!recentIds.has(item.id) && item.id !== currentId) acc.push(item.id);
+    return acc;
+  }, []);
+  if (availableIds.length > 0) {
+    return availableIds[Math.floor(Math.random() * availableIds.length)];
+  }
+
+  const allExceptCurrent = items.reduce<string[]>((acc, item) => {
+    if (item.id !== currentId) acc.push(item.id);
+    return acc;
+  }, []);
+  if (allExceptCurrent.length === 0) return currentId;
+  return allExceptCurrent[
+    Math.floor(Math.random() * allExceptCurrent.length)
+  ];
+}
+
+/** Karaoke shuffle: any track except the current one. */
+export function pickRandomIdAvoidingCurrent(
+  items: readonly MediaItemRef[],
+  currentId: string | null
+): string | null {
+  if (items.length === 0) return null;
+  if (items.length === 1) return items[0].id;
+  const availableIds = items.reduce<string[]>((acc, item) => {
+    if (item.id !== currentId) acc.push(item.id);
+    return acc;
+  }, []);
+  if (availableIds.length === 0) return currentId;
+  return availableIds[Math.floor(Math.random() * availableIds.length)];
+}
+
+// ============================================================================
+// Next / previous navigation
+// ============================================================================
+
+export interface MediaNavigationInput {
+  items: readonly MediaItemRef[];
+  currentId: string | null;
+  loopCurrent: boolean;
+  loopAll: boolean;
+  isShuffled: boolean;
+  history: readonly string[];
+}
+
+export interface MediaNavigationStrategy {
+  /**
+   * When `next` records the outgoing item into history:
+   * - "whenNotLoopingCurrent": always, unless looping the current item
+   *   (iPod YouTube — history also feeds sequential back-navigation).
+   * - "shuffleOnly": only while shuffling (Karaoke, iPod Apple Music).
+   */
+  recordHistoryOnNext: "whenNotLoopingCurrent" | "shuffleOnly";
+  appendToHistory: (history: readonly string[], id: string) => string[];
+  pickShuffleId: (
+    items: readonly MediaItemRef[],
+    history: readonly string[],
+    currentId: string | null
+  ) => string | null;
+  /**
+   * Whether `previous` in shuffle mode only retraces a history entry when it
+   * differs from the current item (iPod) or accepts any entry (Karaoke).
+   */
+  popRequiresDifferentFromCurrent: boolean;
+  /**
+   * What `previous` does while shuffling with no history: step sequentially
+   * (iPod YouTube, Karaoke) or pick another shuffle id (iPod Apple Music).
+   */
+  previousWithoutHistory: "sequential" | "shuffle";
+}
+
+export type MediaNextDecision =
+  | { kind: "empty" }
+  /** End of list with loopAll off: settle on `id` and stop playback. */
+  | { kind: "stop"; id: string | null }
+  | { kind: "advance"; id: string | null; history: string[] };
+
+export type MediaPreviousDecision =
+  | { kind: "empty" }
+  | { kind: "advance"; id: string | null; history: string[] };
+
+export function computeNextNavigation(
+  input: MediaNavigationInput,
+  strategy: MediaNavigationStrategy
+): MediaNextDecision {
+  const { items, currentId, loopCurrent, loopAll, isShuffled } = input;
+  if (items.length === 0) return { kind: "empty" };
+
+  let history = [...input.history];
+  const shouldRecord =
+    currentId !== null &&
+    !loopCurrent &&
+    (strategy.recordHistoryOnNext === "whenNotLoopingCurrent" || isShuffled);
+  if (shouldRecord && currentId) {
+    history = strategy.appendToHistory(input.history, currentId);
+  }
+
+  if (loopCurrent) {
+    return { kind: "advance", id: currentId, history };
+  }
+
+  if (isShuffled) {
+    return {
+      kind: "advance",
+      id: strategy.pickShuffleId(items, history, currentId),
+      history,
+    };
+  }
+
+  const currentIndex = findMediaIndexById(items, currentId);
+  const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % items.length;
+  if (!loopAll && nextIndex === 0 && currentIndex !== -1) {
+    return { kind: "stop", id: items[items.length - 1]?.id ?? null };
+  }
+  return { kind: "advance", id: items[nextIndex]?.id ?? null, history };
+}
+
+export function computePreviousNavigation(
+  input: MediaNavigationInput,
+  strategy: MediaNavigationStrategy
+): MediaPreviousDecision {
+  const { items, currentId, isShuffled } = input;
+  if (items.length === 0) return { kind: "empty" };
+
+  if (isShuffled && input.history.length > 0) {
+    const lastId = input.history[input.history.length - 1];
+    const exists =
+      lastId !== undefined && items.some((item) => item.id === lastId);
+    const acceptable =
+      exists &&
+      (!strategy.popRequiresDifferentFromCurrent || lastId !== currentId);
+    if (acceptable) {
+      return {
+        kind: "advance",
+        id: lastId,
+        history: input.history.slice(0, -1),
+      };
+    }
+    return {
+      kind: "advance",
+      id: strategy.pickShuffleId(items, input.history, currentId),
+      history: [...input.history],
+    };
+  }
+
+  if (isShuffled && strategy.previousWithoutHistory === "shuffle") {
+    return {
+      kind: "advance",
+      id: strategy.pickShuffleId(items, input.history, currentId),
+      history: [...input.history],
+    };
+  }
+
+  const currentIndex = findMediaIndexById(items, currentId);
+  const prevIndex = currentIndex <= 0 ? items.length - 1 : currentIndex - 1;
+  return {
+    kind: "advance",
+    id: items[prevIndex]?.id ?? null,
+    history: [...input.history],
+  };
+}
+
+// ============================================================================
+// Canonical per-app strategies
+// ============================================================================
+
+export const IPOD_YOUTUBE_NAVIGATION: MediaNavigationStrategy = {
+  recordHistoryOnNext: "whenNotLoopingCurrent",
+  appendToHistory: dedupeAppendHistory,
+  pickShuffleId: pickRandomIdAvoidingRecent,
+  popRequiresDifferentFromCurrent: true,
+  previousWithoutHistory: "sequential",
+};
+
+export const IPOD_APPLE_MUSIC_NAVIGATION: MediaNavigationStrategy = {
+  recordHistoryOnNext: "shuffleOnly",
+  appendToHistory: dedupeAppendHistory,
+  pickShuffleId: pickRandomIdAvoidingRecent,
+  popRequiresDifferentFromCurrent: true,
+  previousWithoutHistory: "shuffle",
+};
+
+export const KARAOKE_NAVIGATION: MediaNavigationStrategy = {
+  recordHistoryOnNext: "shuffleOnly",
+  appendToHistory: appendHistory,
+  pickShuffleId: (items, _history, currentId) =>
+    pickRandomIdAvoidingCurrent(items, currentId),
+  popRequiresDifferentFromCurrent: false,
+  previousWithoutHistory: "sequential",
+};

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -44,12 +44,19 @@ import {
 } from "@/utils/appleMusicLibraryCache";
 import type { IpodMenuKind } from "@/apps/ipod/types";
 import {
-  confirmPlayback,
   requestPlayback,
   resetPlaybackConfirmation,
   stopPlayback,
-  togglePlayback,
 } from "@/shared/media/confirmedPlayback";
+import {
+  IPOD_APPLE_MUSIC_NAVIGATION,
+  IPOD_YOUTUBE_NAVIGATION,
+  computeNextNavigation,
+  computePreviousNavigation,
+  createTransportActions,
+  dedupeAppendHistory,
+  findMediaIndexById,
+} from "@/shared/media/transport";
 
 const debug = createClientLogger("IpodStore").debug;
 
@@ -471,13 +478,6 @@ export function isAppleMusicCollectionTrack(
     track?.appleMusicPlayParams?.stationId ||
       track?.appleMusicPlayParams?.playlistId
   );
-}
-
-/** Helper to get current index from song ID */
-function getIndexFromSongId(tracks: Track[], songId: string | null): number {
-  if (!songId || tracks.length === 0) return -1;
-  const index = tracks.findIndex((t) => t.id === songId);
-  return index >= 0 ? index : -1;
 }
 
 export interface IpodState extends IpodData {
@@ -952,89 +952,6 @@ export function sanitizeRomanizationSettings(
   } as RomanizationSettings;
 }
 
-// Helper function to get unplayed track IDs from history
-function getUnplayedTrackIds(
-  tracks: Track[],
-  playbackHistory: string[]
-): string[] {
-  const playedIds = new Set(playbackHistory);
-  return tracks.reduce<string[]>((acc, track) => {
-    if (!playedIds.has(track.id)) {
-      acc.push(track.id);
-    }
-    return acc;
-  }, []);
-}
-
-// Helper function to get a random track ID avoiding recently played songs
-function getRandomTrackIdAvoidingRecent(
-  tracks: Track[],
-  playbackHistory: string[],
-  currentSongId: string | null
-): string | null {
-  if (tracks.length === 0) return null;
-  if (tracks.length === 1) return tracks[0].id;
-
-  // Get unplayed tracks first (tracks that have never been played)
-  const unplayedIds = getUnplayedTrackIds(tracks, playbackHistory);
-
-  // If we have unplayed tracks, prioritize them
-  if (unplayedIds.length > 0) {
-    const availableUnplayed = unplayedIds.filter((id) => id !== currentSongId);
-
-    if (availableUnplayed.length > 0) {
-      return availableUnplayed[Math.floor(Math.random() * availableUnplayed.length)];
-    }
-  }
-
-  // If no unplayed tracks, avoid recently played ones
-  // Keep a reasonable history size to avoid (e.g., half the playlist or 10 tracks, whichever is smaller)
-  const avoidCount = Math.min(Math.floor(tracks.length / 2), 10);
-  const recentTrackIds = playbackHistory.slice(-avoidCount);
-  const recentIds = new Set(recentTrackIds);
-
-  // Find tracks that haven't been played recently
-  const availableIds = tracks.reduce<string[]>((acc, track) => {
-    if (!recentIds.has(track.id) && track.id !== currentSongId) {
-      acc.push(track.id);
-    }
-    return acc;
-  }, []);
-
-  if (availableIds.length > 0) {
-    return availableIds[Math.floor(Math.random() * availableIds.length)];
-  }
-
-  // If all tracks have been played recently, just pick any track except current
-  const allIdsExceptCurrent = tracks.reduce<string[]>((acc, track) => {
-    if (track.id !== currentSongId) {
-      acc.push(track.id);
-    }
-    return acc;
-  }, []);
-
-  if (allIdsExceptCurrent.length > 0) {
-    return allIdsExceptCurrent[Math.floor(Math.random() * allIdsExceptCurrent.length)];
-  }
-
-  // Fallback: return current song ID if it's the only option
-  return currentSongId;
-}
-
-// Helper function to update playback history
-function updatePlaybackHistory(
-  playbackHistory: string[],
-  trackId: string,
-  maxHistory: number = 50
-): string[] {
-  // Remove the track if it's already in history (to avoid duplicates when going back/forward)
-  const filtered = playbackHistory.filter((id) => id !== trackId);
-  // Add the track ID to the end of history
-  const updated = [...filtered, trackId];
-  // Keep only the most recent tracks
-  return updated.slice(-maxHistory);
-}
-
 // ============================================================================
 // DEBOUNCED LYRIC OFFSET SAVE
 // ============================================================================
@@ -1205,7 +1122,7 @@ export const useIpodStore = create<IpodState>()(
           // Only update playback history if we're actually changing tracks
           if (songId !== state.currentSongId) {
             const newPlaybackHistory = state.currentSongId
-              ? updatePlaybackHistory(state.playbackHistory, state.currentSongId)
+              ? dedupeAppendHistory(state.playbackHistory, state.currentSongId)
               : state.playbackHistory;
 
             return {
@@ -1232,7 +1149,7 @@ export const useIpodStore = create<IpodState>()(
       },
       getCurrentIndex: () => {
         const state = get();
-        return getIndexFromSongId(state.tracks, state.currentSongId);
+        return findMediaIndexById(state.tracks, state.currentSongId);
       },
       toggleLoopCurrent: () =>
         set((state) => ({ loopCurrent: !state.loopCurrent })),
@@ -1250,21 +1167,7 @@ export const useIpodStore = create<IpodState>()(
               : state.appleMusicPlaybackHistory,
           };
         }),
-      togglePlay: () => {
-        // Prevent playback when offline
-        if (typeof navigator !== "undefined" && !navigator.onLine) {
-          return;
-        }
-        set((state) => togglePlayback(state));
-      },
-      setIsPlaying: (playing) => {
-        // Prevent starting playback when offline
-        if (playing && typeof navigator !== "undefined" && !navigator.onLine) {
-          return;
-        }
-        set(playing ? requestPlayback() : stopPlayback());
-      },
-      confirmPlayback: () => set((state) => confirmPlayback(state)),
+      ...createTransportActions<IpodState>(set, { guardOffline: true }),
       toggleVideo: () => {
         // Prevent turning on video when offline
         if (typeof navigator !== "undefined" && !navigator.onLine) {
@@ -1486,114 +1389,82 @@ export const useIpodStore = create<IpodState>()(
       },
       nextTrack: () =>
         set((state) => {
-          if (state.tracks.length === 0)
+          const decision = computeNextNavigation(
+            {
+              items: state.tracks,
+              currentId: state.currentSongId,
+              loopCurrent: state.loopCurrent,
+              loopAll: state.loopAll,
+              isShuffled: state.isShuffled,
+              history: state.playbackHistory,
+            },
+            IPOD_YOUTUBE_NAVIGATION
+          );
+
+          if (decision.kind === "empty") {
             return {
               currentSongId: null,
               currentLyrics: null,
               currentFuriganaMap: null,
             };
-
-          // Add current track to history before moving to next
-          let newPlaybackHistory = state.playbackHistory;
-          if (state.currentSongId && !state.loopCurrent) {
-            newPlaybackHistory = updatePlaybackHistory(
-              state.playbackHistory,
-              state.currentSongId
-            );
           }
 
-          let nextSongId: string | null;
-
-          if (state.loopCurrent) {
-            // If looping current track, stay on the same track
-            nextSongId = state.currentSongId;
-          } else if (state.isShuffled) {
-            // Shuffle mode: pick a random track avoiding recent ones
-            nextSongId = getRandomTrackIdAvoidingRecent(
-              state.tracks,
-              newPlaybackHistory,
-              state.currentSongId
-            );
-          } else {
-            // Sequential mode
-            const currentIndex = getIndexFromSongId(state.tracks, state.currentSongId);
-            const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % state.tracks.length;
-
-            // If we've reached the end and loop all is off, stop
-            if (!state.loopAll && nextIndex === 0 && currentIndex !== -1) {
-              const lastSongId =
-                state.tracks[state.tracks.length - 1]?.id ?? null;
-              const isSameTrack = lastSongId === state.currentSongId;
-              return {
-                currentSongId: lastSongId,
-                currentLyrics: isSameTrack ? state.currentLyrics : null,
-                currentFuriganaMap: isSameTrack ? state.currentFuriganaMap : null,
-                ...stopPlayback(),
-                ...(isSameTrack ? {} : { elapsedTime: 0, totalTime: 0 }),
-              };
-            }
-            nextSongId = state.tracks[nextIndex]?.id ?? null;
-          }
-
-          const isSameTrack = nextSongId === state.currentSongId;
-          return {
-            currentSongId: nextSongId,
+          const isSameTrack = decision.id === state.currentSongId;
+          const lyricsPatch = {
             currentLyrics: isSameTrack ? state.currentLyrics : null,
             currentFuriganaMap: isSameTrack ? state.currentFuriganaMap : null,
+          };
+          // Reset playback position on a track change so the new track starts
+          // at 0 instead of inheriting the previous track's elapsedTime.
+          const clockPatch = isSameTrack ? {} : { elapsedTime: 0, totalTime: 0 };
+
+          if (decision.kind === "stop") {
+            // End of the list with loop-all off.
+            return {
+              currentSongId: decision.id,
+              ...lyricsPatch,
+              ...stopPlayback(),
+              ...clockPatch,
+            };
+          }
+          return {
+            currentSongId: decision.id,
+            ...lyricsPatch,
             ...requestPlayback(),
-            playbackHistory: newPlaybackHistory,
+            playbackHistory: decision.history,
             historyPosition: -1, // Always reset to end when moving forward
-            // Reset playback position so the new track starts at 0 instead
-            // of inheriting the previous track's elapsedTime.
-            ...(isSameTrack ? {} : { elapsedTime: 0, totalTime: 0 }),
+            ...clockPatch,
           };
         }),
       previousTrack: () =>
         set((state) => {
-          if (state.tracks.length === 0)
+          const decision = computePreviousNavigation(
+            {
+              items: state.tracks,
+              currentId: state.currentSongId,
+              loopCurrent: state.loopCurrent,
+              loopAll: state.loopAll,
+              isShuffled: state.isShuffled,
+              history: state.playbackHistory,
+            },
+            IPOD_YOUTUBE_NAVIGATION
+          );
+
+          if (decision.kind === "empty") {
             return {
               currentSongId: null,
               currentLyrics: null,
               currentFuriganaMap: null,
             };
-
-          let prevSongId: string | null;
-          let newPlaybackHistory = state.playbackHistory;
-
-          if (state.isShuffled && state.playbackHistory.length > 0) {
-            // In shuffle mode, go back to the last played track from history
-            const lastTrackId = state.playbackHistory[state.playbackHistory.length - 1];
-            const lastTrackExists = state.tracks.some((track) => track.id === lastTrackId);
-
-            if (lastTrackExists && lastTrackId !== state.currentSongId) {
-              // Found the previous track in history
-              prevSongId = lastTrackId;
-              // Remove it from history since we're going back to it
-              newPlaybackHistory = state.playbackHistory.slice(0, -1);
-            } else {
-              // No valid history, pick a random track
-              prevSongId = getRandomTrackIdAvoidingRecent(
-                state.tracks,
-                state.playbackHistory,
-                state.currentSongId
-              );
-            }
-          } else {
-            // Sequential mode or no history
-            const currentIndex = getIndexFromSongId(state.tracks, state.currentSongId);
-            const prevIndex = currentIndex <= 0 
-              ? state.tracks.length - 1 
-              : currentIndex - 1;
-            prevSongId = state.tracks[prevIndex]?.id ?? null;
           }
 
-          const isSameTrack = prevSongId === state.currentSongId;
+          const isSameTrack = decision.id === state.currentSongId;
           return {
-            currentSongId: prevSongId,
+            currentSongId: decision.id,
             currentLyrics: isSameTrack ? state.currentLyrics : null,
             currentFuriganaMap: isSameTrack ? state.currentFuriganaMap : null,
             ...requestPlayback(),
-            playbackHistory: newPlaybackHistory,
+            playbackHistory: decision.history,
             historyPosition: -1,
             // Reset playback position so the new track starts at 0 instead
             // of inheriting the previous track's elapsedTime.
@@ -2418,8 +2289,19 @@ export const useIpodStore = create<IpodState>()(
           // song), step through that ordered list. Otherwise fall back
           // to the full library so behaviour matches the old menu flow.
           const queueTracks = resolveAppleMusicQueueTracks(state);
+          const decision = computeNextNavigation(
+            {
+              items: queueTracks,
+              currentId: state.appleMusicCurrentSongId,
+              loopCurrent: state.loopCurrent,
+              loopAll: state.loopAll,
+              isShuffled: state.isShuffled,
+              history: state.appleMusicPlaybackHistory,
+            },
+            IPOD_APPLE_MUSIC_NAVIGATION
+          );
 
-          if (queueTracks.length === 0) {
+          if (decision.kind === "empty") {
             return {
               appleMusicCurrentSongId: null,
               currentLyrics: null,
@@ -2427,68 +2309,46 @@ export const useIpodStore = create<IpodState>()(
             };
           }
 
-          let nextSongId: string | null;
-          let newPlaybackHistory = state.appleMusicPlaybackHistory;
+          const isSameTrack = decision.id === state.appleMusicCurrentSongId;
+          // Reset playback position on a track change so the new track starts
+          // at 0 instead of inheriting the previous track's elapsedTime —
+          // otherwise the AppleMusicPlayerBridge resumes the new song from
+          // the previous song's current time (visible as a mid-song start in
+          // Apple Music mode).
+          const clockPatch = isSameTrack ? {} : { elapsedTime: 0, totalTime: 0 };
 
-          if (state.loopCurrent) {
-            nextSongId = state.appleMusicCurrentSongId;
-          } else if (state.isShuffled) {
-            // Shuffle: record the current track, then pick avoiding recently
-            // played songs (parity with the YouTube shuffle algorithm) so we
-            // exhaust the queue before repeating instead of picking purely at
-            // random.
-            if (state.appleMusicCurrentSongId) {
-              newPlaybackHistory = updatePlaybackHistory(
-                state.appleMusicPlaybackHistory,
-                state.appleMusicCurrentSongId
-              );
-            }
-            nextSongId = getRandomTrackIdAvoidingRecent(
-              queueTracks,
-              newPlaybackHistory,
-              state.appleMusicCurrentSongId
-            );
-          } else {
-            const currentIndex = queueTracks.findIndex(
-              (t) => t.id === state.appleMusicCurrentSongId
-            );
-            const nextIndex =
-              currentIndex === -1
-                ? 0
-                : (currentIndex + 1) % queueTracks.length;
-            if (!state.loopAll && nextIndex === 0 && currentIndex !== -1) {
-              const lastSongId =
-                queueTracks[queueTracks.length - 1]?.id ?? null;
-              const isSameTrack = lastSongId === state.appleMusicCurrentSongId;
-              return {
-                appleMusicCurrentSongId: lastSongId,
-                ...stopPlayback(),
-                ...(isSameTrack ? {} : { elapsedTime: 0, totalTime: 0 }),
-              };
-            }
-            nextSongId = queueTracks[nextIndex]?.id ?? null;
+          if (decision.kind === "stop") {
+            return {
+              appleMusicCurrentSongId: decision.id,
+              ...stopPlayback(),
+              ...clockPatch,
+            };
           }
-
-          const isSameTrack = nextSongId === state.appleMusicCurrentSongId;
           return {
-            appleMusicCurrentSongId: nextSongId,
-            appleMusicPlaybackHistory: newPlaybackHistory,
+            appleMusicCurrentSongId: decision.id,
+            appleMusicPlaybackHistory: decision.history,
             currentLyrics: isSameTrack ? state.currentLyrics : null,
             currentFuriganaMap: isSameTrack ? state.currentFuriganaMap : null,
             ...requestPlayback(),
-            // Reset playback position so the new track starts at 0 instead
-            // of inheriting the previous track's elapsedTime — otherwise the
-            // AppleMusicPlayerBridge resumes the new song from the previous
-            // song's current time (visible as a mid-song start in Apple
-            // Music mode).
-            ...(isSameTrack ? {} : { elapsedTime: 0, totalTime: 0 }),
+            ...clockPatch,
           };
         }),
       appleMusicPreviousTrack: () =>
         set((state) => {
           const queueTracks = resolveAppleMusicQueueTracks(state);
+          const decision = computePreviousNavigation(
+            {
+              items: queueTracks,
+              currentId: state.appleMusicCurrentSongId,
+              loopCurrent: state.loopCurrent,
+              loopAll: state.loopAll,
+              isShuffled: state.isShuffled,
+              history: state.appleMusicPlaybackHistory,
+            },
+            IPOD_APPLE_MUSIC_NAVIGATION
+          );
 
-          if (queueTracks.length === 0) {
+          if (decision.kind === "empty") {
             return {
               appleMusicCurrentSongId: null,
               currentLyrics: null,
@@ -2496,50 +2356,10 @@ export const useIpodStore = create<IpodState>()(
             };
           }
 
-          let prevSongId: string | null;
-          let newPlaybackHistory = state.appleMusicPlaybackHistory;
-
-          if (state.isShuffled && state.appleMusicPlaybackHistory.length > 0) {
-            // Shuffle: step back to the actually-played previous track from
-            // history (parity with YouTube) instead of jumping to another
-            // random song — pressing "previous" should retrace your steps.
-            const lastTrackId =
-              state.appleMusicPlaybackHistory[
-                state.appleMusicPlaybackHistory.length - 1
-              ];
-            const lastTrackExists = queueTracks.some(
-              (track) => track.id === lastTrackId
-            );
-            if (lastTrackExists && lastTrackId !== state.appleMusicCurrentSongId) {
-              prevSongId = lastTrackId;
-              newPlaybackHistory = state.appleMusicPlaybackHistory.slice(0, -1);
-            } else {
-              prevSongId = getRandomTrackIdAvoidingRecent(
-                queueTracks,
-                state.appleMusicPlaybackHistory,
-                state.appleMusicCurrentSongId
-              );
-            }
-          } else if (state.isShuffled) {
-            // No history yet — fall back to an avoid-recent random pick.
-            prevSongId = getRandomTrackIdAvoidingRecent(
-              queueTracks,
-              state.appleMusicPlaybackHistory,
-              state.appleMusicCurrentSongId
-            );
-          } else {
-            const currentIndex = queueTracks.findIndex(
-              (t) => t.id === state.appleMusicCurrentSongId
-            );
-            const prevIndex =
-              currentIndex <= 0 ? queueTracks.length - 1 : currentIndex - 1;
-            prevSongId = queueTracks[prevIndex]?.id ?? null;
-          }
-
-          const isSameTrack = prevSongId === state.appleMusicCurrentSongId;
+          const isSameTrack = decision.id === state.appleMusicCurrentSongId;
           return {
-            appleMusicCurrentSongId: prevSongId,
-            appleMusicPlaybackHistory: newPlaybackHistory,
+            appleMusicCurrentSongId: decision.id,
+            appleMusicPlaybackHistory: decision.history,
             currentLyrics: isSameTrack ? state.currentLyrics : null,
             currentFuriganaMap: isSameTrack ? state.currentFuriganaMap : null,
             ...requestPlayback(),

--- a/src/stores/useKaraokeStore.ts
+++ b/src/stores/useKaraokeStore.ts
@@ -5,34 +5,17 @@ import { DisplayMode } from "@/types/lyrics";
 import { useIpodStore, Track } from "./useIpodStore";
 import { shouldUpdatePlaybackTime } from "./playbackTime";
 import {
-  confirmPlayback,
   requestPlayback,
   resetPlaybackConfirmation,
   stopPlayback,
-  togglePlayback,
 } from "@/shared/media/confirmedPlayback";
-
-/** Helper to get current index from song ID */
-function getIndexFromSongId(tracks: Track[], songId: string | null): number {
-  if (!songId || tracks.length === 0) return -1;
-  const index = tracks.findIndex((t) => t.id === songId);
-  return index >= 0 ? index : -1;
-}
-
-/** Get a random song ID avoiding the current song */
-function getRandomSongId(tracks: Track[], currentSongId: string | null): string | null {
-  if (tracks.length === 0) return null;
-  if (tracks.length === 1) return tracks[0].id;
-  
-  const availableIds = tracks.reduce<string[]>((acc, track) => {
-    if (track.id !== currentSongId) {
-      acc.push(track.id);
-    }
-    return acc;
-  }, []);
-  if (availableIds.length === 0) return currentSongId;
-  return availableIds[Math.floor(Math.random() * availableIds.length)];
-}
+import {
+  KARAOKE_NAVIGATION,
+  computeNextNavigation,
+  computePreviousNavigation,
+  createTransportActions,
+  findMediaIndexById,
+} from "@/shared/media/transport";
 
 interface KaraokeData {
   /** The ID of the currently playing song */
@@ -114,7 +97,7 @@ export const useKaraokeStore = create<KaraokeState>()(
       getCurrentIndex: () => {
         const { currentSongId } = get();
         const tracks = useIpodStore.getState().tracks;
-        return getIndexFromSongId(tracks, currentSongId);
+        return findMediaIndexById(tracks, currentSongId);
       },
 
       setCurrentSongId: (songId) =>
@@ -125,22 +108,7 @@ export const useKaraokeStore = create<KaraokeState>()(
             : {}),
         })),
 
-      togglePlay: () => {
-        // Prevent playback when offline
-        if (typeof navigator !== "undefined" && !navigator.onLine) {
-          return;
-        }
-        set((state) => togglePlayback(state));
-      },
-
-      setIsPlaying: (playing) => {
-        // Prevent starting playback when offline
-        if (playing && typeof navigator !== "undefined" && !navigator.onLine) {
-          return;
-        }
-        set(playing ? requestPlayback() : stopPlayback());
-      },
-      confirmPlayback: () => set((state) => confirmPlayback(state)),
+      ...createTransportActions<KaraokeState>(set, { guardOffline: true }),
 
       toggleLoopCurrent: () => set((state) => ({ loopCurrent: !state.loopCurrent })),
 
@@ -155,79 +123,53 @@ export const useKaraokeStore = create<KaraokeState>()(
       nextTrack: () =>
         set((state) => {
           const tracks = useIpodStore.getState().tracks;
-          if (tracks.length === 0) {
+          const decision = computeNextNavigation(
+            {
+              items: tracks,
+              currentId: state.currentSongId,
+              loopCurrent: state.loopCurrent,
+              loopAll: state.loopAll,
+              isShuffled: state.isShuffled,
+              history: state.playbackHistory,
+            },
+            KARAOKE_NAVIGATION
+          );
+
+          if (decision.kind === "empty") {
             return { currentSongId: null, ...stopPlayback() };
           }
-
-          let nextSongId: string | null;
-          let newPlaybackHistory = state.playbackHistory;
-
-          if (state.loopCurrent) {
-            // Stay on current track
-            nextSongId = state.currentSongId;
-          } else if (state.isShuffled) {
-            // Shuffle mode - add current to history and pick random
-            if (state.currentSongId) {
-              newPlaybackHistory = [...state.playbackHistory, state.currentSongId].slice(-50);
-            }
-            nextSongId = getRandomSongId(tracks, state.currentSongId);
-          } else {
-            // Sequential mode
-            const currentIndex = getIndexFromSongId(tracks, state.currentSongId);
-            const nextIndex = currentIndex === -1 ? 0 : currentIndex + 1;
-            
-            if (nextIndex >= tracks.length) {
-              if (state.loopAll) {
-                nextSongId = tracks[0]?.id ?? null;
-              } else {
-                // Stop at end
-                return {
-                  currentSongId: tracks[tracks.length - 1]?.id ?? null,
-                  ...stopPlayback(),
-                };
-              }
-            } else {
-              nextSongId = tracks[nextIndex]?.id ?? null;
-            }
+          if (decision.kind === "stop") {
+            return { currentSongId: decision.id, ...stopPlayback() };
           }
-
           return {
-            currentSongId: nextSongId,
+            currentSongId: decision.id,
             ...requestPlayback(),
-            playbackHistory: newPlaybackHistory,
+            playbackHistory: decision.history,
           };
         }),
 
       previousTrack: () =>
         set((state) => {
           const tracks = useIpodStore.getState().tracks;
-          if (tracks.length === 0) {
+          const decision = computePreviousNavigation(
+            {
+              items: tracks,
+              currentId: state.currentSongId,
+              loopCurrent: state.loopCurrent,
+              loopAll: state.loopAll,
+              isShuffled: state.isShuffled,
+              history: state.playbackHistory,
+            },
+            KARAOKE_NAVIGATION
+          );
+
+          if (decision.kind === "empty") {
             return { currentSongId: null, ...stopPlayback() };
           }
-
-          let prevSongId: string | null;
-          let newPlaybackHistory = state.playbackHistory;
-
-          if (state.isShuffled && state.playbackHistory.length > 0) {
-            // Shuffle mode - go back in history
-            const lastSongId = state.playbackHistory[state.playbackHistory.length - 1];
-            if (lastSongId && tracks.some((t) => t.id === lastSongId)) {
-              prevSongId = lastSongId;
-              newPlaybackHistory = state.playbackHistory.slice(0, -1);
-            } else {
-              prevSongId = getRandomSongId(tracks, state.currentSongId);
-            }
-          } else {
-            // Sequential mode
-            const currentIndex = getIndexFromSongId(tracks, state.currentSongId);
-            const prevIndex = currentIndex <= 0 ? tracks.length - 1 : currentIndex - 1;
-            prevSongId = tracks[prevIndex]?.id ?? null;
-          }
-
           return {
-            currentSongId: prevSongId,
+            currentSongId: decision.id,
             ...requestPlayback(),
-            playbackHistory: newPlaybackHistory,
+            playbackHistory: decision.history,
           };
         }),
 

--- a/src/stores/useTvStore.ts
+++ b/src/stores/useTvStore.ts
@@ -10,12 +10,10 @@ import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
 import { shouldUpdatePlaybackTime } from "@/stores/playbackTime";
 import type { Video } from "@/stores/useVideoStore";
 import {
-  confirmPlayback,
-  requestPlayback,
   resetPlaybackConfirmation,
   stopPlayback,
-  togglePlayback,
 } from "@/shared/media/confirmedPlayback";
+import { createTransportActions } from "@/shared/media/transport";
 
 /** Persisted custom channel; `number` is assigned at runtime from lineup order. */
 export interface CustomChannel extends Omit<Channel, "number"> {
@@ -143,10 +141,7 @@ export const useTvStore = create<TvStoreState>()(
             ? resetPlaybackConfirmation(s)
             : {}),
         })),
-      setIsPlaying: (playing) =>
-        set(playing ? requestPlayback() : stopPlayback()),
-      confirmPlayback: () => set((s) => confirmPlayback(s)),
-      togglePlay: () => set((s) => togglePlayback(s)),
+      ...createTransportActions<TvStoreState>(set),
       toggleLcdFilter: () =>
         set((s) => ({ lcdFilterOn: !s.lcdFilterOn })),
       setLcdFilterOn: (on) => set({ lcdFilterOn: on }),

--- a/src/stores/useVideoStore.ts
+++ b/src/stores/useVideoStore.ts
@@ -3,12 +3,10 @@ import { useStoreShallow } from "./helpers";
 import { persist } from "zustand/middleware";
 import { shouldUpdatePlaybackTime } from "./playbackTime";
 import {
-  confirmPlayback,
-  requestPlayback,
   resetPlaybackConfirmation,
   stopPlayback,
-  togglePlayback,
 } from "@/shared/media/confirmedPlayback";
+import { createTransportActions } from "@/shared/media/transport";
 
 export interface Video {
   id: string;
@@ -233,10 +231,7 @@ export const useVideoStore = create<VideoStoreState>()(
       setLoopAll: (val) => set({ loopAll: val }),
       setLoopCurrent: (val) => set({ loopCurrent: val }),
       setIsShuffled: (val) => set({ isShuffled: val }),
-      togglePlay: () => set((state) => togglePlayback(state)),
-      setIsPlaying: (val) =>
-        set(val ? requestPlayback() : stopPlayback()),
-      confirmPlayback: () => set((state) => confirmPlayback(state)),
+      ...createTransportActions<VideoStoreState>(set),
       setPlaybackTime: (seconds) =>
         set((state) => {
           const flooredSeconds = Math.floor(seconds);

--- a/tests/test-media-transport-slice.test.ts
+++ b/tests/test-media-transport-slice.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Unit tests for the shared MediaCore transport module
+ * (`src/shared/media/transport.ts`) — history strategies, shuffle pickers,
+ * and the next/previous navigation decisions each store maps onto its state.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  IPOD_APPLE_MUSIC_NAVIGATION,
+  IPOD_YOUTUBE_NAVIGATION,
+  KARAOKE_NAVIGATION,
+  appendHistory,
+  computeNextNavigation,
+  computePreviousNavigation,
+  createTransportActions,
+  dedupeAppendHistory,
+  findMediaIndexById,
+  pickRandomIdAvoidingCurrent,
+  pickRandomIdAvoidingRecent,
+} from "../src/shared/media/transport";
+import type { ConfirmedPlaybackFields } from "../src/shared/media/confirmedPlayback";
+
+const items = (...ids: string[]) => ids.map((id) => ({ id }));
+
+describe("history strategies", () => {
+  test("dedupeAppendHistory moves an existing entry to the end", () => {
+    expect(dedupeAppendHistory(["a", "b", "c"], "a")).toEqual(["b", "c", "a"]);
+  });
+
+  test("dedupeAppendHistory caps at the history limit", () => {
+    const long = Array.from({ length: 60 }, (_, i) => `t${i}`);
+    const result = dedupeAppendHistory(long, "new");
+    expect(result).toHaveLength(50);
+    expect(result[result.length - 1]).toBe("new");
+  });
+
+  test("appendHistory keeps duplicates and caps at the limit", () => {
+    expect(appendHistory(["a", "b"], "a")).toEqual(["a", "b", "a"]);
+    expect(appendHistory(Array(55).fill("x"), "y")).toHaveLength(50);
+  });
+});
+
+describe("findMediaIndexById", () => {
+  test("returns -1 for null id or empty list", () => {
+    expect(findMediaIndexById([], "a")).toBe(-1);
+    expect(findMediaIndexById(items("a"), null)).toBe(-1);
+    expect(findMediaIndexById(items("a", "b"), "missing")).toBe(-1);
+  });
+
+  test("finds the index by id", () => {
+    expect(findMediaIndexById(items("a", "b", "c"), "b")).toBe(1);
+  });
+});
+
+describe("shuffle pickers", () => {
+  test("pickRandomIdAvoidingRecent prefers unplayed tracks", () => {
+    // Only "c" is unplayed, so the pick is deterministic.
+    const picked = pickRandomIdAvoidingRecent(
+      items("a", "b", "c"),
+      ["a", "b"],
+      "a"
+    );
+    expect(picked).toBe("c");
+  });
+
+  test("pickRandomIdAvoidingRecent never repeats the current track when avoidable", () => {
+    for (let i = 0; i < 20; i++) {
+      expect(pickRandomIdAvoidingRecent(items("a", "b"), [], "a")).toBe("b");
+    }
+  });
+
+  test("pickRandomIdAvoidingRecent returns the only track in a 1-item library", () => {
+    expect(pickRandomIdAvoidingRecent(items("solo"), ["solo"], "solo")).toBe(
+      "solo"
+    );
+  });
+
+  test("pickRandomIdAvoidingCurrent avoids only the current track", () => {
+    for (let i = 0; i < 20; i++) {
+      expect(pickRandomIdAvoidingCurrent(items("a", "b"), "a")).toBe("b");
+    }
+    expect(pickRandomIdAvoidingCurrent([], "a")).toBeNull();
+    expect(pickRandomIdAvoidingCurrent(items("a"), "a")).toBe("a");
+  });
+});
+
+describe("computeNextNavigation", () => {
+  const base = {
+    items: items("a", "b", "c"),
+    currentId: "a",
+    loopCurrent: false,
+    loopAll: true,
+    isShuffled: false,
+    history: [] as string[],
+  };
+
+  test("empty library yields an empty decision", () => {
+    expect(
+      computeNextNavigation({ ...base, items: [] }, IPOD_YOUTUBE_NAVIGATION)
+    ).toEqual({ kind: "empty" });
+  });
+
+  test("sequential next advances", () => {
+    const decision = computeNextNavigation(base, IPOD_YOUTUBE_NAVIGATION);
+    expect(decision).toEqual({
+      kind: "advance",
+      id: "b",
+      history: ["a"],
+    });
+  });
+
+  test("iPod records history on sequential next; Karaoke does not", () => {
+    const ipod = computeNextNavigation(base, IPOD_YOUTUBE_NAVIGATION);
+    const karaoke = computeNextNavigation(base, KARAOKE_NAVIGATION);
+    expect(ipod.kind === "advance" && ipod.history).toEqual(["a"]);
+    expect(karaoke.kind === "advance" && karaoke.history).toEqual([]);
+  });
+
+  test("loopCurrent stays on the current item without recording history", () => {
+    for (const strategy of [
+      IPOD_YOUTUBE_NAVIGATION,
+      IPOD_APPLE_MUSIC_NAVIGATION,
+      KARAOKE_NAVIGATION,
+    ]) {
+      const decision = computeNextNavigation(
+        { ...base, loopCurrent: true },
+        strategy
+      );
+      expect(decision).toEqual({ kind: "advance", id: "a", history: [] });
+    }
+  });
+
+  test("end of list with loopAll off stops on the last item", () => {
+    const decision = computeNextNavigation(
+      { ...base, currentId: "c", loopAll: false },
+      IPOD_YOUTUBE_NAVIGATION
+    );
+    expect(decision).toEqual({ kind: "stop", id: "c" });
+  });
+
+  test("end of list with loopAll on wraps to the first item", () => {
+    const decision = computeNextNavigation(
+      { ...base, currentId: "c" },
+      IPOD_YOUTUBE_NAVIGATION
+    );
+    expect(decision.kind === "advance" && decision.id).toBe("a");
+  });
+
+  test("unknown current id starts from the first item", () => {
+    const decision = computeNextNavigation(
+      { ...base, currentId: null },
+      KARAOKE_NAVIGATION
+    );
+    expect(decision.kind === "advance" && decision.id).toBe("a");
+  });
+
+  test("shuffle picks via the strategy and records history", () => {
+    const decision = computeNextNavigation(
+      { ...base, items: items("a", "b"), isShuffled: true },
+      KARAOKE_NAVIGATION
+    );
+    expect(decision).toEqual({ kind: "advance", id: "b", history: ["a"] });
+  });
+});
+
+describe("computePreviousNavigation", () => {
+  const base = {
+    items: items("a", "b", "c"),
+    currentId: "b",
+    loopCurrent: false,
+    loopAll: true,
+    isShuffled: false,
+    history: [] as string[],
+  };
+
+  test("sequential previous steps back and wraps at the start", () => {
+    expect(
+      computePreviousNavigation(base, IPOD_YOUTUBE_NAVIGATION)
+    ).toEqual({ kind: "advance", id: "a", history: [] });
+    expect(
+      computePreviousNavigation(
+        { ...base, currentId: "a" },
+        IPOD_YOUTUBE_NAVIGATION
+      )
+    ).toEqual({ kind: "advance", id: "c", history: [] });
+  });
+
+  test("shuffle previous retraces and pops history", () => {
+    const decision = computePreviousNavigation(
+      { ...base, isShuffled: true, currentId: "c", history: ["a", "b"] },
+      IPOD_YOUTUBE_NAVIGATION
+    );
+    expect(decision).toEqual({ kind: "advance", id: "b", history: ["a"] });
+  });
+
+  test("iPod skips a history entry equal to the current item; Karaoke accepts it", () => {
+    const input = {
+      ...base,
+      items: items("a", "b"),
+      isShuffled: true,
+      currentId: "a",
+      history: ["a"],
+    };
+    const ipod = computePreviousNavigation(input, IPOD_YOUTUBE_NAVIGATION);
+    // Falls back to the shuffle picker (only "b" is available).
+    expect(ipod).toEqual({ kind: "advance", id: "b", history: ["a"] });
+
+    const karaoke = computePreviousNavigation(input, KARAOKE_NAVIGATION);
+    expect(karaoke).toEqual({ kind: "advance", id: "a", history: [] });
+  });
+
+  test("shuffle without history: iPod YouTube goes sequential, Apple Music picks a shuffle id", () => {
+    const input = { ...base, isShuffled: true, currentId: "b", history: [] };
+    const youtube = computePreviousNavigation(input, IPOD_YOUTUBE_NAVIGATION);
+    expect(youtube).toEqual({ kind: "advance", id: "a", history: [] });
+
+    const appleMusic = computePreviousNavigation(
+      { ...input, items: items("a", "b") },
+      IPOD_APPLE_MUSIC_NAVIGATION
+    );
+    // Avoid-current picker with two items is deterministic.
+    expect(appleMusic).toEqual({ kind: "advance", id: "a", history: [] });
+  });
+
+  test("empty library yields an empty decision", () => {
+    expect(
+      computePreviousNavigation({ ...base, items: [] }, KARAOKE_NAVIGATION)
+    ).toEqual({ kind: "empty" });
+  });
+});
+
+describe("createTransportActions", () => {
+  const makeStore = () => {
+    let state: ConfirmedPlaybackFields = {
+      isPlaying: false,
+      playbackRequested: false,
+    };
+    const set = (
+      partial:
+        | Partial<ConfirmedPlaybackFields>
+        | ((s: ConfirmedPlaybackFields) => Partial<ConfirmedPlaybackFields>)
+    ) => {
+      const patch = typeof partial === "function" ? partial(state) : partial;
+      state = { ...state, ...patch };
+    };
+    return { getState: () => state, set };
+  };
+
+  test("drives the confirm-playback lifecycle", () => {
+    const store = makeStore();
+    const actions = createTransportActions(store.set);
+
+    actions.setIsPlaying(true);
+    expect(store.getState()).toEqual({
+      isPlaying: false,
+      playbackRequested: true,
+    });
+
+    actions.confirmPlayback();
+    expect(store.getState()).toEqual({
+      isPlaying: true,
+      playbackRequested: true,
+    });
+
+    actions.togglePlay();
+    expect(store.getState()).toEqual({
+      isPlaying: false,
+      playbackRequested: false,
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> [!IMPORTANT]
> **Superseded by #1757**, which collapses all MediaCore phases into one PR against `main`. Close this PR without merging.

## Summary

Phase 1 of `docs/proposals/media-core.md` (stacked on Phase 0, PR #1751): one implementation of the playback transport state machine, adopted by all four media stores. Pure behavior-preserving extraction — the Phase 0 parity tests pass unmodified.

New `src/shared/media/transport.ts`:
- `createTransportActions()` — the `togglePlay` / `setIsPlaying` / `confirmPlayback` lifecycle (with the iPod/Karaoke offline guards as an option), previously copied in four stores.
- `computeNextNavigation()` / `computePreviousNavigation()` — the next/previous algorithm (sequential, loopCurrent, loopAll end-stop, shuffle with history retrace) as pure decision functions; stores map decisions onto their own patches (lyrics clearing, clock resets).
- History strategies (`dedupeAppendHistory` iPod-style, `appendHistory` Karaoke-style), shuffle pickers (`pickRandomIdAvoidingRecent` with unplayed-first semantics, `pickRandomIdAvoidingCurrent`), `findMediaIndexById`, and three canonical strategy presets (`IPOD_YOUTUBE_NAVIGATION`, `IPOD_APPLE_MUSIC_NAVIGATION`, `KARAOKE_NAVIGATION`) encoding the real behavioral differences discovered in the audit (when history records, pop-requires-different, previous-without-history).

Adoption:
- `useIpodStore`: YouTube `nextTrack`/`previousTrack` and Apple Music `appleMusicNextTrack`/`appleMusicPreviousTrack` now consume decisions; local copies of `getIndexFromSongId`, `updatePlaybackHistory`, `getUnplayedTrackIds`, `getRandomTrackIdAvoidingRecent` deleted (~130 lines).
- `useKaraokeStore`: same treatment; local helpers deleted.
- `useVideoStore` / `useTvStore`: transport actions from the factory.

Net: the four stores lose ~400 lines of duplicated transport logic; persisted state shapes are unchanged (no version bumps needed).

## Testing

- ✅ `bun test tests/test-media-transport-slice.test.ts` (23 new unit tests for the shared module)
- ✅ `bun test tests/test-media-transport-parity.test.ts` (Phase 0 guardrails, 32 pass, unmodified)
- ✅ iPod suites in isolation: `test-ipod-playback-navigation` (9), `test-ipod-apple-music` (86), `test-ipod-track-order`, `test-ipod-menu-identity`, `test-ipod-library-index`, `test-ipod-production-log-regressions`
- ✅ `test-confirmed-playback-state`, `test-karaoke-title-card`, `test-karaoke-interlude-display`, `test-tv-store-default-channel-removal`, `test-tv-utils`, `test-media-library-store-facade`, `test-playback-time-throttle`, listen suites
- ✅ `bunx tsc -p tsconfig.app.json --noEmit`
- ✅ `bunx eslint` on all changed files (clean)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2808-4335-7fed-9f5b-ffbbb0bcd4b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2808-4335-7fed-9f5b-ffbbb0bcd4b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

