### PR TITLE
Show filename while fetching files in cloud sync status

### DIFF
--- a/src/components/layout/menu-bar/CloudSyncIndicator.tsx
+++ b/src/components/layout/menu-bar/CloudSyncIndicator.tsx
@@ -83,6 +83,7 @@ interface SyncCategoryActivity {
   isDownloading: boolean;
   uploadProgress: number | null;
   downloadProgress: number | null;
+  downloadItemName: string | null;
 }
 
 export function CloudSyncIndicator() {
@@ -113,6 +114,7 @@ export function CloudSyncIndicator() {
       isDownloading: categoryStatus[category].isDownloading,
       uploadProgress: categoryStatus[category].uploadProgress,
       downloadProgress: categoryStatus[category].downloadProgress,
+      downloadItemName: categoryStatus[category].downloadItemName,
     })
   ).filter((entry) => entry.isUploading || entry.isDownloading);
 
@@ -181,11 +183,17 @@ export function CloudSyncIndicator() {
         <MenubarContent
           align="end"
           sideOffset={1}
-          className="min-w-[200px]"
+          className="min-w-[200px] max-w-[280px]"
         >
           <AnimatePresence initial={false}>
             {activeCategories.map(
-              ({ category, isUploading, uploadProgress, downloadProgress }) => {
+              ({
+                category,
+                isUploading,
+                uploadProgress,
+                downloadProgress,
+                downloadItemName,
+              }) => {
                 const meta = SYNC_CATEGORY_META[category];
                 const activeProgress = isUploading
                   ? uploadProgress
@@ -194,9 +202,17 @@ export function CloudSyncIndicator() {
                   typeof activeProgress === "number"
                     ? Math.round(Math.max(0, Math.min(100, activeProgress)))
                     : null;
+                const itemLabel =
+                  !isUploading && downloadItemName
+                    ? downloadItemName
+                    : t(meta.labelKey);
+                // While fetching, the row title already names the item and the
+                // progress bar shows activity — hide the "Fetching" text.
                 const transferLabel = isUploading
                   ? t("apps.control-panels.autoSync.uploading")
-                  : t("apps.control-panels.autoSync.fetching");
+                  : progress === null
+                    ? t("apps.control-panels.autoSync.fetching")
+                    : null;
                 const transferStatusLabel = isUploading
                   ? formatUploadingStatus(uploadProgress, t)
                   : formatFetchingStatus(downloadProgress, t);
@@ -218,12 +234,14 @@ export function CloudSyncIndicator() {
                         alt=""
                         className="size-4 shrink-0 object-contain"
                       />
-                      <span className="min-w-0 flex-1">{t(meta.labelKey)}</span>
+                      <span className="min-w-0 flex-1 truncate">
+                        {itemLabel}
+                      </span>
                       <span
                         className="ml-auto pl-3 text-xs opacity-60 flex items-center gap-1.5"
                         aria-label={transferStatusLabel}
                       >
-                        <span>{transferLabel}</span>
+                        {transferLabel && <span>{transferLabel}</span>}
                         {progress !== null && (
                           <span
                             className="block h-1 w-12 overflow-hidden rounded-full bg-black/15 os-dark:bg-white/20"

--- a/src/stores/useCloudSyncStore.ts
+++ b/src/stores/useCloudSyncStore.ts
@@ -20,6 +20,8 @@ export interface CloudSyncCategoryStatus {
   isDownloading: boolean;
   uploadProgress: number | null;
   downloadProgress: number | null;
+  /** Display name of the item currently being downloaded (e.g. a filename). */
+  downloadItemName: string | null;
 }
 
 export type CloudSyncCategoryStatusMap = Record<
@@ -80,6 +82,7 @@ function createInitialCategoryStatus(): CloudSyncCategoryStatusMap {
     isDownloading: false,
     uploadProgress: null,
     downloadProgress: null,
+    downloadItemName: null,
   });
   return {
     files: empty(),
@@ -111,6 +114,7 @@ export function mergePersistedCloudSyncCategoryStatus(
         isDownloading: false,
         uploadProgress: null,
         downloadProgress: null,
+        downloadItemName: null,
       };
     }
   }
@@ -153,6 +157,10 @@ interface CloudSyncStoreState {
   markCategoryDownloadProgress: (
     category: SyncCategory,
     progress: number | null
+  ) => void;
+  markCategoryDownloadItem: (
+    category: SyncCategory,
+    name: string | null
   ) => void;
   markCategoryUploaded: (category: SyncCategory, uploadedAt: string) => void;
   markCategoryApplied: (category: SyncCategory, appliedAt: string) => void;
@@ -264,7 +272,9 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
                   }
                 : {
                     isDownloading: active,
-                    ...(!active ? { downloadProgress: null } : {}),
+                    ...(!active
+                      ? { downloadProgress: null, downloadItemName: null }
+                      : {}),
                   }),
             },
           },
@@ -311,6 +321,26 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
           };
         }),
 
+      markCategoryDownloadItem: (category, name) =>
+        set((state) => {
+          const normalized =
+            typeof name === "string" && name.trim().length > 0
+              ? name.trim()
+              : null;
+          if (state.categoryStatus[category].downloadItemName === normalized) {
+            return state;
+          }
+          return {
+            categoryStatus: {
+              ...state.categoryStatus,
+              [category]: {
+                ...state.categoryStatus[category],
+                downloadItemName: normalized,
+              },
+            },
+          };
+        }),
+
       markCategoryUploaded: (category, uploadedAt) => {
         cloudSyncLog.debug("Category upload marked complete", {
           category,
@@ -342,6 +372,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
               lastFetchedAt: appliedAt,
               lastAppliedRemoteAt: appliedAt,
               downloadProgress: null,
+              downloadItemName: null,
             },
           },
           lastError: null,
@@ -465,6 +496,7 @@ export const useCloudSyncStore = create<CloudSyncStoreState>()(
               isDownloading: false,
               uploadProgress: null,
               downloadProgress: null,
+              downloadItemName: null,
             },
           ])
         ) as CloudSyncCategoryStatusMap,

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -62,6 +62,7 @@ import {
   type CodecContext,
 } from "@/sync/codecs";
 import { getPersistedSyncShadowKeys } from "@/sync/stateStorage";
+import { useFilesStore } from "@/stores/useFilesStore";
 import type { IndexedDBStoreItemWithKey as StoreItemWithKey } from "@/utils/indexedDBBackup";
 
 const FLUSH_DEBOUNCE_MS = 1000;
@@ -1175,8 +1176,21 @@ export class CloudSyncEngine {
       };
       emitProgress(0);
 
+      // Blob store keys are content UUIDs; resolve display filenames from the
+      // files-store metadata (may be empty on a fresh device — falls back to
+      // the category label in the UI).
+      const namesByUuid = new Map<string, string>();
+      for (const item of Object.values(useFilesStore.getState().items)) {
+        if (item.uuid && item.name) namesByUuid.set(item.uuid, item.name);
+      }
+
       for (let index = 0; index < downloads.length; index += 1) {
         const { op, contentHash, size } = downloads[index];
+        const storeKey = op.k.slice(prefix.length);
+        syncStore.markCategoryDownloadItem(
+          category,
+          namesByUuid.get(storeKey) ?? null
+        );
         const downloadUrl = urls[index];
         if (!downloadUrl) {
           cloudSyncLog.warn("Blob download URL missing", { namespace });

--- a/tests/test-sync-v2-codecs.test.ts
+++ b/tests/test-sync-v2-codecs.test.ts
@@ -787,6 +787,30 @@ describe("cloud sync store", () => {
     expect(status.downloadProgress).toBeNull();
   });
 
+  test("download item name is normalized and cleared with download activity", () => {
+    const store = useCloudSyncStore.getState();
+    store.markCategorySyncing("files", "download", true);
+    store.markCategoryDownloadItem("files", "  photo.png  ");
+    expect(
+      useCloudSyncStore.getState().categoryStatus.files.downloadItemName
+    ).toBe("photo.png");
+
+    const unchangedStatus = useCloudSyncStore.getState().categoryStatus;
+    store.markCategoryDownloadItem("files", "photo.png");
+    expect(useCloudSyncStore.getState().categoryStatus).toBe(unchangedStatus);
+
+    store.markCategoryDownloadItem("files", "   ");
+    expect(
+      useCloudSyncStore.getState().categoryStatus.files.downloadItemName
+    ).toBeNull();
+
+    store.markCategoryDownloadItem("files", "book.epub");
+    store.markCategorySyncing("files", "download", false);
+    expect(
+      useCloudSyncStore.getState().categoryStatus.files.downloadItemName
+    ).toBeNull();
+  });
+
   test("sync status includes upload percentage when available", () => {
     const t = (key: string) => {
       const labels: Record<string, string> = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

In the menu-bar cloud sync status, while file blobs are being fetched:

- The row now shows the **filename being downloaded** in place of the "Files" category label (falls back to "Files" when the name is unknown, e.g. metadata not yet synced on a fresh device or custom wallpapers).
- The "Fetching" text next to the progress bar is removed — the progress bar alone indicates activity. The text still shows for downloads that have no progress bar, and the "Uploading" label is unchanged.

### Implementation

- `useCloudSyncStore`: added `downloadItemName` to `CloudSyncCategoryStatus` plus a `markCategoryDownloadItem` action; the name is cleared when the download ends or is applied, and is never persisted.
- `src/sync/engine.ts` (`applyBlobOps`): resolves each blob item's display name from the files-store metadata (blob store keys are content UUIDs) and reports it per download.
- `CloudSyncIndicator`: renders the filename (truncated, menu capped at 280px) and hides the fetch label when a progress bar is visible; the aria-label keeps the full "Fetching N%" status.

### Testing

- ✅ `bun test ./tests/test-sync-v2-codecs.test.ts` — 42 pass, including a new test for `downloadItemName` normalization/clearing
- ✅ `bun run typecheck`
- ✅ `bunx eslint` on changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2b52-1879-78be-b024-343cdaa4c808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2b52-1879-78be-b024-343cdaa4c808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

