### PR TITLE
Add entry/exit animations for debug console overlay

### DIFF
--- a/src/components/debug/DebugLogOverlay.tsx
+++ b/src/components/debug/DebugLogOverlay.tsx
@@ -7,7 +7,9 @@ import {
   useState,
   useSyncExternalStore,
   type CSSProperties,
+  type ReactNode,
 } from "react";
+import { AnimatePresence, motion, useIsPresent } from "motion/react";
 import {
   ArrowClockwise,
   ArrowDown,
@@ -51,10 +53,16 @@ import {
 } from "@/utils/networkCapture";
 import { osCardClassName } from "@/components/shared/osThemePrimitives";
 import { useTranslation } from "react-i18next";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { DebugIndexedDBPanel } from "./DebugIndexedDBPanel";
 import { DebugLiveDashboard } from "./DebugLiveDashboard";
 import { DebugNetworkPanel } from "./DebugNetworkPanel";
 import { getRestoredScrollTop } from "./debugLogVirtualization";
+import {
+  getDebugPanelMotionProps,
+  getDebugPanelTransformOrigin,
+  type DebugPanelAnchor,
+} from "./debugOverlayAnimations";
 
 const LEVEL_TEXT_CLASS: Record<ConsoleLogLevel, string> = {
   log: "text-os-text-primary",
@@ -272,6 +280,33 @@ function ConsoleEntryContent({
   });
 }
 
+function DebugPanelMotionShell({
+  anchor,
+  prefersReducedMotion,
+  children,
+}: {
+  anchor: DebugPanelAnchor;
+  prefersReducedMotion: boolean;
+  children: ReactNode;
+}) {
+  const isPresent = useIsPresent();
+  const motionProps = getDebugPanelMotionProps({ prefersReducedMotion });
+
+  return (
+    <motion.div
+      key="debug-panel"
+      initial={motionProps.initial}
+      animate={motionProps.animate}
+      exit={motionProps.exit}
+      transition={motionProps.transition}
+      className={cn("mb-2", !isPresent && "pointer-events-none")}
+      style={{ transformOrigin: getDebugPanelTransformOrigin(anchor) }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
 /**
  * Floating, togglable console overlay shown only while Debug Mode is enabled
  * (Control Panels → Accounts → Debug). Mirrors captured `console.*` output into an
@@ -289,6 +324,8 @@ export function DebugLogOverlay() {
   const debugFabBottom = isWindowsTheme
     ? `calc(env(safe-area-inset-bottom, 0px) + ${metadata.taskbarHeight + debugFabGapPx}px)`
     : `calc(env(safe-area-inset-bottom, 0px) + ${debugFabGapPx}px)`;
+  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+  const debugPanelAnchor: DebugPanelAnchor = isWindowsTheme ? "right" : "left";
   const [open, setOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<DebugPanelTab>("logs");
   const [loggerFilter, setLoggerFilter] = useState(ALL_LOGGERS_FILTER);
@@ -710,38 +747,43 @@ export function DebugLogOverlay() {
         zIndex: 2147483000,
       }}
     >
-      {open && (
-        <Tabs
-          value={activeTab}
-          onValueChange={(value) =>
-            setActiveTab(
-              value === "live"
-                ? "live"
-                : value === "network"
-                  ? "network"
-                  : value === "idb"
-                    ? "idb"
-                    : "logs"
-            )
-          }
-          className={cn(
-            isMacOSTheme
-              ? cn(
-                  "window is-foreground flex flex-col overflow-hidden rounded-[0.5rem] font-geneva-12 text-os-text-primary",
-                  flags.isAquaGlass && "window-material-glass"
+      <AnimatePresence initial={false}>
+        {open ? (
+          <DebugPanelMotionShell
+            anchor={debugPanelAnchor}
+            prefersReducedMotion={prefersReducedMotion}
+          >
+            <Tabs
+              value={activeTab}
+              onValueChange={(value) =>
+                setActiveTab(
+                  value === "live"
+                    ? "live"
+                    : value === "network"
+                      ? "network"
+                      : value === "idb"
+                        ? "idb"
+                        : "logs"
                 )
-              : osCardClassName(flags, { embed: "panel" }),
-            "mb-2 h-[min(60vh,420px)] w-[min(92vw,440px)] shadow-os-window"
-          )}
-          style={
-            isMacOSTheme && !flags.isAquaGlass
-              ? {
-                  backgroundColor: "var(--os-color-window-bg)",
-                  backgroundImage: "var(--os-pinstripe-window)",
-                }
-              : undefined
-          }
-        >
+              }
+              className={cn(
+                isMacOSTheme
+                  ? cn(
+                      "window is-foreground flex flex-col overflow-hidden rounded-[0.5rem] font-geneva-12 text-os-text-primary",
+                      flags.isAquaGlass && "window-material-glass"
+                    )
+                  : osCardClassName(flags, { embed: "panel" }),
+                "h-[min(60vh,420px)] w-[min(92vw,440px)] shadow-os-window"
+              )}
+              style={
+                isMacOSTheme && !flags.isAquaGlass
+                  ? {
+                      backgroundColor: "var(--os-color-window-bg)",
+                      backgroundImage: "var(--os-pinstripe-window)",
+                    }
+                  : undefined
+              }
+            >
           {/* Header */}
           <div
             className={cn(
@@ -1188,8 +1230,10 @@ export function DebugLogOverlay() {
               </TabsTrigger>
             </TabsList>
           </div>
-        </Tabs>
-      )}
+            </Tabs>
+          </DebugPanelMotionShell>
+        ) : null}
+      </AnimatePresence>
 
       {/* Toggle button */}
       <button

--- a/src/components/debug/debugOverlayAnimations.ts
+++ b/src/components/debug/debugOverlayAnimations.ts
@@ -1,0 +1,47 @@
+import type { TargetAndTransition, Transition } from "motion/react";
+
+const OPEN_EASE = [0.33, 1, 0.68, 1] as const;
+const CLOSE_EASE = [0.32, 0, 0.67, 0] as const;
+
+export type DebugPanelAnchor = "left" | "right";
+
+export function getDebugPanelTransformOrigin(
+  anchor: DebugPanelAnchor
+): "bottom left" | "bottom right" {
+  return anchor === "right" ? "bottom right" : "bottom left";
+}
+
+export function getDebugPanelMotionProps(params: {
+  prefersReducedMotion: boolean;
+}): {
+  initial: TargetAndTransition;
+  animate: TargetAndTransition;
+  exit: TargetAndTransition;
+  transition: Transition;
+} {
+  if (params.prefersReducedMotion) {
+    return {
+      initial: { opacity: 1 },
+      animate: { opacity: 1 },
+      exit: { opacity: 1 },
+      transition: { duration: 0 },
+    };
+  }
+
+  return {
+    initial: { opacity: 0, scale: 0.95, y: 8 },
+    animate: {
+      opacity: 1,
+      scale: 1,
+      y: 0,
+      transition: { duration: 0.2, ease: OPEN_EASE },
+    },
+    exit: {
+      opacity: 0,
+      scale: 0.95,
+      y: 8,
+      transition: { duration: 0.2, ease: CLOSE_EASE },
+    },
+    transition: { duration: 0.2, ease: OPEN_EASE },
+  };
+}

--- a/tests/test-debug-overlay-animations.test.ts
+++ b/tests/test-debug-overlay-animations.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getDebugPanelMotionProps,
+  getDebugPanelTransformOrigin,
+} from "../src/components/debug/debugOverlayAnimations";
+
+describe("debug overlay animations", () => {
+  test("anchors transform origin above the debug FAB", () => {
+    expect(getDebugPanelTransformOrigin("left")).toBe("bottom left");
+    expect(getDebugPanelTransformOrigin("right")).toBe("bottom right");
+  });
+
+  test("uses subtle scale/opacity/translate when motion is allowed", () => {
+    const motion = getDebugPanelMotionProps({ prefersReducedMotion: false });
+
+    expect(motion.initial).toEqual({ opacity: 0, scale: 0.95, y: 8 });
+    expect(motion.animate).toMatchObject({
+      opacity: 1,
+      scale: 1,
+      y: 0,
+    });
+    expect(motion.exit).toMatchObject({
+      opacity: 0,
+      scale: 0.95,
+      y: 8,
+    });
+    expect(motion.transition).toMatchObject({ duration: 0.2 });
+  });
+
+  test("disables motion when reduced motion is preferred", () => {
+    const motion = getDebugPanelMotionProps({ prefersReducedMotion: true });
+
+    expect(motion.initial).toEqual({ opacity: 1 });
+    expect(motion.animate).toEqual({ opacity: 1 });
+    expect(motion.exit).toEqual({ opacity: 1 });
+    expect(motion.transition).toEqual({ duration: 0 });
+  });
+});
+
+describe("debug overlay animation wiring", () => {
+  test("DebugLogOverlay keeps the panel mounted through AnimatePresence exit", async () => {
+    const source = await Bun.file(
+      "src/components/debug/DebugLogOverlay.tsx"
+    ).text();
+
+    expect(source).toContain("AnimatePresence");
+    expect(source).toContain("getDebugPanelMotionProps");
+    expect(source).toContain('useMediaQuery("(prefers-reduced-motion: reduce)")');
+    expect(source).toContain("useIsPresent");
+    expect(source).toContain("exit={motionProps.exit}");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds polished open/close animations to the debug console overlay (`DebugLogOverlay`), consistent with ryOS window motion (subtle scale, opacity, and translate anchored to the debug FAB).

## Changes

- **`debugOverlayAnimations.ts`** — shared motion props with open/close easing aligned to `windowFrameAnimations`, plus reduced-motion fallback (instant, no transform)
- **`DebugLogOverlay.tsx`** — wraps the panel in `AnimatePresence` + `motion.div` so exit animation completes before unmount; blocks pointer events during exit via `useIsPresent`
- **`test-debug-overlay-animations.test.ts`** — unit tests for motion config and wiring

## Behavior

- **Open:** fades/scales in from slightly below the FAB (`scale: 0.95`, `y: 8`, 200ms)
- **Close:** reverses the motion before unmount (same duration/easing as window close)
- **Reduced motion:** `prefers-reduced-motion: reduce` disables animation (`duration: 0`)
- **Anchor:** transform origin follows FAB placement (`bottom left` on macOS, `bottom right` on Windows)

## Testing

- `bun test tests/test-debug-overlay-animations.test.ts` — pass (4/4)
- `bun run typecheck` — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c3b7096-930d-4a8b-8faf-979ca640a487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c3b7096-930d-4a8b-8faf-979ca640a487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

