### PR TITLE
Improve desktop assistant animation-to-state mapping

### DIFF
--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -654,7 +654,10 @@ function AssistantOverlayInner() {
   // Drop transient animation state when the character changes. Without this,
   // switching characters mid-entrance leaves a stale entrance sequence and a
   // stale entrance clip name behind, which replays the entry animation (and
-  // blocks activity-driven clips) when the sprite next mounts.
+  // blocks activity-driven clips) when the sprite next mounts. The pending
+  // ambient idle timer must go too: it captured the previous character's clip
+  // pool and would otherwise fire mid-entrance with a clip the new character
+  // may not have (flashing it to its base pose and aborting the entry).
   const previousCharacterIdRef = useRef(character.id);
   useEffect(() => {
     if (previousCharacterIdRef.current === character.id) return;
@@ -662,6 +665,10 @@ function AssistantOverlayInner() {
     clearSequencePlan();
     clearEntranceSequence();
     clearPointingTimer();
+    if (idleTimerRef.current) {
+      clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = null;
+    }
     setSpriteAnim({ name: REST_ANIMATION, token: 0 });
   }, [
     character.id,
@@ -975,14 +982,23 @@ function AssistantOverlayInner() {
       if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
       idleTimerRef.current = setTimeout(() => {
         if (activityIntentRef.current !== "idle") return;
+        // Never override an entrance or exit clip.
+        if (entranceSequenceRef.current || quittingAnimationRef.current) return;
+        // Re-read the agent data: the captured `data` may belong to a
+        // character that has since been switched away, and its clip names
+        // would flash the current sprite to its base pose.
+        const currentData = agentDataRef.current;
+        if (!currentData) return;
         // After prolonged inactivity, prefer the character's deep-idle
         // (sleep) clips when it ships them.
         const deepIdlePool =
           Date.now() - lastActiveAtRef.current >= DEEP_IDLE_AFTER_MS
-            ? getDeepIdleAnimationPool(data)
+            ? getDeepIdleAnimationPool(currentData)
             : [];
         const idlePool =
-          deepIdlePool.length > 0 ? deepIdlePool : getIdleAnimationPool(data);
+          deepIdlePool.length > 0
+            ? deepIdlePool
+            : getIdleAnimationPool(currentData);
         playAnimation(
           idlePool[Math.floor(Math.random() * idlePool.length)] ??
             REST_ANIMATION

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -31,10 +31,13 @@ import {
 } from "./ClippySprite";
 import { useAssistantChat } from "./useAssistantChat";
 import {
+  DEEP_IDLE_AFTER_MS,
   getAnimationCandidates,
   getAssistantAnimationIntent,
   getAssistantExitAnimationTimeout,
   getAssistantLifecycleAnimationIntent,
+  getAssistantPointingDirection,
+  getDeepIdleAnimationPool,
   getDocumentToolSequenceKind,
   getIdleAnimationPool,
   isAssistantEntranceAnimation,
@@ -42,7 +45,9 @@ import {
   resolveAssistantEntranceSequencePlan,
   resolveDocumentToolSequencePlan,
   selectAssistantAnimation,
+  selectAssistantPointingAnimation,
   type AssistantAnimationIntent,
+  type AssistantToolActivity,
   type DocumentToolSequencePlan,
 } from "./assistantAnimation";
 import { markAssistantSoundInteraction } from "./assistantSounds";
@@ -89,9 +94,13 @@ const BUBBLE_EXIT: Transition = {
 
 const REST_ANIMATION = "RestPose";
 
+/** Wait for the snap spring to mostly settle before pointing at a window. */
+const POINTING_DELAY_MS = 550;
+
 function isWorkingIntent(intent: AssistantAnimationIntent): boolean {
   return (
     intent === "thinking" ||
+    intent === "speaking" ||
     intent === "processing" ||
     intent === "searching" ||
     intent === "reading" ||
@@ -237,6 +246,15 @@ function AssistantOverlayInner() {
   const inputRef = useRef<HTMLInputElement>(null);
   const bubbleRef = useRef<HTMLDivElement>(null);
   const activateCharacterRef = useRef<() => void>(() => {});
+  const pointAtTargetRef = useRef<
+    (
+      target: { x: number; y: number; width: number; height: number },
+      from: AssistantPosition
+    ) => void
+  >(() => {});
+  const pointingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Last moment the assistant was doing something (drives deep idle). */
+  const lastActiveAtRef = useRef(Date.now());
   const closeBubble = useCallback(() => setBubbleOpen(false), []);
   const {
     cancelAutoClose: cancelBubbleAutoClose,
@@ -370,6 +388,10 @@ function AssistantOverlayInner() {
       if (snapped) {
         setPosition(snapped);
         setStoredPosition(snapped);
+        if (targetBounds) {
+          // Look/point toward the window the assistant just moved to show.
+          pointAtTargetRef.current(targetBounds, snapped);
+        }
       }
       cancel();
     };
@@ -515,6 +537,7 @@ function AssistantOverlayInner() {
       markAssistantSoundInteraction();
       if (event.pointerType === "mouse" && event.button !== 0) return;
       if (contextMenuPos) return;
+      lastActiveAtRef.current = Date.now();
       lastUserDragAtRef.current = Date.now();
       pendingRelocationCancelRef.current?.();
       const { clientX, clientY, pointerId } = event;
@@ -565,6 +588,7 @@ function AssistantOverlayInner() {
     isLoading,
     hasError: errorText !== null,
     toolActivity,
+    hasVisibleReply: !isAwaitingReply,
   });
   const [spriteAnim, setSpriteAnim] = useState<{ name: string; token: number }>({
     name: REST_ANIMATION,
@@ -578,6 +602,9 @@ function AssistantOverlayInner() {
   const previousActivityIntentRef = useRef(activityIntent);
   const toolActivityRef = useRef(toolActivity);
   toolActivityRef.current = toolActivity;
+  const previousToolActivityRef = useRef<AssistantToolActivity | null>(
+    toolActivity
+  );
   const sequencePlanRef = useRef<DocumentToolSequencePlan | null>(null);
   const sequenceToolRef = useRef<string | null>(null);
   const entranceSequenceRef = useRef<string[] | null>(null);
@@ -605,6 +632,32 @@ function AssistantOverlayInner() {
   const clearEntranceSequence = useCallback(() => {
     entranceSequenceRef.current = null;
   }, []);
+
+  const clearPointingTimer = useCallback(() => {
+    if (pointingTimerRef.current) {
+      clearTimeout(pointingTimerRef.current);
+      pointingTimerRef.current = null;
+    }
+  }, []);
+
+  // Drop transient animation state when the character changes. Without this,
+  // switching characters mid-entrance leaves a stale entrance sequence and a
+  // stale entrance clip name behind, which replays the entry animation (and
+  // blocks activity-driven clips) when the sprite next mounts.
+  const previousCharacterIdRef = useRef(character.id);
+  useEffect(() => {
+    if (previousCharacterIdRef.current === character.id) return;
+    previousCharacterIdRef.current = character.id;
+    clearSequencePlan();
+    clearEntranceSequence();
+    clearPointingTimer();
+    setSpriteAnim({ name: REST_ANIMATION, token: 0 });
+  }, [
+    character.id,
+    clearSequencePlan,
+    clearEntranceSequence,
+    clearPointingTimer,
+  ]);
 
   const pickAnimation = useCallback(
     (intent: AssistantAnimationIntent, randomValue?: number) => {
@@ -640,6 +693,36 @@ function AssistantOverlayInner() {
     [playAnimation]
   );
 
+  // Look/gesture toward a window the assistant just relocated next to.
+  // Delayed so the snap spring mostly settles first. Skipped under reduced
+  // motion and never interrupts an entrance or quit clip.
+  pointAtTargetRef.current = (target, from) => {
+    clearPointingTimer();
+    if (reduceMotion) return;
+    pointingTimerRef.current = setTimeout(() => {
+      pointingTimerRef.current = null;
+      const data = agentDataRef.current;
+      if (!data) return;
+      if (entranceSequenceRef.current || quittingAnimationRef.current) return;
+      const direction = getAssistantPointingDirection(
+        {
+          x: from.x,
+          y: from.y,
+          width: character.width,
+          height: character.height,
+        },
+        target
+      );
+      if (!direction) return;
+      const pointingAnimation = selectAssistantPointingAnimation(
+        data,
+        direction
+      );
+      if (!pointingAnimation) return;
+      playAnimation(pointingAnimation);
+    }, POINTING_DELAY_MS);
+  };
+
   // Play Show followed by a greeting once per character appearance. The data
   // identity guard ignores the previous character's data while a switch loads.
   useEffect(() => {
@@ -674,6 +757,11 @@ function AssistantOverlayInner() {
   useEffect(() => {
     const previousIntent = previousActivityIntentRef.current;
     previousActivityIntentRef.current = activityIntent;
+    const previousTool = previousToolActivityRef.current;
+    previousToolActivityRef.current = toolActivity;
+    if (activityIntent !== "idle") {
+      lastActiveAtRef.current = Date.now();
+    }
     if (!agentData) return;
     if (entranceSequenceRef.current) return;
 
@@ -714,6 +802,7 @@ function AssistantOverlayInner() {
     if (
       sequencePlanRef.current &&
       (activityIntent === "thinking" ||
+        activityIntent === "speaking" ||
         activityIntent === "processing" ||
         activityIntent === "searching") &&
       isWorkingIntent(previousIntent)
@@ -731,6 +820,20 @@ function AssistantOverlayInner() {
       clearSequencePlan();
     }
 
+    // Quick nod when a non-sequence tool just completed mid-turn (document
+    // sequences already acknowledge via their return clip). The working loop
+    // resumes once the nod ends.
+    if (
+      toolActivity?.phase === "complete" &&
+      previousTool?.phase === "running" &&
+      previousTool.name === toolActivity.name &&
+      !isDocumentSequenceTool(toolActivity.name) &&
+      (activityIntent === "thinking" || activityIntent === "speaking")
+    ) {
+      playAnimation(pickAnimation("acknowledge"));
+      return;
+    }
+
     playAnimation(pickAnimation(activityIntent));
   }, [
     activityIntent,
@@ -745,6 +848,7 @@ function AssistantOverlayInner() {
   const handleCharacterActivate = useCallback(() => {
     cancelBubbleAutoClose();
     markAssistantSoundInteraction();
+    lastActiveAtRef.current = Date.now();
     const willOpen = !bubbleOpen;
     setBubbleOpen(willOpen);
     if (willOpen) {
@@ -850,34 +954,46 @@ function AssistantOverlayInner() {
         playAnimation(REST_ANIMATION);
       }
 
+      // No ambient idle rotation for reduced motion.
+      if (reduceMotion) return;
+
       if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
       idleTimerRef.current = setTimeout(() => {
         if (activityIntentRef.current !== "idle") return;
-        const idlePool = getIdleAnimationPool(data);
+        // After prolonged inactivity, prefer the character's deep-idle
+        // (sleep) clips when it ships them.
+        const deepIdlePool =
+          Date.now() - lastActiveAtRef.current >= DEEP_IDLE_AFTER_MS
+            ? getDeepIdleAnimationPool(data)
+            : [];
+        const idlePool =
+          deepIdlePool.length > 0 ? deepIdlePool : getIdleAnimationPool(data);
         playAnimation(
           idlePool[Math.floor(Math.random() * idlePool.length)] ??
             REST_ANIMATION
         );
       }, 4000 + Math.random() * 8000);
     },
-    [clearSequencePlan, pickAnimation, playAnimation, setEnabled]
+    [clearSequencePlan, pickAnimation, playAnimation, reduceMotion, setEnabled]
   );
 
   useEffect(
     () => () => {
       if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
       if (quitTimerRef.current) clearTimeout(quitTimerRef.current);
+      if (pointingTimerRef.current) clearTimeout(pointingTimerRef.current);
     },
     []
   );
 
   const handleQuit = useCallback(() => {
     cancelBubbleAutoClose();
+    clearPointingTimer();
     if (quittingAnimationRef.current) return;
 
     const data = agentDataRef.current;
     const intent = getAssistantLifecycleAnimationIntent("quit");
-    if (!data || intent !== "goodbye") {
+    if (!data || intent !== "goodbye" || reduceMotion) {
       setEnabled(false);
       return;
     }
@@ -906,9 +1022,11 @@ function AssistantOverlayInner() {
   }, [
     cancelBubbleAutoClose,
     clearEntranceSequence,
+    clearPointingTimer,
     clearSequencePlan,
     pickAnimation,
     playAnimation,
+    reduceMotion,
     setEnabled,
   ]);
 
@@ -1012,9 +1130,15 @@ function AssistantOverlayInner() {
         mapUrl={character.mapUrl}
         data={agentData}
         characterId={character.id}
-        animation={pendingEntranceAnimation ?? spriteAnim.name}
+        // Reduced motion pins the sprite to its rest pose; state changes are
+        // still conveyed by the bubble (ticker, error text, streamed reply).
+        animation={
+          reduceMotion
+            ? REST_ANIMATION
+            : pendingEntranceAnimation ?? spriteAnim.name
+        }
         playToken={spriteAnim.token}
-        initiallyHidden={initiallyHideSprite}
+        initiallyHidden={initiallyHideSprite && !reduceMotion}
         onAnimationEnd={handleAnimationEnd}
       />
     );
@@ -1026,6 +1150,7 @@ function AssistantOverlayInner() {
     spriteAnim,
     initiallyHideSprite,
     handleAnimationEnd,
+    reduceMotion,
   ]);
 
   return (

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -736,6 +736,9 @@ function AssistantOverlayInner() {
     enteredCharacterIdRef.current = character.id;
     enteredAgentDataRef.current = agentData;
     clearSequencePlan();
+    // Reduced motion keeps the sprite pinned to its rest pose; arming the
+    // sequence would just block activity-driven state forever.
+    if (reduceMotion) return;
     const plan = resolveAssistantEntranceSequencePlan(agentData);
     if (!plan) return;
     entranceSequenceRef.current = plan.followUp
@@ -750,6 +753,7 @@ function AssistantOverlayInner() {
     agentData,
     character.id,
     clearSequencePlan,
+    reduceMotion,
   ]);
 
   // Reflect chat and structured tool lifecycle changes without restarting an

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -65,6 +65,13 @@ import {
 } from "@/apps/chats/components/chat-messages/streamdown";
 import { ArrowUp } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
+import { createDebugLogger } from "@/utils/debug";
+
+/**
+ * Animation state machine trace. Silent in production unless the user opts in
+ * via `localStorage.setItem("ryos:debug", "1")` (see `src/utils/debug.ts`).
+ */
+const animLog = createDebugLogger("AssistantAnim");
 
 /** Distance (px) within which the assistant snaps to an edge on release. */
 const SNAP_THRESHOLD = 32;
@@ -661,6 +668,9 @@ function AssistantOverlayInner() {
   const previousCharacterIdRef = useRef(character.id);
   useEffect(() => {
     if (previousCharacterIdRef.current === character.id) return;
+    animLog(
+      `character switch ${previousCharacterIdRef.current} → ${character.id}; reset transient animation state`
+    );
     previousCharacterIdRef.current = character.id;
     clearSequencePlan();
     clearEntranceSequence();
@@ -693,8 +703,9 @@ function AssistantOverlayInner() {
     [character.id]
   );
 
-  const playAnimation = useCallback((name: string) => {
+  const playAnimation = useCallback((name: string, reason?: string) => {
     if (!name) return;
+    animLog(`play ${name}${reason ? ` — ${reason}` : ""}`);
     if (idleTimerRef.current) {
       clearTimeout(idleTimerRef.current);
       idleTimerRef.current = null;
@@ -706,7 +717,7 @@ function AssistantOverlayInner() {
     (plan: DocumentToolSequencePlan, toolName: string) => {
       sequencePlanRef.current = plan;
       sequenceToolRef.current = toolName;
-      playAnimation(plan.intro);
+      playAnimation(plan.intro, `document ${plan.kind} sequence for ${toolName}`);
     },
     [playAnimation]
   );
@@ -736,8 +747,11 @@ function AssistantOverlayInner() {
         data,
         direction
       );
-      if (!pointingAnimation) return;
-      playAnimation(pointingAnimation);
+      if (!pointingAnimation) {
+        animLog(`pointing ${direction} skipped — no clip for direction`);
+        return;
+      }
+      playAnimation(pointingAnimation, `pointing ${direction} at window`);
     }, POINTING_DELAY_MS);
   };
 
@@ -762,6 +776,11 @@ function AssistantOverlayInner() {
     entranceSequenceRef.current = plan.followUp
       ? [plan.first, plan.followUp]
       : [plan.first];
+    animLog(
+      `entrance ${character.id}: ${plan.first}${
+        plan.followUp ? ` → ${plan.followUp}` : ""
+      }`
+    );
     // The pending-entry render already started this clip. Record it without
     // bumping the replay token, which would restart the entrance.
     setSpriteAnim((prev) =>
@@ -794,7 +813,10 @@ function AssistantOverlayInner() {
     if (activityIntent === "idle") {
       clearSequencePlan();
       if (isWorkingIntent(previousIntent)) {
-        playAnimation(pickAnimation("success"));
+        playAnimation(
+          pickAnimation("success"),
+          `success after ${previousIntent}`
+        );
       }
       return;
     }
@@ -831,7 +853,7 @@ function AssistantOverlayInner() {
     ) {
       const plan = sequencePlanRef.current;
       clearSequencePlan();
-      playAnimation(plan.returnAnim);
+      playAnimation(plan.returnAnim, `return from ${plan.kind} sequence`);
       return;
     }
 
@@ -852,11 +874,18 @@ function AssistantOverlayInner() {
       !isDocumentSequenceTool(toolActivity.name) &&
       (activityIntent === "thinking" || activityIntent === "speaking")
     ) {
-      playAnimation(pickAnimation("acknowledge"));
+      playAnimation(
+        pickAnimation("acknowledge"),
+        `acknowledge — tool ${toolActivity.name} completed`
+      );
       return;
     }
 
-    playAnimation(pickAnimation(activityIntent));
+    playAnimation(
+      pickAnimation(activityIntent),
+      `intent ${previousIntent} → ${activityIntent}` +
+        (activeToolName ? ` (tool ${activeToolName})` : "")
+    );
   }, [
     activityIntent,
     agentData,
@@ -884,7 +913,10 @@ function AssistantOverlayInner() {
 
     clearSequencePlan();
     clearEntranceSequence();
-    playAnimation(pickAnimation(intent));
+    playAnimation(
+      pickAnimation(intent),
+      `bubble ${willOpen ? "open" : "close"}`
+    );
   }, [
     bubbleOpen,
     cancelBubbleAutoClose,
@@ -908,6 +940,7 @@ function AssistantOverlayInner() {
     (endedAnimation: string) => {
       const data = agentDataRef.current;
       if (!data) return;
+      animLog(`ended ${endedAnimation}`);
 
       if (quittingAnimationRef.current) {
         if (endedAnimation === quittingAnimationRef.current) {
@@ -926,10 +959,11 @@ function AssistantOverlayInner() {
         const remaining = entranceSequence.slice(1);
         if (remaining.length > 0) {
           entranceSequenceRef.current = remaining;
-          playAnimation(remaining[0]);
+          playAnimation(remaining[0], "entrance follow-up");
           return;
         }
         entranceSequenceRef.current = null;
+        animLog("entrance complete");
       }
 
       const currentIntent = activityIntentRef.current;
@@ -944,15 +978,7 @@ function AssistantOverlayInner() {
         isDocumentSequenceTool(sequenceTool);
 
       if (sequenceStillActive && plan) {
-        if (endedAnimation === plan.intro) {
-          playAnimation(plan.continued ?? plan.intro);
-          return;
-        }
-        if (plan.continued && endedAnimation === plan.continued) {
-          playAnimation(plan.continued);
-          return;
-        }
-        playAnimation(plan.continued ?? plan.intro);
+        playAnimation(plan.continued ?? plan.intro, `${plan.kind} sequence loop`);
         return;
       }
 
@@ -965,15 +991,21 @@ function AssistantOverlayInner() {
           plan &&
           (currentIntent === "reading" || currentIntent === "writing")
         ) {
-          playAnimation(plan.continued ?? plan.intro);
+          playAnimation(
+            plan.continued ?? plan.intro,
+            `${plan.kind} sequence resume`
+          );
           return;
         }
-        playAnimation(pickAnimation(currentIntent));
+        playAnimation(
+          pickAnimation(currentIntent),
+          `working loop (${currentIntent})`
+        );
         return;
       }
 
       if (endedAnimation !== REST_ANIMATION) {
-        playAnimation(REST_ANIMATION);
+        playAnimation(REST_ANIMATION, "settle to rest");
       }
 
       // No ambient idle rotation for reduced motion.
@@ -1001,7 +1033,8 @@ function AssistantOverlayInner() {
             : getIdleAnimationPool(currentData);
         playAnimation(
           idlePool[Math.floor(Math.random() * idlePool.length)] ??
-            REST_ANIMATION
+            REST_ANIMATION,
+          deepIdlePool.length > 0 ? "deep idle" : "ambient idle"
         );
       }, 4000 + Math.random() * 8000);
     },
@@ -1064,7 +1097,7 @@ function AssistantOverlayInner() {
     clearSequencePlan();
     clearEntranceSequence();
     quittingAnimationRef.current = exitAnimation;
-    playAnimation(exitAnimation);
+    playAnimation(exitAnimation, "quit exit");
     quitTimerRef.current = setTimeout(
       () => {
         quittingAnimationRef.current = null;

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -65,13 +65,14 @@ import {
 } from "@/apps/chats/components/chat-messages/streamdown";
 import { ArrowUp } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
-import { createDebugLogger } from "@/utils/debug";
+import { createClientLogger } from "@/utils/logger";
 
 /**
- * Animation state machine trace. Silent in production unless the user opts in
- * via `localStorage.setItem("ryos:debug", "1")` (see `src/utils/debug.ts`).
+ * Animation state machine trace. Silent in production unless the user enables
+ * Debug Mode (or sets `localStorage["ryos:debug"] = "1"`).
  */
-const animLog = createDebugLogger("AssistantAnim");
+const assistantAnimLogger = createClientLogger("AssistantAnim");
+const animLog = (message: string): void => assistantAnimLogger.debug(message);
 
 /** Distance (px) within which the assistant snaps to an edge on release. */
 const SNAP_THRESHOLD = 32;

--- a/src/components/assistant/ClippySprite.tsx
+++ b/src/components/assistant/ClippySprite.tsx
@@ -48,6 +48,9 @@ function resolveFrameImages(
   return frame.images && frame.images.length > 0 ? frame.images : current;
 }
 
+/** How often a clip held at its WAITING point checks for an interrupt. */
+const WAITING_POLL_MS = 50;
+
 const agentDataCache = new Map<string, Promise<AgentData>>();
 
 export function loadAgentData(url: string): Promise<AgentData> {
@@ -158,6 +161,12 @@ interface PlaybackState {
   exiting: boolean;
   /** Frames stepped while exiting; caps malformed exit-branch loops. */
   exitSteps: number;
+  /**
+   * Reached the natural end of a useExitBranching clip: holding its final
+   * pose (original Microsoft Agent WAITING state). The end has been reported,
+   * and the clip's wind-down frames play when the next clip is requested.
+   */
+  waiting: boolean;
   /** Clip queued to start once the graceful exit completes. */
   pendingName: string | null;
   timer: ReturnType<typeof setTimeout> | null;
@@ -230,6 +239,7 @@ export function ClippySprite({
         index: 0,
         exiting: false,
         exitSteps: 0,
+        waiting: false,
         pendingName: null,
         timer: null,
       };
@@ -253,6 +263,28 @@ export function ClippySprite({
         const frame = playback.anim.frames[playback.index];
         if (!frame) {
           finish();
+          return;
+        }
+
+        // WAITING hold: the frame is already on screen, so just poll for an
+        // interrupt. Once one arrives, jump onto the held frame's exit path.
+        if (playback.waiting) {
+          if (!playback.exiting) {
+            playback.timer = setTimeout(step, WAITING_POLL_MS);
+            return;
+          }
+          playback.waiting = false;
+          playback.exitSteps += 1;
+          const exitIndex =
+            typeof frame.exitBranch === "number"
+              ? frame.exitBranch
+              : playback.index + 1;
+          if (exitIndex >= playback.anim.frames.length) {
+            finish();
+            return;
+          }
+          playback.index = exitIndex;
+          step();
           return;
         }
 
@@ -284,6 +316,27 @@ export function ClippySprite({
           }
         }
 
+        // Exit-branching clips never end on their own (original Microsoft
+        // Agent WAITING state): their last frame is a terminal marker, and
+        // the wind-down frames before it are only reachable via exitBranch
+        // pointers. Finishing here would strand the held pose on screen and
+        // make the next clip a hard cut. Instead hold the current frame —
+        // keeping its exitBranch reachable — and report the end once so the
+        // overlay's state machine can decide what plays next; its request
+        // then winds the clip down through the exit path above.
+        if (
+          !playback.exiting &&
+          playback.anim.useExitBranching &&
+          nextIndex >= playback.anim.frames.length - 1
+        ) {
+          playback.waiting = true;
+          spriteLog(`hold ${playback.name} at exit-branch wait point`);
+          onEndRef.current?.(playback.name);
+          if (playbackRef.current !== playback) return;
+          playback.timer = setTimeout(step, WAITING_POLL_MS);
+          return;
+        }
+
         if (nextIndex >= playback.anim.frames.length) {
           playback.timer = setTimeout(finish, frame.duration);
           return;
@@ -313,12 +366,14 @@ export function ClippySprite({
 
     // Graceful interrupt: clips authored with exit branching wind down along
     // their exitBranch path before the next clip starts (original Microsoft
-    // Agent behavior). Everything else hard-switches immediately.
+    // Agent behavior). Everything else hard-switches immediately. A clip
+    // holding at its WAITING point always winds down first — even a replay of
+    // the same clip, which restarts from the rest pose the exit path ends on.
     if (
       !dataChanged &&
       playback &&
       playback.anim.useExitBranching &&
-      !(playback.name === animation && !playback.exiting)
+      !(playback.name === animation && !playback.exiting && !playback.waiting)
     ) {
       spriteLog(
         `graceful exit of ${playback.name}, then ${animation} (exit-branch wind-down)`

--- a/src/components/assistant/ClippySprite.tsx
+++ b/src/components/assistant/ClippySprite.tsx
@@ -204,6 +204,10 @@ export function ClippySprite({
       const anim = dataRef.current.animations[name];
       if (!anim || anim.frames.length === 0) {
         setFrameImages([[0, 0]]);
+        // Report the clip as ended so the overlay's state machine recovers
+        // (otherwise a missing clip freezes the sprite at its base pose until
+        // the next unrelated state change).
+        onEndRef.current?.(name);
         return;
       }
 

--- a/src/components/assistant/ClippySprite.tsx
+++ b/src/components/assistant/ClippySprite.tsx
@@ -1,13 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { AssistantCharacterId } from "./characters";
 import { AssistantSoundPlayer } from "./assistantSounds";
-import { createDebugLogger } from "@/utils/debug";
+import { createClientLogger } from "@/utils/logger";
 
 /**
- * Sprite playback trace. Silent in production unless the user opts in via
- * `localStorage.setItem("ryos:debug", "1")` (see `src/utils/debug.ts`).
+ * Sprite playback trace. Silent in production unless the user enables Debug
+ * Mode (or sets `localStorage["ryos:debug"] = "1"`).
  */
-const spriteLog = createDebugLogger("AssistantSprite");
+const assistantSpriteLogger = createClientLogger("AssistantSprite");
+const spriteLog = (message: string): void =>
+  assistantSpriteLogger.debug(message);
 
 /**
  * Minimal player for Microsoft Agent animation data (clippy.js format).

--- a/src/components/assistant/ClippySprite.tsx
+++ b/src/components/assistant/ClippySprite.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { AssistantCharacterId } from "./characters";
 import { AssistantSoundPlayer } from "./assistantSounds";
 
@@ -143,6 +143,19 @@ interface ClippySpriteProps {
   onAnimationEnd?: (animation: string) => void;
 }
 
+interface PlaybackState {
+  name: string;
+  anim: AgentAnimation;
+  index: number;
+  /** Following exitBranch frames toward the end after an interrupt request. */
+  exiting: boolean;
+  /** Frames stepped while exiting; caps malformed exit-branch loops. */
+  exitSteps: number;
+  /** Clip queued to start once the graceful exit completes. */
+  pendingName: string | null;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
 export function ClippySprite({
   mapUrl,
   data,
@@ -156,8 +169,10 @@ export function ClippySprite({
   const [frameImages, setFrameImages] = useState<Array<[number, number]>>(() =>
     initiallyHidden ? [] : [[0, 0]]
   );
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const playbackRef = useRef<PlaybackState | null>(null);
   const soundPlayerRef = useRef<AssistantSoundPlayer | null>(null);
+  const dataRef = useRef(data);
+  dataRef.current = data;
   const onEndRef = useRef(onAnimationEnd);
   onEndRef.current = onAnimationEnd;
 
@@ -176,60 +191,133 @@ export function ClippySprite({
 
   const [frameWidth, frameHeight] = data.framesize;
 
+  const stopPlayback = useCallback(() => {
+    const playback = playbackRef.current;
+    if (playback?.timer) clearTimeout(playback.timer);
+    playbackRef.current = null;
+  }, []);
+
+  const startAnimation = useCallback(
+    function start(name: string) {
+      stopPlayback();
+      soundPlayerRef.current?.stopAll();
+      const anim = dataRef.current.animations[name];
+      if (!anim || anim.frames.length === 0) {
+        setFrameImages([[0, 0]]);
+        return;
+      }
+
+      const playback: PlaybackState = {
+        name,
+        anim,
+        index: 0,
+        exiting: false,
+        exitSteps: 0,
+        pendingName: null,
+        timer: null,
+      };
+      playbackRef.current = playback;
+
+      const finish = () => {
+        if (playbackRef.current !== playback) return;
+        const pendingName = playback.pendingName;
+        playbackRef.current = null;
+        if (pendingName !== null) {
+          // Interrupted clips exit silently: the parent state machine already
+          // committed to the pending clip, so no end notification.
+          start(pendingName);
+          return;
+        }
+        onEndRef.current?.(playback.name);
+      };
+
+      const step = () => {
+        if (playbackRef.current !== playback) return;
+        const frame = playback.anim.frames[playback.index];
+        if (!frame) {
+          finish();
+          return;
+        }
+
+        setFrameImages((current) => resolveFrameImages(current, frame));
+        soundPlayerRef.current?.play(frame.sound);
+
+        // Pick the next frame. Exiting follows exitBranch pointers toward the
+        // end (skipping probabilistic loops); normal playback honors
+        // branching, else advances sequentially. Reaching past the last frame
+        // ends the animation.
+        let nextIndex = playback.index + 1;
+        if (playback.exiting) {
+          playback.exitSteps += 1;
+          if (playback.exitSteps > playback.anim.frames.length * 2) {
+            finish();
+            return;
+          }
+          if (typeof frame.exitBranch === "number") {
+            nextIndex = frame.exitBranch;
+          }
+        } else if (frame.branching) {
+          let roll = Math.random() * 100;
+          for (const branch of frame.branching.branches) {
+            if (roll <= branch.weight) {
+              nextIndex = branch.frameIndex;
+              break;
+            }
+            roll -= branch.weight;
+          }
+        }
+
+        if (nextIndex >= playback.anim.frames.length) {
+          playback.timer = setTimeout(finish, frame.duration);
+          return;
+        }
+
+        playback.index = nextIndex;
+        playback.timer = setTimeout(step, frame.duration);
+      };
+
+      step();
+    },
+    [stopPlayback]
+  );
+
+  const previousRequestRef = useRef<{
+    data: AgentData;
+    animation: string;
+    playToken: number;
+  } | null>(null);
+
   useEffect(() => {
-    const anim = data.animations[animation];
-    if (!anim || anim.frames.length === 0) {
-      setFrameImages([[0, 0]]);
+    const previous = previousRequestRef.current;
+    previousRequestRef.current = { data, animation, playToken };
+
+    const playback = playbackRef.current;
+    const dataChanged = previous !== null && previous.data !== data;
+
+    // Graceful interrupt: clips authored with exit branching wind down along
+    // their exitBranch path before the next clip starts (original Microsoft
+    // Agent behavior). Everything else hard-switches immediately.
+    if (
+      !dataChanged &&
+      playback &&
+      playback.anim.useExitBranching &&
+      !(playback.name === animation && !playback.exiting)
+    ) {
+      playback.pendingName = animation;
+      playback.exiting = true;
       return;
     }
 
-    let cancelled = false;
-    let index = 0;
+    startAnimation(animation);
+  }, [data, animation, playToken, startAnimation]);
 
-    const step = () => {
-      if (cancelled) return;
-      const frame = anim.frames[index];
-      if (!frame) {
-        onEndRef.current?.(animation);
-        return;
-      }
-
-      setFrameImages((current) => resolveFrameImages(current, frame));
-      soundPlayerRef.current?.play(frame.sound);
-
-      // Pick the next frame: probabilistic branching when present, else
-      // sequential. Reaching past the last frame ends the animation.
-      let nextIndex = index + 1;
-      if (frame.branching) {
-        let roll = Math.random() * 100;
-        for (const branch of frame.branching.branches) {
-          if (roll <= branch.weight) {
-            nextIndex = branch.frameIndex;
-            break;
-          }
-          roll -= branch.weight;
-        }
-      }
-
-      if (nextIndex >= anim.frames.length) {
-        timerRef.current = setTimeout(() => {
-          if (!cancelled) onEndRef.current?.(animation);
-        }, frame.duration);
-        return;
-      }
-
-      index = nextIndex;
-      timerRef.current = setTimeout(step, frame.duration);
-    };
-
-    step();
-
-    return () => {
-      cancelled = true;
-      if (timerRef.current) clearTimeout(timerRef.current);
+  useEffect(
+    () => () => {
+      stopPlayback();
       soundPlayerRef.current?.stopAll();
-    };
-  }, [data, animation, playToken]);
+    },
+    [stopPlayback]
+  );
 
   return (
     <div

--- a/src/components/assistant/ClippySprite.tsx
+++ b/src/components/assistant/ClippySprite.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { AssistantCharacterId } from "./characters";
 import { AssistantSoundPlayer } from "./assistantSounds";
+import { createDebugLogger } from "@/utils/debug";
+
+/**
+ * Sprite playback trace. Silent in production unless the user opts in via
+ * `localStorage.setItem("ryos:debug", "1")` (see `src/utils/debug.ts`).
+ */
+const spriteLog = createDebugLogger("AssistantSprite");
 
 /**
  * Minimal player for Microsoft Agent animation data (clippy.js format).
@@ -203,6 +210,7 @@ export function ClippySprite({
       soundPlayerRef.current?.stopAll();
       const anim = dataRef.current.animations[name];
       if (!anim || anim.frames.length === 0) {
+        spriteLog(`missing clip "${name}" — falling back to base pose`);
         setFrameImages([[0, 0]]);
         // Report the clip as ended so the overlay's state machine recovers
         // (otherwise a missing clip freezes the sprite at its base pose until
@@ -211,6 +219,11 @@ export function ClippySprite({
         return;
       }
 
+      spriteLog(
+        `start ${name} (${anim.frames.length} frames${
+          anim.useExitBranching ? ", exit-branching" : ""
+        })`
+      );
       const playback: PlaybackState = {
         name,
         anim,
@@ -307,6 +320,9 @@ export function ClippySprite({
       playback.anim.useExitBranching &&
       !(playback.name === animation && !playback.exiting)
     ) {
+      spriteLog(
+        `graceful exit of ${playback.name}, then ${animation} (exit-branch wind-down)`
+      );
       playback.pendingName = animation;
       playback.exiting = true;
       return;

--- a/src/components/assistant/assistantAnimation.ts
+++ b/src/components/assistant/assistantAnimation.ts
@@ -258,6 +258,19 @@ export interface AssistantEntranceSequencePlan {
 }
 
 /**
+ * Follow-up gestures that continue from the visible rest pose. "Greeting" is
+ * intentionally absent: Microsoft Agent "Greeting" clips are alternate
+ * entrances whose first frames are (nearly) empty, so chaining one after Show
+ * pops the character in, blanks it, and materializes it a second time.
+ */
+const ENTRANCE_FOLLOW_UP_CANDIDATES = [
+  "Greet",
+  "Wave",
+  "GetAttention",
+  "Announce",
+] as const;
+
+/**
  * Prefer the agent's real entrance clip, then a separate greeting gesture.
  * Characters without an entrance clip appear in their static default pose.
  */
@@ -270,9 +283,7 @@ export function resolveAssistantEntranceSequencePlan(
   );
   const greeting = pickFirstAvailableAnimation(
     data,
-    ANIMATION_CANDIDATES.greeting.filter(
-      (name) => !isAssistantEntranceAnimation(name)
-    )
+    ENTRANCE_FOLLOW_UP_CANDIDATES
   );
 
   if (entrance) {

--- a/src/components/assistant/assistantAnimation.ts
+++ b/src/components/assistant/assistantAnimation.ts
@@ -29,7 +29,17 @@ export interface AssistantToolActivity {
   phase: AssistantToolPhase;
 }
 
+/**
+ * "Greeting" is preferred over "Show": on every character that ships one,
+ * Greeting is the fully-authored entrance — it starts from (nearly) empty
+ * frames, materializes the character gradually, includes a greeting gesture,
+ * and ends at the rest pose. On those same characters "Show" is a 40–300ms
+ * pop (e.g. Clippy's Show is 5 frames / 50ms vs. its 4.5s Greeting).
+ * Characters without a Greeting clip (Merlin, Genie, Peedy, Rover) have a
+ * real gradual Show and fall through to it.
+ */
 const ENTRANCE_ANIMATION_CANDIDATES = [
+  "Greeting",
   "Show",
   "Appear",
   "AppearQuick",
@@ -43,11 +53,10 @@ const EXIT_ANIMATION_CANDIDATES = [
 ] as const;
 
 const ANIMATION_CANDIDATES = {
-  // Entrance clips (Show/Appear/…) are intentionally NOT candidates here:
-  // they only play through the dedicated entrance sequence plan, so a random
-  // greeting pick can never replay the character's entry animation.
+  // Entrance clips (Greeting/Show/Appear/…) are intentionally NOT candidates
+  // here: they only play through the dedicated entrance sequence plan, so a
+  // random greeting pick can never replay the character's entry animation.
   greeting: [
-    "Greeting",
     "Greet",
     "Wave",
     "Announce",
@@ -258,10 +267,10 @@ export interface AssistantEntranceSequencePlan {
 }
 
 /**
- * Follow-up gestures that continue from the visible rest pose. "Greeting" is
- * intentionally absent: Microsoft Agent "Greeting" clips are alternate
- * entrances whose first frames are (nearly) empty, so chaining one after Show
- * pops the character in, blanks it, and materializes it a second time.
+ * Follow-up gestures that continue from the visible rest pose, for characters
+ * whose entrance is a bare materialization (Show/Appear) with no greeting of
+ * its own. "Greeting" entrances already end on a greeting gesture, so they
+ * never chain a follow-up.
  */
 const ENTRANCE_FOLLOW_UP_CANDIDATES = [
   "Greet",
@@ -271,8 +280,10 @@ const ENTRANCE_FOLLOW_UP_CANDIDATES = [
 ] as const;
 
 /**
- * Prefer the agent's real entrance clip, then a separate greeting gesture.
- * Characters without an entrance clip appear in their static default pose.
+ * Prefer the agent's fully-authored "Greeting" entrance (materialize +
+ * greeting gesture in one clip), else a bare materialization (Show/Appear)
+ * followed by a separate greeting gesture. Characters without any entrance
+ * clip appear in their static default pose.
  */
 export function resolveAssistantEntranceSequencePlan(
   data: AgentData
@@ -281,13 +292,19 @@ export function resolveAssistantEntranceSequencePlan(
     data,
     ENTRANCE_ANIMATION_CANDIDATES
   );
-  const greeting = pickFirstAvailableAnimation(
-    data,
-    ENTRANCE_FOLLOW_UP_CANDIDATES
-  );
+
+  if (entrance === "Greeting") {
+    return { first: entrance, followUp: null };
+  }
 
   if (entrance) {
-    return { first: entrance, followUp: greeting };
+    return {
+      first: entrance,
+      followUp: pickFirstAvailableAnimation(
+        data,
+        ENTRANCE_FOLLOW_UP_CANDIDATES
+      ),
+    };
   }
 
   return { first: "RestPose", followUp: null };

--- a/src/components/assistant/assistantAnimation.ts
+++ b/src/components/assistant/assistantAnimation.ts
@@ -4,6 +4,7 @@ import type { AssistantCharacterId } from "./characters";
 export type AssistantAnimationIntent =
   | "greeting"
   | "thinking"
+  | "speaking"
   | "processing"
   | "searching"
   | "reading"
@@ -11,6 +12,7 @@ export type AssistantAnimationIntent =
   | "success"
   | "error"
   | "attention"
+  | "acknowledge"
   | "goodbye"
   | "idle";
 
@@ -41,10 +43,12 @@ const EXIT_ANIMATION_CANDIDATES = [
 ] as const;
 
 const ANIMATION_CANDIDATES = {
+  // Entrance clips (Show/Appear/…) are intentionally NOT candidates here:
+  // they only play through the dedicated entrance sequence plan, so a random
+  // greeting pick can never replay the character's entry animation.
   greeting: [
     "Greeting",
     "Greet",
-    ...ENTRANCE_ANIMATION_CANDIDATES,
     "Wave",
     "Announce",
     "GetAttention",
@@ -59,6 +63,15 @@ const ANIMATION_CANDIDATES = {
     "Suggest",
     "GetWizardy",
     "Hearing_1",
+  ],
+  // Conversational gestures while reply text is streaming in.
+  speaking: [
+    "Explain",
+    "Announce",
+    "Suggest",
+    "Acknowledge",
+    "Pleased",
+    "GestureUp",
   ],
   processing: [
     "Processing",
@@ -125,6 +138,8 @@ const ANIMATION_CANDIDATES = {
     "GestureRight",
     "GestureDown",
   ],
+  // Brief nod: bubble dismissal and mid-turn tool completions.
+  acknowledge: ["Acknowledge", "Pleased", "GestureDown", "Blink"],
   goodbye: EXIT_ANIMATION_CANDIDATES,
   idle: ["RestPose"],
 } satisfies Record<AssistantAnimationIntent, readonly string[]>;
@@ -148,7 +163,7 @@ export function getAssistantLifecycleAnimationIntent(
   const intents = {
     characterLoad: "greeting",
     bubbleOpen: "attention",
-    bubbleClose: null,
+    bubbleClose: "acknowledge",
     quit: "goodbye",
   } satisfies Record<
     AssistantAnimationLifecycleEvent,
@@ -160,7 +175,7 @@ export function getAssistantLifecycleAnimationIntent(
 const SEARCH_TOOL_NAMES = new Set([
   "list",
   "searchSongs",
-  "songLibrary",
+  "songLibraryControl",
   "webFetch",
   "mapsSearchPlaces",
   "listCursorCloudAgentRuns",
@@ -174,6 +189,8 @@ const WRITE_TOOL_NAMES = new Set([
   "generateHtml",
   "memoryWrite",
   "memoryDelete",
+  "stickiesControl",
+  "documentsControl",
 ]);
 
 /**
@@ -341,20 +358,27 @@ export function resolveDocumentToolSequencePlan(
 /** Idle loops that are too long for ambient rotation. */
 const MEGA_IDLE_ANIMATIONS = new Set(["Idle"]);
 
-/** Prepended when a specific tool is actively running. */
+/**
+ * Prepended when a specific tool is actively running. Entrance/exit clips
+ * (Show, Hide, GoodBye, …) are not usable here — `getAnimationCandidates`
+ * filters them out for every non-lifecycle intent.
+ */
 const TOOL_SPECIFIC_ANIMATIONS: Record<string, readonly string[]> = {
   mediaControl: ["Hearing_1", "StartListening"],
-  launchApp: ["Show", "GetAttention"],
-  closeApp: ["Hide", "Goodbye", "GoodBye"],
-  switchTheme: ["GetWizardy", "DoMagic1", "DoMagic2"],
+  launchApp: ["GetAttention", "Announce"],
+  closeApp: ["Wave", "GestureDown"],
+  settings: ["GetWizardy", "DoMagic1", "DoMagic2"],
   generateHtml: ["DoMagic1", "GetWizardy"],
+  aquarium: ["DoMagic1", "GetArtsy"],
+  infiniteMacControl: ["GetTechy", "DoMagic1"],
+  cursorCloudAgent: ["GetTechy", "Writing"],
 };
 
 /** Rover-only topic animations keyed by active tool name. */
 const ROVER_TOOL_ANIMATIONS: Record<string, readonly string[]> = {
   mapsSearchPlaces: ["Travel"],
   searchSongs: ["Celebrity"],
-  songLibrary: ["Sports"],
+  songLibraryControl: ["Sports"],
   list: ["Books"],
   read: ["Books"],
   write: ["Writing"],
@@ -362,6 +386,25 @@ const ROVER_TOOL_ANIMATIONS: Record<string, readonly string[]> = {
   webFetch: ["Searching"],
   mediaControl: ["Sports"],
 };
+
+/**
+ * Every tool name the animation layer references. Exists so tests can assert
+ * these stay in sync with the real tool registry (`api/chat/tools`) — tool
+ * renames silently killed animations before (e.g. switchTheme → settings).
+ */
+export function getAssistantAnimationMappedToolNames(): string[] {
+  return [
+    ...new Set([
+      ...SEARCH_TOOL_NAMES,
+      ...READ_TOOL_NAMES,
+      ...WRITE_TOOL_NAMES,
+      ...READ_SEQUENCE_TOOL_NAMES,
+      ...WRITE_SEQUENCE_TOOL_NAMES,
+      ...Object.keys(TOOL_SPECIFIC_ANIMATIONS),
+      ...Object.keys(ROVER_TOOL_ANIMATIONS),
+    ]),
+  ];
+}
 
 const EXTRA_IDLE_CANDIDATES = [
   "LookLeft",
@@ -410,9 +453,12 @@ export function getAnimationCandidates(
     ];
   }
 
+  // Entrance clips only ever play via the entrance sequence plan; exit clips
+  // only via the quit flow. Filtering both here guarantees a random pick can
+  // never duplicate the entry animation or hide the character mid-session.
   return dedupeCandidates(candidates).filter(
     (name) =>
-      (intent === "greeting" || !isAssistantEntranceAnimation(name)) &&
+      !isAssistantEntranceAnimation(name) &&
       (intent === "goodbye" || !isAssistantExitAnimation(name))
   );
 }
@@ -430,16 +476,20 @@ export function getAssistantAnimationIntent({
   isLoading,
   hasError,
   toolActivity,
+  hasVisibleReply = false,
 }: {
   isLoading: boolean;
   hasError: boolean;
   toolActivity: AssistantToolActivity | null;
+  /** True once the in-flight turn has streamed visible reply text. */
+  hasVisibleReply?: boolean;
 }): AssistantAnimationIntent {
   if (hasError || toolActivity?.phase === "error") return "error";
   if (!isLoading) return "idle";
   if (toolActivity?.phase === "running") {
     return getToolAnimationIntent(toolActivity.name);
   }
+  if (hasVisibleReply) return "speaking";
   return "thinking";
 }
 
@@ -468,6 +518,116 @@ export function getIdleAnimationPool(data: AgentData): string[] {
       (name) => data.animations[name] !== undefined
     ),
   ];
+}
+
+/** Continuous idle time after which deep-idle (sleep) clips become eligible. */
+export const DEEP_IDLE_AFTER_MS = 2 * 60 * 1000;
+
+/**
+ * Long "falls asleep" clips reserved for prolonged inactivity. Not every
+ * character ships DeepIdle clips; callers fall back to the ambient pool.
+ */
+export function getDeepIdleAnimationPool(data: AgentData): string[] {
+  return Object.keys(data.animations).filter((name) =>
+    name.toLowerCase().startsWith("deepidle")
+  );
+}
+
+// --- Pointing / directional attention ---------------------------------------
+
+export type AssistantPointingDirection =
+  | "left"
+  | "right"
+  | "up"
+  | "down"
+  | "upLeft"
+  | "upRight"
+  | "downLeft"
+  | "downRight";
+
+/**
+ * Microsoft Agent Gesture and Look clip names use the viewer's screen
+ * perspective (GestureLeft points toward the left edge of the screen).
+ * Diagonal Look clips exist on some characters only, so each diagonal falls
+ * back to its horizontal and vertical components.
+ */
+const POINTING_ANIMATION_CANDIDATES: Record<
+  AssistantPointingDirection,
+  readonly string[]
+> = {
+  left: ["GestureLeft", "LookLeft"],
+  right: ["GestureRight", "LookRight"],
+  up: ["GestureUp", "LookUp"],
+  down: ["GestureDown", "LookDown"],
+  upLeft: ["LookUpLeft", "GestureLeft", "LookLeft", "LookUp"],
+  upRight: ["LookUpRight", "GestureRight", "LookRight", "LookUp"],
+  downLeft: ["LookDownLeft", "GestureLeft", "LookLeft", "LookDown"],
+  downRight: ["LookDownRight", "GestureRight", "LookRight", "LookDown"],
+};
+
+export interface AssistantPointingRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Center-to-center offsets below this are too small to point at. */
+const POINTING_MIN_OFFSET_PX = 48;
+/** Secondary-axis share of the primary axis that upgrades to a diagonal. */
+const POINTING_DIAGONAL_RATIO = 0.5;
+
+/**
+ * Direction from the assistant toward a target window, from the viewer's
+ * perspective. Returns null when the target is too close to point at.
+ */
+export function getAssistantPointingDirection(
+  assistant: AssistantPointingRect,
+  target: AssistantPointingRect
+): AssistantPointingDirection | null {
+  const dx =
+    target.x + target.width / 2 - (assistant.x + assistant.width / 2);
+  const dy =
+    target.y + target.height / 2 - (assistant.y + assistant.height / 2);
+  const absX = Math.abs(dx);
+  const absY = Math.abs(dy);
+  if (absX < POINTING_MIN_OFFSET_PX && absY < POINTING_MIN_OFFSET_PX) {
+    return null;
+  }
+
+  const horizontal: AssistantPointingDirection = dx < 0 ? "left" : "right";
+  const vertical: AssistantPointingDirection = dy < 0 ? "up" : "down";
+  const diagonal: AssistantPointingDirection =
+    vertical === "up"
+      ? horizontal === "left"
+        ? "upLeft"
+        : "upRight"
+      : horizontal === "left"
+        ? "downLeft"
+        : "downRight";
+
+  if (absX >= absY) {
+    const isDiagonal =
+      absY >= POINTING_MIN_OFFSET_PX && absY >= absX * POINTING_DIAGONAL_RATIO;
+    return isDiagonal ? diagonal : horizontal;
+  }
+  const isDiagonal =
+    absX >= POINTING_MIN_OFFSET_PX && absX >= absY * POINTING_DIAGONAL_RATIO;
+  return isDiagonal ? diagonal : vertical;
+}
+
+/**
+ * Best available pointing/look clip toward a direction, or null when the
+ * character has none (e.g. Rover lacks right-facing clips).
+ */
+export function selectAssistantPointingAnimation(
+  data: AgentData,
+  direction: AssistantPointingDirection
+): string | null {
+  return pickFirstAvailableAnimation(
+    data,
+    POINTING_ANIMATION_CANDIDATES[direction]
+  );
 }
 
 export function selectAssistantAnimation({

--- a/src/components/assistant/assistantSpeech.ts
+++ b/src/components/assistant/assistantSpeech.ts
@@ -37,6 +37,7 @@ export function prepareAssistantSpeechTexts(text: string): string[] {
 // reply (or a stop) never lets stale `onend` handlers keep speaking.
 let generation = 0;
 let voicesWarmed = false;
+let synthesisPrimed = false;
 
 /** Warm the async voice list (Chrome loads it lazily). Never blocks speech. */
 function warmVoices(synth: SpeechSynthesis) {
@@ -49,6 +50,31 @@ function warmVoices(synth: SpeechSynthesis) {
 export interface AssistantSpeechOptions {
   /** ryOS i18n locale (e.g. "zh-TW"); maps to the utterance language. */
   locale?: string;
+}
+
+/**
+ * Unlock speech synthesis from inside a user gesture. iOS Safari (and some
+ * other engines) ignore `speechSynthesis.speak()` until the page's first
+ * `speak()` happens inside a gesture handler. When Speech was enabled in a
+ * previous session, replies finish asynchronously — outside any gesture — so
+ * without priming they are silently dropped. Call this from gesture handlers
+ * (pointer down, submit); it speaks one muted, empty utterance the first time.
+ */
+export function primeAssistantSpeech(): void {
+  if (synthesisPrimed) return;
+  const synth = getBrowserSpeechSynthesis();
+  if (!synth) return;
+  synthesisPrimed = true;
+
+  warmVoices(synth);
+  synth.resume();
+  // Never clobber speech that is already audible (it also proves synthesis
+  // is unlocked).
+  if (synth.speaking || synth.pending) return;
+
+  const utterance = new SpeechSynthesisUtterance(" ");
+  utterance.volume = 0;
+  synth.speak(utterance);
 }
 
 /**
@@ -116,4 +142,5 @@ export function stopAssistantSpeech(): void {
 export function __resetAssistantSpeechStateForTests(): void {
   generation++;
   voicesWarmed = false;
+  synthesisPrimed = false;
 }

--- a/src/components/assistant/useAssistantChat.ts
+++ b/src/components/assistant/useAssistantChat.ts
@@ -51,8 +51,8 @@ const TOOL_STATUS_KEYS: Record<string, string> = {
   read: "apps.chats.toolCalls.readingFile",
   write: "apps.chats.toolCalls.writingContent",
   edit: "apps.chats.toolCalls.editingFile",
-  switchTheme: "apps.chats.toolCalls.switchingTheme",
-  songLibrary: "apps.chats.toolCalls.loadingMusicLibrary",
+  settings: "apps.chats.toolCalls.changingSettings",
+  songLibraryControl: "apps.chats.toolCalls.loadingMusicLibrary",
 };
 
 function getToolStatusLabel(toolName: string, input: unknown): string {
@@ -289,10 +289,25 @@ export function useAssistantChat(): AssistantChatHandle {
   };
 
   const isLoading = status === "streaming" || status === "submitted";
-  const toolActivity = useMemo(
-    () => getLatestToolActivity(messages),
-    [messages]
-  );
+
+  // Stabilize by value: `messages` gets a new identity on every streamed
+  // chunk, which would otherwise produce a fresh toolActivity object each
+  // update and make the overlay restart the current sprite clip mid-stream.
+  const stableToolActivityRef = useRef<AssistantToolActivity | null>(null);
+  const toolActivity = useMemo(() => {
+    const latest = getLatestToolActivity(messages);
+    const previous = stableToolActivityRef.current;
+    if (
+      latest !== null &&
+      previous !== null &&
+      latest.name === previous.name &&
+      latest.phase === previous.phase
+    ) {
+      return previous;
+    }
+    stableToolActivityRef.current = latest;
+    return latest;
+  }, [messages]);
 
   const latestAssistantText = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {

--- a/src/components/assistant/useAssistantSpeech.ts
+++ b/src/components/assistant/useAssistantSpeech.ts
@@ -1,7 +1,14 @@
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useAssistantStore } from "@/stores/useAssistantStore";
-import { speakAssistantText, stopAssistantSpeech } from "./assistantSpeech";
+import {
+  primeAssistantSpeech,
+  speakAssistantText,
+  stopAssistantSpeech,
+} from "./assistantSpeech";
+
+/** Gesture events iOS Safari accepts for unlocking speech synthesis. */
+const SPEECH_UNLOCK_EVENTS = ["pointerdown", "touchend", "keydown"] as const;
 
 interface UseAssistantSpeechOptions {
   /** Latest visible assistant reply text (streams in while loading). */
@@ -30,6 +37,29 @@ export function useAssistantSpeech({
   useEffect(() => {
     if (isLoading) stopAssistantSpeech();
   }, [isLoading]);
+
+  // When Speech was already on from a previous session, replies finish
+  // outside any user gesture and iOS Safari drops the `speak()` call. Prime
+  // synthesis from the first gesture of the session so those asynchronous
+  // replies are audible. (Toggling Speech on manually primes as a side
+  // effect of speaking inside the menu click, which is why that path
+  // already worked.)
+  useEffect(() => {
+    if (!speechEnabled) return;
+    if (typeof document === "undefined") return;
+    const unlock = () => primeAssistantSpeech();
+    SPEECH_UNLOCK_EVENTS.forEach((event) =>
+      document.addEventListener(event, unlock, {
+        capture: true,
+        passive: true,
+      })
+    );
+    return () => {
+      SPEECH_UNLOCK_EVENTS.forEach((event) =>
+        document.removeEventListener(event, unlock, true)
+      );
+    };
+  }, [speechEnabled]);
 
   useEffect(() => {
     if (isLoading) return;

--- a/tests/test-assistant-animation.test.tsx
+++ b/tests/test-assistant-animation.test.tsx
@@ -99,20 +99,42 @@ describe("assistant semantic animation selection", () => {
     ).toBe("GetWizardy");
   });
 
-  test("plays Show before greeting on initial character load", () => {
-    const data = agentWithAnimations(["Show", "Greeting", "RestPose"]);
+  test("plays Show before a greeting gesture on initial character load", () => {
+    const data = agentWithAnimations(["Show", "Greet", "Wave", "RestPose"]);
 
     expect(resolveAssistantEntranceSequencePlan(data)).toEqual({
       first: "Show",
-      followUp: "Greeting",
+      followUp: "Greet",
     });
     expect(
       resolveAssistantEntranceSequencePlan(
-        agentWithAnimations(["Greeting", "RestPose"])
+        agentWithAnimations(["Greet", "RestPose"])
       )
     ).toEqual({
       first: "RestPose",
       followUp: null,
+    });
+  });
+
+  test("never chains a Greeting clip after Show (it is an alternate entrance)", () => {
+    // Microsoft Agent "Greeting" clips start from (nearly) empty frames, so
+    // playing one right after Show pops the character in, blanks it, and
+    // materializes it a second time (visible on Clippy, Saeko, and others).
+    const greetingOnly = agentWithAnimations(["Show", "Greeting", "RestPose"]);
+    expect(resolveAssistantEntranceSequencePlan(greetingOnly)).toEqual({
+      first: "Show",
+      followUp: null,
+    });
+
+    const withGesture = agentWithAnimations([
+      "Show",
+      "Greeting",
+      "Wave",
+      "RestPose",
+    ]);
+    expect(resolveAssistantEntranceSequencePlan(withGesture)).toEqual({
+      first: "Show",
+      followUp: "Wave",
     });
   });
 

--- a/tests/test-assistant-animation.test.tsx
+++ b/tests/test-assistant-animation.test.tsx
@@ -754,6 +754,73 @@ describe("assistant sprite overlays", () => {
     expect(onAnimationEnd).toEqual([]);
   });
 
+  test("holds exit-branching clips at their wait point, then winds down into the next clip", async () => {
+    // Real Microsoft Agent exit-branching clips (e.g. Merlin's idles) never
+    // reach their wind-down frames naturally: the held pose branches straight
+    // to a terminal keep-previous frame, and the wind-down is only reachable
+    // via exitBranch. Ending the clip there used to strand the held pose and
+    // snap to the next clip.
+    const onAnimationEnd: string[] = [];
+    const data: AgentData = {
+      framesize: [64, 64],
+      animations: {
+        Held: {
+          useExitBranching: true,
+          frames: [
+            {
+              // Held pose: natural flow jumps to the terminal marker.
+              duration: 30,
+              images: [[64, 0]],
+              exitBranch: 1,
+              branching: { branches: [{ frameIndex: 3, weight: 100 }] },
+            },
+            { duration: 30, images: [[128, 0]] }, // wind-down
+            { duration: 30, images: [[0, 0]] }, // back at rest
+            { duration: 0 }, // terminal keep-previous marker
+          ],
+        },
+        Next: { frames: [{ duration: 10_000, images: [[192, 0]] }] },
+      },
+    };
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    const renderSprite = (animation: string) =>
+      act(async () => {
+        root?.render(
+          <ClippySprite
+            mapUrl="/map.png"
+            data={data}
+            characterId="clippy"
+            animation={animation}
+            onAnimationEnd={(name) => onAnimationEnd.push(name)}
+          />
+        );
+      });
+    const layer = () =>
+      host
+        .querySelector("[data-assistant-sprite-layer]")
+        ?.getAttribute("style") ?? "";
+
+    await renderSprite("Held");
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+    // Natural end reached: the end is reported, but the held pose stays on
+    // screen instead of jumping anywhere.
+    expect(onAnimationEnd).toEqual(["Held"]);
+    expect(layer()).toContain("background-position: -64px 0px");
+
+    // The next request winds down through the exit path before Next starts.
+    await renderSprite("Next");
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+    expect(layer()).toContain("background-position: -192px 0px");
+    expect(onAnimationEnd).toEqual(["Held"]);
+  });
+
   test("hard-switches clips that lack exit branching", async () => {
     const data: AgentData = {
       framesize: [64, 64],

--- a/tests/test-assistant-animation.test.tsx
+++ b/tests/test-assistant-animation.test.tsx
@@ -99,7 +99,7 @@ describe("assistant semantic animation selection", () => {
     ).toBe("GetWizardy");
   });
 
-  test("plays Show before a greeting gesture on initial character load", () => {
+  test("falls back to Show plus a greeting gesture when there is no Greeting clip", () => {
     const data = agentWithAnimations(["Show", "Greet", "Wave", "RestPose"]);
 
     expect(resolveAssistantEntranceSequencePlan(data)).toEqual({
@@ -116,26 +116,23 @@ describe("assistant semantic animation selection", () => {
     });
   });
 
-  test("never chains a Greeting clip after Show (it is an alternate entrance)", () => {
-    // Microsoft Agent "Greeting" clips start from (nearly) empty frames, so
-    // playing one right after Show pops the character in, blanks it, and
-    // materializes it a second time (visible on Clippy, Saeko, and others).
-    const greetingOnly = agentWithAnimations(["Show", "Greeting", "RestPose"]);
-    expect(resolveAssistantEntranceSequencePlan(greetingOnly)).toEqual({
-      first: "Show",
-      followUp: null,
-    });
-
-    const withGesture = agentWithAnimations([
+  test("prefers the fully-authored Greeting entrance over Show, with no follow-up", () => {
+    // On every character that ships one, "Greeting" is the real entrance: it
+    // starts from (nearly) empty frames, materializes the character, greets,
+    // and ends at the rest pose — while "Show" on those characters is a
+    // 40–300ms pop. Greeting already contains the greeting gesture, so
+    // chaining a follow-up (or playing Show first) would double the entry.
+    const withGreeting = agentWithAnimations([
       "Show",
       "Greeting",
       "Wave",
       "RestPose",
     ]);
-    expect(resolveAssistantEntranceSequencePlan(withGesture)).toEqual({
-      first: "Show",
-      followUp: "Wave",
+    expect(resolveAssistantEntranceSequencePlan(withGreeting)).toEqual({
+      first: "Greeting",
+      followUp: null,
     });
+    expect(isAssistantEntranceAnimation("Greeting")).toBe(true);
   });
 
   test("uses clip duration for quit with a bounded malformed-data fallback", () => {

--- a/tests/test-assistant-animation.test.tsx
+++ b/tests/test-assistant-animation.test.tsx
@@ -608,6 +608,7 @@ describe("assistant sprite overlays", () => {
   });
 
   test("falls back to the base pose when an entrance clip is missing", async () => {
+    const onAnimationEnd: string[] = [];
     const data: AgentData = {
       framesize: [64, 64],
       animations: {},
@@ -624,6 +625,7 @@ describe("assistant sprite overlays", () => {
           characterId="clippy"
           animation="Show"
           initiallyHidden
+          onAnimationEnd={(name) => onAnimationEnd.push(name)}
         />
       );
     });
@@ -631,6 +633,9 @@ describe("assistant sprite overlays", () => {
     expect(
       host.querySelectorAll("[data-assistant-sprite-layer]")
     ).toHaveLength(1);
+    // A missing clip must still notify the state machine, otherwise the
+    // sprite freezes at its base pose until an unrelated state change.
+    expect(onAnimationEnd).toEqual(["Show"]);
   });
 
   test("keeps the current frame during ordinary animation changes", async () => {

--- a/tests/test-assistant-animation.test.tsx
+++ b/tests/test-assistant-animation.test.tsx
@@ -17,9 +17,12 @@ import {
 } from "../src/components/assistant/ClippySprite";
 import {
   getAssistantAnimationIntent,
+  getAssistantAnimationMappedToolNames,
   getAssistantExitAnimationTimeout,
   getAssistantLifecycleAnimationIntent,
+  getAssistantPointingDirection,
   getAnimationCandidates,
+  getDeepIdleAnimationPool,
   getDocumentToolSequenceKind,
   getIdleAnimationPool,
   getToolAnimationIntent,
@@ -28,8 +31,11 @@ import {
   resolveAssistantEntranceSequencePlan,
   resolveDocumentToolSequencePlan,
   selectAssistantAnimation,
+  selectAssistantPointingAnimation,
 } from "../src/components/assistant/assistantAnimation";
 import { ASSISTANT_CHARACTERS } from "../src/components/assistant/characters";
+import { TOOL_DESCRIPTIONS } from "../api/chat/tools/index.js";
+import { SERVER_EXECUTED_TOOL_NAMES } from "../src/shared/tools/serverExecuted";
 
 const frameImages: Array<[number, number]> = [[0, 0]];
 const frame = { duration: 100, images: frameImages };
@@ -52,11 +58,18 @@ describe("assistant semantic animation selection", () => {
     expect(getAssistantLifecycleAnimationIntent("bubbleOpen")).toBe(
       "attention"
     );
-    expect(getAssistantLifecycleAnimationIntent("bubbleClose")).toBeNull();
+    expect(getAssistantLifecycleAnimationIntent("bubbleClose")).toBe(
+      "acknowledge"
+    );
     expect(getAssistantLifecycleAnimationIntent("quit")).toBe("goodbye");
   });
 
-  test("keeps entrance clips out of attention and working candidates", () => {
+  test("keeps entrance clips out of every non-entrance candidate pool", () => {
+    // Entrance clips must only play through the entrance sequence plan;
+    // random picks replaying the entry animation looked like a double entry.
+    expect(
+      getAnimationCandidates("greeting").some(isAssistantEntranceAnimation)
+    ).toBe(false);
     expect(
       getAnimationCandidates("attention").some(isAssistantEntranceAnimation)
     ).toBe(false);
@@ -70,6 +83,20 @@ describe("assistant semantic animation selection", () => {
         toolName: "closeApp",
       })
     ).not.toContain("Hide");
+  });
+
+  test("tool-specific prepends survive the entrance/exit filter", () => {
+    // "Show" (launchApp) and "Hide" (closeApp) prepends used to be filtered
+    // out entirely, leaving those tools with generic clips only.
+    expect(
+      getAnimationCandidates("processing", { toolName: "launchApp" })[0]
+    ).toBe("GetAttention");
+    expect(
+      getAnimationCandidates("processing", { toolName: "closeApp" })[0]
+    ).toBe("Wave");
+    expect(
+      getAnimationCandidates("processing", { toolName: "settings" })[0]
+    ).toBe("GetWizardy");
   });
 
   test("plays Show before greeting on initial character load", () => {
@@ -205,9 +232,51 @@ describe("assistant semantic animation selection", () => {
     ).toBe("Hearing_1");
   });
 
-  test("maps open and songLibrary tools to reading and searching", () => {
+  test("maps open and songLibraryControl tools to reading and searching", () => {
     expect(getToolAnimationIntent("open")).toBe("reading");
-    expect(getToolAnimationIntent("songLibrary")).toBe("searching");
+    expect(getToolAnimationIntent("songLibraryControl")).toBe("searching");
+    expect(getToolAnimationIntent("stickiesControl")).toBe("writing");
+  });
+
+  test("speaks once the in-flight turn has visible reply text", () => {
+    expect(
+      getAssistantAnimationIntent({
+        isLoading: true,
+        hasError: false,
+        toolActivity: null,
+        hasVisibleReply: true,
+      })
+    ).toBe("speaking");
+    // A running tool still wins over streamed text.
+    expect(
+      getAssistantAnimationIntent({
+        isLoading: true,
+        hasError: false,
+        toolActivity: { name: "webFetch", phase: "running" },
+        hasVisibleReply: true,
+      })
+    ).toBe("searching");
+    expect(
+      getAssistantAnimationIntent({
+        isLoading: false,
+        hasError: false,
+        toolActivity: null,
+        hasVisibleReply: true,
+      })
+    ).toBe("idle");
+  });
+
+  test("every animation-mapped tool name exists in the tool registry", () => {
+    // Guards against tool renames silently killing animations (this bit us
+    // when switchTheme became settings and songLibrary became
+    // songLibraryControl).
+    const knownToolNames = new Set<string>([
+      ...Object.keys(TOOL_DESCRIPTIONS),
+      ...SERVER_EXECUTED_TOOL_NAMES,
+    ]);
+    for (const toolName of getAssistantAnimationMappedToolNames()) {
+      expect(knownToolNames).toContain(toolName);
+    }
   });
 
   test("excludes mega idle loops from the ambient idle pool", () => {
@@ -219,6 +288,66 @@ describe("assistant semantic animation selection", () => {
     ]);
 
     expect(getIdleAnimationPool(data)).toEqual(["Idle1_1"]);
+    expect(getDeepIdleAnimationPool(data)).toEqual(["DeepIdle1"]);
+    expect(getDeepIdleAnimationPool(agentWithAnimations(["RestPose"]))).toEqual(
+      []
+    );
+  });
+
+  test("resolves pointing directions from viewer-space geometry", () => {
+    const assistant = { x: 500, y: 400, width: 100, height: 100 };
+    const at = (x: number, y: number) => ({ x, y, width: 200, height: 100 });
+
+    // Window centered far to the left / right of the character.
+    expect(getAssistantPointingDirection(assistant, at(100, 420))).toBe(
+      "left"
+    );
+    expect(getAssistantPointingDirection(assistant, at(900, 420))).toBe(
+      "right"
+    );
+    // Mostly above / below.
+    expect(getAssistantPointingDirection(assistant, at(460, 40))).toBe("up");
+    expect(getAssistantPointingDirection(assistant, at(460, 800))).toBe(
+      "down"
+    );
+    // Clearly diagonal.
+    expect(getAssistantPointingDirection(assistant, at(100, 100))).toBe(
+      "upLeft"
+    );
+    expect(getAssistantPointingDirection(assistant, at(900, 800))).toBe(
+      "downRight"
+    );
+    // Too close to point at.
+    expect(getAssistantPointingDirection(assistant, at(470, 410))).toBeNull();
+  });
+
+  test("selects pointing clips with diagonal fallbacks and null when unavailable", () => {
+    const clippyLike = agentWithAnimations([
+      "GestureLeft",
+      "GestureRight",
+      "LookUpLeft",
+      "LookUp",
+      "RestPose",
+    ]);
+    expect(selectAssistantPointingAnimation(clippyLike, "left")).toBe(
+      "GestureLeft"
+    );
+    expect(selectAssistantPointingAnimation(clippyLike, "upLeft")).toBe(
+      "LookUpLeft"
+    );
+    expect(selectAssistantPointingAnimation(clippyLike, "up")).toBe("LookUp");
+
+    // Rover only ships GestureLeft / LookUp / LookUpLeft.
+    const roverLike = agentWithAnimations([
+      "GestureLeft",
+      "LookUp",
+      "LookUpLeft",
+      "RestPose",
+    ]);
+    expect(selectAssistantPointingAnimation(roverLike, "right")).toBeNull();
+    expect(selectAssistantPointingAnimation(roverLike, "upRight")).toBe(
+      "LookUp"
+    );
   });
 
   test("adds enriched semantic candidates", () => {
@@ -541,6 +670,99 @@ describe("assistant sprite overlays", () => {
     expect(
       host.querySelectorAll("[data-assistant-sprite-layer]")
     ).toHaveLength(1);
+  });
+
+  test("winds down exit-branching clips before starting the next animation", async () => {
+    const onAnimationEnd: string[] = [];
+    const data: AgentData = {
+      framesize: [64, 64],
+      animations: {
+        // Loops frame 0 forever; the only way out is the exitBranch path.
+        Loop: {
+          useExitBranching: true,
+          frames: [
+            {
+              duration: 30,
+              images: [[0, 0]],
+              exitBranch: 1,
+              branching: { branches: [{ frameIndex: 0, weight: 100 }] },
+            },
+            { duration: 30, images: [[64, 0]] },
+          ],
+        },
+        Next: { frames: [{ duration: 10_000, images: [[128, 0]] }] },
+      },
+    };
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    const renderSprite = (animation: string) =>
+      act(async () => {
+        root?.render(
+          <ClippySprite
+            mapUrl="/map.png"
+            data={data}
+            characterId="clippy"
+            animation={animation}
+            onAnimationEnd={(name) => onAnimationEnd.push(name)}
+          />
+        );
+      });
+
+    await renderSprite("Loop");
+    const layer = () =>
+      host
+        .querySelector("[data-assistant-sprite-layer]")
+        ?.getAttribute("style") ?? "";
+    expect(layer()).toContain("background-position: 0px 0px");
+
+    // Interrupt: the clip must not hard-cut to Next…
+    await renderSprite("Next");
+    expect(layer()).toContain("background-position: 0px 0px");
+
+    // …but follow its exit frame, then start Next without reporting an end
+    // for the interrupted clip.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 120));
+    });
+    expect(layer()).toContain("background-position: -128px 0px");
+    expect(onAnimationEnd).toEqual([]);
+  });
+
+  test("hard-switches clips that lack exit branching", async () => {
+    const data: AgentData = {
+      framesize: [64, 64],
+      animations: {
+        Busy: {
+          frames: [{ duration: 10_000, images: [[0, 0]] }],
+        },
+        Next: { frames: [{ duration: 10_000, images: [[128, 0]] }] },
+      },
+    };
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+
+    const renderSprite = (animation: string) =>
+      act(async () => {
+        root?.render(
+          <ClippySprite
+            mapUrl="/map.png"
+            data={data}
+            characterId="clippy"
+            animation={animation}
+          />
+        );
+      });
+
+    await renderSprite("Busy");
+    await renderSprite("Next");
+    expect(
+      host
+        .querySelector("[data-assistant-sprite-layer]")
+        ?.getAttribute("style")
+    ).toContain("background-position: -128px 0px");
   });
 
   test("stacks every image and keeps layers through duration-only frames", async () => {

--- a/tests/test-assistant-speech.test.ts
+++ b/tests/test-assistant-speech.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   prepareAssistantSpeechTexts,
+  primeAssistantSpeech,
   speakAssistantText,
   stopAssistantSpeech,
   __resetAssistantSpeechStateForTests,
@@ -54,6 +55,7 @@ class FakeUtterance {
   text: string;
   lang = "";
   rate = 1;
+  volume = 1;
   voice: unknown = null;
   onend: (() => void) | null = null;
   onerror: (() => void) | null = null;
@@ -69,12 +71,24 @@ describe("assistant speech playback", () => {
   let spoken: FakeUtterance[];
   let cancelCount: number;
   let fakeVoices: SpeechSynthesisVoice[];
+  let synth: {
+    speaking: boolean;
+    pending: boolean;
+    speak: (utterance: FakeUtterance) => void;
+    cancel: () => void;
+    resume: () => void;
+    getVoices: () => SpeechSynthesisVoice[];
+    addEventListener: () => void;
+    removeEventListener: () => void;
+  };
 
   beforeEach(() => {
     spoken = [];
     cancelCount = 0;
     fakeVoices = [];
-    const synth = {
+    synth = {
+      speaking: false,
+      pending: false,
       speak: (utterance: FakeUtterance) => {
         spoken.push(utterance);
       },
@@ -158,6 +172,35 @@ describe("assistant speech playback", () => {
     expect((spoken[0].voice as SpeechSynthesisVoice).name).toBe("English UK");
   });
 
+  test("primeAssistantSpeech speaks one muted utterance, once", () => {
+    primeAssistantSpeech();
+    primeAssistantSpeech();
+    expect(spoken).toHaveLength(1);
+    expect(spoken[0].volume).toBe(0);
+    // Priming must not cancel anything (it runs on arbitrary gestures).
+    expect(cancelCount).toBe(0);
+  });
+
+  test("primeAssistantSpeech skips the muted utterance while speech is active", () => {
+    synth.speaking = true;
+    primeAssistantSpeech();
+    expect(spoken).toHaveLength(0);
+    // Active speech already proves synthesis is unlocked, so later gestures
+    // stay no-ops too.
+    synth.speaking = false;
+    primeAssistantSpeech();
+    expect(spoken).toHaveLength(0);
+  });
+
+  test("real speech still plays after priming", () => {
+    primeAssistantSpeech();
+    speakAssistantText("Hello there!", { locale: "en" });
+    expect(spoken.map((utterance) => utterance.text)).toEqual([
+      " ",
+      "Hello there!",
+    ]);
+    expect(spoken[1].volume).toBe(1);
+  });
 });
 
 describe("assistant sound effects coexist with speech", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to a study of how the desktop assistant (Clippy-style sprite agent) maps animations to system actions and states. Fixes the drift bugs found and implements the suggested improvements.

### Fixes

- **Stale tool-name mappings**: `switchTheme` → `settings` and `songLibrary` → `songLibraryControl` in both the animation maps (`assistantAnimation.ts`) and the bubble status labels (`useAssistantChat.ts`). These tools silently lost their dedicated animations/status lines when they were renamed.
- **Dead clip prepends**: `launchApp` prepended `Show` and `closeApp` prepended `Hide`/`Goodbye` — all silently removed by the entrance/exit filter, so they never played. Replaced with clips that survive the filter (`GetAttention`/`Announce`, `Wave`/`GestureDown`).
- **Duplicate entry animation**: two causes fixed — (1) switching characters mid-entrance left a stale entrance sequence and stale entrance clip name behind, which replayed the entry clip (and blocked activity-driven clips) on the next sprite mount; transient animation state is now reset on character change. (2) entrance clips were legal candidates for random `greeting` picks; they are now excluded from every pool and only play via the entrance sequence plan.
- **Character pops in, blanks out, then materializes a second time on load** (paint-level repro in headless Chrome, polling sprite layers every animation frame): the entrance sequence chained the `Greeting` clip after `Show`, but Microsoft Agent `Greeting` clips are *alternate entrances* whose first frames are nearly empty. Root fix: `Greeting` is now the **preferred entrance** — measured across all 12 characters, every character that ships a `Greeting` has it as the fully-authored entrance (starts ~empty, materializes the character with its signature intro — Clippy rides in on a bicycle, Saeko walks in through a door — and ends at the rest pose), while `Show` on those characters is just a 40–300ms pop (Clippy's `Show`: 5 frames/50ms vs. its 4.5s `Greeting`). Characters without a `Greeting` (Merlin, Genie, Peedy, Rover) have a real gradual `Show` and keep the `Show` → greeting-gesture sequence. `Greeting` is also now classified as an entrance clip, so random greeting picks can never blank the character mid-session.
- **Base-pose flash during entrance after character switch** (reproduced via CDP console capture): the ambient idle timer scheduled by the previous character survived a character switch and fired mid-entrance with a clip name from the old character's pool (e.g. Rover's `GetAttentionMinor` while Merlin's `Show` was playing). The missing clip hard-set the sprite to its base tile — full character flash — and froze the entrance. Fixed threefold: the character-switch reset now clears the pending idle timer; the idle callback re-reads current agent data and never overrides an entrance/exit clip; and `ClippySprite` reports missing clips as ended so the state machine recovers instead of freezing.
- **Exit-branching clips snapped back to rest at their natural end** (reported on Merlin idles via the new debug trace): Microsoft Agent `useExitBranching` clips never end on their own — the held pose branches to a terminal keep-previous marker, and the wind-down frames are only reachable via `exitBranch` pointers (36 of Merlin's 37 such clips). The player used to finish there with the held pose stranded on screen, so the follow-up `RestPose` was a hard cut. `ClippySprite` now holds the pose at that WAITING point (original MS Agent behavior), reports the end once so the state machine advances, and winds the clip down through its authored exit path when the next clip is requested — including same-clip replays.
- **Sprite restarts during streaming**: `toolActivity` got a fresh identity on every streamed chunk, restarting the current clip mid-stream. Now stabilized by value.
- **Speech silent when previously enabled (iOS Safari)**: with Speech persisted on from an earlier session, replies finish outside any user gesture and Safari silently drops `speechSynthesis.speak()`. While Speech is enabled, the first gesture of the session (pointerdown/touchend/keydown) now primes synthesis with a one-time muted utterance, so asynchronous replies become audible. Toggling Speech on manually already worked because it speaks inside the menu-click gesture.

### Improvements

- **`speaking` intent**: conversational gestures (`Explain`, `Announce`, …) once the in-flight turn has visible reply text, instead of looping `thinking` for the whole stream.
- **`acknowledge` intent**: quick nod on user-initiated bubble close (was: nothing) and when a non-sequence tool completes mid-turn (document read/write sequences keep their return clip).
- **Pointing animations**: after the assistant relocates next to a window it just opened, it now looks/gestures toward it (`GestureLeft`, `LookUpLeft`, etc.). 8-way direction is computed from viewer-space geometry with diagonal→cardinal fallbacks; characters without a matching clip (e.g. Rover facing right) skip gracefully.
- **Graceful interrupts**: `ClippySprite` honors `useExitBranching`/`exitBranch` frame data — interrupted clips wind down along their exit path before the next clip starts, instead of hard-cutting (Merlin/Genie/Peedy ship ~37 such clips each).
- **Deep idle**: after 2 minutes of inactivity, characters with `DeepIdle*` clips fall asleep instead of cycling ambient idles.
- **Reduced motion**: sprite pins to `RestPose`, ambient idle rotation and pointing are skipped, and quit is immediate under `prefers-reduced-motion` (previously only the chrome springs were reduced).
- **More tool mappings**: `stickiesControl`/`documentsControl` → writing; `aquarium`, `infiniteMacControl`, `cursorCloudAgent`, `settings` get tool-specific clips.
- **Debug-mode sequence trace**: with ryOS Debug Mode on (Control Panels toggle, or `localStorage.setItem("ryos:debug", "1")`), the animation state machine now logs every step — `[AssistantAnim]` traces each clip start with its reason (entrance plan, entrance follow-up, intent transitions with tool names, document-sequence intro/loop/return, acknowledge, bubble open/close, pointing, ambient/deep idle, settle-to-rest, quit) plus clip-end and character-switch resets; `[AssistantSprite]` traces actual playback (clip start with frame count, WAITING holds, exit-branch wind-downs, missing-clip fallbacks). Routed through the shared `createClientLogger` (`src/utils/logger.ts`), keeping the client-logging guardrail tests green.
- **Drift guard test**: every tool name referenced by the animation layer must exist in the real tool registry (`api/chat/tools` + server-executed tools), so future renames fail CI instead of silently killing animations.

### Merge

- Merged `origin/main` (browser TTS #1780, 4-column assistant picker #1781, bubble shimmer #1779). Single simple conflict in `AssistantOverlay.tsx` `handleQuit` — both sides added independent cleanup calls (`clearPointingTimer()` from this branch, `stopAssistantSpeech()` from main); kept both.

## Testing

- ✅ CI green after routing the trace through `createClientLogger`: the `Unit tests (Bun 1.3.9)` job failed only on `client logging guardrails > legacy debug helper is not imported by feature code` because the first trace revision imported `@/utils/debug` directly from feature code.
- ✅ `bun test tests/test-assistant-animation.test.tsx` (34 pass, includes new suites: pointing directions/selection, speaking intent, exit-branching wind-down, WAITING hold + wind-down into next clip, hard-switch fallback, entrance-clip exclusion, Greeting-as-entrance preference, missing-clip end notification, registry drift guard)
- ✅ `bun test tests/test-assistant-speech.test.ts` (17 pass, includes new priming tests: one-time muted utterance, skip while speaking, real speech after priming)
- ✅ `bun test tests/test-assistant-window-snap.test.ts tests/test-assistant-store-defaults.test.ts tests/test-assistant-sounds.test.ts tests/test-assistant-bubble-auto-close.test.tsx tests/test-assistant-bubble-shimmer.test.ts`
- ✅ Headless-Chrome paint-level reproduction (sprite layers polled every animation frame on fresh boots of Clippy and Saeko) — before: `Show` pops the character, then the `Greeting` clip blanks it and materializes it a second time; after: blank → `Show` → gesture continuing from the visible pose:
  - Before: [entrance_double_show_before_fix.log](https://cursor.com/artifacts/c/art-c323c424-272c-4a3b-b028-f27596feb301)
  - After: [entrance_after_fix.log](https://cursor.com/artifacts/c/art-c0a28c9c-b457-4050-8682-020bf38fed7f)
- ✅ Headless-Chrome CDP reproduction of the character-switch flash — before: a stale idle timer interrupted Merlin's entrance with a missing clip (base-pose flash); after: every entrance starts hidden and plays through uninterrupted:
  - Before: [assistant_flash_repro_before_fix.log](https://cursor.com/artifacts/c/art-1dd6eaef-d438-4973-abb9-3ef9ee851580)
  - After: [assistant_flash_after_fix.log](https://cursor.com/artifacts/c/art-1beb9cc4-da63-4cfb-a100-5db56fc03e83)
- ✅ Paint-level + screenshot verification of the Greeting-as-entrance change (fresh boots of Clippy and Saeko): opacity ramps from 0% once, no pop/blank/re-materialize; entrance sequence strips: [clippy_greeting_entrance_bicycle_sequence.png](/opt/cursor/artifacts/clippy_greeting_entrance_bicycle_sequence.png), [saeko_greeting_entrance_door_walkin_sequence.png](/opt/cursor/artifacts/saeko_greeting_entrance_door_walkin_sequence.png)
- ✅ Debug-trace + paint-level verification of the WAITING-hold fix on a Merlin boot: `Idle1_1` holds its wand pose (`hold Idle1_1 at exit-branch wait point`), the overlay's rest request triggers `graceful exit … (exit-branch wind-down)`, and paint states show the exitBranch-only wind-down frame rendering before rest — previously a hard snap: [merlin_idle_exit_branch_hold_and_winddown_trace.log](/opt/cursor/artifacts/merlin_idle_exit_branch_hold_and_winddown_trace.log)
- ✅ Headless-Chrome capture of the new debug trace (Debug Mode seeded on, fresh boot → entrance → ambient idles → bubble close/open → reload as Saeko): [assistant_debug_trace_boot_bubble_idle.log](/opt/cursor/artifacts/assistant_debug_trace_boot_bubble_idle.log), [assistant_debug_trace_saeko_boot.log](/opt/cursor/artifacts/assistant_debug_trace_saeko_boot.log)
- ✅ `bun run typecheck`
- ✅ `bun run build`
- ⚠️ `bun run lint` — pre-existing errors/warnings unrelated to this change; no new issues in touched files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2d8b-eeaf-74e2-8779-ba208a48d9aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2d8b-eeaf-74e2-8779-ba208a48d9aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

