### PR TITLE
Control Panels: show assistant picker in 4 columns

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
@@ -106,7 +106,7 @@ export function AssistantPaneContent({ t, tabStyles }: AssistantPaneContentProps
         <hr className="border-t" style={tabStyles.separatorStyle} />
 
         <div className="@container">
-          <div className="grid grid-cols-2 @min-[360px]:grid-cols-4 gap-2 py-1">
+          <div className="grid grid-cols-4 @max-[339px]:grid-cols-2 gap-2 py-1">
             {ASSISTANT_CHARACTERS.map((character) => {
               const isSelected = enabled && character.id === characterId;
               return (

--- a/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
@@ -120,7 +120,7 @@ export function AssistantPaneContent({ t, tabStyles }: AssistantPaneContentProps
                   type="button"
                   aria-label={character.name}
                   aria-pressed={isSelected}
-                  className="preview-button relative grid w-full aspect-square grid-rows-[72px_11px] content-center justify-items-center gap-1 overflow-hidden bg-black/5 cursor-pointer hover:opacity-90"
+                  className="preview-button relative grid w-full aspect-square grid-rows-[72px_11px] content-start justify-items-center gap-0 overflow-hidden bg-black/5 cursor-pointer hover:opacity-90"
                   style={{
                     boxShadow: isSelected
                       ? "0 0 0 1px var(--os-color-selection-ring-gap), 0 0 0 3px var(--os-color-selection-bg)"
@@ -137,7 +137,7 @@ export function AssistantPaneContent({ t, tabStyles }: AssistantPaneContentProps
                   <span className="pointer-events-none flex h-[72px] w-full items-center justify-center">
                     <CharacterTilePreview character={character} />
                   </span>
-                  <span className="pointer-events-none block h-[11px] w-full truncate px-1 text-center font-geneva-12 text-[11px] leading-[11px] text-neutral-600">
+                  <span className="pointer-events-none -mt-1.5 block h-[11px] w-full truncate px-1 text-center font-geneva-12 text-[11px] leading-[11px] text-neutral-600">
                     {character.name}
                   </span>
                 </button>

--- a/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
@@ -105,38 +105,40 @@ export function AssistantPaneContent({ t, tabStyles }: AssistantPaneContentProps
 
         <hr className="border-t" style={tabStyles.separatorStyle} />
 
-        <div className="grid grid-cols-3 gap-2 py-1">
-          {ASSISTANT_CHARACTERS.map((character) => {
-            const isSelected = enabled && character.id === characterId;
-            return (
-              <button
-                key={character.id}
-                type="button"
-                aria-label={character.name}
-                aria-pressed={isSelected}
-                className="preview-button relative grid w-full aspect-square grid-rows-[88px_11px] content-center justify-items-center gap-1 overflow-hidden bg-black/5 cursor-pointer hover:opacity-90"
-                style={{
-                  boxShadow: isSelected
-                    ? "0 0 0 1px var(--os-color-selection-ring-gap), 0 0 0 3px var(--os-color-selection-bg)"
-                    : undefined,
-                }}
-                onClick={() => handleCharacterSelect(character)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    handleCharacterSelect(character);
-                  }
-                }}
-              >
-                <span className="pointer-events-none flex h-[88px] w-full items-center justify-center">
-                  <CharacterTilePreview character={character} />
-                </span>
-                <span className="pointer-events-none block h-[11px] w-full truncate px-1 text-center font-geneva-12 text-[11px] leading-[11px] text-neutral-600">
-                  {character.name}
-                </span>
-              </button>
-            );
-          })}
+        <div className="@container">
+          <div className="grid grid-cols-2 @min-[360px]:grid-cols-4 gap-2 py-1">
+            {ASSISTANT_CHARACTERS.map((character) => {
+              const isSelected = enabled && character.id === characterId;
+              return (
+                <button
+                  key={character.id}
+                  type="button"
+                  aria-label={character.name}
+                  aria-pressed={isSelected}
+                  className="preview-button relative grid w-full aspect-square grid-rows-[88px_11px] content-center justify-items-center gap-1 overflow-hidden bg-black/5 cursor-pointer hover:opacity-90"
+                  style={{
+                    boxShadow: isSelected
+                      ? "0 0 0 1px var(--os-color-selection-ring-gap), 0 0 0 3px var(--os-color-selection-bg)"
+                      : undefined,
+                  }}
+                  onClick={() => handleCharacterSelect(character)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleCharacterSelect(character);
+                    }
+                  }}
+                >
+                  <span className="pointer-events-none flex h-[88px] w-full items-center justify-center">
+                    <CharacterTilePreview character={character} />
+                  </span>
+                  <span className="pointer-events-none block h-[11px] w-full truncate px-1 text-center font-geneva-12 text-[11px] leading-[11px] text-neutral-600">
+                    {character.name}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
         </div>
 
         <p className="text-[11px] text-neutral-600 font-geneva-12">

--- a/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
@@ -15,7 +15,6 @@ import {
 import { controlPanelItemIconShell } from "./constants";
 
 const TILE_PREVIEW_MAX = 64;
-const TILE_PREVIEW_ROW_HEIGHT = 72;
 
 /** Scale a character preview to fit the tile (downscales only — never upscales). */
 function getCharacterTileScale(width: number, height: number): number {

--- a/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
@@ -120,7 +120,7 @@ export function AssistantPaneContent({ t, tabStyles }: AssistantPaneContentProps
                   type="button"
                   aria-label={character.name}
                   aria-pressed={isSelected}
-                  className="preview-button relative grid w-full aspect-square grid-rows-[72px_11px] content-start justify-items-center gap-0 overflow-hidden bg-black/5 cursor-pointer hover:opacity-90"
+                  className="preview-button relative grid w-full aspect-square grid-rows-[72px_11px] content-start justify-items-center gap-0.5 overflow-hidden bg-black/5 cursor-pointer hover:opacity-90"
                   style={{
                     boxShadow: isSelected
                       ? "0 0 0 1px var(--os-color-selection-ring-gap), 0 0 0 3px var(--os-color-selection-bg)"
@@ -137,7 +137,7 @@ export function AssistantPaneContent({ t, tabStyles }: AssistantPaneContentProps
                   <span className="pointer-events-none flex h-[72px] w-full items-center justify-center">
                     <CharacterTilePreview character={character} />
                   </span>
-                  <span className="pointer-events-none -mt-1.5 block h-[11px] w-full truncate px-1 text-center font-geneva-12 text-[11px] leading-[11px] text-neutral-600">
+                  <span className="pointer-events-none block h-[11px] w-full truncate px-1 text-center font-geneva-12 text-[11px] leading-[11px] text-neutral-600">
                     {character.name}
                   </span>
                 </button>

--- a/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
@@ -14,21 +14,26 @@ import {
 } from "@/components/assistant/ClippySprite";
 import { controlPanelItemIconShell } from "./constants";
 
-const TILE_PREVIEW_MAX = 88;
+const TILE_PREVIEW_MAX = 64;
+const TILE_PREVIEW_ROW_HEIGHT = 72;
+
+/** Scale a character preview to fit the tile (downscales only — never upscales). */
+function getCharacterTileScale(width: number, height: number): number {
+  return Math.min(TILE_PREVIEW_MAX / height, TILE_PREVIEW_MAX / width);
+}
 
 /** Static character preview (sprite rest pose) scaled to fit a tile. */
 function CharacterTilePreview({ character }: { character: AssistantCharacter }) {
   const agentData = useAgentData(character.agentUrl);
-  const scale = Math.min(
-    TILE_PREVIEW_MAX / character.height,
-    TILE_PREVIEW_MAX / character.width
-  );
+  const frameWidth = agentData?.framesize[0] ?? character.width;
+  const frameHeight = agentData?.framesize[1] ?? character.height;
+  const scale = getCharacterTileScale(frameWidth, frameHeight);
 
   return (
     <div
       style={{
-        width: character.width * scale,
-        height: character.height * scale,
+        width: frameWidth * scale,
+        height: frameHeight * scale,
       }}
     >
       <div style={{ transform: `scale(${scale})`, transformOrigin: "top left" }}>
@@ -41,7 +46,7 @@ function CharacterTilePreview({ character }: { character: AssistantCharacter }) 
             muted
           />
         ) : (
-          <div style={{ width: character.width, height: character.height }} />
+          <div style={{ width: frameWidth, height: frameHeight }} />
         )}
       </div>
     </div>
@@ -115,7 +120,7 @@ export function AssistantPaneContent({ t, tabStyles }: AssistantPaneContentProps
                   type="button"
                   aria-label={character.name}
                   aria-pressed={isSelected}
-                  className="preview-button relative grid w-full aspect-square grid-rows-[88px_11px] content-center justify-items-center gap-1 overflow-hidden bg-black/5 cursor-pointer hover:opacity-90"
+                  className="preview-button relative grid w-full aspect-square grid-rows-[72px_11px] content-center justify-items-center gap-1 overflow-hidden bg-black/5 cursor-pointer hover:opacity-90"
                   style={{
                     boxShadow: isSelected
                       ? "0 0 0 1px var(--os-color-selection-ring-gap), 0 0 0 3px var(--os-color-selection-bg)"
@@ -129,7 +134,7 @@ export function AssistantPaneContent({ t, tabStyles }: AssistantPaneContentProps
                     }
                   }}
                 >
-                  <span className="pointer-events-none flex h-[88px] w-full items-center justify-center">
+                  <span className="pointer-events-none flex h-[72px] w-full items-center justify-center">
                     <CharacterTilePreview character={character} />
                   </span>
                   <span className="pointer-events-none block h-[11px] w-full truncate px-1 text-center font-geneva-12 text-[11px] leading-[11px] text-neutral-600">

--- a/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
@@ -137,7 +137,7 @@ export function AssistantPaneContent({ t, tabStyles }: AssistantPaneContentProps
                   <span className="pointer-events-none flex h-[72px] w-full items-center justify-center">
                     <CharacterTilePreview character={character} />
                   </span>
-                  <span className="pointer-events-none block h-[11px] w-full truncate px-1 text-center font-geneva-12 text-[11px] leading-[11px] text-neutral-600">
+                  <span className="pointer-events-none -mt-[3px] block h-[11px] w-full truncate px-1 text-center font-geneva-12 text-[11px] leading-[11px] text-neutral-600">
                     {character.name}
                   </span>
                 </button>

--- a/tests/test-control-panels-mac-layout.test.ts
+++ b/tests/test-control-panels-mac-layout.test.ts
@@ -812,7 +812,7 @@ describe("Control Panels macOS 10.3 layout", () => {
       "src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx"
     );
     expect(assistantSource.includes("@container")).toBe(true);
-    expect(assistantSource.includes("grid-cols-2 @min-[360px]:grid-cols-4")).toBe(
+    expect(assistantSource.includes("grid-cols-4 @max-[339px]:grid-cols-2")).toBe(
       true
     );
     expect(assistantSource.includes("grid-cols-3")).toBe(false);

--- a/tests/test-control-panels-mac-layout.test.ts
+++ b/tests/test-control-panels-mac-layout.test.ts
@@ -815,6 +815,7 @@ describe("Control Panels macOS 10.3 layout", () => {
     expect(assistantSource.includes("grid-cols-4 @max-[339px]:grid-cols-2")).toBe(
       true
     );
+    expect(assistantSource.includes("TILE_PREVIEW_MAX = 64")).toBe(true);
     expect(assistantSource.includes("grid-cols-3")).toBe(false);
   });
 

--- a/tests/test-control-panels-mac-layout.test.ts
+++ b/tests/test-control-panels-mac-layout.test.ts
@@ -807,6 +807,17 @@ describe("Control Panels macOS 10.3 layout", () => {
     expect(displaysSource.includes("Intentionally visible to all users")).toBe(true);
   });
 
+  test("Assistant pane shows character grid in four columns on wide panes", () => {
+    const assistantSource = readSource(
+      "src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx"
+    );
+    expect(assistantSource.includes("@container")).toBe(true);
+    expect(assistantSource.includes("grid-cols-2 @min-[360px]:grid-cols-4")).toBe(
+      true
+    );
+    expect(assistantSource.includes("grid-cols-3")).toBe(false);
+  });
+
   test("macosx preview window is centered within visible canvas width", () => {
     const scale = 1;
     const hostWidth = 400;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Control Panels **Assistant** pane character picker from a 3-column grid to **4 columns** at desktop Control Panels widths, with a responsive fallback to 2 columns on narrow panes (e.g. phone-width windows).

Also shrinks assistant tile previews, fixes Rover appearing oversized, and fine-tunes name label spacing below previews.

## Changes

- `AssistantPaneContent.tsx`: wrap the assistant tile grid in a `@container` and use `grid-cols-4` with `@max-[339px]:grid-cols-2` so the default 400px Control Panels window (~356px content area) renders four columns while phone-width panes stay at two columns.
- Preview scaling: lower cap from 88px → 64px, scale from agent `framesize`, and shrink preview row height to 72px. Rover was upscaled before because his 80×80 bounding box was blown up to the old 88px cap while larger characters were only downscaled.
- Label spacing: top-align tiles with `gap-0.5` plus a half-step `-mt-[3px]` nudge on labels.
- Build fix: remove unused `TILE_PREVIEW_ROW_HEIGHT` (TS6133 under `noUnusedLocals`).
- `test-control-panels-mac-layout.test.ts`: wiring tests for grid classes and preview cap.

## Verification

- `bun run build` — pass
- `bun test tests/test-control-panels-mac-layout.test.ts` — 26/26 pass
- Manual UI check: desktop 4 columns; mobile 2 columns; label spacing balanced

![Assistant grid with half-step label nudge](https://cursor.com/artifacts/c/art-9b9abdb1-b50a-453e-ac19-2e75e1442e72)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-772543b8-d896-4c7b-b1af-de7a8f34f2ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-772543b8-d896-4c7b-b1af-de7a8f34f2ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

