### PR TITLE
MediaCore Phase 2: now-playing bus, single-active arbitration, adapter contract

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import { DesktopErrorBoundary } from "@/components/errors/ErrorBoundaries";
 import { DeferredAutoCloudSync } from "@/hooks/useDeferredAutoCloudSync";
 import { DeferredAirDropListener } from "@/components/DeferredAirDropListener";
 import { WallpaperAccentRunner } from "@/hooks/WallpaperAccentRunner";
+import { MediaCoreRunner } from "@/hooks/MediaCoreRunner";
 import { DesktopCornerMask } from "@/components/layout/desktop/DesktopCornerMask";
 import { installNativeToastNotifications } from "@/utils/nativeToastNotifications";
 import { createClientLogger } from "@/utils/logger";
@@ -298,6 +299,7 @@ export function App() {
       <DeferredAutoCloudSync />
       <DeferredBackgroundChatNotifications />
       <WallpaperAccentRunner />
+      <MediaCoreRunner />
       <ScreenSaverOverlay />
       {debugMode && (
         <Suspense fallback={null}>

--- a/src/hooks/MediaCoreRunner.tsx
+++ b/src/hooks/MediaCoreRunner.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+
+/**
+ * Mounts the MediaCore runtime (now-playing bus + single-active playback
+ * arbitration) once at the app root. The runtime module subscribes to the
+ * full iPod / Karaoke / Videos / TV store stack, so it is loaded lazily to
+ * keep those stores out of the boot chunk.
+ */
+export function MediaCoreRunner() {
+  useEffect(() => {
+    let cancelled = false;
+    let cleanup: (() => void) | undefined;
+    import("@/shared/media/mediaCoreRuntime").then((module) => {
+      if (cancelled) return;
+      cleanup = module.initMediaCoreRuntime();
+    });
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
+  }, []);
+  return null;
+}

--- a/src/shared/media/adapters/types.ts
+++ b/src/shared/media/adapters/types.ts
@@ -1,0 +1,37 @@
+/**
+ * MediaCore source adapter contract.
+ *
+ * A `MediaSourceAdapter` is the seam between a transport (store state) and a
+ * concrete playback engine — the ReactPlayer-based YouTube embeds (iPod,
+ * Karaoke, Videos, TV), the MusicKit `AppleMusicPlayerBridge`, and Winamp's
+ * raw IFrame wrapper. Phase 4 replaces the per-app `getActivePlayer` ref
+ * juggling with adapter instances; Listen Together and cross-device handoff
+ * then target this interface instead of app internals.
+ */
+
+export interface MediaAdapterEvents {
+  /** Provider confirmed playback actually started. */
+  onPlay?: () => void;
+  /** Provider paused (user gesture, buffer stall resolution, etc.). */
+  onPause?: () => void;
+  /** Current item finished playing. */
+  onEnded?: () => void;
+  /** Playback clock tick, in seconds. */
+  onProgress?: (seconds: number) => void;
+  /** Total duration became known, in seconds. */
+  onDuration?: (seconds: number) => void;
+  /** Provider-level failure (embed blocked, network, autoplay denial). */
+  onError?: (error: unknown) => void;
+}
+
+export interface MediaSourceAdapter {
+  /** Stable id for diagnostics ("youtube", "apple-music", "webamp"). */
+  readonly kind: string;
+  play: () => void;
+  pause: () => void;
+  seekTo: (seconds: number) => void;
+  /** Current playback position in seconds, or null when unavailable. */
+  getCurrentTime: () => number | null;
+  /** Attach event handlers; returns an unsubscribe function. */
+  subscribe: (events: MediaAdapterEvents) => () => void;
+}

--- a/src/shared/media/mediaCoreRuntime.ts
+++ b/src/shared/media/mediaCoreRuntime.ts
@@ -1,0 +1,152 @@
+/**
+ * MediaCore runtime — feeds the now-playing bus and enforces the
+ * single-active-playback policy across the four media transports.
+ *
+ * Arbitration: when any transport requests playback, every other transport
+ * with an in-flight or confirmed request is stopped. Historically nothing
+ * arbitrated, so the iPod and Videos could play over each other.
+ *
+ * This module imports the media stores, so it must only be loaded lazily
+ * (see `MediaCoreRunner`) to keep them out of the boot chunk.
+ */
+import { useIpodStore } from "@/stores/useIpodStore";
+import { useKaraokeStore } from "@/stores/useKaraokeStore";
+import { useVideoStore } from "@/stores/useVideoStore";
+import { useTvStore } from "@/stores/useTvStore";
+import {
+  type MediaAppId,
+  type NowPlayingEntry,
+  useNowPlayingStore,
+} from "./nowPlayingStore";
+
+interface TransportBinding {
+  appId: MediaAppId;
+  subscribe: (listener: () => void) => () => void;
+  read: () => NowPlayingEntry;
+  /** Stop playback without changing the current selection. */
+  stop: () => void;
+}
+
+const bindings: TransportBinding[] = [
+  {
+    appId: "ipod",
+    subscribe: (listener) => useIpodStore.subscribe(listener),
+    read: () => {
+      const s = useIpodStore.getState();
+      const itemId =
+        s.librarySource === "appleMusic"
+          ? s.appleMusicCurrentSongId
+          : s.currentSongId;
+      return {
+        itemId,
+        isPlaying: s.isPlaying,
+        playbackRequested: s.playbackRequested,
+        hasSelection: itemId !== null,
+      };
+    },
+    stop: () => useIpodStore.getState().setIsPlaying(false),
+  },
+  {
+    appId: "karaoke",
+    subscribe: (listener) => useKaraokeStore.subscribe(listener),
+    read: () => {
+      const s = useKaraokeStore.getState();
+      return {
+        itemId: s.currentSongId,
+        isPlaying: s.isPlaying,
+        playbackRequested: s.playbackRequested,
+        hasSelection: s.currentSongId !== null,
+      };
+    },
+    stop: () => useKaraokeStore.getState().setIsPlaying(false),
+  },
+  {
+    appId: "videos",
+    subscribe: (listener) => useVideoStore.subscribe(listener),
+    read: () => {
+      const s = useVideoStore.getState();
+      return {
+        itemId: s.currentVideoId,
+        isPlaying: s.isPlaying,
+        playbackRequested: s.playbackRequested,
+        // Videos always has a default selection; only an active request
+        // should surface it on the now-playing bus.
+        hasSelection: s.playbackRequested,
+      };
+    },
+    stop: () => useVideoStore.getState().setIsPlaying(false),
+  },
+  {
+    appId: "tv",
+    subscribe: (listener) => useTvStore.subscribe(listener),
+    read: () => {
+      const s = useTvStore.getState();
+      return {
+        itemId: s.currentChannelId,
+        isPlaying: s.isPlaying,
+        playbackRequested: s.playbackRequested,
+        // TV is always tuned to some channel; same rule as Videos.
+        hasSelection: s.playbackRequested,
+      };
+    },
+    stop: () => useTvStore.getState().setIsPlaying(false),
+  },
+];
+
+let runtimeCleanup: (() => void) | null = null;
+
+/**
+ * Start mirroring the four transports onto the now-playing bus and enforcing
+ * single-active playback. Idempotent; returns a cleanup function.
+ */
+export function initMediaCoreRuntime(): () => void {
+  if (runtimeCleanup) return runtimeCleanup;
+
+  const updateEntry = useNowPlayingStore.getState().updateEntry;
+  const lastRequested = new Map<MediaAppId, boolean>();
+  let arbitrating = false;
+
+  const pauseOthers = (winner: MediaAppId) => {
+    // Re-entrancy guard: stopping a transport triggers its subscription
+    // synchronously; those callbacks must not re-arbitrate.
+    if (arbitrating) return;
+    arbitrating = true;
+    try {
+      for (const binding of bindings) {
+        if (binding.appId === winner) continue;
+        const entry = binding.read();
+        if (entry.playbackRequested || entry.isPlaying) {
+          binding.stop();
+          lastRequested.set(binding.appId, false);
+          updateEntry(binding.appId, binding.read());
+        }
+      }
+    } finally {
+      arbitrating = false;
+    }
+  };
+
+  const unsubscribers = bindings.map((binding) => {
+    // Seed the bus (and the transition tracker) with the current state.
+    const initial = binding.read();
+    lastRequested.set(binding.appId, initial.playbackRequested);
+    updateEntry(binding.appId, initial);
+
+    return binding.subscribe(() => {
+      const entry = binding.read();
+      const wasRequested = lastRequested.get(binding.appId) ?? false;
+      lastRequested.set(binding.appId, entry.playbackRequested);
+      updateEntry(binding.appId, entry);
+      if (!wasRequested && entry.playbackRequested && !arbitrating) {
+        pauseOthers(binding.appId);
+      }
+    });
+  });
+
+  runtimeCleanup = () => {
+    for (const unsubscribe of unsubscribers) unsubscribe();
+    useNowPlayingStore.getState().reset();
+    runtimeCleanup = null;
+  };
+  return runtimeCleanup;
+}

--- a/src/shared/media/nowPlayingStore.ts
+++ b/src/shared/media/nowPlayingStore.ts
@@ -1,0 +1,92 @@
+/**
+ * MediaCore now-playing bus.
+ *
+ * A single answer to "which media app is driving playback right now".
+ * Fed by `mediaCoreRuntime.ts` (which subscribes to the iPod, Karaoke,
+ * Videos, and TV stores); consumed by cross-app surfaces like the dynamic
+ * wallpaper and, later, the unified `mediaControl` AI tool.
+ *
+ * This module deliberately imports no app stores so it can be consumed from
+ * boot-time code without pulling the media apps into the boot chunk.
+ */
+import { create } from "zustand";
+
+export type MediaAppId = "ipod" | "karaoke" | "videos" | "tv";
+
+/** Tie-break order: music surfaces win over video surfaces. */
+export const MEDIA_APP_PRIORITY: readonly MediaAppId[] = [
+  "ipod",
+  "karaoke",
+  "videos",
+  "tv",
+];
+
+export interface NowPlayingEntry {
+  /** Current item id (track / video / channel) or null. */
+  itemId: string | null;
+  /** Confirmed playback (provider emitted a play event). */
+  isPlaying: boolean;
+  /** Desired player state, including an in-flight play attempt. */
+  playbackRequested: boolean;
+  /** Whether the app has something selected to show/play. */
+  hasSelection: boolean;
+}
+
+const EMPTY_ENTRY: NowPlayingEntry = {
+  itemId: null,
+  isPlaying: false,
+  playbackRequested: false,
+  hasSelection: false,
+};
+
+export interface NowPlayingState {
+  entries: Record<MediaAppId, NowPlayingEntry>;
+  /**
+   * The app currently driving playback: the highest-priority playing app,
+   * falling back to the highest-priority app with a selection (so paused
+   * players keep surfaces like the cover wallpaper alive).
+   */
+  activeAppId: MediaAppId | null;
+  updateEntry: (appId: MediaAppId, entry: NowPlayingEntry) => void;
+  reset: () => void;
+}
+
+function deriveActiveAppId(
+  entries: Record<MediaAppId, NowPlayingEntry>
+): MediaAppId | null {
+  for (const appId of MEDIA_APP_PRIORITY) {
+    if (entries[appId].isPlaying) return appId;
+  }
+  for (const appId of MEDIA_APP_PRIORITY) {
+    if (entries[appId].hasSelection) return appId;
+  }
+  return null;
+}
+
+function entriesEqual(a: NowPlayingEntry, b: NowPlayingEntry): boolean {
+  return (
+    a.itemId === b.itemId &&
+    a.isPlaying === b.isPlaying &&
+    a.playbackRequested === b.playbackRequested &&
+    a.hasSelection === b.hasSelection
+  );
+}
+
+const initialEntries: Record<MediaAppId, NowPlayingEntry> = {
+  ipod: EMPTY_ENTRY,
+  karaoke: EMPTY_ENTRY,
+  videos: EMPTY_ENTRY,
+  tv: EMPTY_ENTRY,
+};
+
+export const useNowPlayingStore = create<NowPlayingState>()((set) => ({
+  entries: initialEntries,
+  activeAppId: null,
+  updateEntry: (appId, entry) =>
+    set((state) => {
+      if (entriesEqual(state.entries[appId], entry)) return state;
+      const entries = { ...state.entries, [appId]: entry };
+      return { entries, activeAppId: deriveActiveAppId(entries) };
+    }),
+  reset: () => set({ entries: initialEntries, activeAppId: null }),
+}));

--- a/tests/test-media-now-playing-arbitration.test.ts
+++ b/tests/test-media-now-playing-arbitration.test.ts
@@ -1,0 +1,205 @@
+/**
+ * MediaCore Phase 2 — now-playing bus + single-active playback arbitration.
+ *
+ * Exercises `mediaCoreRuntime` against the real media stores: requesting
+ * playback in one app must stop every other app's in-flight or confirmed
+ * playback, and the bus must always know which app is driving.
+ */
+import "fake-indexeddb/auto";
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+class MemoryStorage implements Storage {
+  private readonly map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.map.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+}
+
+const browserGlobals = globalThis as typeof globalThis & {
+  localStorage?: Storage;
+  navigator?: Navigator;
+};
+if (!browserGlobals.localStorage) {
+  Object.defineProperty(browserGlobals, "localStorage", {
+    configurable: true,
+    value: new MemoryStorage(),
+    writable: true,
+  });
+}
+Object.defineProperty(browserGlobals, "navigator", {
+  value: {
+    ...(browserGlobals.navigator ?? {}),
+    onLine: true,
+    userAgent: "test",
+  },
+  configurable: true,
+});
+
+const { useIpodStore } = await import("../src/stores/useIpodStore");
+const { useKaraokeStore } = await import("../src/stores/useKaraokeStore");
+const { useVideoStore } = await import("../src/stores/useVideoStore");
+const { useTvStore } = await import("../src/stores/useTvStore");
+const { useNowPlayingStore } = await import(
+  "../src/shared/media/nowPlayingStore"
+);
+const { initMediaCoreRuntime } = await import(
+  "../src/shared/media/mediaCoreRuntime"
+);
+
+const resetStores = () => {
+  useIpodStore.setState({
+    tracks: [
+      { id: "song1", url: "https://youtu.be/song1", title: "Song 1" },
+      { id: "song2", url: "https://youtu.be/song2", title: "Song 2" },
+    ],
+    librarySource: "youtube",
+    currentSongId: "song1",
+    isPlaying: false,
+    playbackRequested: false,
+  });
+  useKaraokeStore.setState({
+    currentSongId: "song1",
+    isPlaying: false,
+    playbackRequested: false,
+  });
+  useVideoStore.setState({
+    currentVideoId: "vid1",
+    videos: [
+      { id: "vid1", url: "https://youtu.be/vid1", title: "Video 1" },
+    ],
+    isPlaying: false,
+    playbackRequested: false,
+  });
+  useTvStore.setState({
+    currentChannelId: "ryo",
+    isPlaying: false,
+    playbackRequested: false,
+  });
+};
+
+resetStores();
+const cleanup = initMediaCoreRuntime();
+afterAll(() => cleanup());
+
+describe("single-active playback arbitration", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  test("starting the iPod stops an in-flight Videos request", () => {
+    useVideoStore.getState().setIsPlaying(true);
+    expect(useVideoStore.getState().playbackRequested).toBe(true);
+
+    useIpodStore.getState().setIsPlaying(true);
+
+    expect(useIpodStore.getState().playbackRequested).toBe(true);
+    expect(useVideoStore.getState().playbackRequested).toBe(false);
+    expect(useVideoStore.getState().isPlaying).toBe(false);
+  });
+
+  test("starting Videos stops confirmed iPod playback", () => {
+    useIpodStore.getState().setIsPlaying(true);
+    useIpodStore.getState().confirmPlayback();
+    expect(useIpodStore.getState().isPlaying).toBe(true);
+
+    useVideoStore.getState().togglePlay();
+
+    expect(useVideoStore.getState().playbackRequested).toBe(true);
+    expect(useIpodStore.getState().isPlaying).toBe(false);
+    expect(useIpodStore.getState().playbackRequested).toBe(false);
+  });
+
+  test("starting TV stops Karaoke; the winner's request survives arbitration", () => {
+    useKaraokeStore.getState().setIsPlaying(true);
+    useKaraokeStore.getState().confirmPlayback();
+
+    useTvStore.getState().setIsPlaying(true);
+    useTvStore.getState().confirmPlayback();
+
+    expect(useTvStore.getState().isPlaying).toBe(true);
+    expect(useKaraokeStore.getState().isPlaying).toBe(false);
+    expect(useKaraokeStore.getState().playbackRequested).toBe(false);
+  });
+
+  test("pausing does not disturb the other transports", () => {
+    useIpodStore.getState().setIsPlaying(true);
+    useIpodStore.getState().confirmPlayback();
+
+    useVideoStore.getState().setIsPlaying(false);
+
+    expect(useIpodStore.getState().isPlaying).toBe(true);
+  });
+
+  test("track navigation inside one app keeps its own playback request", () => {
+    useIpodStore.getState().setIsPlaying(true);
+    useIpodStore.getState().confirmPlayback();
+
+    useIpodStore.getState().nextTrack();
+
+    expect(useIpodStore.getState().currentSongId).toBe("song2");
+    expect(useIpodStore.getState().playbackRequested).toBe(true);
+  });
+});
+
+describe("now-playing bus", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  test("mirrors the playing app and its item id", () => {
+    useVideoStore.getState().setIsPlaying(true);
+    useVideoStore.getState().confirmPlayback();
+
+    const bus = useNowPlayingStore.getState();
+    expect(bus.activeAppId).toBe("videos");
+    expect(bus.entries.videos).toEqual({
+      itemId: "vid1",
+      isPlaying: true,
+      playbackRequested: true,
+      hasSelection: true,
+    });
+  });
+
+  test("music surfaces win the priority tie-break over video surfaces", () => {
+    // Arbitration means only one can *request*, but a paused iPod with a
+    // selection still outranks idle video surfaces in the fallback tier.
+    useIpodStore.getState().setIsPlaying(true);
+    useIpodStore.getState().confirmPlayback();
+    useIpodStore.getState().setIsPlaying(false);
+
+    expect(useNowPlayingStore.getState().activeAppId).toBe("ipod");
+  });
+
+  test("idle Videos/TV do not surface their default selection", () => {
+    useIpodStore.setState({ currentSongId: null });
+    useKaraokeStore.setState({ currentSongId: null });
+
+    const bus = useNowPlayingStore.getState();
+    expect(bus.entries.videos.hasSelection).toBe(false);
+    expect(bus.entries.tv.hasSelection).toBe(false);
+    expect(bus.activeAppId).toBeNull();
+  });
+
+  test("Apple Music mode reports the Apple Music song id", () => {
+    useIpodStore.setState({
+      librarySource: "appleMusic",
+      appleMusicCurrentSongId: "am:9",
+    });
+    expect(useNowPlayingStore.getState().entries.ipod.itemId).toBe("am:9");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> [!IMPORTANT]
> **Superseded by #1757**, which collapses all MediaCore phases into one PR against `main`. Close this PR without merging.

## Summary

Phase 2 of `docs/proposals/media-core.md` (stacked on Phase 1, PR #1752).

- `src/shared/media/nowPlayingStore.ts` — the now-playing bus: one store answering "which media app is driving playback" with a priority tie-break (`ipod > karaoke > videos > tv`), a playing tier and a paused-with-selection fallback tier. Imports no app stores, so it is safe to consume from boot-time code.
- `src/shared/media/mediaCoreRuntime.ts` — mirrors the four transports onto the bus and enforces **single-active playback**: when any transport requests playback, every other in-flight or confirmed transport is stopped (previously nothing arbitrated — the iPod and Videos could play over each other). Re-entrancy guarded; idle Videos/TV default selections do not surface on the bus.
- `src/hooks/MediaCoreRunner.tsx` — mounts the runtime at the app root via lazy import (keeps the media stores out of the boot chunk; `test-boot-import-graph` stays green), wired into `App.tsx` next to `WallpaperAccentRunner`.
- `src/shared/media/adapters/types.ts` — the `MediaSourceAdapter` contract (play/pause/seek/clock/events) that Phase 4 uses to replace per-app `getActivePlayer` ref juggling.

Scope note: the plan also suggested rewriting `useNowPlayingCover`/`useNowPlayingLyrics` onto the bus. Deferred — with arbitration in place, at most one transport plays, so their existing precedence logic is behaviorally equivalent; rewiring them is Phase 4 cleanup where their app-hook consumers are already being touched.

## Testing

- ✅ `bun test tests/test-media-now-playing-arbitration.test.ts` (9 new tests against the real stores: cross-app stop on request, winner survives, pause doesn't disturb others, in-app navigation keeps its own request, bus mirroring incl. Apple Music id)
- ✅ `bun test tests/test-boot-import-graph.test.ts` (15 pass — lazy loading keeps boot chunk clean)
- ✅ Phase 0/1 guardrails re-run: `test-media-transport-parity`, `test-ipod-playback-navigation`, `test-confirmed-playback-state` (0 fail)
- ✅ `bunx tsc -p tsconfig.app.json --noEmit`
- ✅ `bunx eslint` on all changed files (clean)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2808-4335-7fed-9f5b-ffbbb0bcd4b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2808-4335-7fed-9f5b-ffbbb0bcd4b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

