### PR TITLE
MediaCore Phase 3: unified media library model and API

### DIFF
--- a/api/_utils/song-library-state.ts
+++ b/api/_utils/song-library-state.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Redis } from "./redis.js";
-import type { Track } from "../../src/stores/useIpodStore.js";
+import type { Track } from "../../src/shared/media/library.js";
 import { sortTracksLikeServerOrder } from "../../src/stores/ipodTrackOrder.js";
 import {
   hlcFromTimestamp,

--- a/src/apps/tv/hooks/useTvLogic.ts
+++ b/src/apps/tv/hooks/useTvLogic.ts
@@ -6,6 +6,7 @@ import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
 import { useTvStore } from "@/stores/useTvStore";
 import { useIpodStore, type Track } from "@/stores/useIpodStore";
 import { useVideoStore, type Video } from "@/stores/useVideoStore";
+import { trackToVideoItem } from "@/shared/media/library";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { helpItems } from "..";
 import { buildTvChannelLineup, type Channel } from "@/apps/tv/data/channels";
@@ -25,14 +26,7 @@ import { formatSecondsMmSs } from "@/utils/formatDuration";
 export const MTV_CHANNEL_ID = "mtv";
 export const RYO_TV_CHANNEL_ID = "ryos-picks";
 
-function trackToVideo(track: Track): Video {
-  return {
-    id: track.id,
-    url: track.url,
-    title: track.title,
-    artist: track.artist,
-  };
-}
+const trackToVideo = (track: Track): Video => trackToVideoItem(track);
 
 export interface UseTvLogicOptions {
   isWindowOpen: boolean;

--- a/src/shared/media/library.ts
+++ b/src/shared/media/library.ts
@@ -1,0 +1,120 @@
+/**
+ * MediaCore unified library model.
+ *
+ * One item model for the media apps: songs (iPod / Karaoke / Winamp library)
+ * and videos (Videos / TV library) share the same base shape — `Video` was
+ * historically a strict subset of `Track`. The physical storage remains in
+ * `useIpodStore.tracks` and `useVideoStore.videos` (keeping the Cloud Sync v2
+ * wire format byte-identical); `useMediaLibraryStore` exposes the unified
+ * read API over both.
+ *
+ * This module is shared with the server (`api/_utils/song-library-state.ts`),
+ * so it must stay free of client-only imports.
+ */
+
+/** Lyrics source from Kugou */
+export interface LyricsSource {
+  hash: string;
+  albumId: string | number;
+  title: string;
+  artist: string;
+  album?: string;
+}
+
+/** Library source the iPod is currently displaying. */
+export type LibrarySource = "youtube" | "appleMusic";
+
+/** Apple Music play parameters needed for `setQueue` (catalog vs library). */
+export interface AppleMusicPlayParams {
+  /** Catalog song ID (numeric string) when available — preferred for setQueue. */
+  catalogId?: string;
+  /** Library song ID (`i.<hash>` form) for personal library tracks. */
+  libraryId?: string;
+  /** Catalog station ID (`ra.*` form) for Apple Music radio playback. */
+  stationId?: string;
+  /** Catalog playlist ID (`pl.*` form) for recommendation playback. */
+  playlistId?: string;
+  /** MusicKit kind, e.g. "song", "library-song". */
+  kind: string;
+  isLibrary?: boolean;
+}
+
+/** Base shape shared by every library item (song or video). */
+export interface MediaItemBase {
+  id: string;
+  url: string;
+  title: string;
+  artist?: string;
+}
+
+/** Song in the music library (iPod / Karaoke / Winamp). */
+export interface Track extends MediaItemBase {
+  album?: string;
+  /** Album-level artist for grouping compilations/collaborative albums. */
+  albumArtist?: string;
+  /** Apple Music album/library album id when available, used for album grouping. */
+  appleMusicAlbumId?: string;
+  /** Cover image URL from Kugou */
+  cover?: string;
+  /** Cached boosted cover color for lyrics/title glow */
+  coverColor?: string;
+  /** Offset in milliseconds to adjust lyrics timing for this track (positive = lyrics earlier) */
+  lyricOffset?: number;
+  /** Selected lyrics source from Kugou (user override) */
+  lyricsSource?: LyricsSource;
+  /** Server/library creation time (ms); used for All Songs order (newest first) */
+  createdAt?: number;
+  /** Stable sequence when createdAt ties (e.g. bulk import index) */
+  importOrder?: number;
+  /** Last metadata update from server (ms); tiebreaker for list order */
+  updatedAt?: number;
+  /** Origin of this track. Defaults to "youtube" when unset for back-compat. */
+  source?: LibrarySource;
+  /** Track duration in milliseconds (Apple Music exposes this up front). */
+  durationMs?: number;
+  /** Apple Music play parameters used to drive MusicKit playback. */
+  appleMusicPlayParams?: AppleMusicPlayParams;
+}
+
+/** Video in the Videos / TV library. */
+export type VideoItem = MediaItemBase;
+
+export type MediaItemKind = "song" | "video";
+
+/** A library item tagged with which library it came from. */
+export interface MediaItem extends MediaItemBase {
+  kind: MediaItemKind;
+}
+
+export function trackToMediaItem(track: Track): MediaItem {
+  return {
+    id: track.id,
+    url: track.url,
+    title: track.title,
+    artist: track.artist,
+    kind: "song",
+  };
+}
+
+export function videoToMediaItem(video: VideoItem): MediaItem {
+  return {
+    id: video.id,
+    url: video.url,
+    title: video.title,
+    artist: video.artist,
+    kind: "video",
+  };
+}
+
+/**
+ * Project a song onto the video shape (used by the TV app's MTV channel,
+ * which plays the music library as a channel lineup).
+ */
+export function trackToVideoItem(track: Track): VideoItem {
+  return {
+    id: track.id,
+    url: track.url,
+    title: track.title,
+    artist: track.artist,
+  };
+}

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -63,17 +63,20 @@ const debug = createClientLogger("IpodStore").debug;
 /** Special value for lyricsTranslationLanguage that means "use ryOS locale" */
 export const LYRICS_TRANSLATION_AUTO = "auto";
 
-/** Lyrics source from Kugou */
-export interface LyricsSource {
-  hash: string;
-  albumId: string | number;
-  title: string;
-  artist: string;
-  album?: string;
-}
-
-/** Library source the iPod is currently displaying. */
-export type LibrarySource = "youtube" | "appleMusic";
+// Track / library item types moved to the shared MediaCore library model so
+// the server (`api/_utils/song-library-state.ts`) and other apps stop
+// importing them from this store. Re-exported here for compatibility.
+export type {
+  AppleMusicPlayParams,
+  LibrarySource,
+  LyricsSource,
+  Track,
+} from "@/shared/media/library";
+import type {
+  LibrarySource,
+  LyricsSource,
+  Track,
+} from "@/shared/media/library";
 
 export const IPOD_BACKLIGHT_TIMEOUT_OPTIONS = ["2s", "10s", "always-on", "off"] as const;
 export type IpodBacklightTimeout = (typeof IPOD_BACKLIGHT_TIMEOUT_OPTIONS)[number];
@@ -110,54 +113,6 @@ export interface AppleMusicPlaylist {
   description?: string;
   trackCount?: number;
   canEdit?: boolean;
-}
-
-/** Apple Music play parameters needed for `setQueue` (catalog vs library). */
-export interface AppleMusicPlayParams {
-  /** Catalog song ID (numeric string) when available — preferred for setQueue. */
-  catalogId?: string;
-  /** Library song ID (`i.<hash>` form) for personal library tracks. */
-  libraryId?: string;
-  /** Catalog station ID (`ra.*` form) for Apple Music radio playback. */
-  stationId?: string;
-  /** Catalog playlist ID (`pl.*` form) for recommendation playback. */
-  playlistId?: string;
-  /** MusicKit kind, e.g. "song", "library-song". */
-  kind: string;
-  isLibrary?: boolean;
-}
-
-// Define the Track type (can be shared or defined here)
-export interface Track {
-  id: string;
-  url: string;
-  title: string;
-  artist?: string;
-  album?: string;
-  /** Album-level artist for grouping compilations/collaborative albums. */
-  albumArtist?: string;
-  /** Apple Music album/library album id when available, used for album grouping. */
-  appleMusicAlbumId?: string;
-  /** Cover image URL from Kugou */
-  cover?: string;
-  /** Cached boosted cover color for lyrics/title glow */
-  coverColor?: string;
-  /** Offset in milliseconds to adjust lyrics timing for this track (positive = lyrics earlier) */
-  lyricOffset?: number;
-  /** Selected lyrics source from Kugou (user override) */
-  lyricsSource?: LyricsSource;
-  /** Server/library creation time (ms); used for All Songs order (newest first) */
-  createdAt?: number;
-  /** Stable sequence when createdAt ties (e.g. bulk import index) */
-  importOrder?: number;
-  /** Last metadata update from server (ms); tiebreaker for list order */
-  updatedAt?: number;
-  /** Origin of this track. Defaults to "youtube" when unset for back-compat. */
-  source?: LibrarySource;
-  /** Track duration in milliseconds (Apple Music exposes this up front). */
-  durationMs?: number;
-  /** Apple Music play parameters used to drive MusicKit playback. */
-  appleMusicPlayParams?: AppleMusicPlayParams;
 }
 
 function updateTrackCoverColorList(

--- a/src/stores/useMediaLibraryStore.ts
+++ b/src/stores/useMediaLibraryStore.ts
@@ -1,3 +1,13 @@
+/**
+ * Unified media library API (MediaCore Phase 3).
+ *
+ * One read surface over the two physical libraries — songs in
+ * `useIpodStore.tracks` and videos in `useVideoStore.videos`. The physical
+ * stores (and therefore the Cloud Sync v2 `songs/*` and `videos/*` wire
+ * format) are unchanged; this module is where cross-app consumers and the
+ * AI `mediaControl` tool resolve library items without knowing which app
+ * owns them.
+ */
 import {
   flushPendingLyricOffsetSave,
   getEffectiveTranslationLanguage,
@@ -5,9 +15,17 @@ import {
   useIpodStore,
   type Track,
 } from "@/stores/useIpodStore";
+import { useVideoStore } from "@/stores/useVideoStore";
+import {
+  trackToMediaItem,
+  videoToMediaItem,
+  type MediaItem,
+  type MediaItemKind,
+} from "@/shared/media/library";
 import { useStoreShallow } from "./helpers";
 
 export type { Track } from "@/stores/useIpodStore";
+export type { MediaItem, MediaItemKind } from "@/shared/media/library";
 export {
   flushPendingLyricOffsetSave,
   getEffectiveTranslationLanguage,
@@ -16,10 +34,36 @@ export {
 
 export type MediaLibraryState = ReturnType<typeof useIpodStore.getState>;
 
+/**
+ * The music library store. Karaoke / Winamp / MTV consumers read tracks
+ * through this alias rather than reaching into the iPod app's store.
+ */
 export const useMediaLibraryStore = useIpodStore;
 
 export function getMediaLibraryTracks(): Track[] {
   return useIpodStore.getState().tracks;
+}
+
+/** All library items of a kind — or the whole unified library. */
+export function getMediaLibraryItems(kind?: MediaItemKind): MediaItem[] {
+  const songs =
+    kind === "video"
+      ? []
+      : useIpodStore.getState().tracks.map(trackToMediaItem);
+  const videos =
+    kind === "song"
+      ? []
+      : useVideoStore.getState().videos.map(videoToMediaItem);
+  return [...songs, ...videos];
+}
+
+/** Resolve a library item by id across both libraries (songs win ties). */
+export function findMediaLibraryItem(id: string): MediaItem | null {
+  const track = useIpodStore.getState().tracks.find((t) => t.id === id);
+  if (track) return trackToMediaItem(track);
+  const video = useVideoStore.getState().videos.find((v) => v.id === id);
+  if (video) return videoToMediaItem(video);
+  return null;
 }
 
 /**

--- a/src/stores/useVideoStore.ts
+++ b/src/stores/useVideoStore.ts
@@ -8,12 +8,11 @@ import {
 } from "@/shared/media/confirmedPlayback";
 import { createTransportActions } from "@/shared/media/transport";
 
-export interface Video {
-  id: string;
-  url: string;
-  title: string;
-  artist?: string;
-}
+// The video item shape now lives in the shared MediaCore library model
+// (`Video` is a strict subset of the music `Track`). Re-exported here for
+// compatibility with existing importers.
+export type { VideoItem as Video } from "@/shared/media/library";
+import type { VideoItem as Video } from "@/shared/media/library";
 
 export const DEFAULT_VIDEOS: Video[] = [
   {

--- a/tests/test-media-library-unified.test.ts
+++ b/tests/test-media-library-unified.test.ts
@@ -1,0 +1,158 @@
+/**
+ * MediaCore Phase 3 — unified library model + API.
+ *
+ * The unified `MediaItem` API must merge both physical libraries without
+ * changing them, and the Cloud Sync v2 songs/videos wire format must remain
+ * byte-identical to the pre-Phase-3 shape.
+ */
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+class MemoryStorage implements Storage {
+  private readonly map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.map.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+}
+
+const browserGlobals = globalThis as typeof globalThis & {
+  localStorage?: Storage;
+};
+if (!browserGlobals.localStorage) {
+  Object.defineProperty(browserGlobals, "localStorage", {
+    configurable: true,
+    value: new MemoryStorage(),
+    writable: true,
+  });
+}
+
+const {
+  trackToMediaItem,
+  trackToVideoItem,
+  videoToMediaItem,
+} = await import("../src/shared/media/library");
+const { useIpodStore } = await import("../src/stores/useIpodStore");
+const { useVideoStore } = await import("../src/stores/useVideoStore");
+const { getMediaLibraryItems, findMediaLibraryItem } = await import(
+  "../src/stores/useMediaLibraryStore"
+);
+type Track = import("../src/shared/media/library").Track;
+
+const track: Track = {
+  id: "song1",
+  url: "https://youtu.be/song1",
+  title: "Song One",
+  artist: "Artist A",
+  album: "Album A",
+  cover: "https://example.com/cover.jpg",
+  lyricOffset: 250,
+};
+
+describe("media item converters", () => {
+  test("trackToMediaItem keeps identity fields and tags kind=song", () => {
+    expect(trackToMediaItem(track)).toEqual({
+      id: "song1",
+      url: "https://youtu.be/song1",
+      title: "Song One",
+      artist: "Artist A",
+      kind: "song",
+    });
+  });
+
+  test("videoToMediaItem tags kind=video", () => {
+    expect(
+      videoToMediaItem({ id: "v1", url: "u", title: "T", artist: "A" })
+    ).toEqual({ id: "v1", url: "u", title: "T", artist: "A", kind: "video" });
+  });
+
+  test("trackToVideoItem matches the TV app's historical projection", () => {
+    // Exact shape the MTV channel used to build via its local trackToVideo.
+    expect(trackToVideoItem(track)).toEqual({
+      id: "song1",
+      url: "https://youtu.be/song1",
+      title: "Song One",
+      artist: "Artist A",
+    });
+  });
+});
+
+describe("unified library API", () => {
+  beforeEach(() => {
+    useIpodStore.setState({ tracks: [track] });
+    useVideoStore.setState({
+      videos: [{ id: "vid1", url: "https://youtu.be/vid1", title: "Video 1" }],
+      currentVideoId: "vid1",
+    });
+  });
+
+  test("getMediaLibraryItems merges both libraries with kind tags", () => {
+    const items = getMediaLibraryItems();
+    expect(items.map((i) => `${i.kind}:${i.id}`)).toEqual([
+      "song:song1",
+      "video:vid1",
+    ]);
+  });
+
+  test("getMediaLibraryItems filters by kind", () => {
+    expect(getMediaLibraryItems("song").map((i) => i.id)).toEqual(["song1"]);
+    expect(getMediaLibraryItems("video").map((i) => i.id)).toEqual(["vid1"]);
+  });
+
+  test("findMediaLibraryItem resolves across libraries", () => {
+    expect(findMediaLibraryItem("song1")?.kind).toBe("song");
+    expect(findMediaLibraryItem("vid1")?.kind).toBe("video");
+    expect(findMediaLibraryItem("missing")).toBeNull();
+  });
+});
+
+describe("sync wire format is unchanged", () => {
+  test("songs and videos codecs emit the exact pre-Phase-3 keys and payloads", async () => {
+    const { SYNC_CODECS } = await import("../src/sync/codecs");
+    const songsCodec = SYNC_CODECS.songs;
+    const videosCodec = SYNC_CODECS.videos;
+
+    useIpodStore.setState({
+      tracks: [track],
+      libraryState: "loaded",
+      lastKnownVersion: 7,
+    });
+    useVideoStore.setState({
+      videos: [{ id: "vid1", url: "https://youtu.be/vid1", title: "Video 1" }],
+    });
+
+    const songDocs = songsCodec.collect();
+    expect(JSON.stringify(songDocs.get("songs/track:song1"))).toBe(
+      JSON.stringify(track)
+    );
+    expect(songDocs.get("songs/lib")).toEqual({
+      libraryState: "loaded",
+      lastKnownVersion: 7,
+      order: ["song1"],
+    });
+
+    const videoDocs = videosCodec.collect();
+    expect(JSON.stringify(videoDocs.get("videos/video:vid1"))).toBe(
+      JSON.stringify({
+        id: "vid1",
+        url: "https://youtu.be/vid1",
+        title: "Video 1",
+      })
+    );
+    expect(videoDocs.get("videos/lib")).toEqual({ order: ["vid1"] });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> [!IMPORTANT]
> **Superseded by #1757**, which collapses all MediaCore phases into one PR against `main`. Close this PR without merging.

## Summary

Phase 3 of `docs/proposals/media-core.md` (stacked on Phase 2, PR #1753): one library model over songs and videos, with the Cloud Sync v2 wire format provably unchanged.

- `src/shared/media/library.ts` — the unified model: `MediaItemBase`, `Track` (song), `VideoItem`, and kind-tagged `MediaItem` with converters (`trackToMediaItem`, `videoToMediaItem`, `trackToVideoItem`). `Track`, `LyricsSource`, `LibrarySource`, `AppleMusicPlayParams` moved here out of `useIpodStore` (re-exported for compatibility — no importer churn). The module is client-import-free so the server can use it.
- `api/_utils/song-library-state.ts` now imports `Track` from the shared model instead of reaching into the iPod app's store.
- `useMediaLibraryStore` grows the unified read API: `getMediaLibraryItems(kind?)` merges both libraries with kind tags; `findMediaLibraryItem(id)` resolves across them. Phase 5's `mediaControl` resolves items here instead of knowing which app owns what.
- `useVideoStore`'s `Video` re-exports the shared `VideoItem`; TV's local `trackToVideo` projection replaced by the shared `trackToVideoItem`.

Scope note (deviation from the proposal, deliberate): the physical storage stays in `useIpodStore.tracks` / `useVideoStore.videos` rather than moving data into a new store. This keeps the sync codecs, persist pipelines, IndexedDB storage, and v42 migration chain untouched — the wire-format fixture test below locks that in. The single-physical-store merge remains possible later behind this API without touching any consumer again.

## Testing

- ✅ `bun test tests/test-media-library-unified.test.ts` (7 new tests: converters, kind filtering, cross-library resolution, TV projection parity, and a **byte-identical sync codec fixture** for `songs/track:*`, `songs/lib`, `videos/video:*`, `videos/lib`)
- ✅ `bun run test:sync-v2:unit` scope: `test-sync-v2-codecs` (41), `test-songs-tombstone-sync` (3)
- ✅ iPod suites: `test-ipod-playback-navigation`, `test-ipod-apple-music` (86), `test-ipod-track-order`, `test-ipod-track-metadata-sync`
- ✅ `test-media-transport-parity` (Phase 0 guardrails), `test-media-library-store-facade`, `test-tv-utils`, `test-vfs-virtual-trees`, `test-media-now-playing-arbitration`, `test-boot-import-graph`
- ✅ `bunx tsc -p tsconfig.app.json --noEmit` and `bunx tsc -p tsconfig.node.json --noEmit`
- ✅ `bunx eslint` on all changed files (clean)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2808-4335-7fed-9f5b-ffbbb0bcd4b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2808-4335-7fed-9f5b-ffbbb0bcd4b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

