### PR TITLE
Style IndexedDB debug pane like other tabs

### DIFF
--- a/src/components/debug/DebugIndexedDBPanel.tsx
+++ b/src/components/debug/DebugIndexedDBPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
+import { OS_NATIVE_CHROME_SKIP_CLASS } from "@/lib/themeChrome";
 import { DB_NAME } from "@/utils/indexedDB";
 import {
   formatIDBEntriesForCopy,
@@ -144,7 +145,12 @@ export function DebugIndexedDBPanel({
   }, []);
 
   return (
-    <div className="h-full overflow-auto px-2 py-1 font-os-mono text-[10px] leading-[1.45]">
+    <div
+      className={cn(
+        "h-full overflow-auto px-2 py-1 font-os-mono text-[10px] leading-[1.45]",
+        OS_NATIVE_CHROME_SKIP_CLASS
+      )}
+    >
       {loadState === "loading" ? (
         <div className="py-4 text-center opacity-50">
           {t("debug.idb.loading")}

--- a/src/components/debug/DebugIndexedDBPanel.tsx
+++ b/src/components/debug/DebugIndexedDBPanel.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from "react";
-import { CaretLeft, CaretRight } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { DB_NAME } from "@/utils/indexedDB";
@@ -16,6 +15,11 @@ import {
 interface DebugIndexedDBPanelProps {
   /** Incremented by the header refresh action to force a reload. */
   refreshToken: number;
+  /** Currently drilled-in object store, or null for the store list. */
+  selectedStore: string | null;
+  onSelectedStoreChange: (storeName: string | null) => void;
+  /** Reports the total record count for the drilled-in store (header nav). */
+  onEntryTotalChange: (count: number) => void;
   /** Reports the copyable dump of the current view (stores or entries). */
   onCopyTextChange: (text: string) => void;
 }
@@ -42,7 +46,7 @@ function EntryRow({ entry }: { entry: IDBEntrySummary }) {
         <span className="min-w-0 flex-1 truncate text-os-text-primary">
           {entry.key}
         </span>
-        <span className="shrink-0 tabular-nums text-os-text-secondary">
+        <span className="shrink-0 tabular-nums opacity-50">
           {entry.summary}
         </span>
       </button>
@@ -69,12 +73,14 @@ function EntryRow({ entry }: { entry: IDBEntrySummary }) {
  */
 export function DebugIndexedDBPanel({
   refreshToken,
+  selectedStore,
+  onSelectedStoreChange,
+  onEntryTotalChange,
   onCopyTextChange,
 }: DebugIndexedDBPanelProps) {
   const { t } = useTranslation();
 
   const [stores, setStores] = useState<IDBStoreSummary[]>([]);
-  const [selectedStore, setSelectedStore] = useState<string | null>(null);
   const [entries, setEntries] = useState<IDBEntrySummary[]>([]);
   const [entryTotal, setEntryTotal] = useState(0);
   const [entryLimit, setEntryLimit] = useState(IDB_ENTRY_PAGE_SIZE);
@@ -90,12 +96,14 @@ export function DebugIndexedDBPanel({
           const nextStores = await listIDBStores();
           if (cancelled) return;
           setStores(nextStores);
+          onEntryTotalChange(0);
           onCopyTextChange(formatIDBStoresForCopy(DB_NAME, nextStores));
         } else {
           const page = await readIDBStoreEntries(selectedStore, entryLimit);
           if (cancelled) return;
           setEntries(page.entries);
           setEntryTotal(page.total);
+          onEntryTotalChange(page.total);
           onCopyTextChange(
             formatIDBEntriesForCopy(selectedStore, page.entries)
           );
@@ -112,19 +120,24 @@ export function DebugIndexedDBPanel({
     return () => {
       cancelled = true;
     };
-  }, [selectedStore, entryLimit, refreshToken, onCopyTextChange]);
+  }, [
+    selectedStore,
+    entryLimit,
+    refreshToken,
+    onCopyTextChange,
+    onEntryTotalChange,
+  ]);
 
-  const openStore = useCallback((storeName: string) => {
-    setEntries([]);
-    setEntryTotal(0);
-    setEntryLimit(IDB_ENTRY_PAGE_SIZE);
-    setSelectedStore(storeName);
-  }, []);
-
-  const backToStores = useCallback(() => {
-    setSelectedStore(null);
-    setEntries([]);
-  }, []);
+  const openStore = useCallback(
+    (storeName: string) => {
+      setEntries([]);
+      setEntryTotal(0);
+      onEntryTotalChange(0);
+      setEntryLimit(IDB_ENTRY_PAGE_SIZE);
+      onSelectedStoreChange(storeName);
+    },
+    [onEntryTotalChange, onSelectedStoreChange]
+  );
 
   const loadMore = useCallback(() => {
     setEntryLimit((limit) => limit + IDB_ENTRY_PAGE_SIZE);
@@ -132,42 +145,17 @@ export function DebugIndexedDBPanel({
 
   return (
     <div className="h-full overflow-auto px-2 py-1 font-os-mono text-[10px] leading-[1.45]">
-      {selectedStore !== null ? (
-        <div
-          className={cn(
-            "sticky -top-1 z-10 -mx-2 flex items-center gap-1 border-b px-2 py-1",
-            "border-[color:var(--os-color-separator)] bg-os-window-bg"
-          )}
-        >
-          <button
-            type="button"
-            onClick={backToStores}
-            title={t("debug.idb.backToStores")}
-            aria-label={t("debug.idb.backToStores")}
-            className="flex size-5 shrink-0 items-center justify-center rounded hover:bg-black/10 os-mac-aqua-dark:hover:bg-white/15"
-          >
-            <CaretLeft weight="bold" className="size-3" />
-          </button>
-          <span className="min-w-0 flex-1 truncate font-semibold text-os-text-primary">
-            {selectedStore}
-          </span>
-          <span className="shrink-0 tabular-nums text-os-text-secondary">
-            {t("debug.idb.recordCount", { count: entryTotal })}
-          </span>
-        </div>
-      ) : null}
-
       {loadState === "loading" ? (
-        <div className="py-4 text-center text-[11px] opacity-50">
+        <div className="py-4 text-center opacity-50">
           {t("debug.idb.loading")}
         </div>
       ) : loadState === "error" ? (
-        <div className="py-4 text-center text-[11px] text-red-500">
+        <div className="py-4 text-center text-red-500">
           {t("debug.idb.error")}
         </div>
       ) : selectedStore === null ? (
         stores.length === 0 ? (
-          <div className="py-4 text-center text-[11px] opacity-50">
+          <div className="py-4 text-center opacity-50">
             {t("debug.idb.emptyDatabase")}
           </div>
         ) : (
@@ -184,19 +172,14 @@ export function DebugIndexedDBPanel({
               <span className="min-w-0 flex-1 truncate text-os-text-primary">
                 {store.name}
               </span>
-              <span className="shrink-0 tabular-nums text-os-text-secondary">
+              <span className="shrink-0 tabular-nums opacity-50">
                 {t("debug.idb.recordCount", { count: store.count })}
               </span>
-              <CaretRight
-                weight="bold"
-                className="size-3 shrink-0 opacity-40"
-                aria-hidden
-              />
             </button>
           ))
         )
       ) : entries.length === 0 ? (
-        <div className="py-4 text-center text-[11px] opacity-50">
+        <div className="py-4 text-center opacity-50">
           {t("debug.idb.emptyStore")}
         </div>
       ) : (
@@ -208,7 +191,7 @@ export function DebugIndexedDBPanel({
             <button
               type="button"
               onClick={loadMore}
-              className="w-full py-1.5 text-center text-[11px] text-os-text-secondary hover:text-os-text-primary"
+              className="w-full py-1.5 text-center opacity-50 hover:opacity-100"
             >
               {t("debug.idb.loadMore", {
                 count: entryTotal - entries.length,

--- a/src/components/debug/DebugLogOverlay.tsx
+++ b/src/components/debug/DebugLogOverlay.tsx
@@ -13,6 +13,7 @@ import {
   ArrowDown,
   Bug,
   CaretDown,
+  CaretLeft,
   Check,
   Copy,
   Trash,
@@ -55,6 +56,7 @@ import { DebugIndexedDBPanel } from "./DebugIndexedDBPanel";
 import { DebugLiveDashboard } from "./DebugLiveDashboard";
 import { DebugNetworkPanel } from "./DebugNetworkPanel";
 import { getRestoredScrollTop } from "./debugLogVirtualization";
+import { DB_NAME } from "@/utils/indexedDB";
 
 const LEVEL_TEXT_CLASS: Record<ConsoleLogLevel, string> = {
   log: "text-os-text-primary",
@@ -304,6 +306,8 @@ export function DebugLogOverlay() {
   const liveReportRef = useRef("");
   const idbCopyTextRef = useRef("");
   const [idbRefreshToken, setIdbRefreshToken] = useState(0);
+  const [idbSelectedStore, setIdbSelectedStore] = useState<string | null>(null);
+  const [idbEntryTotal, setIdbEntryTotal] = useState(0);
 
   const entries = useSyncExternalStore(
     subscribeConsoleCapture,
@@ -655,6 +659,15 @@ export function DebugLogOverlay() {
     setIdbRefreshToken((token) => token + 1);
   }, []);
 
+  const handleIdbBackToStores = useCallback(() => {
+    setIdbSelectedStore(null);
+    setIdbEntryTotal(0);
+  }, []);
+
+  const handleIdbEntryTotalChange = useCallback((count: number) => {
+    setIdbEntryTotal(count);
+  }, []);
+
   const handleClearNetwork = useCallback(() => {
     clearNetworkCapture();
   }, []);
@@ -919,6 +932,30 @@ export function DebugLogOverlay() {
                   onValueChange={setNetworkFilter}
                 />
               </div>
+            ) : activeTab === "idb" ? (
+              <div className="flex min-w-0 items-center gap-1 font-os-mono text-[10px] leading-none">
+                {idbSelectedStore !== null ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={handleIdbBackToStores}
+                      title={t("debug.idb.backToStores")}
+                      aria-label={t("debug.idb.backToStores")}
+                      className="flex size-5 shrink-0 items-center justify-center rounded hover:bg-black/10 os-mac-aqua-dark:hover:bg-white/15"
+                    >
+                      <CaretLeft weight="bold" className="size-3" />
+                    </button>
+                    <span className="min-w-0 truncate text-os-text-primary">
+                      {idbSelectedStore}
+                    </span>
+                    <span className="shrink-0 tabular-nums opacity-60">
+                      {t("debug.idb.recordCount", { count: idbEntryTotal })}
+                    </span>
+                  </>
+                ) : (
+                  <span className="truncate opacity-60">{DB_NAME}</span>
+                )}
+              </div>
             ) : null}
             <div className="ml-auto flex shrink-0 items-center gap-0.5">
               {activeTab === "logs" ? (
@@ -1124,6 +1161,9 @@ export function DebugLogOverlay() {
           >
             <DebugIndexedDBPanel
               refreshToken={idbRefreshToken}
+              selectedStore={idbSelectedStore}
+              onSelectedStoreChange={setIdbSelectedStore}
+              onEntryTotalChange={handleIdbEntryTotalChange}
               onCopyTextChange={handleIdbCopyTextChange}
             />
           </TabsContent>

--- a/src/components/debug/DebugLogOverlay.tsx
+++ b/src/components/debug/DebugLogOverlay.tsx
@@ -933,7 +933,7 @@ export function DebugLogOverlay() {
                 />
               </div>
             ) : activeTab === "idb" ? (
-              <div className="flex min-w-0 items-center gap-1 font-os-mono text-[10px] leading-none">
+              <div className="flex min-w-0 items-center gap-1 font-os-ui text-[10px] leading-none">
                 {idbSelectedStore !== null ? (
                   <>
                     <button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the IndexedDB tab in the debug overlay with the styling and layout patterns used by Logs and Network.

- Removes the extra sticky in-panel navigation bar when drilling into a store
- Moves secondary navigation (back button, store name, record count) to the top bar left side
- Shows the database name (`ryOS`) in the header when viewing the store list
- Uses consistent 10px monospace typography and opacity-based secondary text for record counts

## Testing

- `bun test tests/test-debug-indexeddb-inspector.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2b03-de97-7a9f-91f3-bafafba9f96e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2b03-de97-7a9f-91f3-bafafba9f96e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

