### PR TITLE
Fix CloudSync crash when deletion marker buckets are missing

### DIFF
--- a/src/stores/useCloudSyncStore.ts
+++ b/src/stores/useCloudSyncStore.ts
@@ -6,6 +6,7 @@ import {
 } from "@/shared/sync2/namespaces";
 import {
   mergeDeletionMarkerMaps,
+  normalizeDeletionMarkerMap,
   type DeletionMarkerMap,
 } from "@/utils/cloudSyncDeletionMarkers";
 import { persistAutoSyncPreferenceToServer } from "@/utils/autoSyncPreference";
@@ -93,6 +94,17 @@ function createInitialCategoryStatus(): CloudSyncCategoryStatusMap {
     maps: empty(),
     books: empty(),
   };
+}
+
+export function mergePersistedDeletionMarkers(
+  partial: Partial<CloudSyncDeletionMarkerState> | undefined
+): CloudSyncDeletionMarkerState {
+  const next = createEmptyDeletionMarkers();
+  if (!partial || typeof partial !== "object") return next;
+  for (const bucket of CLOUD_SYNC_DELETION_BUCKETS) {
+    next[bucket] = normalizeDeletionMarkerMap(partial[bucket]);
+  }
+  return next;
 }
 
 export function mergePersistedCloudSyncCategoryStatus(
@@ -350,7 +362,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
 
       markDeletedKeys: (bucket, keys, deletedAt = new Date().toISOString()) =>
         set((state) => {
-          const nextBucket = { ...state.deletionMarkers[bucket] };
+          const nextBucket = { ...(state.deletionMarkers[bucket] ?? {}) };
           let changed = false;
           let markerCount = 0;
           for (const key of keys) {
@@ -376,7 +388,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
 
       clearDeletedKeys: (bucket, keys) =>
         set((state) => {
-          const nextBucket = { ...state.deletionMarkers[bucket] };
+          const nextBucket = { ...(state.deletionMarkers[bucket] ?? {}) };
           let changed = false;
           let clearedCount = 0;
           for (const key of keys) {
@@ -401,11 +413,8 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
 
       mergeDeletedKeys: (bucket, markers) =>
         set((state) => {
-          const nextBucket = mergeDeletionMarkerMaps(
-            state.deletionMarkers[bucket],
-            markers
-          );
-          const currentBucket = state.deletionMarkers[bucket];
+          const currentBucket = state.deletionMarkers[bucket] ?? {};
+          const nextBucket = mergeDeletionMarkerMaps(currentBucket, markers);
           const changed =
             Object.keys(nextBucket).length !== Object.keys(currentBucket).length ||
             Object.entries(nextBucket).some(
@@ -438,6 +447,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
           ...currentState,
           ...p,
           categoryStatus: mergePersistedCloudSyncCategoryStatus(p.categoryStatus),
+          deletionMarkers: mergePersistedDeletionMarkers(p.deletionMarkers),
         };
       },
       partialize: (state) => ({

--- a/src/sync/codecs.ts
+++ b/src/sync/codecs.ts
@@ -144,7 +144,9 @@ export function getDeletionMarkerForKey(key: string): string | null {
     [CloudSyncDeletionBucket, string]
   >) {
     if (key.startsWith(prefix)) {
-      return markers[bucket][key.slice(prefix.length)] || null;
+      const bucketMarkers = markers[bucket];
+      if (!bucketMarkers) return null;
+      return bucketMarkers[key.slice(prefix.length)] || null;
     }
   }
   return null;
@@ -168,6 +170,7 @@ export function clearDeletionMarkersForKeys(keys: Iterable<string>): number {
   const store = useCloudSyncStore.getState();
   for (const [bucket, ids] of idsByBucket) {
     const markers = store.deletionMarkers[bucket];
+    if (!markers) continue;
     const presentIds = [...ids].filter((id) => id in markers);
     if (presentIds.length === 0) continue;
     store.clearDeletedKeys(bucket, presentIds);
@@ -184,7 +187,9 @@ export function pruneDeletionMarkersWithoutShadow(
   for (const [bucket, prefix] of Object.entries(DELETION_BUCKET_PREFIXES) as Array<
     [CloudSyncDeletionBucket, string]
   >) {
-    const staleIds = Object.keys(store.deletionMarkers[bucket]).filter(
+    const bucketMarkers = store.deletionMarkers[bucket];
+    if (!bucketMarkers) continue;
+    const staleIds = Object.keys(bucketMarkers).filter(
       (id) => !shadowKeys.has(`${prefix}${id}`)
     );
     if (staleIds.length === 0) continue;

--- a/tests/test-cloud-sync-deletion-marker-pruning.test.ts
+++ b/tests/test-cloud-sync-deletion-marker-pruning.test.ts
@@ -98,6 +98,20 @@ describe("Cloud Sync deletion marker pruning", () => {
     ).toEqual({});
   });
 
+  test("clearDeletionMarkersForKeys tolerates missing marker buckets", () => {
+    useCloudSyncStore.setState({
+      deletionMarkers: {
+        stickyNoteIds: {},
+      } as never,
+    });
+
+    expect(
+      clearDeletionMarkersForKeys([
+        "contacts/contact:31efd9cc-87e3-4d09-b222-689674cafc54",
+      ])
+    ).toBe(0);
+  });
+
   test("remote convergence clears a matching local deletion marker", async () => {
     const store = useCloudSyncStore.getState();
     store.markDeletedKeys("stickyNoteIds", ["remote-delete"]);

--- a/tests/test-sync-v2-codecs.test.ts
+++ b/tests/test-sync-v2-codecs.test.ts
@@ -20,6 +20,7 @@ import {
 import { useAudioSettingsStore } from "../src/stores/useAudioSettingsStore";
 import {
   mergePersistedCloudSyncCategoryStatus,
+  mergePersistedDeletionMarkers,
   useCloudSyncStore,
 } from "../src/stores/useCloudSyncStore";
 import {
@@ -736,6 +737,20 @@ describe("cloud sync store", () => {
     expect(merged.files.downloadProgress).toBeNull();
     expect(merged.maps).toBeDefined();
     expect(merged.tv).toBeDefined();
+  });
+
+  test("persist merge keeps all deletion marker buckets when persisted state is partial", () => {
+    const merged = mergePersistedDeletionMarkers({
+      contactIds: {
+        "31efd9cc-87e3-4d09-b222-689674cafc54": "2026-07-04T04:12:01.251Z",
+      },
+    });
+    expect(merged.contactIds).toEqual({
+      "31efd9cc-87e3-4d09-b222-689674cafc54": "2026-07-04T04:12:01.251Z",
+    });
+    expect(merged.mapsFavoriteIds).toEqual({});
+    expect(merged.tvCustomChannelIds).toEqual({});
+    expect(merged.stickyNoteIds).toEqual({});
   });
 
   test("category toggles round-trip through setCategoryEnabled", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes recurring `[CloudSync] Sync operation failed` errors:

```
TypeError: Cannot use 'in' operator to search for '<uuid>' in undefined
```

## Root cause

`clearDeletionMarkersForKeys` in `src/sync/codecs.ts` runs during sync flush and checks `id in markers` for each deletion-marker bucket. When persisted cloud-sync state was partial (e.g. from an older store version or manual restore), newer buckets like `contactIds` could be missing from `deletionMarkers`, leaving `markers` as `undefined` and throwing during contact (or other) sync.

The stack trace referenced `manualRestoreIntent-*.js` because Vite bundles that module with the sync engine, not because manual restore intent logic was at fault.

## Fix

- Add `mergePersistedDeletionMarkers()` and use it in the zustand persist `merge` callback so all buckets are initialized on hydrate.
- Guard codec helpers (`getDeletionMarkerForKey`, `clearDeletionMarkersForKeys`, `pruneDeletionMarkersWithoutShadow`) against missing buckets.
- Harden store bucket mutations to treat missing buckets as `{}`.

## Testing

- `bun test tests/test-cloud-sync-deletion-marker-pruning.test.ts tests/test-sync-v2-codecs.test.ts` — 50/50 pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8df60168-afb9-4ae8-afd0-6a968ebb5636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8df60168-afb9-4ae8-afd0-6a968ebb5636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

