### PR TITLE
Default desktop assistant on with Rover character

### DIFF
--- a/src/components/assistant/characters.ts
+++ b/src/components/assistant/characters.ts
@@ -56,13 +56,15 @@ export const ASSISTANT_CHARACTERS: AssistantCharacter[] = [
   spriteCharacter("f1", "F1", 124, 93),
 ];
 
-export const DEFAULT_ASSISTANT_CHARACTER_ID: AssistantCharacterId = "clippy";
+export const DEFAULT_ASSISTANT_CHARACTER_ID: AssistantCharacterId = "rover";
 
 export function getAssistantCharacter(
   id: string | null | undefined
 ): AssistantCharacter {
   return (
     ASSISTANT_CHARACTERS.find((character) => character.id === id) ??
-    ASSISTANT_CHARACTERS[0]
+    ASSISTANT_CHARACTERS.find(
+      (character) => character.id === DEFAULT_ASSISTANT_CHARACTER_ID
+    )!
   );
 }

--- a/src/stores/useAssistantStore.ts
+++ b/src/stores/useAssistantStore.ts
@@ -40,7 +40,7 @@ interface AssistantStoreState {
 export const useAssistantStore = create<AssistantStoreState>()(
   persist(
     (set) => ({
-      enabled: false,
+      enabled: true,
       characterId: DEFAULT_ASSISTANT_CHARACTER_ID,
       position: null,
       messages: [],

--- a/tests/test-assistant-store-defaults.test.ts
+++ b/tests/test-assistant-store-defaults.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  DEFAULT_ASSISTANT_CHARACTER_ID,
+  getAssistantCharacter,
+} from "../src/components/assistant/characters";
+import { STORAGE_KEYS } from "../src/utils/storageKeys";
+import { useAssistantStore } from "../src/stores/useAssistantStore";
+
+describe("assistant store defaults", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAssistantStore.setState({
+      enabled: true,
+      characterId: DEFAULT_ASSISTANT_CHARACTER_ID,
+      position: null,
+      messages: [],
+      lastInteractionAt: null,
+    });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test("defaults the desktop assistant to enabled with Rover selected", () => {
+    expect(DEFAULT_ASSISTANT_CHARACTER_ID).toBe("rover");
+    expect(useAssistantStore.getState().enabled).toBe(true);
+    expect(useAssistantStore.getState().characterId).toBe("rover");
+  });
+
+  test("falls back unknown character ids to Rover", () => {
+    expect(getAssistantCharacter("missing").id).toBe("rover");
+    expect(getAssistantCharacter(undefined).id).toBe("rover");
+  });
+
+  test("rehydrates explicit stored preferences without overwriting them", async () => {
+    localStorage.setItem(
+      STORAGE_KEYS.assistant,
+      JSON.stringify({
+        state: {
+          enabled: false,
+          characterId: "clippy",
+          position: { x: 12, y: 34 },
+          messages: [],
+          lastInteractionAt: 1_700_000_000_000,
+        },
+        version: 1,
+      })
+    );
+
+    await useAssistantStore.persist.rehydrate();
+
+    const state = useAssistantStore.getState();
+    expect(state.enabled).toBe(false);
+    expect(state.characterId).toBe("clippy");
+    expect(state.position).toEqual({ x: 12, y: 34 });
+    expect(state.lastInteractionAt).toBe(1_700_000_000_000);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Enable the floating desktop assistant by default for new users and after a full settings reset.
- Change the default assistant character from Clippy to Rover.
- Keep existing persisted assistant preferences intact on rehydrate (enabled state, character, position, conversation).

## Changes

- `src/stores/useAssistantStore.ts`: initial `enabled` state is now `true`.
- `src/components/assistant/characters.ts`: `DEFAULT_ASSISTANT_CHARACTER_ID` is now `"rover"`; unknown character IDs fall back to Rover.
- `tests/test-assistant-store-defaults.test.ts`: covers new defaults and persisted-preference preservation.

## Testing

- `bun test tests/test-assistant-store-defaults.test.ts`
- `bun test tests/test-assistant-animation.test.tsx tests/test-assistant-sounds.test.ts tests/test-assistant-bubble-auto-close.test.tsx tests/test-assistant-window-snap.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9172ad44-1673-461b-b416-cbabbe21058b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9172ad44-1673-461b-b416-cbabbe21058b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

