### PR TITLE
Move growing library stores to IndexedDB

### DIFF
--- a/src/stores/useBooksStore.ts
+++ b/src/stores/useBooksStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
+import { persist } from "zustand/middleware";
+import { createIndexedDBPersistStorage } from "@/utils/indexedDBPersistStorage";
 
 export type BooksColumnMode = "auto" | "single" | "double";
 export type BooksThemeOverride =
@@ -476,7 +477,7 @@ export const useBooksStore = create<BooksStoreState>()(
     }),
     {
       name: "ryos:books",
-      storage: createJSONStorage(() => localStorage),
+      storage: createIndexedDBPersistStorage(),
       // v5+: backfill `settings.speechRate` (added in v4 without a version
       // bump, so persisted settings were missing it after the shallow merge).
       // v6: raised line-height floor.

--- a/src/stores/useCalendarStore.ts
+++ b/src/stores/useCalendarStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
+import { persist } from "zustand/middleware";
 import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
+import { createIndexedDBPersistStorage } from "@/utils/indexedDBPersistStorage";
 import {
   calendarEventOccursOnDate,
   calendarEventOverlapsDateRange,
@@ -336,7 +337,7 @@ export const useCalendarStore = create<CalendarStoreState>()(
     },
     {
       name: "calendar-storage",
-      storage: createJSONStorage(() => localStorage),
+      storage: createIndexedDBPersistStorage(),
       // Do not persist viewport — opening Calendar should show today, not last session.
       partialize: (state) => ({
         events: state.events,

--- a/src/stores/useTvStore.ts
+++ b/src/stores/useTvStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
+import { persist } from "zustand/middleware";
 import {
   buildTvChannelLineup,
   DEFAULT_CHANNEL_ID,
@@ -7,6 +7,7 @@ import {
   type Channel,
 } from "@/apps/tv/data/channels";
 import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
+import { createIndexedDBPersistStorage } from "@/utils/indexedDBPersistStorage";
 import { shouldUpdatePlaybackTime } from "@/stores/playbackTime";
 import type { Video } from "@/stores/useVideoStore";
 import {
@@ -389,7 +390,7 @@ export const useTvStore = create<TvStoreState>()(
     }),
     {
       name: "ryos:tv",
-      storage: createJSONStorage(() => localStorage),
+      storage: createIndexedDBPersistStorage(),
       version: 5,
       // Channel lineup rotation uses an in-memory per-channel shuffle (see
       // `useTvLogic`); persisted indices would drift after reload.

--- a/src/stores/useVideoStore.ts
+++ b/src/stores/useVideoStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { useStoreShallow } from "./helpers";
 import { persist } from "zustand/middleware";
 import { shouldUpdatePlaybackTime } from "./playbackTime";
+import { createIndexedDBPersistStorage } from "@/utils/indexedDBPersistStorage";
 import {
   resetPlaybackConfirmation,
   stopPlayback,
@@ -269,6 +270,7 @@ export const useVideoStore = create<VideoStoreState>()(
     {
       name: "ryos:videos",
       version: CURRENT_VIDEO_STORE_VERSION,
+      storage: createIndexedDBPersistStorage(),
       // Persist videos array to prevent ID-based errors
       partialize: (state) => ({
         videos: state.videos,

--- a/src/sync/codecs.ts
+++ b/src/sync/codecs.ts
@@ -1054,8 +1054,14 @@ const videosCodec: SyncCodec = {
   },
   subscribe(onChange) {
     return useVideoStore.subscribe((state, prev) => {
-      if (state.videos !== prev.videos) onChange();
+      if (state.videos !== prev.videos) {
+        if (!useVideoStore.persist.hasHydrated()) return;
+        onChange();
+      }
     });
+  },
+  isReady() {
+    return useVideoStore.persist.hasHydrated();
   },
 };
 

--- a/tests/test-indexeddb-store-migrations-wiring.test.ts
+++ b/tests/test-indexeddb-store-migrations-wiring.test.ts
@@ -10,6 +10,10 @@ describe("large Zustand stores use one IndexedDB persistence path", () => {
     "src/stores/useIpodStore.ts",
     "src/stores/useStickiesStore.ts",
     "src/stores/useContactsStore.ts",
+    "src/stores/useBooksStore.ts",
+    "src/stores/useCalendarStore.ts",
+    "src/stores/useVideoStore.ts",
+    "src/stores/useTvStore.ts",
   ];
 
   for (const path of storePaths) {
@@ -21,7 +25,7 @@ describe("large Zustand stores use one IndexedDB persistence path", () => {
     });
   }
 
-  test("async hydration gates default-seeding and iPod sync paths", () => {
+  test("async hydration gates consumers and cloud sync paths", () => {
     const textEditState = readSource(
       "src/apps/textedit/hooks/useTextEditState.ts"
     );
@@ -42,9 +46,22 @@ describe("large Zustand stores use one IndexedDB persistence path", () => {
     expect(ipodUpdateChecker).toContain(
       "usePersistHydrated(useIpodStore.persist)"
     );
+    expect(readSource("src/apps/books/hooks/useBooksLogic.ts")).toContain(
+      "usePersistHydrated(useBooksStore.persist)"
+    );
     expect(syncCodecs).toContain(
       "return useIpodStore.persist.hasHydrated();"
     );
+    for (const store of [
+      "useBooksStore",
+      "useCalendarStore",
+      "useVideoStore",
+      "useTvStore",
+    ]) {
+      expect(syncCodecs).toContain(
+        `return ${store}.persist.hasHydrated();`
+      );
+    }
   });
 
   test("full-state stores partialize away action functions", () => {

--- a/tests/test-large-store-indexeddb-persistence.test.ts
+++ b/tests/test-large-store-indexeddb-persistence.test.ts
@@ -45,8 +45,20 @@ const { ensureIndexedDBInitialized, STORES } = await import(
 const { useTextEditStore } = await import("../src/stores/useTextEditStore");
 const { useStickiesStore } = await import("../src/stores/useStickiesStore");
 const { useContactsStore } = await import("../src/stores/useContactsStore");
+const { useBooksStore } = await import("../src/stores/useBooksStore");
+const { useCalendarStore } = await import("../src/stores/useCalendarStore");
+const { useVideoStore } = await import("../src/stores/useVideoStore");
+const { useTvStore } = await import("../src/stores/useTvStore");
 
-const stores = [useTextEditStore, useStickiesStore, useContactsStore];
+const stores = [
+  useTextEditStore,
+  useStickiesStore,
+  useContactsStore,
+  useBooksStore,
+  useCalendarStore,
+  useVideoStore,
+  useTvStore,
+];
 
 await Promise.all(stores.map((store) => store.persist.rehydrate()));
 await settleAllPersistWrites();
@@ -88,6 +100,14 @@ beforeEach(async () => {
     myContactId: null,
     lastRemoteSyncAt: 0,
   });
+  useBooksStore.setState({
+    progressByPath: {},
+    highlightsByPath: {},
+    bookmarksByPath: {},
+  });
+  useCalendarStore.setState({ events: [], todos: [] });
+  useVideoStore.setState({ videos: [], currentVideoId: null });
+  useTvStore.setState({ customChannels: [], hiddenDefaultChannelIds: [] });
   resetPersistWritesForTests();
 });
 
@@ -162,6 +182,86 @@ describe("large store IndexedDB persistence", () => {
         version: 0,
       })
     );
+    localStorage.setItem(
+      "ryos:books",
+      JSON.stringify({
+        state: {
+          progressByPath: {
+            "/Books/migrated.epub": {
+              cfi: "epubcfi(/6/2)",
+              percentage: 0.5,
+              updatedAt: 1,
+            },
+          },
+          highlightsByPath: {},
+          bookmarksByPath: {},
+        },
+        version: 9,
+      })
+    );
+    localStorage.setItem(
+      "calendar-storage",
+      JSON.stringify({
+        state: {
+          events: [
+            {
+              id: "migrated-event",
+              title: "Migrated event",
+              date: "2026-07-03",
+              color: "blue",
+              calendarId: "home",
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+          calendars: [],
+          todos: [],
+        },
+        version: 0,
+      })
+    );
+    localStorage.setItem(
+      "ryos:videos",
+      JSON.stringify({
+        state: {
+          videos: [
+            {
+              id: "migrated-video",
+              url: "https://youtu.be/migrated-video",
+              title: "Migrated video",
+              artist: "ryOS",
+            },
+          ],
+          currentVideoId: "migrated-video",
+          loopAll: true,
+          loopCurrent: false,
+          isShuffled: false,
+        },
+        version: 8,
+      })
+    );
+    localStorage.setItem(
+      "ryos:tv",
+      JSON.stringify({
+        state: {
+          currentChannelId: "migrated-channel",
+          customChannels: [
+            {
+              id: "migrated-channel",
+              name: "Migrated channel",
+              videos: [],
+              createdAt: 1,
+            },
+          ],
+          hiddenDefaultChannelIds: [],
+          hiddenDefaultChannelIdsUpdatedAt: null,
+          hiddenDefaultChannelIdsResetAt: null,
+          lcdFilterOn: true,
+          closedCaptionsOn: false,
+        },
+        version: 5,
+      })
+    );
 
     await Promise.all(stores.map((store) => store.persist.rehydrate()));
 
@@ -170,9 +270,26 @@ describe("large store IndexedDB persistence", () => {
     expect(
       useContactsStore.getState().contacts.some((contact) => contact.id === "friend")
     ).toBe(true);
-    expect(localStorage.getItem("ryos:textedit")).toBeNull();
-    expect(localStorage.getItem("stickies-storage")).toBeNull();
-    expect(localStorage.getItem("contacts-storage")).toBeNull();
+    expect(
+      useBooksStore.getState().progressByPath["/Books/migrated.epub"]?.percentage
+    ).toBe(0.5);
+    expect(useCalendarStore.getState().events[0]?.id).toBe("migrated-event");
+    expect(useVideoStore.getState().videos[0]?.id).toBe("migrated-video");
+    expect(useTvStore.getState().customChannels[0]?.id).toBe(
+      "migrated-channel"
+    );
+    for (const key of [
+      "ryos:textedit",
+      "stickies-storage",
+      "contacts-storage",
+      "ryos:books",
+      "calendar-storage",
+      "ryos:videos",
+      "ryos:tv",
+    ]) {
+      expect(localStorage.getItem(key)).toBeNull();
+      expect(await readPersistedRecord(key)).not.toBeNull();
+    }
   });
 
   test("persists document-sized payloads without consuming localStorage quota", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- move Books, Calendar, Videos, and TV Zustand persistence from localStorage to the shared IndexedDB adapter
- preserve and test transparent migration from each legacy localStorage key
- gate Videos cloud sync on asynchronous hydration
- extend persistence wiring and runtime migration coverage for the migrated stores

## Testing
- `bun test tests/test-indexeddb-store-migrations-wiring.test.ts tests/test-indexeddb-persist-storage.test.ts tests/test-large-store-indexeddb-persistence.test.ts tests/test-sync-v2-codecs.test.ts` (64 passed)
- `bun test tests/test-sync-v2-codecs.test.ts tests/test-books-annotations-store.test.ts tests/test-calendar-tool-reducer.test.ts tests/test-calendar-ical-multiday.test.ts tests/test-tv-store-default-channel-removal.test.ts tests/test-media-library-unified.test.ts tests/test-media-transport-parity.test.ts` (99 passed)
- `bun run typecheck`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f29aa-06b5-7aea-beb3-462a8ac9cc83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f29aa-06b5-7aea-beb3-462a8ac9cc83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

