### PR TITLE
Fix null parameters in karaoke media controls

### DIFF
--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from "zod";
+import { appendFileSync } from "node:fs";
 import { appIds } from "../../../src/config/appIds.js";
 import {
   THEME_IDS,
@@ -37,6 +38,9 @@ import {
  * Converts empty/whitespace strings and placeholder values to undefined
  */
 export const normalizeOptionalString = (value: unknown) => {
+  if (value === null) {
+    return undefined;
+  }
   if (typeof value === "string") {
     const trimmed = value.trim().toLowerCase();
     // Treat empty strings and common AI placeholder values as undefined
@@ -1017,12 +1021,18 @@ const TV_ONLY_MEDIA_FIELDS = [
 ] as const;
 
 const normalizeMediaControlInput = (value: unknown): unknown => {
+  // #region agent log
+  appendFileSync("/opt/cursor/logs/debug.log", JSON.stringify({ hypothesisId: "A", location: "api/chat/tools/schemas.ts:1021", message: "media normalizer entry", data: { inputKind: value === null ? "null" : Array.isArray(value) ? "array" : typeof value }, timestamp: Date.now() }) + "\n");
+  // #endregion
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     return value;
   }
 
   const data: Record<string, unknown> = { ...value };
   const target = data.target;
+  // #region agent log
+  appendFileSync("/opt/cursor/logs/debug.log", JSON.stringify({ hypothesisId: "B", location: "api/chat/tools/schemas.ts:1031", message: "media input before neutral-field filtering", data: { target: typeof target === "string" ? target : typeof target, action: typeof data.action === "string" ? data.action : typeof data.action, nullSharedFields: ["id", "title", "artist", "enableTranslation"].filter((field) => data[field] === null), nullTvFields: TV_ONLY_MEDIA_STRING_FIELDS.filter((field) => data[field] === null) }, timestamp: Date.now() }) + "\n");
+  // #endregion
 
   // Some tool clients populate every optional field with a neutral default.
   // Drop only values that cannot express an intent for the selected target.
@@ -1048,6 +1058,9 @@ const normalizeMediaControlInput = (value: unknown): unknown => {
     }
   }
 
+  // #region agent log
+  appendFileSync("/opt/cursor/logs/debug.log", JSON.stringify({ hypothesisId: "B", location: "api/chat/tools/schemas.ts:1060", message: "media input after neutral-field filtering", data: { nullSharedFields: ["id", "title", "artist", "enableTranslation"].filter((field) => data[field] === null), nullTvFields: TV_ONLY_MEDIA_STRING_FIELDS.filter((field) => data[field] === null) }, timestamp: Date.now() }) + "\n");
+  // #endregion
   return data;
 };
 
@@ -1142,6 +1155,9 @@ const mediaControlObjectSchema = z.object({
 export const mediaControlSchema = z
   .preprocess(normalizeMediaControlInput, mediaControlObjectSchema)
   .superRefine((data, ctx) => {
+    // #region agent log
+    appendFileSync("/opt/cursor/logs/debug.log", JSON.stringify({ hypothesisId: "C", location: "api/chat/tools/schemas.ts:1157", message: "media refinement entered", data: { target: data.target, action: data.action }, timestamp: Date.now() }) + "\n");
+    // #endregion
     const { target, action } = data;
 
     if (isTvChannelAction(action)) {

--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -6,7 +6,6 @@
  */
 
 import { z } from "zod";
-import { appendFileSync } from "node:fs";
 import { appIds } from "../../../src/config/appIds.js";
 import {
   THEME_IDS,
@@ -1021,18 +1020,12 @@ const TV_ONLY_MEDIA_FIELDS = [
 ] as const;
 
 const normalizeMediaControlInput = (value: unknown): unknown => {
-  // #region agent log
-  appendFileSync("/opt/cursor/logs/debug.log", JSON.stringify({ hypothesisId: "A", location: "api/chat/tools/schemas.ts:1021", message: "media normalizer entry", data: { inputKind: value === null ? "null" : Array.isArray(value) ? "array" : typeof value }, timestamp: Date.now() }) + "\n");
-  // #endregion
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     return value;
   }
 
   const data: Record<string, unknown> = { ...value };
   const target = data.target;
-  // #region agent log
-  appendFileSync("/opt/cursor/logs/debug.log", JSON.stringify({ hypothesisId: "B", location: "api/chat/tools/schemas.ts:1031", message: "media input before neutral-field filtering", data: { target: typeof target === "string" ? target : typeof target, action: typeof data.action === "string" ? data.action : typeof data.action, nullSharedFields: ["id", "title", "artist", "enableTranslation"].filter((field) => data[field] === null), nullTvFields: TV_ONLY_MEDIA_STRING_FIELDS.filter((field) => data[field] === null) }, timestamp: Date.now() }) + "\n");
-  // #endregion
 
   // Some tool clients populate every optional field with a neutral default.
   // Drop only values that cannot express an intent for the selected target.
@@ -1058,9 +1051,6 @@ const normalizeMediaControlInput = (value: unknown): unknown => {
     }
   }
 
-  // #region agent log
-  appendFileSync("/opt/cursor/logs/debug.log", JSON.stringify({ hypothesisId: "B", location: "api/chat/tools/schemas.ts:1060", message: "media input after neutral-field filtering", data: { nullSharedFields: ["id", "title", "artist", "enableTranslation"].filter((field) => data[field] === null), nullTvFields: TV_ONLY_MEDIA_STRING_FIELDS.filter((field) => data[field] === null) }, timestamp: Date.now() }) + "\n");
-  // #endregion
   return data;
 };
 
@@ -1155,9 +1145,6 @@ const mediaControlObjectSchema = z.object({
 export const mediaControlSchema = z
   .preprocess(normalizeMediaControlInput, mediaControlObjectSchema)
   .superRefine((data, ctx) => {
-    // #region agent log
-    appendFileSync("/opt/cursor/logs/debug.log", JSON.stringify({ hypothesisId: "C", location: "api/chat/tools/schemas.ts:1157", message: "media refinement entered", data: { target: data.target, action: data.action }, timestamp: Date.now() }) + "\n");
-    // #endregion
     const { target, action } = data;
 
     if (isTvChannelAction(action)) {

--- a/tests/test-media-control-unified.test.ts
+++ b/tests/test-media-control-unified.test.ts
@@ -128,6 +128,10 @@ describe("mediaControl schema", () => {
       const result = mediaControlSchema.safeParse({
         target: "karaoke",
         action: "next",
+        id: neutralString,
+        title: neutralString,
+        artist: neutralString,
+        enableTranslation: neutralString,
         prompt: neutralString,
         name: neutralString,
         videoId: neutralString,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Normalize `null` optional strings before validation.
- Strip parameters that cannot apply to the selected media target and action.
- Cover the exact overfilled Karaoke `next` payload and preservation of applicable values.

## Root cause
The unified `mediaControl` tool exposes one flat schema for music, Karaoke, Videos, and TV. Models can fill unrelated optional fields with valid-looking values. The old normalizer removed only empty or neutral defaults, so TV-only fields such as `prompt`, `name`, and `channelNumber` reached target validation and rejected an otherwise valid Karaoke navigation call.

## Testing
- `bun test tests/test-media-control-unified.test.ts tests/test-settings-language-schema.test.ts tests/test-maps-search-tool.test.ts tests/test-calendar-tool-reducer.test.ts` (36 pass)
- Direct replay of the reported overfilled payload parses successfully as Karaoke `next`
- `bun run typecheck`
- `bun run test:registration`
- `bunx eslint api/chat/tools/schemas.ts tests/test-media-control-unified.test.ts`
- `git diff origin/main...HEAD --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f29eb-b5ed-74a2-96bb-f6ecd7832f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f29eb-b5ed-74a2-96bb-f6ecd7832f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

