### PR TITLE
Replace docs home diagram with latest changelog card

### DIFF
--- a/docs/1-overview.md
+++ b/docs/1-overview.md
@@ -4,41 +4,8 @@ ryOS is a web-based desktop environment that brings the nostalgia of classic ope
 
 Whether you're exploring the retro aesthetics, building HTML applets, or chatting with Ryo (the AI assistant), ryOS offers a unique blend of nostalgia and modern web technology.
 
-```mermaid
-graph TB
-    subgraph Presentation["Presentation Layer"]
-        Apps[27 App Modules]
-        UI[UI Components]
-        Themes[4 Themes]
-    end
-    
-    subgraph State["State Management"]
-        Zustand[Zustand Stores]
-    end
-    
-    subgraph Data["Data Layer"]
-        IndexedDB[(IndexedDB)]
-        LocalStorage[(LocalStorage)]
-        API[Vercel + Bun API]
-    end
-    
-    subgraph External["External Services"]
-        AI[AI Providers]
-        Pusher[Real-time<br/>Pusher / Local WS]
-        Redis[(Redis<br/>Upstash / Standard)]
-        ObjectStorage[(Object Storage<br/>Vercel Blob / S3)]
-    end
-    
-    Apps --> Zustand
-    UI --> Zustand
-    Zustand --> IndexedDB
-    Zustand --> LocalStorage
-    Zustand --> API
-    API --> AI
-    API --> Redis
-    API --> ObjectStorage
-    Apps --> Pusher
-```
+<!-- latest-changelog-card -->
+
 
 ## Quick Start
 

--- a/public/docs/overview.html
+++ b/public/docs/overview.html
@@ -470,39 +470,25 @@
         <h1>Overview</h1>
 <p>ryOS is a web-based desktop environment that brings the nostalgia of classic operating systems to modern browsers. Experience the charm of Mac OS X Aqua, System 7, Windows XP, and Windows 98—all running in your browser with 27 fully-functional apps, an AI assistant, and a complete virtual file system.</p>
 <p>Whether you're exploring the retro aesthetics, building HTML applets, or chatting with Ryo (the AI assistant), ryOS offers a unique blend of nostalgia and modern web technology.</p>
-<pre class="mermaid">graph TB
-    subgraph Presentation["Presentation Layer"]
-        Apps[27 App Modules]
-        UI[UI Components]
-        Themes[4 Themes]
-    end
-    
-    subgraph State["State Management"]
-        Zustand[Zustand Stores]
-    end
-    
-    subgraph Data["Data Layer"]
-        IndexedDB[(IndexedDB)]
-        LocalStorage[(LocalStorage)]
-        API[Vercel + Bun API]
-    end
-    
-    subgraph External["External Services"]
-        AI[AI Providers]
-        Pusher[Real-time<br/>Pusher / Local WS]
-        Redis[(Redis<br/>Upstash / Standard)]
-        ObjectStorage[(Object Storage<br/>Vercel Blob / S3)]
-    end
-    
-    Apps --> Zustand
-    UI --> Zustand
-    Zustand --> IndexedDB
-    Zustand --> LocalStorage
-    Zustand --> API
-    API --> AI
-    API --> Redis
-    API --> ObjectStorage
-    Apps --> Pusher</pre>
+<style>
+.latest-changelog-card { display: block; margin: 16px 0 24px; border: 1px solid var(--doc-border); border-radius: 12px; overflow: hidden; background: var(--doc-surface-alt); text-decoration: none; color: inherit; }
+.latest-changelog-card:hover { border-color: var(--doc-text-faint); }
+.latest-changelog-card img { display: block; width: 100%; height: auto; object-fit: contain; border-bottom: 1px solid var(--doc-border); background: var(--doc-surface); }
+.latest-changelog-card-copy { padding: 14px 16px 16px; }
+.latest-changelog-card h3 { font-size: 14px; margin: 0 0 6px; }
+.latest-changelog-card p { color: var(--doc-text-secondary); font-size: 12px; margin: 0; }
+.latest-changelog-card p.latest-changelog-card-label { color: var(--doc-text-tertiary); font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; margin: 0 0 6px; }
+.latest-changelog-card p.latest-changelog-card-cta { color: var(--doc-link); font-size: 11px; margin-top: 8px; }
+</style>
+<a class="latest-changelog-card" href="/docs/changelog">
+<img src="/docs-assets/changelog/2026-07-01-books-library-16x9.webp" alt="Books library in the July 2026 ryOS snapshot" width="1280" height="720" loading="lazy">
+<div class="latest-changelog-card-copy">
+<p class="latest-changelog-card-label">Latest changelog — July 2026</p>
+<h3>Books library</h3>
+<p>A wooden EPUB shelf keeps imports, reading progress, and Meditations together.</p>
+<p class="latest-changelog-card-cta">See what's new →</p>
+</div>
+</a>
 <h2>Quick Start</h2>
 <table><thead><tr><th>I want to...</th><th>Go to</th></tr></thead><tbody><tr><td>Learn about the apps</td><td><a href="/docs/apps">Apps Overview</a></td></tr><tr><td>Understand the architecture</td><td><a href="/docs/architecture">Architecture</a></td></tr><tr><td>Understand the API layer</td><td><a href="/docs/api-architecture">API Architecture</a></td></tr><tr><td>Build with the framework</td><td><a href="/docs/application-framework">Application Framework</a></td></tr><tr><td>Work with AI features</td><td><a href="/docs/ai-system">AI System</a></td></tr><tr><td>Use the APIs</td><td><a href="/docs/api-reference">API Reference</a></td></tr></tbody></table>
 <h2>Key Features</h2>

--- a/public/docs/overview.html
+++ b/public/docs/overview.html
@@ -471,24 +471,37 @@
 <p>ryOS is a web-based desktop environment that brings the nostalgia of classic operating systems to modern browsers. Experience the charm of Mac OS X Aqua, System 7, Windows XP, and Windows 98—all running in your browser with 27 fully-functional apps, an AI assistant, and a complete virtual file system.</p>
 <p>Whether you're exploring the retro aesthetics, building HTML applets, or chatting with Ryo (the AI assistant), ryOS offers a unique blend of nostalgia and modern web technology.</p>
 <style>
-.latest-changelog-card { display: block; margin: 16px 0 24px; border: 1px solid var(--doc-border); border-radius: 12px; overflow: hidden; background: var(--doc-surface-alt); text-decoration: none; color: inherit; }
+.latest-changelog-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; margin: 16px 0 24px; }
+.latest-changelog-card { display: flex; flex-direction: column; border: 1px solid var(--doc-border); border-radius: 12px; overflow: hidden; background: var(--doc-surface-alt); text-decoration: none; color: inherit; }
 .latest-changelog-card:hover { border-color: var(--doc-text-faint); }
 .latest-changelog-card img { display: block; width: 100%; height: auto; object-fit: contain; border-bottom: 1px solid var(--doc-border); background: var(--doc-surface); }
-.latest-changelog-card-copy { padding: 14px 16px 16px; }
+.latest-changelog-card-copy { padding: 14px 16px 16px; display: flex; flex-direction: column; flex: 1; }
 .latest-changelog-card h3 { font-size: 14px; margin: 0 0 6px; }
 .latest-changelog-card p { color: var(--doc-text-secondary); font-size: 12px; margin: 0; }
 .latest-changelog-card p.latest-changelog-card-label { color: var(--doc-text-tertiary); font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; margin: 0 0 6px; }
-.latest-changelog-card p.latest-changelog-card-cta { color: var(--doc-link); font-size: 11px; margin-top: 8px; }
+.latest-changelog-card p.latest-changelog-card-cta { color: var(--doc-link); font-size: 11px; margin-top: auto; padding-top: 8px; }
+@media screen and (max-width: 768px) { .latest-changelog-grid { grid-template-columns: 1fr; gap: 14px; } .latest-changelog-card-copy { padding: 12px 14px 14px; } }
 </style>
+<div class="latest-changelog-grid">
 <a class="latest-changelog-card" href="/docs/changelog">
 <img src="/docs-assets/changelog/2026-07-01-books-library-16x9.webp" alt="Books library in the July 2026 ryOS snapshot" width="1280" height="720" loading="lazy">
 <div class="latest-changelog-card-copy">
-<p class="latest-changelog-card-label">Latest changelog — July 2026</p>
+<p class="latest-changelog-card-label">July 2026</p>
 <h3>Books library</h3>
 <p>A wooden EPUB shelf keeps imports, reading progress, and Meditations together.</p>
 <p class="latest-changelog-card-cta">See what's new →</p>
 </div>
 </a>
+<a class="latest-changelog-card" href="/docs/changelog">
+<img src="/docs-assets/changelog/2026-07-05-aqua-appearance-16x9.webp" alt="Aqua Glass in the June 2026 ryOS snapshot" width="1280" height="720" loading="lazy">
+<div class="latest-changelog-card-copy">
+<p class="latest-changelog-card-label">June 2026</p>
+<h3>Aqua Glass</h3>
+<p>The new macOS material brings translucent chrome and wallpaper-aware controls.</p>
+<p class="latest-changelog-card-cta">See what's new →</p>
+</div>
+</a>
+</div>
 <h2>Quick Start</h2>
 <table><thead><tr><th>I want to...</th><th>Go to</th></tr></thead><tbody><tr><td>Learn about the apps</td><td><a href="/docs/apps">Apps Overview</a></td></tr><tr><td>Understand the architecture</td><td><a href="/docs/architecture">Architecture</a></td></tr><tr><td>Understand the API layer</td><td><a href="/docs/api-architecture">API Architecture</a></td></tr><tr><td>Build with the framework</td><td><a href="/docs/application-framework">Application Framework</a></td></tr><tr><td>Work with AI features</td><td><a href="/docs/ai-system">AI System</a></td></tr><tr><td>Use the APIs</td><td><a href="/docs/api-reference">API Reference</a></td></tr></tbody></table>
 <h2>Key Features</h2>

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -262,49 +262,97 @@ function markdownToHtml(md: string, appContext?: string): string {
 const LATEST_CHANGELOG_CARD_PLACEHOLDER = "<!-- latest-changelog-card -->";
 const CHANGELOG_FILE = "9-changelog.md";
 
+interface FeaturedChangelogEntry {
+  monthLabel: string;
+  imageHtml: string;
+  title: string;
+  description: string;
+}
+
+const CHANGELOG_MONTH_OR_FEATURE_RE =
+  /^## (.+)$|<article class="changelog-feature"><img src="([^"]+)" alt="([^"]*)"([^>]*)><div class="changelog-feature-copy"><h3>([^<]+)<\/h3><p>([^<]+)<\/p>/gm;
+
 /**
- * Build a card linking to the changelog that showcases the newest featured
- * entry (image + title + blurb). The changelog is ordered newest-first, so the
- * first `.changelog-feature` article in the file is the latest.
+ * Collect the newest featured changelog entries in document order (the
+ * changelog is ordered newest-first), pairing each entry with the month
+ * heading it appears under.
+ */
+function parseFeaturedChangelogEntries(
+  changelogMd: string,
+  limit: number,
+): FeaturedChangelogEntry[] {
+  const entries: FeaturedChangelogEntry[] = [];
+  let currentMonth = "";
+
+  for (const match of changelogMd.matchAll(CHANGELOG_MONTH_OR_FEATURE_RE)) {
+    if (match[1] !== undefined) {
+      currentMonth = match[1].trim();
+      continue;
+    }
+    entries.push({
+      monthLabel: currentMonth,
+      imageHtml: `<img src="${match[2]}" alt="${match[3]}"${match[4]}>`,
+      title: match[5],
+      description: match[6],
+    });
+    if (entries.length >= limit) break;
+  }
+
+  return entries;
+}
+
+/**
+ * Build cards linking to the changelog that showcase the two newest featured
+ * entries (image + title + blurb), laid out as a 2-column grid on large
+ * screens and a single column on mobile.
  */
 export function buildLatestChangelogCard(changelogMd: string): string {
-  const monthMatch = changelogMd.match(/^## (.+)$/m);
-  const featureMatch = changelogMd.match(
-    /<article class="changelog-feature"><img src="([^"]+)" alt="([^"]*)"([^>]*)><div class="changelog-feature-copy"><h3>([^<]+)<\/h3><p>([^<]+)<\/p>/
-  );
+  const entries = parseFeaturedChangelogEntries(changelogMd, 2);
 
-  const monthLabel = monthMatch ? monthMatch[1].trim() : "";
-  const label = monthLabel ? `Latest changelog — ${monthLabel}` : "Latest changelog";
-
-  const imageHtml = featureMatch
-    ? `<img src="${featureMatch[1]}" alt="${featureMatch[2]}"${featureMatch[3]}>`
-    : "";
-  const title = featureMatch ? featureMatch[4] : "See what's new";
-  const description = featureMatch ? featureMatch[5] : "";
+  const cards =
+    entries.length > 0
+      ? entries.map((entry) =>
+          [
+            `<a class="latest-changelog-card" href="/docs/changelog">`,
+            entry.imageHtml,
+            `<div class="latest-changelog-card-copy">`,
+            `<p class="latest-changelog-card-label">${entry.monthLabel || "Changelog"}</p>`,
+            `<h3>${entry.title}</h3>`,
+            `<p>${entry.description}</p>`,
+            `<p class="latest-changelog-card-cta">See what's new →</p>`,
+            `</div>`,
+            `</a>`,
+          ].join("\n"),
+        )
+      : [
+          [
+            `<a class="latest-changelog-card" href="/docs/changelog">`,
+            `<div class="latest-changelog-card-copy">`,
+            `<p class="latest-changelog-card-label">Latest changelog</p>`,
+            `<h3>See what's new</h3>`,
+            `<p class="latest-changelog-card-cta">See what's new →</p>`,
+            `</div>`,
+            `</a>`,
+          ].join("\n"),
+        ];
 
   return [
     `<style>`,
-    `.latest-changelog-card { display: block; margin: 16px 0 24px; border: 1px solid var(--doc-border); border-radius: 12px; overflow: hidden; background: var(--doc-surface-alt); text-decoration: none; color: inherit; }`,
+    `.latest-changelog-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; margin: 16px 0 24px; }`,
+    `.latest-changelog-card { display: flex; flex-direction: column; border: 1px solid var(--doc-border); border-radius: 12px; overflow: hidden; background: var(--doc-surface-alt); text-decoration: none; color: inherit; }`,
     `.latest-changelog-card:hover { border-color: var(--doc-text-faint); }`,
     `.latest-changelog-card img { display: block; width: 100%; height: auto; object-fit: contain; border-bottom: 1px solid var(--doc-border); background: var(--doc-surface); }`,
-    `.latest-changelog-card-copy { padding: 14px 16px 16px; }`,
+    `.latest-changelog-card-copy { padding: 14px 16px 16px; display: flex; flex-direction: column; flex: 1; }`,
     `.latest-changelog-card h3 { font-size: 14px; margin: 0 0 6px; }`,
     `.latest-changelog-card p { color: var(--doc-text-secondary); font-size: 12px; margin: 0; }`,
     `.latest-changelog-card p.latest-changelog-card-label { color: var(--doc-text-tertiary); font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; margin: 0 0 6px; }`,
-    `.latest-changelog-card p.latest-changelog-card-cta { color: var(--doc-link); font-size: 11px; margin-top: 8px; }`,
+    `.latest-changelog-card p.latest-changelog-card-cta { color: var(--doc-link); font-size: 11px; margin-top: auto; padding-top: 8px; }`,
+    `@media screen and (max-width: 768px) { .latest-changelog-grid { grid-template-columns: 1fr; gap: 14px; } .latest-changelog-card-copy { padding: 12px 14px 14px; } }`,
     `</style>`,
-    `<a class="latest-changelog-card" href="/docs/changelog">`,
-    imageHtml,
-    `<div class="latest-changelog-card-copy">`,
-    `<p class="latest-changelog-card-label">${label}</p>`,
-    `<h3>${title}</h3>`,
-    description ? `<p>${description}</p>` : "",
-    `<p class="latest-changelog-card-cta">See what's new →</p>`,
+    `<div class="latest-changelog-grid">`,
+    ...cards,
     `</div>`,
-    `</a>`,
-  ]
-    .filter(Boolean)
-    .join("\n");
+  ].join("\n");
 }
 
 interface DocEntry {

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -259,6 +259,54 @@ function markdownToHtml(md: string, appContext?: string): string {
   return html;
 }
 
+const LATEST_CHANGELOG_CARD_PLACEHOLDER = "<!-- latest-changelog-card -->";
+const CHANGELOG_FILE = "9-changelog.md";
+
+/**
+ * Build a card linking to the changelog that showcases the newest featured
+ * entry (image + title + blurb). The changelog is ordered newest-first, so the
+ * first `.changelog-feature` article in the file is the latest.
+ */
+export function buildLatestChangelogCard(changelogMd: string): string {
+  const monthMatch = changelogMd.match(/^## (.+)$/m);
+  const featureMatch = changelogMd.match(
+    /<article class="changelog-feature"><img src="([^"]+)" alt="([^"]*)"([^>]*)><div class="changelog-feature-copy"><h3>([^<]+)<\/h3><p>([^<]+)<\/p>/
+  );
+
+  const monthLabel = monthMatch ? monthMatch[1].trim() : "";
+  const label = monthLabel ? `Latest changelog — ${monthLabel}` : "Latest changelog";
+
+  const imageHtml = featureMatch
+    ? `<img src="${featureMatch[1]}" alt="${featureMatch[2]}"${featureMatch[3]}>`
+    : "";
+  const title = featureMatch ? featureMatch[4] : "See what's new";
+  const description = featureMatch ? featureMatch[5] : "";
+
+  return [
+    `<style>`,
+    `.latest-changelog-card { display: block; margin: 16px 0 24px; border: 1px solid var(--doc-border); border-radius: 12px; overflow: hidden; background: var(--doc-surface-alt); text-decoration: none; color: inherit; }`,
+    `.latest-changelog-card:hover { border-color: var(--doc-text-faint); }`,
+    `.latest-changelog-card img { display: block; width: 100%; height: auto; object-fit: contain; border-bottom: 1px solid var(--doc-border); background: var(--doc-surface); }`,
+    `.latest-changelog-card-copy { padding: 14px 16px 16px; }`,
+    `.latest-changelog-card h3 { font-size: 14px; margin: 0 0 6px; }`,
+    `.latest-changelog-card p { color: var(--doc-text-secondary); font-size: 12px; margin: 0; }`,
+    `.latest-changelog-card p.latest-changelog-card-label { color: var(--doc-text-tertiary); font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; margin: 0 0 6px; }`,
+    `.latest-changelog-card p.latest-changelog-card-cta { color: var(--doc-link); font-size: 11px; margin-top: 8px; }`,
+    `</style>`,
+    `<a class="latest-changelog-card" href="/docs/changelog">`,
+    imageHtml,
+    `<div class="latest-changelog-card-copy">`,
+    `<p class="latest-changelog-card-label">${label}</p>`,
+    `<h3>${title}</h3>`,
+    description ? `<p>${description}</p>` : "",
+    `<p class="latest-changelog-card-cta">See what's new →</p>`,
+    `</div>`,
+    `</a>`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
 interface DocEntry {
   id: string;
   title: string;
@@ -822,6 +870,12 @@ async function generate() {
   const files = await readdir(DOCS_DIR);
   const mdFiles = files.filter((f) => f.endsWith(".md")).sort();
 
+  let latestChangelogCard = "";
+  if (mdFiles.includes(CHANGELOG_FILE)) {
+    const changelogMd = await readFile(join(DOCS_DIR, CHANGELOG_FILE), "utf-8");
+    latestChangelogCard = buildLatestChangelogCard(changelogMd);
+  }
+
   const docs: DocEntry[] = [];
 
   for (const file of mdFiles) {
@@ -839,7 +893,10 @@ async function generate() {
       appContext = appNameMatch[1];
     }
     
-    const html = markdownToHtml(content, appContext);
+    let html = markdownToHtml(content, appContext);
+    if (latestChangelogCard && html.includes(LATEST_CHANGELOG_CARD_PLACEHOLDER)) {
+      html = html.replace(LATEST_CHANGELOG_CARD_PLACEHOLDER, latestChangelogCard);
+    }
     docs.push({ 
       id, 
       title, 

--- a/tests/test-generate-docs-path-links.test.ts
+++ b/tests/test-generate-docs-path-links.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveInlineCodePath } from "../scripts/generate-docs";
+import {
+  buildLatestChangelogCard,
+  resolveInlineCodePath,
+} from "../scripts/generate-docs";
 
 describe("generate-docs inline code path links", () => {
   test("keeps repo-root test files out of src links", () => {
@@ -37,5 +40,49 @@ describe("generate-docs inline code path links", () => {
       fullPath: "src/stores/useLanguageStore.ts",
       matchedText: "stores/useLanguageStore.ts",
     });
+  });
+});
+
+describe("generate-docs latest changelog card", () => {
+  const changelogMd = `# Changelog
+
+Intro copy.
+
+---
+
+## July 2026
+
+<div class="changelog-feature-grid">
+<article class="changelog-feature"><img src="/docs-assets/changelog/2026-07-01-books-library-16x9.webp" alt="Books library in the July 2026 ryOS snapshot" width="1280" height="720" loading="lazy"><div class="changelog-feature-copy"><h3>Books library</h3><p>A wooden EPUB shelf keeps imports, reading progress, and Meditations together.</p></div></article>
+</div>
+
+## June 2026
+
+<div class="changelog-feature-grid">
+<article class="changelog-feature"><img src="/docs-assets/changelog/2026-07-05-aqua-appearance-16x9.webp" alt="Aqua Glass" width="1280" height="720" loading="lazy"><div class="changelog-feature-copy"><h3>Aqua Glass</h3><p>Older entry.</p></div></article>
+</div>
+`;
+
+  test("builds a card from the newest featured entry", () => {
+    const card = buildLatestChangelogCard(changelogMd);
+    expect(card).toContain('href="/docs/changelog"');
+    expect(card).toContain("Latest changelog — July 2026");
+    expect(card).toContain(
+      'src="/docs-assets/changelog/2026-07-01-books-library-16x9.webp"',
+    );
+    expect(card).toContain("<h3>Books library</h3>");
+    expect(card).toContain(
+      "A wooden EPUB shelf keeps imports, reading progress, and Meditations together.",
+    );
+    // Must not pick up the older month's entry
+    expect(card).not.toContain("Aqua Glass");
+  });
+
+  test("falls back gracefully when no featured entry exists", () => {
+    const card = buildLatestChangelogCard("# Changelog\n\nNo entries yet.\n");
+    expect(card).toContain('href="/docs/changelog"');
+    expect(card).toContain("Latest changelog");
+    expect(card).toContain("See what's new");
+    expect(card).not.toContain("<img");
   });
 });

--- a/tests/test-generate-docs-path-links.test.ts
+++ b/tests/test-generate-docs-path-links.test.ts
@@ -59,23 +59,26 @@ Intro copy.
 ## June 2026
 
 <div class="changelog-feature-grid">
-<article class="changelog-feature"><img src="/docs-assets/changelog/2026-07-05-aqua-appearance-16x9.webp" alt="Aqua Glass" width="1280" height="720" loading="lazy"><div class="changelog-feature-copy"><h3>Aqua Glass</h3><p>Older entry.</p></div></article>
+<article class="changelog-feature"><img src="/docs-assets/changelog/2026-07-05-aqua-appearance-16x9.webp" alt="Aqua Glass" width="1280" height="720" loading="lazy"><div class="changelog-feature-copy"><h3>Aqua Glass</h3><p>Translucent chrome.</p></div></article>
+<article class="changelog-feature"><img src="/docs-assets/changelog/2026-07-02-cloud-sync-16x9.webp" alt="Cloud Sync v2" width="1280" height="720" loading="lazy"><div class="changelog-feature-copy"><h3>Cloud Sync v2</h3><p>Journal-based delta sync.</p></div></article>
 </div>
 `;
 
-  test("builds a card from the newest featured entry", () => {
+  test("builds cards from the two newest featured entries with month labels", () => {
     const card = buildLatestChangelogCard(changelogMd);
-    expect(card).toContain('href="/docs/changelog"');
-    expect(card).toContain("Latest changelog — July 2026");
+    expect(card).toContain('class="latest-changelog-grid"');
+    expect(card.match(/href="\/docs\/changelog"/g)?.length).toBe(2);
+    // Newest entry (July) with its month label
+    expect(card).toContain("July 2026");
     expect(card).toContain(
       'src="/docs-assets/changelog/2026-07-01-books-library-16x9.webp"',
     );
     expect(card).toContain("<h3>Books library</h3>");
-    expect(card).toContain(
-      "A wooden EPUB shelf keeps imports, reading progress, and Meditations together.",
-    );
-    // Must not pick up the older month's entry
-    expect(card).not.toContain("Aqua Glass");
+    // Second-newest entry crosses into the previous month (June)
+    expect(card).toContain("June 2026");
+    expect(card).toContain("<h3>Aqua Glass</h3>");
+    // Must stop at two entries
+    expect(card).not.toContain("Cloud Sync v2");
   });
 
   test("falls back gracefully when no featured entry exists", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the architecture mermaid diagram at the top of the docs home page (`/docs/overview`) with cards linking to `/docs/changelog` that showcase the **two newest featured changelog entries** (image, month label, title, blurb) — laid out as a 2-column grid on large screens and a single column on mobile.

- `docs/1-overview.md`: swap the mermaid diagram for a `<!-- latest-changelog-card -->` placeholder.
- `scripts/generate-docs.ts`: `buildLatestChangelogCard()` parses the two newest featured `.changelog-feature` articles from `docs/9-changelog.md` (tracking the month heading each appears under, so entries can span months) and injects the rendered card grid wherever the placeholder appears; the cards automatically track the latest changelog on regeneration.
- `public/docs/overview.html`: regenerated output.
- `tests/test-generate-docs-path-links.test.ts`: unit tests covering two-entry selection across months and the no-entry fallback.

## Screenshots

Desktop (2-column):
![Docs home with two changelog cards, desktop 2-column](https://cursor.com/artifacts/c/art-f39f0a01-b575-4d3c-a094-ff8cb908364f)

Mobile (1-column):
![Docs home with two changelog cards, mobile 1-column](https://cursor.com/artifacts/c/art-297c8927-64ad-48b1-b52d-b69b76b5596d)

Dark mode:
![Docs home changelog card, dark mode](https://cursor.com/artifacts/c/art-d442e566-8ea3-4cd9-b2e5-bc8c779f84ec)

## Testing

- ✅ `bun test tests/test-generate-docs-path-links.test.ts` (6 pass)
- ✅ `bun run scripts/generate-docs.ts` regenerates cleanly
- ✅ Verified rendered page in headless Chrome at desktop (1100px) and mobile (420px) widths, plus dark mode
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2b41-79a7-7b98-ac58-efd0c3d4b1d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2b41-79a7-7b98-ac58-efd0c3d4b1d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

