### PR TITLE
Fix Stickies glossary inconsistencies in zh-CN and zh-TW

### DIFF
--- a/scripts/apple-ui-terminology-data.ts
+++ b/scripts/apple-ui-terminology-data.ts
@@ -869,6 +869,18 @@ export const RAW_APPLE_UI_TERMINOLOGY = {
     "it": "Borsa",
     "ru": "Акции"
   },
+  "Stickies": {
+    "zh-TW": "便條紙",
+    "zh-CN": "便笺",
+    "ja": "スティッキーズ",
+    "ko": "스티커",
+    "fr": "Aide-mémoire",
+    "de": "Notizzettel",
+    "es": "Notas Adhesivas",
+    "pt": "Anotações",
+    "it": "Memo",
+    "ru": "Записки"
+  },
   "Empty Trash": {
     "zh-TW": "清空垃圾桶",
     "zh-CN": "清倒废纸篓",

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -1462,18 +1462,18 @@
         "skippingToNext": "跳到下一首…",
         "skippingToPrevious": "跳到上一首…",
         "stickies": {
-          "cleared": "已清除 {{count}} 张便笺",
-          "createdWithColor": "已创建{{color}}便笺",
-          "deleted": "便笺已删除",
-          "foundStickies": "找到 {{count}} 张便笺",
+          "cleared": "已清除 {{count}} 张便条",
+          "createdWithColor": "已创建{{color}}便条",
+          "deleted": "便条已删除",
+          "foundStickies": "找到 {{count}} 张便条",
           "invalidAction": "无效的动作：{{action}}",
-          "managing": "正在管理便笺…",
-          "missingId": "缺少便笺 ID",
-          "noStickies": "没有便笺",
+          "managing": "正在管理便条…",
+          "missingId": "缺少便条 ID",
+          "noStickies": "没有便条",
           "noUpdates": "没有提供更新内容",
-          "notFound": "找不到便笺：{{id}}",
-          "nothingToClear": "没有可清除的便笺",
-          "updated": "便笺已更新"
+          "notFound": "找不到便条：{{id}}",
+          "nothingToClear": "没有可清除的便条",
+          "updated": "便条已更新"
         },
         "switchedTo": "已切换至 {{theme}}",
         "switchingTheme": "切换主题…",
@@ -2246,8 +2246,8 @@
           "purple": "紫色",
           "yellow": "黄色"
         },
-        "noteColor": "便笺颜色",
-        "placeholder": "输入便笺…"
+        "noteColor": "便条颜色",
+        "placeholder": "输入便条…"
       },
       "stocks": {
         "allAdded": "已添加所有股票代码",
@@ -3906,7 +3906,7 @@
           "title": "全部清除"
         },
         "colors": {
-          "description": "从「便条」菜单中选择黄色、粉色、蓝色、绿色、紫色等颜色",
+          "description": "从「颜色」菜单中选择黄色、粉色、蓝色、绿色、紫色等颜色",
           "title": "颜色标签"
         },
         "createNote": {

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1070,7 +1070,7 @@
           "title": "與 Ryo 聊天"
         },
         "controlApps": {
-          "description": "Ryo 可以啟動 App、切換主題、移動便條、調整電視以及播放 iPod 歌曲。",
+          "description": "Ryo 可以啟動 App、切換主題、移動便條紙、調整電視以及播放 iPod 歌曲。",
           "title": "控制您的作業系統"
         },
         "createEditFiles": {
@@ -3898,20 +3898,20 @@
       },
       "help": {
         "autoSave": {
-          "description": "筆記會自動儲存，並在下次啟動時顯示在相同位置",
+          "description": "便條紙會自動儲存，下次開啟「便條紙」時仍會顯示在相同位置",
           "title": "自動儲存"
         },
         "clearAll": {
-          "description": "「檔案 ▸ 全部清除筆記」可一次清空佈告欄",
+          "description": "「檔案 ▸ 清除所有便條紙」可一次清空所有便條紙",
           "title": "全部清除"
         },
         "colors": {
-          "description": "從「筆記」選單中選擇黃色、粉紅色、藍色、綠色、紫色等顏色",
+          "description": "從「顏色」選單中選擇黃色、粉紅色、藍色、綠色、紫色等顏色",
           "title": "顏色標籤"
         },
         "createNote": {
-          "description": "檔案 ▸ 新增筆記（或 ⌘N）即可在桌面上放置一個新的便條紙",
-          "title": "建立筆記"
+          "description": "「檔案 ▸ 新增便條紙」（或 ⌘N）即可在桌面上放置一個新的便條紙",
+          "title": "建立便條紙"
         },
         "moveResize": {
           "description": "拖移標題列以重新定位；拖移角落以自由調整大小",
@@ -3930,7 +3930,7 @@
         "help": "便條紙輔助說明",
         "newNote": "新增便條紙",
         "note": "便條紙",
-        "syncStickies": "同步便條"
+        "syncStickies": "同步便條紙"
       },
       "name": "便條紙",
       "placeholder": "撰寫便條紙⋯",

--- a/tests/test-translation-audit.test.ts
+++ b/tests/test-translation-audit.test.ts
@@ -16,6 +16,8 @@ import fr from "../src/lib/locales/fr/translation.json";
 import it from "../src/lib/locales/it/translation.json";
 import pt from "../src/lib/locales/pt/translation.json";
 import ru from "../src/lib/locales/ru/translation.json";
+import zhCN from "../src/lib/locales/zh-CN/translation.json";
+import zhTW from "../src/lib/locales/zh-TW/translation.json";
 
 function collectEnglishStringValues(
   source: Record<string, unknown>
@@ -175,6 +177,27 @@ describe("translation audit", () => {
     expect(
       getExpectedAppleUiTerm("Pink", "zh-TW", "common.colors.pink")
     ).toBe("粉色");
+  });
+
+  test("uses consistent Apple Stickies terminology in Chinese locales", () => {
+    expect(zhCN.apps.stickies.name).toBe("便笺");
+    expect(zhTW.apps.stickies.name).toBe("便條紙");
+    expect(APPLE_UI_TERMINOLOGY.Stickies["zh-CN"]).toBe("便笺");
+    expect(APPLE_UI_TERMINOLOGY.Stickies["zh-TW"]).toBe("便條紙");
+
+    for (const value of Object.values(zhCN.apps.chats.toolCalls.stickies)) {
+      expect(value).not.toMatch(/张便笺/u);
+      expect(value).not.toMatch(/(?<![「])便笺(?!」)/u);
+    }
+
+    const stickiesHelpAndMenu = JSON.stringify({
+      ...zhTW.apps.stickies.help,
+      ...zhTW.apps.stickies.menu,
+    });
+    expect(stickiesHelpAndMenu).not.toContain("筆記");
+    expect(stickiesHelpAndMenu).not.toContain("佈告欄");
+    expect(zhTW.apps.stickies.menu.syncStickies).toBe("同步便條紙");
+    expect(zhCN.apps.stickies.help.colors.description).toContain("「颜色」");
   });
 
   test("all locales match the source and Apple UI terminology", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited Stickies-related Chinese copy against Apple’s terminology and fixed internal glossary drift that `i18n:audit` did not catch because **Stickies was missing from the Apple UI glossary**.

### Findings

**Simplified Chinese (zh-CN)** — Apple uses two terms:
- **便笺** = Stickies app name
- **便条** = individual sticky notes (e.g. File ▸ 新建便条)

Issues found:
- Chat tool toasts used **便笺** for individual notes (`张便笺`, `便笺已删除`, etc.)
- Dashboard widget copy used **便笺颜色** / **输入便笺** for note UI
- Help colors text incorrectly referenced a **「便条」菜单** instead of **「颜色」菜单**

**Traditional Chinese (zh-TW)** — Apple uses **便條紙** consistently.

Issues found:
- Stickies help used **筆記** (Notes app) and **佈告欄** (literal “bulletin board” from English)
- **同步便條** and chat help **移動便條** dropped the **紙** suffix

### Changes

- Normalize zh-CN note/tool/dashboard strings to **便条**; keep **便笺** for app-name surfaces
- Rewrite zh-TW Stickies help/menu copy to **便條紙** / **顏色** menu wording
- Add **Stickies** to `scripts/apple-ui-terminology-data.ts` (96 Apple terms)
- Add regression test in `tests/test-translation-audit.test.ts`

## Testing

- `bun test tests/test-translation-audit.test.ts`
- `bun run i18n:audit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f297b-53eb-78bb-8d55-7e38698bf7cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f297b-53eb-78bb-8d55-7e38698bf7cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

