### PR TITLE
Fix freeze when switching assistant characters

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
@@ -38,6 +38,7 @@ function CharacterTilePreview({ character }: { character: AssistantCharacter }) 
             data={agentData}
             characterId={character.id}
             animation="RestPose"
+            muted
           />
         ) : (
           <div style={{ width: character.width, height: character.height }} />
@@ -61,8 +62,12 @@ export function AssistantPaneContent({ t, tabStyles }: AssistantPaneContentProps
 
   const handleCharacterSelect = (character: AssistantCharacter) => {
     playClick();
-    setCharacterId(character.id);
-    setEnabled(true);
+    if (character.id !== characterId) {
+      setCharacterId(character.id);
+    }
+    if (!enabled) {
+      setEnabled(true);
+    }
   };
 
   return (

--- a/src/components/assistant/ClippySprite.tsx
+++ b/src/components/assistant/ClippySprite.tsx
@@ -138,6 +138,8 @@ interface ClippySpriteProps {
    * rendered visual, including intentionally empty entrance frames.
    */
   initiallyHidden?: boolean;
+  /** Skip sound playback entirely (e.g. static preference-pane previews). */
+  muted?: boolean;
   onAnimationEnd?: (animation: string) => void;
 }
 
@@ -148,6 +150,7 @@ export function ClippySprite({
   animation,
   playToken = 0,
   initiallyHidden = false,
+  muted = false,
   onAnimationEnd,
 }: ClippySpriteProps) {
   const [frameImages, setFrameImages] = useState<Array<[number, number]>>(() =>
@@ -159,6 +162,7 @@ export function ClippySprite({
   onEndRef.current = onAnimationEnd;
 
   useEffect(() => {
+    if (muted) return;
     const player = new AssistantSoundPlayer();
     soundPlayerRef.current = player;
     player.loadCharacter(characterId);
@@ -168,7 +172,7 @@ export function ClippySprite({
         soundPlayerRef.current = null;
       }
     };
-  }, [characterId]);
+  }, [characterId, muted]);
 
   const [frameWidth, frameHeight] = data.framesize;
 

--- a/src/components/assistant/assistantSounds.ts
+++ b/src/components/assistant/assistantSounds.ts
@@ -1,6 +1,12 @@
 /**
  * Microsoft Agent animation sound playback (clippy.js MP3 data URLs).
  * Source: https://github.com/clippyjs/clippy.js
+ *
+ * Audio elements are created lazily on first play and shared across sprite
+ * instances through a bounded module-level cache. Characters ship 10–34 clips
+ * each, so eagerly instantiating them per sprite (preference pane previews +
+ * the desktop overlay) exhausted the browser's media-player pool and could
+ * freeze the tab when switching characters.
  */
 
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
@@ -9,17 +15,29 @@ import { ASSISTANT_SOUND_MAPS } from "./sounds";
 
 const MAX_CONCURRENT_ASSISTANT_SOUNDS = 2;
 const MIN_SOUND_GAP_MS = 80;
+/** Upper bound on cached HTMLAudioElements across all characters. */
+const MAX_CACHED_ASSISTANT_SOUNDS = 24;
 
 let userHasInteracted = false;
 let lastPlayedAt = 0;
+
+const activeAudios = new Set<HTMLAudioElement>();
+
+/** Shared clip cache keyed by `${characterId}:${soundId}`, in LRU order. */
+const sharedAudioCache = new Map<string, HTMLAudioElement>();
 
 /** Test-only reset for module-level playback gate state. */
 export function resetAssistantSoundStateForTests(): void {
   userHasInteracted = false;
   lastPlayedAt = 0;
+  activeAudios.clear();
+  sharedAudioCache.clear();
 }
 
-const activeAudios = new Set<HTMLAudioElement>();
+/** Test-only helper to bypass the minimum gap between consecutive plays. */
+export function resetAssistantSoundPlaybackGapForTests(): void {
+  lastPlayedAt = 0;
+}
 
 export function markAssistantSoundInteraction(): void {
   userHasInteracted = true;
@@ -32,6 +50,48 @@ export function canPlayAssistantSounds(): boolean {
 export function getAssistantSoundVolume(): number {
   const { masterVolume, uiVolume } = useAudioSettingsStore.getState();
   return masterVolume * uiVolume;
+}
+
+/** Detach the media resource so the browser can release its player slot. */
+function releaseAudio(audio: HTMLAudioElement): void {
+  audio.pause();
+  audio.removeAttribute("src");
+  audio.load();
+}
+
+function evictLeastRecentlyUsedAudio(): void {
+  for (const [key, audio] of sharedAudioCache) {
+    if (activeAudios.has(audio)) continue;
+    sharedAudioCache.delete(key);
+    releaseAudio(audio);
+    return;
+  }
+}
+
+function getOrCreateAudio(
+  characterId: AssistantCharacterId,
+  soundId: string
+): HTMLAudioElement | undefined {
+  const key = `${characterId}:${soundId}`;
+  const cached = sharedAudioCache.get(key);
+  if (cached) {
+    // Refresh recency so hot clips survive eviction.
+    sharedAudioCache.delete(key);
+    sharedAudioCache.set(key, cached);
+    return cached;
+  }
+
+  const src = ASSISTANT_SOUND_MAPS[characterId]?.[soundId];
+  if (!src) return undefined;
+
+  if (sharedAudioCache.size >= MAX_CACHED_ASSISTANT_SOUNDS) {
+    evictLeastRecentlyUsedAudio();
+  }
+
+  const audio = new Audio(src);
+  audio.preload = "auto";
+  sharedAudioCache.set(key, audio);
+  return audio;
 }
 
 function trimActiveAudios(): void {
@@ -60,20 +120,9 @@ function trackAudio(audio: HTMLAudioElement): void {
 
 export class AssistantSoundPlayer {
   private characterId: AssistantCharacterId | null = null;
-  private audioById = new Map<string, HTMLAudioElement>();
 
   loadCharacter(characterId: AssistantCharacterId): void {
-    if (this.characterId === characterId) return;
-    this.dispose();
     this.characterId = characterId;
-
-    const soundMap = ASSISTANT_SOUND_MAPS[characterId];
-    if (!soundMap) return;
-    for (const [soundId, src] of Object.entries(soundMap)) {
-      const audio = new Audio(src);
-      audio.preload = "auto";
-      this.audioById.set(soundId, audio);
-    }
   }
 
   play(soundId: string | undefined): void {
@@ -83,7 +132,7 @@ export class AssistantSoundPlayer {
     const now = Date.now();
     if (now - lastPlayedAt < MIN_SOUND_GAP_MS) return;
 
-    const audio = this.audioById.get(soundId);
+    const audio = getOrCreateAudio(this.characterId, soundId);
     if (!audio) return;
 
     trimActiveAudios();
@@ -108,13 +157,13 @@ export class AssistantSoundPlayer {
 
   dispose(): void {
     this.stopAll();
-    for (const audio of this.audioById.values()) {
-      audio.pause();
-      audio.src = "";
-    }
-    this.audioById.clear();
     this.characterId = null;
   }
+}
+
+/** Test-only view of how many clips are currently cached. */
+export function getCachedAssistantSoundCountForTests(): number {
+  return sharedAudioCache.size;
 }
 
 export function resolveAssistantSoundSrc(

--- a/tests/test-assistant-sounds.test.ts
+++ b/tests/test-assistant-sounds.test.ts
@@ -2,10 +2,13 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   AssistantSoundPlayer,
   canPlayAssistantSounds,
+  getCachedAssistantSoundCountForTests,
   markAssistantSoundInteraction,
+  resetAssistantSoundPlaybackGapForTests,
   resetAssistantSoundStateForTests,
   resolveAssistantSoundSrc,
 } from "../src/components/assistant/assistantSounds";
+import { ASSISTANT_SOUND_MAPS } from "../src/components/assistant/sounds";
 import { useAudioSettingsStore } from "../src/stores/useAudioSettingsStore";
 
 describe("assistant sound mapping", () => {
@@ -94,8 +97,10 @@ describe("AssistantSoundPlayer", () => {
       src = "";
       play = play;
       pause() {}
+      load() {}
       addEventListener() {}
       removeEventListener() {}
+      removeAttribute() {}
     }
     // @ts-expect-error test double
     globalThis.Audio = MockAudio;
@@ -109,6 +114,132 @@ describe("AssistantSoundPlayer", () => {
       markAssistantSoundInteraction();
       player.play("1");
       expect(play).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.Audio = originalAudio;
+    }
+  });
+
+  test("creates audio elements lazily on play, never on loadCharacter", () => {
+    let created = 0;
+    const originalAudio = globalThis.Audio;
+    class MockAudio {
+      preload = "";
+      volume = 1;
+      currentTime = 0;
+      src = "";
+      constructor() {
+        created += 1;
+      }
+      play() {
+        return Promise.resolve();
+      }
+      pause() {}
+      load() {}
+      addEventListener() {}
+      removeEventListener() {}
+      removeAttribute() {}
+    }
+    // @ts-expect-error test double
+    globalThis.Audio = MockAudio;
+
+    try {
+      markAssistantSoundInteraction();
+      const player = new AssistantSoundPlayer();
+      player.loadCharacter("rocky");
+      expect(created).toBe(0);
+
+      player.play("1");
+      expect(created).toBe(1);
+      expect(getCachedAssistantSoundCountForTests()).toBe(1);
+    } finally {
+      globalThis.Audio = originalAudio;
+    }
+  });
+
+  test("reuses cached clips across player instances and character switches", () => {
+    let created = 0;
+    const originalAudio = globalThis.Audio;
+    class MockAudio {
+      preload = "";
+      volume = 1;
+      currentTime = 0;
+      src = "";
+      constructor() {
+        created += 1;
+      }
+      play() {
+        return Promise.resolve();
+      }
+      pause() {}
+      load() {}
+      addEventListener() {}
+      removeEventListener() {}
+      removeAttribute() {}
+    }
+    // @ts-expect-error test double
+    globalThis.Audio = MockAudio;
+
+    try {
+      markAssistantSoundInteraction();
+
+      const first = new AssistantSoundPlayer();
+      first.loadCharacter("clippy");
+      first.play("1");
+      first.dispose();
+      expect(created).toBe(1);
+
+      // Remounted sprite (character switch back) reuses the cached element.
+      const second = new AssistantSoundPlayer();
+      second.loadCharacter("clippy");
+      resetAssistantSoundPlaybackGapForTests();
+      second.play("1");
+      expect(created).toBe(1);
+      expect(getCachedAssistantSoundCountForTests()).toBe(1);
+    } finally {
+      globalThis.Audio = originalAudio;
+    }
+  });
+
+  test("caps the shared clip cache and releases evicted elements", () => {
+    const released: string[] = [];
+    const originalAudio = globalThis.Audio;
+    class MockAudio {
+      preload = "";
+      volume = 1;
+      currentTime = 0;
+      src: string;
+      constructor(src: string) {
+        this.src = src;
+      }
+      play() {
+        return Promise.resolve();
+      }
+      pause() {}
+      load() {}
+      addEventListener() {}
+      removeEventListener() {}
+      removeAttribute(name: string) {
+        if (name === "src") released.push(this.src);
+      }
+    }
+    // @ts-expect-error test double
+    globalThis.Audio = MockAudio;
+
+    try {
+      markAssistantSoundInteraction();
+      const player = new AssistantSoundPlayer();
+      player.loadCharacter("rocky");
+
+      const soundIds = Object.keys(ASSISTANT_SOUND_MAPS.rocky);
+      for (const soundId of soundIds) {
+        resetAssistantSoundPlaybackGapForTests();
+        player.play(soundId);
+      }
+
+      expect(getCachedAssistantSoundCountForTests()).toBeLessThanOrEqual(24);
+      expect(released.length).toBe(
+        Math.max(0, soundIds.length - 24)
+      );
     } finally {
       globalThis.Audio = originalAudio;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Switching characters from the Assistant preference pane could freeze the app. The root cause was in assistant sound loading: every `ClippySprite` mount eagerly created an `HTMLAudioElement` for **every** sound clip of its character (10–34 base64-embedded MP3s each).

With the Assistant pane open, nine preview tiles each held a full clip set (~210 audio elements), and every character switch remounted the overlay sprite — creating ~30 more elements and tearing down ~30 (with `src = ""` churn) on the main thread. Repeated switching exhausted the browser's media-player pool and could freeze the tab.

## Fix

- `assistantSounds.ts`: audio elements are now created **lazily on first play** (only clips actually referenced by animation frames), shared across sprite instances through a bounded LRU cache (24 clips), with evicted elements properly released (`removeAttribute("src")` + `load()`).
- `ClippySprite.tsx`: new `muted` prop skips the sound pipeline entirely; used by the preference-pane preview tiles (their `RestPose` animation has no sounds anyway).
- `AssistantPaneContent.tsx`: re-clicking the already-selected character no longer issues redundant `setCharacterId`/`setEnabled` localStorage persist writes.

## Testing

- ✅ `bun test tests/test-assistant-sounds.test.ts tests/test-assistant-animation.test.tsx tests/test-assistant-bubble-auto-close.test.tsx tests/test-assistant-window-snap.test.ts` — 49 pass, including 3 new tests covering lazy creation, cross-instance clip reuse, and LRU cap/release
- ✅ `bun run typecheck`
- ✅ `bun run build`
- ✅ `bunx eslint` on touched files (only pre-existing `react-refresh` warnings)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2c3c-69d8-75d4-b93e-4de4e89019d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2c3c-69d8-75d4-b93e-4de4e89019d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

