### PR TITLE
Don't auto-close the assistant bubble too early on mobile

### DIFF
--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -252,6 +252,10 @@ function AssistantOverlayInner() {
     inputRef,
     onClose: closeBubble,
     resetKey: characterId,
+    // Never close mid-reply: on mobile the input blurs as soon as the
+    // keyboard dismisses, which would otherwise start the countdown while
+    // the reply is still generating (or before the user can read it).
+    holdOpen: isLoading,
   });
 
   // --- Position + dragging ---------------------------------------------------

--- a/src/components/assistant/useAssistantBubbleAutoClose.ts
+++ b/src/components/assistant/useAssistantBubbleAutoClose.ts
@@ -7,8 +7,21 @@ import {
   type RefObject,
   type WheelEventHandler,
 } from "react";
+import { isTouchDevice } from "@/utils/device";
 
 export const ASSISTANT_BUBBLE_AUTO_CLOSE_MS = 5_000;
+/**
+ * Touch devices drop focus easily (soft keyboard dismissal, taps on
+ * non-focusable bubble content), so focus can't keep the bubble alive the way
+ * it does with a mouse + hardware keyboard. Give a longer reading window.
+ */
+export const ASSISTANT_BUBBLE_AUTO_CLOSE_TOUCH_MS = 15_000;
+
+export function getAssistantBubbleAutoCloseDelayMs(): number {
+  return isTouchDevice()
+    ? ASSISTANT_BUBBLE_AUTO_CLOSE_TOUCH_MS
+    : ASSISTANT_BUBBLE_AUTO_CLOSE_MS;
+}
 
 interface UseAssistantBubbleAutoCloseOptions {
   bubbleOpen: boolean;
@@ -16,6 +29,13 @@ interface UseAssistantBubbleAutoCloseOptions {
   inputRef: RefObject<HTMLInputElement | null>;
   onClose: () => void;
   resetKey: string;
+  /**
+   * While true (e.g. a reply is generating), the bubble never auto-closes.
+   * Close requests that arrive during the hold are deferred and re-armed with
+   * a fresh full grace period once the hold ends, so the user gets the whole
+   * window to read the finished reply.
+   */
+  holdOpen?: boolean;
 }
 
 interface AssistantBubbleAutoCloseHandlers {
@@ -34,6 +54,7 @@ export function useAssistantBubbleAutoClose({
   inputRef,
   onClose,
   resetKey,
+  holdOpen = false,
 }: UseAssistantBubbleAutoCloseOptions): AssistantBubbleAutoCloseHandlers {
   const autoCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const deferredFocusCheckRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -42,10 +63,15 @@ export function useAssistantBubbleAutoClose({
   const composingRef = useRef(false);
   const bubbleOpenRef = useRef(bubbleOpen);
   const onCloseRef = useRef(onClose);
+  const holdOpenRef = useRef(holdOpen);
+  /** A countdown was requested (or interrupted) while holdOpen was active. */
+  const pendingRestartAfterHoldRef = useRef(false);
   bubbleOpenRef.current = bubbleOpen;
   onCloseRef.current = onClose;
+  holdOpenRef.current = holdOpen;
 
   const cancelAutoClose = useCallback(() => {
+    pendingRestartAfterHoldRef.current = false;
     if (autoCloseTimerRef.current !== null) {
       clearTimeout(autoCloseTimerRef.current);
       autoCloseTimerRef.current = null;
@@ -74,6 +100,11 @@ export function useAssistantBubbleAutoClose({
     ) {
       return;
     }
+    if (holdOpenRef.current) {
+      // Defer: re-arm with a fresh full grace period once the hold lifts.
+      pendingRestartAfterHoldRef.current = true;
+      return;
+    }
 
     autoCloseTimerRef.current = setTimeout(() => {
       autoCloseTimerRef.current = null;
@@ -84,8 +115,12 @@ export function useAssistantBubbleAutoClose({
       ) {
         return;
       }
+      if (holdOpenRef.current) {
+        pendingRestartAfterHoldRef.current = true;
+        return;
+      }
       onCloseRef.current();
-    }, ASSISTANT_BUBBLE_AUTO_CLOSE_MS);
+    }, getAssistantBubbleAutoCloseDelayMs());
   }, [cancelAutoClose, hasFocusInsideBubble]);
 
   const deferFocusCheck = useCallback(() => {
@@ -143,6 +178,22 @@ export function useAssistantBubbleAutoClose({
   useEffect(() => {
     cancelAutoClose();
   }, [bubbleOpen, cancelAutoClose, resetKey]);
+
+  useEffect(() => {
+    if (holdOpen) {
+      // A countdown that was already running is interrupted by the hold and
+      // will restart from zero once the hold lifts.
+      if (autoCloseTimerRef.current !== null) {
+        cancelAutoClose();
+        pendingRestartAfterHoldRef.current = true;
+      }
+      return;
+    }
+    if (pendingRestartAfterHoldRef.current) {
+      pendingRestartAfterHoldRef.current = false;
+      startAutoClose();
+    }
+  }, [holdOpen, cancelAutoClose, startAutoClose]);
 
   useEffect(() => cancelAutoClose, [cancelAutoClose]);
 

--- a/tests/test-assistant-bubble-auto-close.test.tsx
+++ b/tests/test-assistant-bubble-auto-close.test.tsx
@@ -13,6 +13,7 @@ import React, { act, useCallback, useRef, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import {
   ASSISTANT_BUBBLE_AUTO_CLOSE_MS,
+  ASSISTANT_BUBBLE_AUTO_CLOSE_TOUCH_MS,
   useAssistantBubbleAutoClose,
 } from "../src/components/assistant/useAssistantBubbleAutoClose";
 
@@ -23,9 +24,11 @@ let root: Root | null = null;
 function AutoCloseProbe({
   onAutoClose,
   resetKey = "clippy",
+  holdOpen = false,
 }: {
   onAutoClose: () => void;
   resetKey?: string;
+  holdOpen?: boolean;
 }) {
   const [bubbleOpen, setBubbleOpen] = useState(true);
   const bubbleRef = useRef<HTMLDivElement>(null);
@@ -40,6 +43,7 @@ function AutoCloseProbe({
     inputRef,
     onClose: closeBubble,
     resetKey,
+    holdOpen,
   });
 
   const toggleBubble = () => {
@@ -329,5 +333,139 @@ describe("assistant bubble auto-close", () => {
     advanceTimers(ASSISTANT_BUBBLE_AUTO_CLOSE_MS);
 
     expect(closeCount).toBe(0);
+  });
+
+  test("never closes while holdOpen is active, restarts fresh after", async () => {
+    let closeCount = 0;
+    const onAutoClose = () => {
+      closeCount += 1;
+    };
+    await act(async () => {
+      root?.render(<AutoCloseProbe onAutoClose={onAutoClose} holdOpen />);
+    });
+
+    // Blur out while a reply is generating (e.g. mobile keyboard dismissed).
+    focusElement("[data-input]");
+    focusElement("[data-outside]");
+    advanceTimers(0);
+    advanceTimers(ASSISTANT_BUBBLE_AUTO_CLOSE_MS * 3);
+
+    expect(host?.querySelector("[data-bubble]")).not.toBeNull();
+    expect(closeCount).toBe(0);
+
+    // Reply finished: the full grace period restarts from zero.
+    await act(async () => {
+      root?.render(
+        <AutoCloseProbe onAutoClose={onAutoClose} holdOpen={false} />
+      );
+    });
+    advanceTimers(ASSISTANT_BUBBLE_AUTO_CLOSE_MS - 1);
+
+    expect(host?.querySelector("[data-bubble]")).not.toBeNull();
+    expect(closeCount).toBe(0);
+
+    advanceTimers(1);
+
+    expect(host?.querySelector("[data-bubble]")).toBeNull();
+    expect(closeCount).toBe(1);
+  });
+
+  test("holdOpen interrupts a running countdown and restarts it fresh", async () => {
+    let closeCount = 0;
+    const onAutoClose = () => {
+      closeCount += 1;
+    };
+    await act(async () => {
+      root?.render(<AutoCloseProbe onAutoClose={onAutoClose} />);
+    });
+
+    focusElement("[data-input]");
+    focusElement("[data-outside]");
+    advanceTimers(0);
+    advanceTimers(ASSISTANT_BUBBLE_AUTO_CLOSE_MS - 1);
+
+    // A new reply starts streaming just before the deadline.
+    await act(async () => {
+      root?.render(<AutoCloseProbe onAutoClose={onAutoClose} holdOpen />);
+    });
+    advanceTimers(ASSISTANT_BUBBLE_AUTO_CLOSE_MS * 3);
+
+    expect(host?.querySelector("[data-bubble]")).not.toBeNull();
+    expect(closeCount).toBe(0);
+
+    await act(async () => {
+      root?.render(
+        <AutoCloseProbe onAutoClose={onAutoClose} holdOpen={false} />
+      );
+    });
+    advanceTimers(ASSISTANT_BUBBLE_AUTO_CLOSE_MS - 1);
+
+    expect(host?.querySelector("[data-bubble]")).not.toBeNull();
+
+    advanceTimers(1);
+
+    expect(host?.querySelector("[data-bubble]")).toBeNull();
+    expect(closeCount).toBe(1);
+  });
+
+  test("holdOpen without a blur never arms a countdown after it lifts", async () => {
+    let closeCount = 0;
+    const onAutoClose = () => {
+      closeCount += 1;
+    };
+    await act(async () => {
+      root?.render(<AutoCloseProbe onAutoClose={onAutoClose} holdOpen />);
+    });
+
+    await act(async () => {
+      root?.render(
+        <AutoCloseProbe onAutoClose={onAutoClose} holdOpen={false} />
+      );
+    });
+    advanceTimers(ASSISTANT_BUBBLE_AUTO_CLOSE_MS * 3);
+
+    expect(host?.querySelector("[data-bubble]")).not.toBeNull();
+    expect(closeCount).toBe(0);
+  });
+
+  test("touch devices get the longer grace period", async () => {
+    const original = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(navigator),
+      "maxTouchPoints"
+    );
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      configurable: true,
+      value: 5,
+    });
+    try {
+      let closeCount = 0;
+      await act(async () => {
+        root?.render(
+          <AutoCloseProbe onAutoClose={() => (closeCount += 1)} />
+        );
+      });
+
+      focusElement("[data-input]");
+      focusElement("[data-outside]");
+      advanceTimers(0);
+      advanceTimers(ASSISTANT_BUBBLE_AUTO_CLOSE_TOUCH_MS - 1);
+
+      expect(host?.querySelector("[data-bubble]")).not.toBeNull();
+      expect(closeCount).toBe(0);
+
+      advanceTimers(1);
+
+      expect(host?.querySelector("[data-bubble]")).toBeNull();
+      expect(closeCount).toBe(1);
+    } finally {
+      Reflect.deleteProperty(navigator, "maxTouchPoints");
+      if (original) {
+        Object.defineProperty(
+          Object.getPrototypeOf(navigator),
+          "maxTouchPoints",
+          original
+        );
+      }
+    }
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The assistant bubble auto-closes 5s after focus leaves it. On mobile this fires far too early: the input blurs as soon as the soft keyboard dismisses (or when tapping non-focusable bubble content), so the bubble could close while a reply was still generating or before the user had a chance to read it — focus can't keep it alive the way it does with a mouse and hardware keyboard.

## Changes

- `useAssistantBubbleAutoClose` gains a `holdOpen` option: while active, the bubble never auto-closes. Close requests during the hold are deferred, and when the hold lifts the full grace period restarts from zero. A hold that starts mid-countdown also interrupts and restarts the timer.
- `AssistantOverlay` passes `holdOpen: isLoading`, so the bubble stays open for the whole reply (submitted + streaming) and the user then gets the full window to read the finished reply.
- Touch devices get a longer grace period (15s via `ASSISTANT_BUBBLE_AUTO_CLOSE_TOUCH_MS` instead of 5s), since focus loss there doesn't indicate the user walked away.

## Testing

- Extended `tests/test-assistant-bubble-auto-close.test.tsx` with four cases: hold blocks close and restarts fresh, hold interrupts a running countdown, hold without a prior blur never arms a timer, and touch devices use the longer delay. All 12 suite tests pass.
- `bun run typecheck` and `eslint` on the touched files pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2c61-3f73-78f1-b478-f53f0b6fb5f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2c61-3f73-78f1-b478-f53f0b6fb5f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

