### PR TITLE
Add shimmer loading to assistant bubble thinking and tool-call states

### DIFF
--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -155,12 +155,16 @@ function snapAxis(value: number, candidates: number[]): number {
  * status ("Thinking…" or a friendly tool-call line) and rolls the old line up
  * and out only when a new one arrives.
  */
+/** Shared vertical envelope for thinking/tool-call and final reply text. */
+const ASSISTANT_BUBBLE_BODY_CLASS =
+  "max-h-40 overflow-y-auto break-words py-1.5 leading-snug";
+
 function ThinkingTicker({ items }: { items: string[] }) {
   const current = items[items.length - 1] ?? "";
 
   return (
     <div
-      className="relative h-[18px] overflow-hidden"
+      className="relative min-h-[1lh] overflow-hidden"
       aria-live="polite"
       aria-label={current}
     >
@@ -171,7 +175,7 @@ function ThinkingTicker({ items }: { items: string[] }) {
           animate={{ y: 0, opacity: 1 }}
           exit={{ y: -14, opacity: 0 }}
           transition={{ duration: 0.22, ease: "easeOut" }}
-          className="absolute inset-x-0 top-0 truncate text-black/60"
+          className="absolute inset-x-0 top-0 truncate leading-snug shimmer-gray"
         >
           {current}
         </motion.div>
@@ -1073,41 +1077,35 @@ function AssistantOverlayInner() {
               role="log"
               aria-live="polite"
             >
-              {showTyping ? (
-                <div className="py-1.5">
+              <div className={ASSISTANT_BUBBLE_BODY_CLASS}>
+                {showTyping ? (
                   <ThinkingTicker
                     items={[t("common.assistant.thinking"), ...statusLabels]}
                   />
-                </div>
-              ) : errorText ? (
-                <div className="max-h-40 overflow-y-auto whitespace-pre-wrap break-words py-1.5">
-                  {errorText}
-                </div>
-              ) : (
-                <div className="max-h-40 overflow-y-auto break-words py-1.5">
-                  {bubbleText ? (
-                    <Streamdown
-                      className="ryos-chat-streamdown"
-                      components={chatStreamdownComponents}
-                      disallowedElements={STREAMDOWN_DISALLOWED_ELEMENTS}
-                      controls={false}
-                      lineNumbers={false}
-                      shikiTheme={CHAT_STREAMDOWN_SHIKI_THEME}
-                      plugins={CHAT_STREAMDOWN_PLUGINS}
-                      skipHtml
-                      unwrapDisallowed
-                      mode={isLoading ? "streaming" : "static"}
-                      animated={CHAT_STREAMDOWN_ANIMATED}
-                      isAnimating={isLoading}
-                      parseIncompleteMarkdown={isLoading}
-                    >
-                      {bubbleText}
-                    </Streamdown>
-                  ) : (
-                    t("common.assistant.emptyBubble")
-                  )}
-                </div>
-              )}
+                ) : errorText ? (
+                  <div className="whitespace-pre-wrap">{errorText}</div>
+                ) : bubbleText ? (
+                  <Streamdown
+                    className="ryos-chat-streamdown"
+                    components={chatStreamdownComponents}
+                    disallowedElements={STREAMDOWN_DISALLOWED_ELEMENTS}
+                    controls={false}
+                    lineNumbers={false}
+                    shikiTheme={CHAT_STREAMDOWN_SHIKI_THEME}
+                    plugins={CHAT_STREAMDOWN_PLUGINS}
+                    skipHtml
+                    unwrapDisallowed
+                    mode={isLoading ? "streaming" : "static"}
+                    animated={CHAT_STREAMDOWN_ANIMATED}
+                    isAnimating={isLoading}
+                    parseIncompleteMarkdown={isLoading}
+                  >
+                    {bubbleText}
+                  </Streamdown>
+                ) : (
+                  t("common.assistant.emptyBubble")
+                )}
+              </div>
               <form
                 onSubmit={handleSubmit}
                 className="-mx-3 mt-1.5 flex items-center gap-1 border-t border-black/15 px-3 pt-1 pb-0.5"

--- a/src/components/shared/tool-invocation-message/ToolInvocationMessageDefaultView.tsx
+++ b/src/components/shared/tool-invocation-message/ToolInvocationMessageDefaultView.tsx
@@ -30,7 +30,7 @@ export function ToolInvocationMessageDefaultView({
   });
 
   return (
-    <div key={partKey} className="mb-0 px-1 py-0.5 italic text-[12px]">
+    <div key={partKey} className="mb-0 italic text-[12px] leading-snug">
       {(state === "input-streaming" || state === "input-available") &&
         !output && (
           <ToolInvocationStatusRow
@@ -40,7 +40,7 @@ export function ToolInvocationMessageDefaultView({
             {displayCallMessage ? (
               <span className="shimmer">{displayCallMessage}</span>
             ) : (
-              <span>
+              <span className="shimmer">
                 {t("apps.chats.toolCalls.calling", {
                   toolName: formatToolName(toolName),
                 })}

--- a/src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx
+++ b/src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx
@@ -270,7 +270,7 @@ export function tryRenderToolInvocationSpecialContent(
       }
       // Show loading state if HTML not yet available
       return (
-        <div key={partKey} className="mb-0 px-1 py-0.5 italic text-[12px]">
+        <div key={partKey} className="mb-0 italic text-[12px] leading-snug">
           <ToolInvocationStatusRow
             icon={<ActivityIndicator size="xs" className="text-neutral-500 dark:text-neutral-400" />}
             className="text-neutral-600 dark:text-neutral-300"
@@ -300,7 +300,7 @@ export function tryRenderToolInvocationSpecialContent(
         );
       }
       return (
-        <div key={partKey} className="mb-0 px-1 py-0.5 italic text-[12px]">
+        <div key={partKey} className="mb-0 italic text-[12px] leading-snug">
           <ToolInvocationStatusRow
             icon={<ActivityIndicator size="xs" className="text-neutral-500 dark:text-neutral-400" />}
             className="text-neutral-500 dark:text-neutral-400"

--- a/tests/test-assistant-bubble-shimmer.test.ts
+++ b/tests/test-assistant-bubble-shimmer.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const assistantOverlaySource = readFileSync(
+  join(import.meta.dir, "../src/components/assistant/AssistantOverlay.tsx"),
+  "utf8"
+);
+const toolInvocationDefaultSource = readFileSync(
+  join(
+    import.meta.dir,
+    "../src/components/shared/tool-invocation-message/ToolInvocationMessageDefaultView.tsx"
+  ),
+  "utf8"
+);
+
+describe("assistant bubble loading shimmer", () => {
+  test("thinking ticker uses shimmer-gray on rolling status text", () => {
+    expect(assistantOverlaySource).toContain("shimmer-gray");
+    expect(assistantOverlaySource).toContain("function ThinkingTicker");
+  });
+
+  test("thinking, error, and reply states share one padded body wrapper", () => {
+    expect(assistantOverlaySource).toContain("ASSISTANT_BUBBLE_BODY_CLASS");
+    expect(assistantOverlaySource).toContain(
+      'className={ASSISTANT_BUBBLE_BODY_CLASS}'
+    );
+    expect(assistantOverlaySource).toContain("py-1.5 leading-snug");
+    expect(assistantOverlaySource).not.toContain("h-[18px]");
+  });
+
+  test("tool-call loading fallback uses shimmer treatment", () => {
+    expect(toolInvocationDefaultSource).toContain('className="shimmer"');
+    expect(toolInvocationDefaultSource).toContain("leading-snug");
+    expect(toolInvocationDefaultSource).not.toContain("py-0.5");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a subtle shimmer loading treatment to the floating assistant bubble while it is thinking or running a tool, and normalizes vertical padding so transitions into the final reply text do not jump.

## Changes

- **Assistant overlay bubble** (`AssistantOverlay.tsx`): `ThinkingTicker` now uses `shimmer-gray` for both the initial "Thinking…" label and rolling tool-call status lines. Thinking, error, and reply content share a single `ASSISTANT_BUBBLE_BODY_CLASS` wrapper (`py-1.5 leading-snug`) so the vertical envelope matches the final text bubble. Replaced the fixed `h-[18px]` ticker height with `min-h-[1lh]` to align with `leading-snug`.
- **Chat tool-call rows** (`ToolInvocationMessageDefaultView.tsx`, `tryRenderToolInvocationSpecialContent.tsx`): Apply shimmer to the generic "Calling …" fallback (previously only custom call messages shimmered). Removed extra `px-1 py-0.5` padding on loading tool rows and normalized to `leading-snug` for consistent line height with assistant text parts.

## Testing

- `bun test tests/test-assistant-bubble-shimmer.test.ts` — validates shimmer class usage, shared body wrapper, and padding normalization
- `bun test tests/test-tool-call-shimmer-dark.test.ts` — existing dark-mode shimmer regression suite still passes

## Acceptance criteria

- [x] Thinking state shimmers
- [x] Tool-call state shimmers
- [x] Final text message uses the same vertical padding envelope
- [x] Transition from thinking/tool-call to final text does not shift top/bottom padding
- [x] Responsive behavior unchanged
- [x] No unrelated UI changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1e91fab-eeb1-467c-ada8-0f8bb9402b23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1e91fab-eeb1-467c-ada8-0f8bb9402b23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

