### PR TITLE
MediaCore Phase 4: extract shared media hooks from app logic

### DIFF
--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -15,6 +15,8 @@ import { useCustomEventListener, useEventListener } from "@/hooks/useEventListen
 import { useLibraryUpdateChecker } from "./useLibraryUpdateChecker";
 import { useIpodActiveLibrary } from "./useIpodActiveLibrary";
 import { useIpodPlayback } from "./useIpodPlayback";
+import { useActiveMediaPlayer } from "@/shared/media/useActiveMediaPlayer";
+import { useLyricOffsetTrackChange } from "@/shared/media/useLyricOffsetTrackChange";
 import { useIpodScale } from "./useIpodScale";
 import { useIpodStatusBacklight } from "./useIpodStatusBacklight";
 import {
@@ -471,6 +473,7 @@ export function useIpodLogic({
     userHasInteractedRef,
     isTrackSwitchingRef,
     trackSwitchTimeoutRef,
+    startTrackSwitch: startTrackSwitchGuard,
     pauseBeforeWindowClose,
   } = useIpodPlayback({
     isWindowOpen,
@@ -1353,62 +1356,25 @@ export function useIpodLogic({
 
   // Backlight timer + foreground handling live in useIpodStatusBacklight.
 
-  // Reset elapsed time on track change and set track switching guard
-  // This catches track changes from any source (AI tools, shared URLs, menu selections, etc.)
-  // Using null as initial value ensures first render triggers the auto-skip check
-  const prevCurrentIndexRef = useRef<number | null>(null);
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    // Check if track changed or this is initial render (prevCurrentIndexRef.current is null)
-    if (prevCurrentIndexRef.current !== currentIndex) {
-      isTrackSwitchingRef.current = true;
-      if (trackSwitchTimeoutRef.current) {
-        clearTimeout(trackSwitchTimeoutRef.current);
-      }
-      
-      // Get the new track's offset
-      const newTrack = tracks[currentIndex];
-      const newLyricOffset = newTrack?.lyricOffset ?? 0;
-      
-      // For negative offset, auto-skip to where lyrics time = 0
-      // Formula: lyricsTime = playerTime + (lyricOffset / 1000)
-      // When lyricsTime = 0: playerTime = -lyricOffset / 1000
-      // Only seek if offset is negative (produces positive seek target)
-      // and the seek target is reasonable (less than track duration, at least 1 second)
-      const seekTarget = -newLyricOffset / 1000;
-      
-      if (newLyricOffset < 0 && seekTarget >= 1) {
-        useIpodStore.getState().setElapsedTime(seekTarget);
-        
-        timeoutId = setTimeout(() => {
-          isTrackSwitchingRef.current = false;
-          const activePlayer = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
-          if (activePlayer) {
-            activePlayer.seekTo(seekTarget);
-            showStatus(`▶ ${formatSecondsAsMinutesSeconds(seekTarget)}`);
-          }
-        }, 2000);
-        trackSwitchTimeoutRef.current = timeoutId;
-      } else {
-        // Start from beginning for positive/zero offset or small negative offset
-        useIpodStore.getState().setElapsedTime(0);
-        timeoutId = setTimeout(() => {
-          isTrackSwitchingRef.current = false;
-        }, 2000);
-        trackSwitchTimeoutRef.current = timeoutId;
-      }
-    }
-    prevCurrentIndexRef.current = currentIndex;
-    return () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        if (trackSwitchTimeoutRef.current === timeoutId) {
-          trackSwitchTimeoutRef.current = null;
-        }
-      }
-    };
-  }, [currentIndex, tracks, isFullScreen, showStatus]);
+  // Reset elapsed time on track change, arm the track-switch guard, and
+  // auto-seek for negative lyric offsets (shared MediaCore behavior).
+  const getActiveReactPlayer = useActiveMediaPlayer(
+    isFullScreen,
+    playerRef,
+    fullScreenPlayerRef
+  );
+  const setIpodElapsedTime = useCallback((seconds: number) => {
+    useIpodStore.getState().setElapsedTime(seconds);
+  }, []);
+  useLyricOffsetTrackChange({
+    currentIndex,
+    tracks,
+    isFullScreen,
+    guard: { isTrackSwitchingRef, trackSwitchTimeoutRef, startTrackSwitch: startTrackSwitchGuard },
+    getActivePlayer: getActiveReactPlayer,
+    setElapsedTime: setIpodElapsedTime,
+    showStatus,
+  });
 
   // Cleanup track-switch timeout on unmount (status timeout cleanup lives in
   // useIpodStatusBacklight).
@@ -3620,16 +3586,8 @@ export function useIpodLogic({
       playbackRequested: state.playbackRequested,
       isPlaying: state.isPlaying,
     });
-    isTrackSwitchingRef.current = true;
-    if (trackSwitchTimeoutRef.current) {
-      clearTimeout(trackSwitchTimeoutRef.current);
-    }
-    // Allow 2 seconds for YouTube to load before accepting play/pause events
-    trackSwitchTimeoutRef.current = setTimeout(() => {
-      isTrackSwitchingRef.current = false;
-      ipodLog.debug("Ended track-switch guard");
-    }, 2000);
-  }, []);
+    startTrackSwitchGuard();
+  }, [startTrackSwitchGuard]);
 
   const getCurrentAppleMusicCollectionShellTrack = useCallback(() => {
     const state = useIpodStore.getState();

--- a/src/apps/ipod/hooks/useIpodPlayback.ts
+++ b/src/apps/ipod/hooks/useIpodPlayback.ts
@@ -1,6 +1,7 @@
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import type ReactPlayer from "react-player";
 import { useIpodStore } from "@/stores/useIpodStore";
+import { useTrackSwitchGuard } from "@/shared/media/useTrackSwitchGuard";
 import { createClientLogger } from "@/utils/logger";
 
 const ipodLog = createClientLogger("iPod");
@@ -26,8 +27,10 @@ export function useIpodPlayback(options: {
   const lastTrackedSongRef = useRef<{ trackId: string; elapsedTime: number } | null>(null);
   const skipOperationRef = useRef(false);
   const userHasInteractedRef = useRef(false);
-  const isTrackSwitchingRef = useRef(false);
-  const trackSwitchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const { isTrackSwitchingRef, trackSwitchTimeoutRef, startTrackSwitch } =
+    useTrackSwitchGuard({
+      onGuardEnd: () => ipodLog.debug("Ended track-switch guard"),
+    });
 
   const pauseBeforeWindowClose = useCallback(() => {
     const store = useIpodStore.getState();
@@ -104,6 +107,7 @@ export function useIpodPlayback(options: {
     userHasInteractedRef,
     isTrackSwitchingRef,
     trackSwitchTimeoutRef,
+    startTrackSwitch,
     pauseBeforeWindowClose,
   };
 }

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -36,6 +36,9 @@ import { onAppUpdate } from "@/utils/appEventBus";
 import { MEDIA_ANALYTICS, track as trackAnalytics } from "@/utils/analytics";
 import { formatSecondsAsMinutesSeconds } from "@/utils/timeFormat";
 import { shouldRestartTrackOnPrevious } from "@/shared/media/previousTrackBehavior";
+import { useTrackSwitchGuard } from "@/shared/media/useTrackSwitchGuard";
+import { useActiveMediaPlayer } from "@/shared/media/useActiveMediaPlayer";
+import { useLyricOffsetTrackChange } from "@/shared/media/useLyricOffsetTrackChange";
 import { createClientLogger } from "@/utils/logger";
 
 // User-agent sniffing is constant for the document lifetime, so compute once
@@ -296,8 +299,13 @@ export function useKaraokeLogic({
   const hideControlsTimeoutRef = useRef<number | null>(null);
 
   // Track switching state to prevent race conditions
-  const isTrackSwitchingRef = useRef(false);
-  const trackSwitchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const {
+    isTrackSwitchingRef,
+    trackSwitchTimeoutRef,
+    startTrackSwitch: startTrackSwitchGuard,
+  } = useTrackSwitchGuard({
+    onGuardEnd: () => karaokeLog.debug("Ended track-switch guard"),
+  });
 
   // Volume from audio settings store
   const { ipodVolume } = useAudioSettingsStoreShallow((state) => ({ ipodVolume: state.ipodVolume }));
@@ -454,9 +462,10 @@ export function useKaraokeLogic({
     tracks,
   ]);
 
-  const getActivePlayer = useCallback(
-    () => (isFullScreen ? fullScreenPlayerRef.current : playerRef.current),
-    [isFullScreen]
+  const getActivePlayer = useActiveMediaPlayer(
+    isFullScreen,
+    playerRef,
+    fullScreenPlayerRef
   );
 
   const pushListenState = useCallback(async () => {
@@ -547,16 +556,8 @@ export function useKaraokeLogic({
       playbackRequested: state.playbackRequested,
       isPlaying: state.isPlaying,
     });
-    isTrackSwitchingRef.current = true;
-    if (trackSwitchTimeoutRef.current) {
-      clearTimeout(trackSwitchTimeoutRef.current);
-    }
-    // Allow 2 seconds for YouTube to load before accepting play/pause events
-    trackSwitchTimeoutRef.current = setTimeout(() => {
-      isTrackSwitchingRef.current = false;
-      karaokeLog.debug("Ended track-switch guard");
-    }, 2000);
-  }, []);
+    startTrackSwitchGuard();
+  }, [startTrackSwitchGuard]);
 
   // Classic click-wheel iPod behavior: restart the current track when the
   // back button is pressed after the song is already underway, instead of
@@ -696,69 +697,29 @@ export function useKaraokeLogic({
     };
   }, [isPlaying, anyMenuOpen, isSyncModeOpen, restartAutoHideTimer]);
 
-  // Reset elapsed time on track change and set track switching guard
-  // This catches track changes from any source (AI tools, shared URLs, menu selections, etc.)
-  // Using null as initial value ensures first render triggers the auto-skip check
-  const prevCurrentIndexRef = useRef<number | null>(null);
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    // Check if track changed or this is initial render (prevCurrentIndexRef.current is null)
-    if (prevCurrentIndexRef.current !== currentIndex) {
+  // Reset elapsed time on track change, arm the track-switch guard, and
+  // auto-seek for negative lyric offsets (shared MediaCore behavior).
+  useLyricOffsetTrackChange({
+    currentIndex,
+    tracks,
+    isFullScreen,
+    guard: {
+      isTrackSwitchingRef,
+      trackSwitchTimeoutRef,
+      startTrackSwitch: startTrackSwitchGuard,
+    },
+    getActivePlayer,
+    setElapsedTime: setStoreElapsedTime,
+    showStatus,
+    onTrackChange: (info) =>
       karaokeLog.debug("Selected track changed", {
-        previousIndex: prevCurrentIndexRef.current,
-        currentIndex,
-        currentTrackId: tracks[currentIndex]?.id ?? null,
-        lyricOffset: tracks[currentIndex]?.lyricOffset ?? 0,
+        previousIndex: info.previousIndex,
+        currentIndex: info.currentIndex,
+        currentTrackId: info.trackId,
+        lyricOffset: info.lyricOffset,
         isFullScreen,
-      });
-      isTrackSwitchingRef.current = true;
-      if (trackSwitchTimeoutRef.current) {
-        clearTimeout(trackSwitchTimeoutRef.current);
-      }
-      
-      // Get the new track's offset
-      const newTrack = tracks[currentIndex];
-      const newLyricOffset = newTrack?.lyricOffset ?? 0;
-      
-      // For negative offset, auto-skip to where lyrics time = 0
-      // Formula: lyricsTime = playerTime + (lyricOffset / 1000)
-      // When lyricsTime = 0: playerTime = -lyricOffset / 1000
-      // Only seek if offset is negative (produces positive seek target)
-      // and the seek target is reasonable (at least 1 second)
-      const seekTarget = -newLyricOffset / 1000;
-      
-      if (newLyricOffset < 0 && seekTarget >= 1) {
-        setStoreElapsedTime(seekTarget);
-        
-        timeoutId = setTimeout(() => {
-          isTrackSwitchingRef.current = false;
-          const activePlayer = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
-          if (activePlayer) {
-            activePlayer.seekTo(seekTarget);
-            showStatus(`▶ ${formatSecondsAsMinutesSeconds(seekTarget)}`);
-          }
-        }, 2000);
-        trackSwitchTimeoutRef.current = timeoutId;
-      } else {
-        // Start from beginning for positive/zero offset or small negative offset
-        setStoreElapsedTime(0);
-        timeoutId = setTimeout(() => {
-          isTrackSwitchingRef.current = false;
-        }, 2000);
-        trackSwitchTimeoutRef.current = timeoutId;
-      }
-    }
-    prevCurrentIndexRef.current = currentIndex;
-    return () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        if (trackSwitchTimeoutRef.current === timeoutId) {
-          trackSwitchTimeoutRef.current = null;
-        }
-      }
-    };
-  }, [currentIndex, tracks, isFullScreen, showStatus, setStoreElapsedTime]);
+      }),
+  });
 
   // Cleanup
   useEffect(() => {

--- a/src/apps/videos/hooks/useVideosLogic.ts
+++ b/src/apps/videos/hooks/useVideosLogic.ts
@@ -17,6 +17,7 @@ import { onAppUpdate } from "@/utils/appEventBus";
 import { MEDIA_ANALYTICS, track } from "@/utils/analytics";
 import { formatSecondsMmSs } from "@/utils/formatDuration";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { useTrackSwitchGuard } from "@/shared/media/useTrackSwitchGuard";
 import { createClientLogger } from "@/utils/logger";
 
 const log = createClientLogger("Videos");
@@ -229,8 +230,8 @@ export function useVideosLogic({
   const playerRef = useRef<ReactPlayer | null>(null);
   const fullScreenPlayerRef = useRef<ReactPlayer | null>(null);
   const statusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const isTrackSwitchingRef = useRef(false);
-  const trackSwitchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const { isTrackSwitchingRef, trackSwitchTimeoutRef, startTrackSwitch } =
+    useTrackSwitchGuard();
   const prevIsPlayingRef = useRef(isPlaying);
   const autoShowHoverResetRef = useRef<NodeJS.Timeout | null>(null);
   const hasAutoplayCheckedRef = useRef(false);
@@ -250,18 +251,6 @@ export function useVideosLogic({
     pointerId: number | null;
   } | null>(null);
   const SWIPE_MOVE_THRESHOLD = 10; // px
-
-  // Helper to mark track/fullscreen switch start and schedule end
-  const startTrackSwitch = useCallback(() => {
-    isTrackSwitchingRef.current = true;
-    if (trackSwitchTimeoutRef.current) {
-      clearTimeout(trackSwitchTimeoutRef.current);
-    }
-    // Allow 2 seconds for YouTube to load before accepting play/pause events
-    trackSwitchTimeoutRef.current = setTimeout(() => {
-      isTrackSwitchingRef.current = false;
-    }, 2000);
-  }, []);
 
   // Function to show status message
   const showStatus = useCallback(

--- a/src/shared/media/useActiveMediaPlayer.ts
+++ b/src/shared/media/useActiveMediaPlayer.ts
@@ -1,0 +1,17 @@
+import { useCallback } from "react";
+
+/**
+ * Selects the player instance that is currently visible — the fullscreen
+ * portal player while fullscreen is active, the windowed player otherwise.
+ * Shared by the media apps' seek / listen-sync / restart paths.
+ */
+export function useActiveMediaPlayer<T>(
+  isFullScreen: boolean,
+  playerRef: React.MutableRefObject<T | null>,
+  fullScreenPlayerRef: React.MutableRefObject<T | null>
+): () => T | null {
+  return useCallback(
+    () => (isFullScreen ? fullScreenPlayerRef.current : playerRef.current),
+    [isFullScreen, playerRef, fullScreenPlayerRef]
+  );
+}

--- a/src/shared/media/useLyricOffsetTrackChange.ts
+++ b/src/shared/media/useLyricOffsetTrackChange.ts
@@ -1,0 +1,127 @@
+import { useEffect, useRef } from "react";
+import { formatSecondsAsMinutesSeconds } from "@/utils/timeFormat";
+import type { TrackSwitchGuard } from "./useTrackSwitchGuard";
+
+interface LyricOffsetTrack {
+  id: string;
+  lyricOffset?: number;
+}
+
+/**
+ * Where playback should start for a track's lyric offset. Only a negative
+ * offset produces a positive seek target; targets under 1s start from 0.
+ * Formula: lyricsTime = playerTime + (lyricOffset / 1000); when
+ * lyricsTime = 0, playerTime = -lyricOffset / 1000.
+ */
+export function getLyricOffsetSeekTarget(lyricOffset: number): number | null {
+  const seekTarget = -lyricOffset / 1000;
+  return lyricOffset < 0 && seekTarget >= 1 ? seekTarget : null;
+}
+
+/**
+ * MediaCore track-change guard + negative-lyric-offset auto-seek (Phase 4).
+ *
+ * On every track change (from any source — AI tools, shared URLs, menu
+ * selections) the iPod and Karaoke apps arm the track-switch guard, reset
+ * the playback clock, and — when the new track has a negative lyric offset —
+ * seek to where lyrics time hits 0 once the player has loaded.
+ *
+ * Formula: lyricsTime = playerTime + (lyricOffset / 1000); when
+ * lyricsTime = 0, playerTime = -lyricOffset / 1000. Only negative offsets
+ * produce a positive seek target, and targets under 1s just start from 0.
+ */
+export function useLyricOffsetTrackChange(args: {
+  currentIndex: number;
+  tracks: readonly LyricOffsetTrack[];
+  isFullScreen: boolean;
+  guard: TrackSwitchGuard;
+  getActivePlayer: () => { seekTo: (seconds: number) => void } | null;
+  setElapsedTime: (seconds: number) => void;
+  showStatus: (message: string) => void;
+  /** Optional app-specific debug logging on each track change. */
+  onTrackChange?: (info: {
+    previousIndex: number | null;
+    currentIndex: number;
+    trackId: string | null;
+    lyricOffset: number;
+  }) => void;
+}): void {
+  const {
+    currentIndex,
+    tracks,
+    isFullScreen,
+    guard,
+    getActivePlayer,
+    setElapsedTime,
+    showStatus,
+    onTrackChange,
+  } = args;
+  const { isTrackSwitchingRef, trackSwitchTimeoutRef } = guard;
+  // Using null as the initial value ensures the first render triggers the
+  // auto-skip check.
+  const prevCurrentIndexRef = useRef<number | null>(null);
+  const onTrackChangeRef = useRef(onTrackChange);
+  onTrackChangeRef.current = onTrackChange;
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    if (prevCurrentIndexRef.current !== currentIndex) {
+      const newTrack = tracks[currentIndex];
+      const newLyricOffset = newTrack?.lyricOffset ?? 0;
+      onTrackChangeRef.current?.({
+        previousIndex: prevCurrentIndexRef.current,
+        currentIndex,
+        trackId: newTrack?.id ?? null,
+        lyricOffset: newLyricOffset,
+      });
+
+      isTrackSwitchingRef.current = true;
+      if (trackSwitchTimeoutRef.current) {
+        clearTimeout(trackSwitchTimeoutRef.current);
+      }
+
+      const seekTarget = getLyricOffsetSeekTarget(newLyricOffset);
+
+      if (seekTarget !== null) {
+        setElapsedTime(seekTarget);
+
+        timeoutId = setTimeout(() => {
+          isTrackSwitchingRef.current = false;
+          const activePlayer = getActivePlayer();
+          if (activePlayer) {
+            activePlayer.seekTo(seekTarget);
+            showStatus(`▶ ${formatSecondsAsMinutesSeconds(seekTarget)}`);
+          }
+        }, 2000);
+        trackSwitchTimeoutRef.current = timeoutId;
+      } else {
+        // Start from the beginning for positive/zero or small negative offsets.
+        setElapsedTime(0);
+        timeoutId = setTimeout(() => {
+          isTrackSwitchingRef.current = false;
+        }, 2000);
+        trackSwitchTimeoutRef.current = timeoutId;
+      }
+    }
+    prevCurrentIndexRef.current = currentIndex;
+    return () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        if (trackSwitchTimeoutRef.current === timeoutId) {
+          trackSwitchTimeoutRef.current = null;
+        }
+      }
+    };
+    // isFullScreen re-arms the effect so the deferred seek targets the active
+    // player, matching the historical per-app effects.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    currentIndex,
+    tracks,
+    isFullScreen,
+    getActivePlayer,
+    setElapsedTime,
+    showStatus,
+  ]);
+}

--- a/src/shared/media/useTrackSwitchGuard.ts
+++ b/src/shared/media/useTrackSwitchGuard.ts
@@ -1,0 +1,54 @@
+import { useCallback, useRef } from "react";
+
+/**
+ * MediaCore track-switch guard (Phase 4).
+ *
+ * The media apps ignore spurious ReactPlayer play/pause events for a short
+ * window after a track (or fullscreen) switch, because YouTube embeds emit
+ * transient state churn while loading. Previously the iPod, Karaoke, and
+ * Videos hooks each hand-rolled the same two refs + timeout dance.
+ *
+ * The refs are exposed directly so app-specific effects (lyric-offset seek,
+ * fullscreen sync) can keep managing bespoke guard windows.
+ */
+export interface TrackSwitchGuard {
+  /** True while player events should be ignored. */
+  isTrackSwitchingRef: React.MutableRefObject<boolean>;
+  /** Pending guard-clearing timeout, shared across guard writers. */
+  trackSwitchTimeoutRef: React.MutableRefObject<ReturnType<
+    typeof setTimeout
+  > | null>;
+  /** Begin a guard window; clears any previous pending timeout. */
+  startTrackSwitch: (durationMs?: number) => void;
+}
+
+export const TRACK_SWITCH_GUARD_MS = 2000;
+
+export function useTrackSwitchGuard(options?: {
+  /** Called when a `startTrackSwitch` guard window ends (debug logging). */
+  onGuardEnd?: () => void;
+}): TrackSwitchGuard {
+  const isTrackSwitchingRef = useRef(false);
+  const trackSwitchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const onGuardEndRef = useRef(options?.onGuardEnd);
+  onGuardEndRef.current = options?.onGuardEnd;
+
+  const startTrackSwitch = useCallback(
+    (durationMs: number = TRACK_SWITCH_GUARD_MS) => {
+      isTrackSwitchingRef.current = true;
+      if (trackSwitchTimeoutRef.current) {
+        clearTimeout(trackSwitchTimeoutRef.current);
+      }
+      // Allow the player to load before accepting play/pause events again.
+      trackSwitchTimeoutRef.current = setTimeout(() => {
+        isTrackSwitchingRef.current = false;
+        onGuardEndRef.current?.();
+      }, durationMs);
+    },
+    []
+  );
+
+  return { isTrackSwitchingRef, trackSwitchTimeoutRef, startTrackSwitch };
+}

--- a/tests/test-media-lyric-offset-seek.test.ts
+++ b/tests/test-media-lyric-offset-seek.test.ts
@@ -1,0 +1,25 @@
+/**
+ * MediaCore Phase 4 — lyric-offset auto-seek decision shared by the iPod and
+ * Karaoke track-change effects.
+ */
+import { describe, expect, test } from "bun:test";
+import { getLyricOffsetSeekTarget } from "../src/shared/media/useLyricOffsetTrackChange";
+
+describe("getLyricOffsetSeekTarget", () => {
+  test("negative offsets of 1s or more seek to where lyrics time hits 0", () => {
+    expect(getLyricOffsetSeekTarget(-1000)).toBe(1);
+    expect(getLyricOffsetSeekTarget(-2500)).toBe(2.5);
+    expect(getLyricOffsetSeekTarget(-60000)).toBe(60);
+  });
+
+  test("small negative offsets start from the beginning", () => {
+    expect(getLyricOffsetSeekTarget(-999)).toBeNull();
+    expect(getLyricOffsetSeekTarget(-1)).toBeNull();
+  });
+
+  test("zero and positive offsets start from the beginning", () => {
+    expect(getLyricOffsetSeekTarget(0)).toBeNull();
+    expect(getLyricOffsetSeekTarget(500)).toBeNull();
+    expect(getLyricOffsetSeekTarget(120000)).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> [!IMPORTANT]
> **Superseded by #1757**, which collapses all MediaCore phases into one PR against `main`. Close this PR without merging.

Phase 4 of the MediaCore consolidation plan (`docs/proposals/media-core.md`). Stacked on Phase 3 (`cursor/media-core-phase3-library-d4b7`).

### What

Extracts three near-identical logic blocks that were copy-pasted across the iPod, Karaoke, and Videos app hooks into shared modules under `src/shared/media/`:

- **`useTrackSwitchGuard`** — the `isTrackSwitchingRef` / `trackSwitchTimeoutRef` / `startTrackSwitch` pattern that suppresses spurious play/pause events during track loads (was duplicated in `useIpodPlayback`, `useKaraokeLogic`, `useVideosLogic`). Supports an `onGuardEnd` callback so iPod keeps its debug logging.
- **`useActiveMediaPlayer`** — picks the windowed vs. fullscreen `ReactPlayer` ref based on fullscreen state (was duplicated in iPod and Karaoke).
- **`useLyricOffsetTrackChange`** — the lyric-offset auto-seek effect on track change, with the seek computation extracted as a pure `getLyricOffsetSeekTarget` function (was duplicated in iPod and Karaoke).

### Adoption

- `src/apps/ipod/hooks/useIpodPlayback.ts` and `useIpodLogic.ts`
- `src/apps/karaoke/hooks/useKaraokeLogic.ts`
- `src/apps/videos/hooks/useVideosLogic.ts`

No behavior change intended; per-app logging and timing preserved.

### Testing

- ✅ `bun test tests/test-media-lyric-offset-seek.test.ts` (new pure-function tests)
- ✅ `bun test tests/test-media-transport-parity.test.ts tests/test-media-transport-slice.test.ts tests/test-media-now-playing-arbitration.test.ts tests/test-media-library-unified.test.ts` (74 pass, 0 fail)
- ✅ `bunx tsc -p tsconfig.app.json --noEmit`
- ⚠️ `bunx eslint` on changed files: 0 errors, 92 warnings — all pre-existing-style `react-hooks/exhaustive-deps` warnings in the consuming app hooks (the codebase has these throughout; not introduced-error blockers per AGENTS.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2808-4335-7fed-9f5b-ffbbb0bcd4b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2808-4335-7fed-9f5b-ffbbb0bcd4b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

