### PR TITLE
Normalize overfilled media control parameters

### DIFF
--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -1019,34 +1019,82 @@ const TV_ONLY_MEDIA_FIELDS = [
   "channelNumber",
 ] as const;
 
+const MEDIA_CONTROL_PARAMETER_FIELDS = [
+  "id",
+  "title",
+  "artist",
+  "enableTranslation",
+  "enableFullscreen",
+  "enableVideo",
+  ...TV_ONLY_MEDIA_FIELDS,
+] as const;
+
+const getAllowedMediaControlFields = (
+  target: unknown,
+  action: unknown
+): ReadonlySet<string> => {
+  const allowed = new Set<string>();
+
+  if (target === "music") {
+    allowed.add("enableTranslation");
+    allowed.add("enableFullscreen");
+    allowed.add("enableVideo");
+  } else if (target === "karaoke") {
+    allowed.add("enableTranslation");
+    allowed.add("enableFullscreen");
+  }
+
+  switch (action) {
+    case "playKnown":
+      allowed.add("id");
+      allowed.add("title");
+      allowed.add("artist");
+      break;
+    case "addAndPlay":
+      allowed.add("id");
+      break;
+    case "tune":
+      allowed.add("channelId");
+      allowed.add("channelNumber");
+      break;
+    case "createChannel":
+      allowed.add("prompt");
+      allowed.add("name");
+      break;
+    case "deleteChannel":
+      allowed.add("channelId");
+      break;
+    case "addVideo":
+      allowed.add("channelId");
+      allowed.add("videoId");
+      allowed.add("url");
+      allowed.add("title");
+      allowed.add("artist");
+      break;
+    case "removeVideo":
+      allowed.add("channelId");
+      allowed.add("removeVideoId");
+      break;
+  }
+
+  return allowed;
+};
+
 const normalizeMediaControlInput = (value: unknown): unknown => {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     return value;
   }
 
   const data: Record<string, unknown> = { ...value };
-  const target = data.target;
 
-  // Some tool clients populate every optional field with a neutral default.
-  // Drop only values that cannot express an intent for the selected target.
-  if (target !== "music" && data.enableVideo === false) {
-    delete data.enableVideo;
-  }
-  if (
-    target !== "music" &&
-    target !== "karaoke" &&
-    data.enableFullscreen === false
-  ) {
-    delete data.enableFullscreen;
-  }
-  if (
-    data.channelNumber === null ||
-    (target !== "tv" && data.channelNumber === 0)
-  ) {
-    delete data.channelNumber;
-  }
-  for (const field of TV_ONLY_MEDIA_STRING_FIELDS) {
-    if (data[field] === null) {
+  // Some tool clients populate every optional field, including fields that
+  // belong to a different target or action. Keep only parameters that can
+  // affect the requested operation, then validate those parameters normally.
+  const target = data.target === undefined ? "music" : data.target;
+  const action = data.action === undefined ? "toggle" : data.action;
+  const allowedFields = getAllowedMediaControlFields(target, action);
+  for (const field of MEDIA_CONTROL_PARAMETER_FIELDS) {
+    if (!allowedFields.has(field)) {
       delete data[field];
     }
   }

--- a/tests/test-media-control-unified.test.ts
+++ b/tests/test-media-control-unified.test.ts
@@ -160,21 +160,36 @@ describe("mediaControl schema", () => {
     });
   });
 
-  test("rejects meaningful fields for the wrong media target", () => {
+  test("strips overfilled fields that do not apply to karaoke navigation", () => {
     expect(
       mediaControlSchema.safeParse({
         target: "karaoke",
         action: "next",
-        enableVideo: true,
-      }).success
-    ).toBe(false);
-    expect(
-      mediaControlSchema.safeParse({
+        id: "",
+        title: "",
+        artist: "",
+        enableTranslation: "",
+        enableFullscreen: false,
+        enableVideo: false,
+        channelId: "",
+        channelNumber: 1,
+        prompt: "next karaoke song",
+        name: "x",
+        videoId: "",
+        url: "",
+        removeVideoId: "",
+      })
+    ).toEqual({
+      success: true,
+      data: {
         target: "karaoke",
         action: "next",
-        channelNumber: 2,
-      }).success
-    ).toBe(false);
+        enableFullscreen: false,
+      },
+    });
+  });
+
+  test("still rejects channel actions and parameters that are invalid after normalization", () => {
     expect(
       mediaControlSchema.safeParse({
         target: "tv",
@@ -194,6 +209,15 @@ describe("mediaControl schema", () => {
     expect(result).toEqual({
       success: true,
       data: { target: "music", action: "play", enableVideo: false },
+    });
+
+    expect(
+      mediaControlSchema.safeParse({
+        enableVideo: true,
+      })
+    ).toEqual({
+      success: true,
+      data: { target: "music", action: "toggle", enableVideo: true },
     });
   });
 
@@ -278,7 +302,7 @@ describe("mediaControl schema", () => {
     ).toBe(false);
   });
 
-  test("enableVideo is only valid for target music", () => {
+  test("enableVideo is only applied to target music", () => {
     expect(
       mediaControlSchema.safeParse({
         target: "music",
@@ -292,12 +316,15 @@ describe("mediaControl schema", () => {
           target,
           action: "play",
           enableVideo: true,
-        }).success
-      ).toBe(false);
+        })
+      ).toEqual({
+        success: true,
+        data: { target, action: "play" },
+      });
     }
   });
 
-  test("enableTranslation and enableFullscreen are gated to music/karaoke", () => {
+  test("enableTranslation and enableFullscreen are only applied to music/karaoke", () => {
     for (const target of ["music", "karaoke"]) {
       expect(
         mediaControlSchema.safeParse({
@@ -314,20 +341,26 @@ describe("mediaControl schema", () => {
           target,
           action: "play",
           enableTranslation: "zh-TW",
-        }).success
-      ).toBe(false);
+        })
+      ).toEqual({
+        success: true,
+        data: { target, action: "play" },
+      });
       expect(
         mediaControlSchema.safeParse({
           target,
           action: "play",
           enableFullscreen: true,
-        }).success
-      ).toBe(false);
+        })
+      ).toEqual({
+        success: true,
+        data: { target, action: "play" },
+      });
     }
   });
 
   test("enforces transport parameter rules", () => {
-    // addAndPlay requires id and rejects manual title/artist.
+    // addAndPlay requires id and ignores inapplicable manual metadata.
     expect(
       mediaControlSchema.safeParse({ target: "music", action: "addAndPlay" })
         .success
@@ -338,8 +371,15 @@ describe("mediaControl schema", () => {
         action: "addAndPlay",
         id: "dQw4w9WgXcQ",
         title: "Manual",
-      }).success
-    ).toBe(false);
+      })
+    ).toEqual({
+      success: true,
+      data: {
+        target: "music",
+        action: "addAndPlay",
+        id: "dQw4w9WgXcQ",
+      },
+    });
     // playKnown allows bare invocation and id/title/artist.
     expect(
       mediaControlSchema.safeParse({ target: "karaoke", action: "playKnown" })
@@ -353,12 +393,14 @@ describe("mediaControl schema", () => {
         artist: "Artist",
       }).success
     ).toBe(true);
-    // Playback-state and navigation actions reject item identifiers.
+    // Playback-state and navigation actions ignore inapplicable identifiers.
     for (const action of ["toggle", "play", "pause", "next", "previous"]) {
       expect(
         mediaControlSchema.safeParse({ target: "videos", action, id: "x" })
-          .success
-      ).toBe(false);
+      ).toEqual({
+        success: true,
+        data: { target: "videos", action },
+      });
     }
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Strip parameters that cannot apply to the selected media target and action.
- Cover the exact overfilled Karaoke `next` payload while preserving applicable settings.

## Root cause
The unified `mediaControl` tool exposes one flat schema for music, Karaoke, Videos, and TV. Models can fill unrelated optional fields with valid-looking values. The null-only fix in #1760 does not remove non-empty TV-only values such as `prompt`, `name`, and `channelNumber`, so they still reject valid Karaoke navigation calls.

## Testing
- `bun test tests/test-media-control-unified.test.ts tests/test-settings-language-schema.test.ts tests/test-maps-search-tool.test.ts tests/test-calendar-tool-reducer.test.ts` (36 pass)
- `bun run typecheck`
- `bunx eslint api/chat/tools/schemas.ts tests/test-media-control-unified.test.ts`
- Verified `origin/main` is an ancestor and the branch diff is clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f29eb-b5ed-74a2-96bb-f6ecd7832f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f29eb-b5ed-74a2-96bb-f6ecd7832f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

