### PR TITLE
Offload cloud sync serialization, hashing, and compression to a Web Worker

### DIFF
--- a/src/sync/blobs.ts
+++ b/src/sync/blobs.ts
@@ -8,49 +8,17 @@ import { uploadBlobWithStorageInstruction } from "@/utils/storageUpload";
 import type { StorageUploadInstruction } from "@/utils/storageUpload";
 import type { SyncBlobRef } from "@/shared/sync2/types";
 import { postSyncBlobs } from "@/sync/transport";
+import { decodeBlobItemOffThread } from "@/sync/workerClient";
 
-function assertCompressionSupport(): void {
-  if (
-    typeof CompressionStream === "undefined" ||
-    typeof DecompressionStream === "undefined"
-  ) {
-    throw new Error("Cloud sync requires browser compression support.");
-  }
-}
-
-export async function gzipJson(value: unknown): Promise<Uint8Array> {
-  assertCompressionSupport();
-  const inputData = new TextEncoder().encode(JSON.stringify(value));
-  const stream = new Blob([inputData])
-    .stream()
-    .pipeThrough(new CompressionStream("gzip"));
-  return new Uint8Array(await new Response(stream).arrayBuffer());
-}
-
-export async function gunzipJson<T>(data: ArrayBuffer | Uint8Array): Promise<T> {
-  assertCompressionSupport();
-  const buffer = data instanceof Uint8Array ? (data.slice().buffer as ArrayBuffer) : data;
-  const stream = new Blob([buffer])
-    .stream()
-    .pipeThrough(new DecompressionStream("gzip"));
-  const text = await new Response(stream).text();
-  return JSON.parse(text) as T;
-}
-
-/** SHA-256 hex of the serialized item JSON. */
-export async function sha256Json(value: unknown): Promise<string> {
-  const payload = new TextEncoder().encode(JSON.stringify(value));
-  const digest = await crypto.subtle.digest("SHA-256", payload);
-  return Array.from(new Uint8Array(digest), (byte) =>
-    byte.toString(16).padStart(2, "0")
-  ).join("");
-}
+// Pure content transforms live in the shared codec module (also bundled by
+// the cloud sync worker); re-exported here for existing import sites.
+export { gunzipJson, gzipJson, sha256Json } from "@/sync/contentCodec";
 
 export interface BlobUploadItem {
   key: string;
   sha256: string;
-  /** Serialized store item (JSON-able). */
-  item: unknown;
+  /** Gzip of the serialized item JSON (precompressed off the main thread). */
+  compressed: Uint8Array;
 }
 
 export interface BlobUploadBatchProgress {
@@ -89,7 +57,7 @@ export async function uploadBlobItems(
   const refs = new Map<string, SyncBlobRef>();
   if (items.length === 0) return refs;
 
-  // Pre-compress to know sizes; dedupe identical content within the batch.
+  // Items arrive precompressed; dedupe identical content within the batch.
   const byDigest = new Map<string, { compressed: Uint8Array; keys: string[] }>();
   for (const item of items) {
     options.signal?.throwIfAborted();
@@ -98,8 +66,7 @@ export async function uploadBlobItems(
       existing.keys.push(item.key);
       continue;
     }
-    const compressed = await gzipJson(item.item);
-    byDigest.set(item.sha256, { compressed, keys: [item.key] });
+    byDigest.set(item.sha256, { compressed: item.compressed, keys: [item.key] });
   }
 
   const digests = Array.from(byDigest.keys());
@@ -258,7 +225,7 @@ async function readResponseWithProgress(
   return result.buffer;
 }
 
-/** Download and decode one blob item. */
+/** Download and decode one blob item (gunzip + parse run off-thread). */
 export async function downloadBlobItem(
   downloadUrl: string,
   options: BlobDownloadOptions = {}
@@ -267,7 +234,7 @@ export async function downloadBlobItem(
   if (!response.ok) {
     throw new Error(`Failed to fetch sync blob: ${response.status}`);
   }
-  return await gunzipJson<unknown>(
+  return await decodeBlobItemOffThread(
     await readResponseWithProgress(response, options)
   );
 }

--- a/src/sync/codecs.ts
+++ b/src/sync/codecs.ts
@@ -1828,8 +1828,10 @@ function createBlobCodec(
     usesIndexedDb: true,
     storeName,
     async collect(ctx, keys) {
-      // Blob codec collect returns serialized items keyed by sync key; the
-      // engine converts them to `{ blob: ref }` docs after content upload.
+      // Blob codec collect returns *raw* store items keyed by sync key
+      // (binary fields still Blob/ArrayBuffer). The engine hands them to the
+      // sync worker, which serializes (base64), digests, and gzips them off
+      // the main thread before converting to `{ blob: ref }` docs.
       const db = requireDb(ctx, namespace);
       const itemPrefix = `${namespace}/item:`;
       const itemKeys = keys
@@ -1840,13 +1842,9 @@ function createBlobCodec(
       const storeItems = itemKeys
         ? await readStoreItemsByKeys(db, storeName, itemKeys)
         : await readStoreItems(db, storeName);
-      const items = await serializeStoreItems(
-        storeItems.map((item) =>
-          prepareStoreItemForSync(storeName, item)
-        )
-      );
       const docs = new Map<string, unknown>();
-      for (const item of items) {
+      for (const storeItem of storeItems) {
+        const item = prepareStoreItemForSync(storeName, storeItem);
         if (item.key) {
           docs.set(`${namespace}/item:${item.key}`, item);
         }

--- a/src/sync/contentCodec.ts
+++ b/src/sync/contentCodec.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure Cloud Sync v2 content transforms: JSON gzip envelopes, SHA-256
+ * content digests, and the fast cyrb53 document hash used by the shadow map.
+ *
+ * Dependency-free so the cloud sync Web Worker can bundle these without
+ * dragging in stores, transport, or IndexedDB code. Main-thread callers
+ * import them via `@/sync/blobs` and `@/sync/state` re-exports.
+ */
+
+function assertCompressionSupport(): void {
+  if (
+    typeof CompressionStream === "undefined" ||
+    typeof DecompressionStream === "undefined"
+  ) {
+    throw new Error("Cloud sync requires browser compression support.");
+  }
+}
+
+export async function gzipJson(value: unknown): Promise<Uint8Array> {
+  assertCompressionSupport();
+  const inputData = new TextEncoder().encode(JSON.stringify(value));
+  const stream = new Blob([inputData])
+    .stream()
+    .pipeThrough(new CompressionStream("gzip"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+export async function gunzipJson<T>(data: ArrayBuffer | Uint8Array): Promise<T> {
+  assertCompressionSupport();
+  const buffer = data instanceof Uint8Array ? (data.slice().buffer as ArrayBuffer) : data;
+  const stream = new Blob([buffer])
+    .stream()
+    .pipeThrough(new DecompressionStream("gzip"));
+  const text = await new Response(stream).text();
+  return JSON.parse(text) as T;
+}
+
+/** SHA-256 hex of the serialized item JSON. */
+export async function sha256Json(value: unknown): Promise<string> {
+  const payload = new TextEncoder().encode(JSON.stringify(value));
+  const digest = await crypto.subtle.digest("SHA-256", payload);
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("");
+}
+
+/** Fast 53-bit string hash (cyrb53) for shadow content hashes. */
+export function hashDocJson(json: string): string {
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  for (let i = 0; i < json.length; i += 1) {
+    const ch = json.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(36);
+}
+
+export function hashDoc(doc: unknown): string {
+  return hashDocJson(JSON.stringify(doc));
+}

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -31,7 +31,6 @@ import {
 } from "@/shared/sync2/types";
 import {
   getSyncClientId,
-  hashDoc,
   SyncClientState,
 } from "@/sync/state";
 import {
@@ -46,6 +45,10 @@ import {
   uploadBlobItems,
   type BlobUploadItem,
 } from "@/sync/blobs";
+import {
+  hashDocsOffThread,
+  prepareBlobUpsertsOffThread,
+} from "@/sync/workerClient";
 import {
   cloudSyncLog,
   summarizeDirtyScope,
@@ -69,7 +72,6 @@ const FLUSH_MAX_DEBOUNCE_MS = 3000;
 const FLUSH_IDLE_TIMEOUT_MS = 2000;
 const FLUSH_FAILURE_BACKOFF_BASE_MS = 2000;
 const FLUSH_FAILURE_BACKOFF_MAX_MS = 60_000;
-const BLOB_HASH_YIELD_INTERVAL = 4;
 const OPS_BATCH_SIZE = 400;
 const SYNC_FLUSH_LOCK = "ryos:cloud-sync-flush";
 
@@ -81,10 +83,6 @@ const SUSPICIOUS_DELETE_RATIO = 0.8;
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
-}
-
-async function yieldToMainThread(): Promise<void> {
-  await new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
 interface EngineStatusCallbacks {
@@ -431,6 +429,17 @@ export class CloudSyncEngine {
     );
   }
 
+  private collectShadowHashes(
+    keys: Iterable<string>
+  ): Record<string, string> {
+    const shadowHashes: Record<string, string> = {};
+    for (const key of keys) {
+      const shadow = this.state.getShadow(key);
+      if (shadow) shadowHashes[key] = shadow.h;
+    }
+    return shadowHashes;
+  }
+
   private isNamespaceEnabled(namespace: SyncNamespace): boolean {
     const syncStore = useCloudSyncStore.getState();
     return (
@@ -547,20 +556,28 @@ export class CloudSyncEngine {
 
           // Upserts: keys whose content hash differs from the shadow.
           if (isSyncBlobNamespace(namespace)) {
+            // Serialize + digest + gzip run in the sync worker (or the
+            // yielding main-thread fallback); only changed items come back
+            // with compressed payloads.
+            const candidates = await prepareBlobUpsertsOffThread(
+              [...collected].map(([key, item]) => ({
+                key,
+                item: item as StoreItemWithKey,
+              })),
+              this.collectShadowHashes(collected.keys()),
+              Boolean(options.force)
+            );
+            if (this.stopped) return;
             const pendingUploads: BlobUploadItem[] = [];
             const pendingTimestamps = new Map<string, string>();
-            let itemIndex = 0;
-            for (const [key, item] of collected) {
-              if (itemIndex > 0 && itemIndex % BLOB_HASH_YIELD_INTERVAL === 0) {
-                await yieldToMainThread();
-                if (this.stopped) return;
-              }
-              itemIndex += 1;
-              const sha256 = await sha256Json(item);
-              const shadow = this.state.getShadow(key);
-              if (!options.force && shadow?.h === sha256) continue;
-              pendingUploads.push({ key, sha256, item });
-              pendingTimestamps.set(key, this.state.nextTimestamp());
+            for (const candidate of candidates) {
+              if (!candidate.compressed) continue;
+              pendingUploads.push({
+                key: candidate.key,
+                sha256: candidate.sha256,
+                compressed: candidate.compressed,
+              });
+              pendingTimestamps.set(candidate.key, this.state.nextTimestamp());
             }
             upsertCount += pendingUploads.length;
             if (pendingUploads.length > 0) {
@@ -591,8 +608,12 @@ export class CloudSyncEngine {
               }
             }
           } else {
+            const hashes = await hashDocsOffThread(
+              [...collected].map(([key, doc]) => ({ key, doc }))
+            );
+            if (this.stopped) return;
             for (const [key, doc] of collected) {
-              const h = hashDoc(doc);
+              const h = hashes.get(key)!;
               const shadow = this.state.getShadow(key);
               if (!options.force && shadow?.h === h) continue;
               const t = this.state.nextTimestamp();
@@ -1061,11 +1082,19 @@ export class CloudSyncEngine {
               namespaceOps,
               ctx
             );
+            const upsertHashes = await hashDocsOffThread(
+              namespaceOps
+                .filter((op) => !op.del)
+                .map((op) => ({ key: op.k, doc: op.v }))
+            );
             for (const op of namespaceOps) {
               if (op.del) {
                 this.state.deleteShadow(op.k);
               } else {
-                this.state.setShadow(op.k, { t: op.t, h: hashDoc(op.v) });
+                this.state.setShadow(op.k, {
+                  t: op.t,
+                  h: upsertHashes.get(op.k)!,
+                });
               }
             }
             // A codec can reject an op when a newer local value won an
@@ -1312,20 +1341,26 @@ export class CloudSyncEngine {
         }
 
         if (isSyncBlobNamespace(namespace)) {
+          const candidates = await prepareBlobUpsertsOffThread(
+            [...collected].map(([key, item]) => ({
+              key,
+              item: item as StoreItemWithKey,
+            })),
+            {},
+            true
+          );
+          if (this.stopped) {
+            throw new DOMException("Cloud sync stopped", "AbortError");
+          }
           const pendingUploads: BlobUploadItem[] = [];
           const pendingTimestamps = new Map<string, string>();
-          let itemIndex = 0;
-          for (const [key, item] of collected) {
-            if (itemIndex > 0 && itemIndex % BLOB_HASH_YIELD_INTERVAL === 0) {
-              await yieldToMainThread();
-              if (this.stopped) {
-                throw new DOMException("Cloud sync stopped", "AbortError");
-              }
-            }
-            itemIndex += 1;
-            const sha256 = await sha256Json(item);
-            pendingUploads.push({ key, sha256, item });
-            pendingTimestamps.set(key, this.state.nextTimestamp());
+          for (const candidate of candidates) {
+            pendingUploads.push({
+              key: candidate.key,
+              sha256: candidate.sha256,
+              compressed: candidate.compressed!,
+            });
+            pendingTimestamps.set(candidate.key, this.state.nextTimestamp());
           }
 
           if (pendingUploads.length > 0) {
@@ -1350,8 +1385,11 @@ export class CloudSyncEngine {
             }
           }
         } else {
+          const hashes = await hashDocsOffThread(
+            [...collected].map(([key, doc]) => ({ key, doc }))
+          );
           for (const [key, doc] of collected) {
-            const h = hashDoc(doc);
+            const h = hashes.get(key)!;
             const t = this.state.nextTimestamp();
             ops.push({ k: key, v: doc, t });
             shadowUpdates.set(key, { t, h });

--- a/src/sync/state.ts
+++ b/src/sync/state.ts
@@ -179,22 +179,6 @@ export async function markSyncLocalReconcileRequired(
   await state.persistNow();
 }
 
-/** Fast 53-bit string hash (cyrb53) for shadow content hashes. */
-export function hashDocJson(json: string): string {
-  let h1 = 0xdeadbeef;
-  let h2 = 0x41c6ce57;
-  for (let i = 0; i < json.length; i += 1) {
-    const ch = json.charCodeAt(i);
-    h1 = Math.imul(h1 ^ ch, 2654435761);
-    h2 = Math.imul(h2 ^ ch, 1597334677);
-  }
-  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
-  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
-  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
-  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
-  return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(36);
-}
-
-export function hashDoc(doc: unknown): string {
-  return hashDocJson(JSON.stringify(doc));
-}
+// Fast cyrb53 shadow hash; implementation lives in the pure content codec so
+// the cloud sync worker can bundle it without this module's storage deps.
+export { hashDoc, hashDocJson } from "@/sync/contentCodec";

--- a/src/sync/workerClient.ts
+++ b/src/sync/workerClient.ts
@@ -1,0 +1,201 @@
+/**
+ * Client facade for the cloud sync worker. Prefers running the CPU-heavy
+ * sync transforms (serialize/hash/gzip/gunzip) in a dedicated Web Worker;
+ * falls back to cooperative main-thread execution (with event-loop yields)
+ * when workers are unavailable (tests, exotic embeds) or the worker fails.
+ *
+ * Both paths call the exact same task implementations in
+ * `@/sync/workerTasks`, so shadow hashes and blob digests are identical
+ * regardless of where they were computed.
+ */
+
+import { cloudSyncLog } from "@/sync/logging";
+import {
+  runDecodeBlobTask,
+  runHashDocsTask,
+  runPrepareBlobUpsertTask,
+  type BlobUpsertCandidate,
+  type BlobUpsertInput,
+  type CloudSyncWorkerRequestBody,
+  type CloudSyncWorkerResponse,
+  type HashDocInput,
+} from "@/sync/workerTasks";
+
+const HASH_DOCS_YIELD_CHUNK = 25;
+const BLOB_PREPARE_YIELD_INTERVAL = 4;
+
+let worker: Worker | null = null;
+let workerDisabled = false;
+let nextRequestId = 1;
+const pendingRequests = new Map<
+  number,
+  { resolve: (result: unknown) => void; reject: (error: Error) => void }
+>();
+
+function yieldToMainThread(): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+function isWorkerSupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof document !== "undefined" &&
+    typeof Worker === "function"
+  );
+}
+
+function failWorker(error: Error): void {
+  workerDisabled = true;
+  try {
+    worker?.terminate();
+  } catch {
+    // best-effort teardown
+  }
+  worker = null;
+  for (const pending of pendingRequests.values()) {
+    pending.reject(error);
+  }
+  pendingRequests.clear();
+  cloudSyncLog.warn("Cloud sync worker disabled; using main-thread fallback", {
+    error: error.message,
+  });
+}
+
+function getWorker(): Worker | null {
+  if (workerDisabled || !isWorkerSupported()) return null;
+  if (worker) return worker;
+  try {
+    worker = new Worker(
+      new URL("../workers/cloudSync.worker.ts", import.meta.url),
+      { type: "module" }
+    );
+  } catch (error) {
+    failWorker(
+      error instanceof Error ? error : new Error("Worker construction failed")
+    );
+    return null;
+  }
+  worker.onmessage = (event: MessageEvent<CloudSyncWorkerResponse>) => {
+    const message = event.data;
+    const pending = pendingRequests.get(message.id);
+    if (!pending) return;
+    pendingRequests.delete(message.id);
+    if (message.ok) {
+      pending.resolve(message.result);
+    } else {
+      pending.reject(new Error(message.error));
+    }
+  };
+  worker.onerror = () => failWorker(new Error("Cloud sync worker crashed"));
+  worker.onmessageerror = () =>
+    failWorker(new Error("Cloud sync worker message deserialization failed"));
+  return worker;
+}
+
+/**
+ * Post one request to the worker. Returns null when no worker is available
+ * or the request could not be sent (caller should run the fallback).
+ * Worker-side task errors also resolve to null so the caller retries
+ * locally — a task may fail in the worker for transport reasons (e.g.
+ * structured clone limits) that don't apply on the main thread.
+ */
+async function dispatch(
+  request: CloudSyncWorkerRequestBody
+): Promise<unknown | null> {
+  const target = getWorker();
+  if (!target) return null;
+  const id = nextRequestId;
+  nextRequestId += 1;
+  const result = new Promise<unknown>((resolve, reject) => {
+    pendingRequests.set(id, { resolve, reject });
+  });
+  try {
+    target.postMessage({ ...request, id });
+  } catch (error) {
+    pendingRequests.delete(id);
+    cloudSyncLog.warn("Cloud sync worker request not cloneable; falling back", {
+      type: request.type,
+      error,
+    });
+    return null;
+  }
+  try {
+    return await result;
+  } catch (error) {
+    cloudSyncLog.warn("Cloud sync worker task failed; falling back", {
+      type: request.type,
+      error,
+    });
+    return null;
+  }
+}
+
+/** Compute shadow hashes for a batch of documents. */
+export async function hashDocsOffThread(
+  docs: readonly HashDocInput[]
+): Promise<Map<string, string>> {
+  if (docs.length === 0) return new Map();
+  const result = (await dispatch({
+    type: "hash-docs",
+    docs: [...docs],
+  })) as Array<[string, string]> | null;
+  if (result) return new Map(result);
+
+  const hashes = new Map<string, string>();
+  for (let offset = 0; offset < docs.length; offset += HASH_DOCS_YIELD_CHUNK) {
+    if (offset > 0) await yieldToMainThread();
+    const chunk = docs.slice(offset, offset + HASH_DOCS_YIELD_CHUNK);
+    for (const [key, hash] of runHashDocsTask(chunk)) {
+      hashes.set(key, hash);
+    }
+  }
+  return hashes;
+}
+
+/**
+ * Serialize, digest, and (when changed or forced) gzip raw blob store items.
+ * Blob-typed fields transfer to the worker by reference, so the expensive
+ * base64 + stringify + digest + gzip pipeline runs entirely off-thread.
+ */
+export async function prepareBlobUpsertsOffThread(
+  items: readonly BlobUpsertInput[],
+  shadowHashes: Record<string, string>,
+  force: boolean
+): Promise<BlobUpsertCandidate[]> {
+  if (items.length === 0) return [];
+  const result = (await dispatch({
+    type: "prepare-blob-upserts",
+    items: [...items],
+    shadowHashes,
+    force,
+  })) as BlobUpsertCandidate[] | null;
+  if (result) return result;
+
+  const candidates: BlobUpsertCandidate[] = [];
+  for (let index = 0; index < items.length; index += 1) {
+    if (index > 0 && index % BLOB_PREPARE_YIELD_INTERVAL === 0) {
+      await yieldToMainThread();
+    }
+    const item = items[index];
+    candidates.push(
+      await runPrepareBlobUpsertTask(item, shadowHashes[item.key], force)
+    );
+  }
+  return candidates;
+}
+
+/** Decompress and parse one downloaded blob payload. */
+export async function decodeBlobItemOffThread(
+  buffer: ArrayBuffer
+): Promise<unknown> {
+  // The buffer is cloned (not transferred) so the main-thread fallback can
+  // still run if the worker rejects the request.
+  const result = await dispatch({ type: "decode-blob", buffer });
+  if (result !== null) return result;
+  return runDecodeBlobTask(buffer);
+}
+
+/** Test seam: force the main-thread fallback path. */
+export function disableCloudSyncWorkerForTests(): void {
+  workerDisabled = true;
+}

--- a/src/sync/workerTasks.ts
+++ b/src/sync/workerTasks.ts
@@ -1,0 +1,108 @@
+/**
+ * Cloud Sync v2 worker tasks: the CPU-heavy, pure data transforms shared by
+ * the cloud sync Web Worker and the main-thread fallback in
+ * `@/sync/workerClient`.
+ *
+ * Everything here is deterministic and dependency-free (no stores, no
+ * IndexedDB, no transport) so the worker bundle stays small and results are
+ * bit-identical regardless of which thread ran the task — shadow hashes and
+ * server-side blob dedupe must not depend on where the work happened.
+ */
+
+import { gunzipJson, gzipJson, hashDocJson, sha256Json } from "@/sync/contentCodec";
+import {
+  serializeStoreItem,
+  type IndexedDBStoreItemWithKey,
+} from "@/utils/storeItemSerialization";
+
+export interface HashDocInput {
+  key: string;
+  doc: unknown;
+}
+
+export interface BlobUpsertInput {
+  key: string;
+  /** Raw store item; Blob/ArrayBuffer fields are still binary. */
+  item: IndexedDBStoreItemWithKey;
+}
+
+export interface BlobUpsertCandidate {
+  key: string;
+  /** SHA-256 of the serialized item JSON (shadow + server dedupe hash). */
+  sha256: string;
+  /** Gzip of the serialized item JSON; absent when the shadow hash matched. */
+  compressed?: Uint8Array;
+}
+
+/** cyrb53 shadow hash per document (JSON.stringify + hash). */
+export function runHashDocsTask(
+  docs: readonly HashDocInput[]
+): Map<string, string> {
+  const hashes = new Map<string, string>();
+  for (const { key, doc } of docs) {
+    hashes.set(key, hashDocJson(JSON.stringify(doc)));
+  }
+  return hashes;
+}
+
+/**
+ * Serialize one raw store item (base64-encode binary fields), digest it, and
+ * gzip it when its content differs from the shadow hash (or when forced).
+ *
+ * The digest is computed over the serialized `{ key, value }` JSON — the
+ * same formula the engine previously used via `sha256Json`, so existing
+ * shadow entries stay valid and nothing re-uploads after this change.
+ */
+export async function runPrepareBlobUpsertTask(
+  input: BlobUpsertInput,
+  shadowHash: string | undefined,
+  force: boolean
+): Promise<BlobUpsertCandidate> {
+  const serialized = await serializeStoreItem(input.item);
+  const sha256 = await sha256Json(serialized);
+  if (!force && shadowHash === sha256) {
+    return { key: input.key, sha256 };
+  }
+  return { key: input.key, sha256, compressed: await gzipJson(serialized) };
+}
+
+/** Decompress and parse one downloaded blob payload. */
+export async function runDecodeBlobTask(
+  data: ArrayBuffer | Uint8Array
+): Promise<unknown> {
+  return gunzipJson<unknown>(data);
+}
+
+// ---------------------------------------------------------------------------
+// Worker message protocol
+// ---------------------------------------------------------------------------
+
+export type CloudSyncWorkerRequest =
+  | { id: number; type: "hash-docs"; docs: HashDocInput[] }
+  | {
+      id: number;
+      type: "prepare-blob-upserts";
+      items: BlobUpsertInput[];
+      /** Existing shadow content hash per sync key. */
+      shadowHashes: Record<string, string>;
+      force: boolean;
+    }
+  | { id: number; type: "decode-blob"; buffer: ArrayBuffer };
+
+/** Request without the client-assigned id (distributes over the union). */
+export type CloudSyncWorkerRequestBody = CloudSyncWorkerRequest extends infer R
+  ? R extends CloudSyncWorkerRequest
+    ? Omit<R, "id">
+    : never
+  : never;
+
+export type CloudSyncWorkerResponse =
+  | {
+      id: number;
+      ok: true;
+      result:
+        | Array<[string, string]> // hash-docs (map entries)
+        | BlobUpsertCandidate[] // prepare-blob-upserts
+        | unknown; // decode-blob
+    }
+  | { id: number; ok: false; error: string };

--- a/src/utils/indexedDBBackup.ts
+++ b/src/utils/indexedDBBackup.ts
@@ -1,13 +1,24 @@
 import { STORES } from "@/utils/indexedDB";
+import {
+  deserializeStoreItem,
+  serializeStoreItem,
+  type IndexedDBStoreItem,
+  type IndexedDBStoreItemWithKey,
+} from "@/utils/storeItemSerialization";
 
-export interface IndexedDBStoreItem {
-  [key: string]: unknown;
-}
-
-export interface IndexedDBStoreItemWithKey {
-  key: string;
-  value: IndexedDBStoreItem;
-}
+// Item (de)serialization is a pure module shared with the cloud sync worker;
+// re-exported here for the existing import sites.
+export {
+  arrayBufferToBase64,
+  base64ToArrayBuffer,
+  base64ToBlob,
+  blobToBase64,
+  deserializeStoreItem,
+  serializeStoreItem,
+  serializeStoreItems,
+  type IndexedDBStoreItem,
+  type IndexedDBStoreItemWithKey,
+} from "@/utils/storeItemSerialization";
 
 export const MANUAL_BACKUP_VERSION = 6;
 
@@ -46,40 +57,6 @@ export const createEmptyManualBackupIndexedDBData =
     Object.fromEntries(
       MANUAL_BACKUP_INDEXEDDB_STORES.map((storeName) => [storeName, []])
     ) as unknown as ManualBackupIndexedDBData;
-
-const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
-  const bytes = new Uint8Array(buffer);
-  const chunkSize = 0x8000;
-  const chunks: string[] = [];
-  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
-    let chunk = "";
-    const end = Math.min(offset + chunkSize, bytes.length);
-    for (let index = offset; index < end; index += 1) {
-      chunk += String.fromCharCode(bytes[index]);
-    }
-    chunks.push(chunk);
-  }
-  return btoa(chunks.join(""));
-};
-
-export const blobToBase64 = async (blob: Blob): Promise<string> => {
-  const base64 = arrayBufferToBase64(await blob.arrayBuffer());
-  return `data:${blob.type || "application/octet-stream"};base64,${base64}`;
-};
-
-export const base64ToBlob = (dataUrl: string): Blob => {
-  const [meta, base64] = dataUrl.split(",");
-  const mimeMatch = meta.match(/data:(.*);base64/);
-  const mime = mimeMatch ? mimeMatch[1] : "application/octet-stream";
-  const binary = atob(base64);
-  const array = Uint8Array.from(binary, (char) => char.charCodeAt(0));
-  return new Blob([array], { type: mime });
-};
-
-const base64ToArrayBuffer = (base64: string): ArrayBuffer => {
-  const binary = atob(base64);
-  return Uint8Array.from(binary, (char) => char.charCodeAt(0)).buffer;
-};
 
 export async function readStoreItemByKey(
   db: IDBDatabase,
@@ -205,63 +182,6 @@ export async function readStoresAtomically(
     transaction.onabort = () =>
       reject(transaction.error ?? new Error("Backup read transaction aborted"));
   });
-}
-
-export async function serializeStoreItem(
-  item: IndexedDBStoreItemWithKey
-): Promise<IndexedDBStoreItemWithKey> {
-  const serializedValue: Record<string, unknown> = {
-    ...item.value,
-  };
-
-  for (const key of Object.keys(item.value)) {
-    if (item.value[key] instanceof Blob) {
-      serializedValue[key] = await blobToBase64(item.value[key] as Blob);
-      serializedValue[`_isBlob_${key}`] = true;
-    } else if (item.value[key] instanceof ArrayBuffer) {
-      serializedValue[key] = arrayBufferToBase64(
-        item.value[key] as ArrayBuffer
-      );
-      serializedValue[`_isArrayBuffer_${key}`] = true;
-    }
-  }
-
-  return {
-    key: item.key,
-    value: serializedValue,
-  };
-}
-
-export async function serializeStoreItems(
-  items: IndexedDBStoreItemWithKey[]
-): Promise<IndexedDBStoreItemWithKey[]> {
-  return Promise.all(items.map((item) => serializeStoreItem(item)));
-}
-
-export function deserializeStoreItem(
-  item: IndexedDBStoreItemWithKey
-): Record<string, unknown> {
-  const restoredValue: Record<string, unknown> = {
-    ...item.value,
-  };
-
-  for (const key of Object.keys(item.value)) {
-    const isBlobKey = `_isBlob_${key}`;
-    if (item.value[isBlobKey] === true && typeof item.value[key] === "string") {
-      restoredValue[key] = base64ToBlob(item.value[key] as string);
-      delete restoredValue[isBlobKey];
-    }
-    const isArrayBufferKey = `_isArrayBuffer_${key}`;
-    if (
-      item.value[isArrayBufferKey] === true &&
-      typeof item.value[key] === "string"
-    ) {
-      restoredValue[key] = base64ToArrayBuffer(item.value[key] as string);
-      delete restoredValue[isArrayBufferKey];
-    }
-  }
-
-  return restoredValue;
 }
 
 interface RestoreStoreOptions {

--- a/src/utils/storeItemSerialization.ts
+++ b/src/utils/storeItemSerialization.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure (de)serialization for IndexedDB store items: Blob/ArrayBuffer fields
+ * are converted to base64 data strings and back. Dependency-free so it can
+ * run inside the cloud sync Web Worker as well as the main thread (manual
+ * backup, sync codecs).
+ */
+
+export interface IndexedDBStoreItem {
+  [key: string]: unknown;
+}
+
+export interface IndexedDBStoreItemWithKey {
+  key: string;
+  value: IndexedDBStoreItem;
+}
+
+export const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  const chunks: string[] = [];
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    let chunk = "";
+    const end = Math.min(offset + chunkSize, bytes.length);
+    for (let index = offset; index < end; index += 1) {
+      chunk += String.fromCharCode(bytes[index]);
+    }
+    chunks.push(chunk);
+  }
+  return btoa(chunks.join(""));
+};
+
+export const blobToBase64 = async (blob: Blob): Promise<string> => {
+  const base64 = arrayBufferToBase64(await blob.arrayBuffer());
+  return `data:${blob.type || "application/octet-stream"};base64,${base64}`;
+};
+
+export const base64ToBlob = (dataUrl: string): Blob => {
+  const [meta, base64] = dataUrl.split(",");
+  const mimeMatch = meta.match(/data:(.*);base64/);
+  const mime = mimeMatch ? mimeMatch[1] : "application/octet-stream";
+  const binary = atob(base64);
+  const array = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new Blob([array], { type: mime });
+};
+
+export const base64ToArrayBuffer = (base64: string): ArrayBuffer => {
+  const binary = atob(base64);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0)).buffer;
+};
+
+export async function serializeStoreItem(
+  item: IndexedDBStoreItemWithKey
+): Promise<IndexedDBStoreItemWithKey> {
+  const serializedValue: Record<string, unknown> = {
+    ...item.value,
+  };
+
+  for (const key of Object.keys(item.value)) {
+    if (item.value[key] instanceof Blob) {
+      serializedValue[key] = await blobToBase64(item.value[key] as Blob);
+      serializedValue[`_isBlob_${key}`] = true;
+    } else if (item.value[key] instanceof ArrayBuffer) {
+      serializedValue[key] = arrayBufferToBase64(
+        item.value[key] as ArrayBuffer
+      );
+      serializedValue[`_isArrayBuffer_${key}`] = true;
+    }
+  }
+
+  return {
+    key: item.key,
+    value: serializedValue,
+  };
+}
+
+export async function serializeStoreItems(
+  items: IndexedDBStoreItemWithKey[]
+): Promise<IndexedDBStoreItemWithKey[]> {
+  return Promise.all(items.map((item) => serializeStoreItem(item)));
+}
+
+export function deserializeStoreItem(
+  item: IndexedDBStoreItemWithKey
+): Record<string, unknown> {
+  const restoredValue: Record<string, unknown> = {
+    ...item.value,
+  };
+
+  for (const key of Object.keys(item.value)) {
+    const isBlobKey = `_isBlob_${key}`;
+    if (item.value[isBlobKey] === true && typeof item.value[key] === "string") {
+      restoredValue[key] = base64ToBlob(item.value[key] as string);
+      delete restoredValue[isBlobKey];
+    }
+    const isArrayBufferKey = `_isArrayBuffer_${key}`;
+    if (
+      item.value[isArrayBufferKey] === true &&
+      typeof item.value[key] === "string"
+    ) {
+      restoredValue[key] = base64ToArrayBuffer(item.value[key] as string);
+      delete restoredValue[isArrayBufferKey];
+    }
+  }
+
+  return restoredValue;
+}

--- a/src/workers/cloudSync.worker.ts
+++ b/src/workers/cloudSync.worker.ts
@@ -1,0 +1,74 @@
+/**
+ * Cloud Sync v2 worker: runs the CPU-heavy sync transforms (JSON
+ * serialization, base64 encoding of binary store fields, SHA-256 / cyrb53
+ * hashing, gzip compress/decompress) off the main thread so large libraries
+ * (images, EPUBs, wallpapers, applets) don't jank the UI during flush,
+ * bootstrap, or blob download.
+ *
+ * The task implementations live in `../sync/workerTasks` and are shared with
+ * the main-thread fallback, guaranteeing identical hashes on either thread.
+ */
+
+import {
+  runDecodeBlobTask,
+  runHashDocsTask,
+  runPrepareBlobUpsertTask,
+  type BlobUpsertCandidate,
+  type CloudSyncWorkerRequest,
+  type CloudSyncWorkerResponse,
+} from "../sync/workerTasks";
+
+async function handleRequest(
+  request: CloudSyncWorkerRequest
+): Promise<{ response: CloudSyncWorkerResponse; transfer: Transferable[] }> {
+  switch (request.type) {
+    case "hash-docs": {
+      const hashes = runHashDocsTask(request.docs);
+      return {
+        response: { id: request.id, ok: true, result: [...hashes.entries()] },
+        transfer: [],
+      };
+    }
+    case "prepare-blob-upserts": {
+      const candidates: BlobUpsertCandidate[] = [];
+      for (const item of request.items) {
+        candidates.push(
+          await runPrepareBlobUpsertTask(
+            item,
+            request.shadowHashes[item.key],
+            request.force
+          )
+        );
+      }
+      const transfer = candidates
+        .map((candidate) => candidate.compressed?.buffer)
+        .filter((buffer): buffer is ArrayBuffer => buffer instanceof ArrayBuffer);
+      return {
+        response: { id: request.id, ok: true, result: candidates },
+        transfer,
+      };
+    }
+    case "decode-blob": {
+      const item = await runDecodeBlobTask(request.buffer);
+      return {
+        response: { id: request.id, ok: true, result: item },
+        transfer: [],
+      };
+    }
+  }
+}
+
+self.onmessage = async (event: MessageEvent<CloudSyncWorkerRequest>) => {
+  const request = event.data;
+  try {
+    const { response, transfer } = await handleRequest(request);
+    self.postMessage(response, { transfer });
+  } catch (error) {
+    const response: CloudSyncWorkerResponse = {
+      id: request.id,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+    self.postMessage(response);
+  }
+};

--- a/tests/test-books-cloud-blob-sync.test.ts
+++ b/tests/test-books-cloud-blob-sync.test.ts
@@ -24,6 +24,8 @@ const { SYNC_CODECS, isBlobCodec } = await import("../src/sync/codecs");
 const { STORES, dbOperations, ensureIndexedDBInitialized } = await import(
   "../src/utils/indexedDB"
 );
+const { runPrepareBlobUpsertTask } = await import("../src/sync/workerTasks");
+const { gunzipJson } = await import("../src/sync/contentCodec");
 
 async function deleteRyOsDatabase(): Promise<void> {
   await new Promise<void>((resolve, reject) => {
@@ -72,8 +74,21 @@ describe("Books cloud blob sync", () => {
     const docs = await SYNC_CODECS.books.collect({ db });
     db.close();
 
+    // Collect returns the raw item with binary content (as a Blob for
+    // Safari-safe cross-thread cloning); serialization happens in the sync
+    // worker task before upload.
     const item = docs.get(`books/item:${uuid}`) as IndexedDBStoreItemWithKey;
-    const uploaded = JSON.parse(JSON.stringify(item)) as IndexedDBStoreItemWithKey;
+    expect(item.value.content).toBeInstanceOf(Blob);
+
+    const candidate = await runPrepareBlobUpsertTask(
+      { key: `books/item:${uuid}`, item },
+      undefined,
+      true
+    );
+    expect(candidate.compressed).toBeDefined();
+    const uploaded = await gunzipJson<IndexedDBStoreItemWithKey>(
+      candidate.compressed!
+    );
 
     expect(typeof uploaded.value.content).toBe("string");
     expect(

--- a/tests/test-cloud-sync-worker-tasks.test.ts
+++ b/tests/test-cloud-sync-worker-tasks.test.ts
@@ -1,0 +1,162 @@
+import "./local-storage-stub";
+import { describe, expect, test } from "bun:test";
+import { gunzipJson, hashDoc, sha256Json } from "../src/sync/contentCodec";
+import {
+  runDecodeBlobTask,
+  runHashDocsTask,
+  runPrepareBlobUpsertTask,
+} from "../src/sync/workerTasks";
+import {
+  decodeBlobItemOffThread,
+  hashDocsOffThread,
+  prepareBlobUpsertsOffThread,
+} from "../src/sync/workerClient";
+import { serializeStoreItem } from "../src/utils/storeItemSerialization";
+import type { IndexedDBStoreItemWithKey } from "../src/utils/indexedDBBackup";
+
+/**
+ * Cloud sync worker tasks: the pure transforms that run in the sync Web
+ * Worker (or its main-thread fallback) must produce byte-identical results
+ * to the previous inline implementations — shadow hashes and server-side
+ * blob dedupe both depend on the exact serialization formula.
+ */
+
+const rawItem: IndexedDBStoreItemWithKey = {
+  key: "img-1",
+  value: {
+    name: "photo.png",
+    content: new Blob([new Uint8Array([1, 2, 3, 4])], { type: "image/png" }),
+    meta: { width: 2, height: 2 },
+  },
+};
+
+describe("runHashDocsTask", () => {
+  test("matches hashDoc for every entry", () => {
+    const docs = [
+      { key: "stickies/note:n1", doc: { id: "n1", content: "hello" } },
+      { key: "settings/display/theme", doc: "system7" },
+      { key: "maps/home", doc: null },
+    ];
+    const hashes = runHashDocsTask(docs);
+    for (const { key, doc } of docs) {
+      expect(hashes.get(key)).toBe(hashDoc(doc));
+    }
+  });
+});
+
+describe("runPrepareBlobUpsertTask", () => {
+  test("digest matches the legacy sha256Json(serializeStoreItem(item)) formula", async () => {
+    const serialized = await serializeStoreItem(rawItem);
+    const legacySha = await sha256Json(serialized);
+    const candidate = await runPrepareBlobUpsertTask(
+      { key: "images/item:img-1", item: rawItem },
+      undefined,
+      false
+    );
+    expect(candidate.sha256).toBe(legacySha);
+  });
+
+  test("skips compression when the shadow hash matches", async () => {
+    const serialized = await serializeStoreItem(rawItem);
+    const sha = await sha256Json(serialized);
+    const candidate = await runPrepareBlobUpsertTask(
+      { key: "images/item:img-1", item: rawItem },
+      sha,
+      false
+    );
+    expect(candidate.compressed).toBeUndefined();
+  });
+
+  test("force compresses even when the shadow hash matches", async () => {
+    const serialized = await serializeStoreItem(rawItem);
+    const sha = await sha256Json(serialized);
+    const candidate = await runPrepareBlobUpsertTask(
+      { key: "images/item:img-1", item: rawItem },
+      sha,
+      true
+    );
+    expect(candidate.compressed).toBeDefined();
+  });
+
+  test("compressed payload round-trips to the serialized wire form", async () => {
+    const candidate = await runPrepareBlobUpsertTask(
+      { key: "images/item:img-1", item: rawItem },
+      undefined,
+      false
+    );
+    const decoded = await gunzipJson<IndexedDBStoreItemWithKey>(
+      candidate.compressed!
+    );
+    expect(decoded).toEqual(await serializeStoreItem(rawItem));
+    expect(typeof decoded.value.content).toBe("string");
+    expect(
+      (decoded.value.content as string).startsWith("data:image/png;base64,")
+    ).toBe(true);
+    expect(decoded.value._isBlob_content).toBe(true);
+  });
+});
+
+describe("runDecodeBlobTask", () => {
+  test("round-trips a prepared upload payload", async () => {
+    const candidate = await runPrepareBlobUpsertTask(
+      { key: "images/item:img-1", item: rawItem },
+      undefined,
+      true
+    );
+    const decoded = await runDecodeBlobTask(candidate.compressed!);
+    expect(decoded).toEqual(await serializeStoreItem(rawItem));
+  });
+});
+
+describe("workerClient main-thread fallback (no Worker in bun)", () => {
+  test("hashDocsOffThread matches hashDoc", async () => {
+    const docs = Array.from({ length: 60 }, (_, index) => ({
+      key: `stickies/note:n${index}`,
+      doc: { id: `n${index}`, content: `note ${index}` },
+    }));
+    const hashes = await hashDocsOffThread(docs);
+    expect(hashes.size).toBe(docs.length);
+    for (const { key, doc } of docs) {
+      expect(hashes.get(key)).toBe(hashDoc(doc));
+    }
+  });
+
+  test("prepareBlobUpsertsOffThread applies shadow skip per key", async () => {
+    const otherItem: IndexedDBStoreItemWithKey = {
+      key: "img-2",
+      value: { name: "other.png", content: new ArrayBuffer(8) },
+    };
+    const unchangedSha = (
+      await runPrepareBlobUpsertTask(
+        { key: "images/item:img-1", item: rawItem },
+        undefined,
+        false
+      )
+    ).sha256;
+
+    const candidates = await prepareBlobUpsertsOffThread(
+      [
+        { key: "images/item:img-1", item: rawItem },
+        { key: "images/item:img-2", item: otherItem },
+      ],
+      { "images/item:img-1": unchangedSha },
+      false
+    );
+
+    const byKey = new Map(candidates.map((c) => [c.key, c]));
+    expect(byKey.get("images/item:img-1")!.compressed).toBeUndefined();
+    expect(byKey.get("images/item:img-2")!.compressed).toBeDefined();
+  });
+
+  test("decodeBlobItemOffThread round-trips", async () => {
+    const candidate = await runPrepareBlobUpsertTask(
+      { key: "images/item:img-1", item: rawItem },
+      undefined,
+      true
+    );
+    const decoded = await decodeBlobItemOffThread(
+      candidate.compressed!.slice().buffer as ArrayBuffer
+    );
+    expect(decoded).toEqual(await serializeStoreItem(rawItem));
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The Cloud Sync v2 engine's orchestration (store subscriptions, IndexedDB, HTTP) is inherently main-thread, but its CPU-heavy data transforms also ran there and are the real jank sources with large libraries (images, EPUBs, wallpapers, applets):

- base64-encoding Blob/ArrayBuffer store fields during blob collect (`serializeStoreItem` — a tight char loop over MBs)
- `JSON.stringify` + SHA-256 per blob item (`sha256Json`) and `JSON.stringify` + cyrb53 per doc (`hashDoc`) during flush and remote apply
- gzip compress on upload, gunzip + `JSON.parse` on download

These now run in a dedicated Web Worker; the engine only awaits results.

## What

- **`src/workers/cloudSync.worker.ts`** — new worker handling three tasks: `hash-docs` (batched cyrb53 shadow hashes), `prepare-blob-upserts` (serialize → digest → shadow-skip → gzip), `decode-blob` (gunzip + parse). Bundles to **2.6 kB** with zero store/IndexedDB deps.
- **`src/sync/workerClient.ts`** — dispatch facade with a cooperative main-thread fallback (event-loop yields) when workers are unavailable or fail. Both paths run the identical pure task code in `src/sync/workerTasks.ts`, so hashes are bit-identical either way.
- **Hash-compatible by construction**: the worker digest uses the exact legacy `sha256Json(serializeStoreItem(item))` formula, so existing shadow maps stay valid and no re-upload storm occurs on update (covered by a parity test).
- **`src/sync/codecs.ts`** — blob codec `collect` now returns raw store items (Blobs transfer to the worker by reference; base64 happens off-thread). Compressed payloads transfer back zero-copy.
- **`src/sync/blobs.ts`** — `uploadBlobItems` takes precompressed payloads; `downloadBlobItem` decodes off-thread.
- **Pure modules extracted**: `src/sync/contentCodec.ts` (gzip/sha/cyrb53) and `src/utils/storeItemSerialization.ts` (base64 item codec); `src/sync/state.ts` and `src/utils/indexedDBBackup.ts` re-export for existing import sites.
- New `tests/test-cloud-sync-worker-tasks.test.ts` covering hash/digest parity, shadow-skip, gzip round-trips, and the fallback path.

## Testing

- ✅ `bun run typecheck`
- ✅ `bun run test:sync-v2:unit` (83 pass)
- ✅ `bun test tests/test-sync-v2-api.test.ts tests/test-sync-v2-engine-e2e.test.ts` (20 pass, against live dev API)
- ✅ `bun test tests/test-cloud-sync-worker-tasks.test.ts tests/test-books-cloud-blob-sync.test.ts` (12 pass)
- ✅ `bun run build` — Vite emits `cloudSync.worker-*.js` (2.6 kB, dependency-free)
- ✅ Worker smoke test under Bun: real `Worker` round-trip of all three message types, hash/sha parity with main-thread implementations verified
- ⚠️ `bun run test:api` — 333/335; the 2 failures are `/api/chat` + `/api/applet-ai` "Invalid auth token" expecting 401 but getting 429 from the exhausted shared AI rate-limit budget (documented environment behavior; no `api/` files changed here)
- ⚠️ `bun run test:unit` aggregate — 19 pre-existing cross-file state-pollution failures (documented; all affected suites pass in isolation, none sync-related)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2b5a-09dc-78ef-9044-6941d0bb77a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2b5a-09dc-78ef-9044-6941d0bb77a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

