### PR TITLE
fix: resolve MapKit origin warning and TextEdit missing-document restore noise

### DIFF
--- a/api/_utils/_mapkit-jwt.ts
+++ b/api/_utils/_mapkit-jwt.ts
@@ -1,4 +1,6 @@
 import { SignJWT, importPKCS8, type CryptoKey } from "jose";
+import { isAllowedOrigin } from "./_cors.js";
+import { getConfiguredPublicOrigin } from "./runtime-config.js";
 
 /**
  * Shared utilities for parsing the MapKit `.p8` private key and signing the
@@ -114,6 +116,43 @@ async function getPrivateKey(): Promise<CryptoKey> {
   return cachedPrivateKey;
 }
 
+function normalizeConfiguredOrigin(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  try {
+    const parsed = new URL(
+      trimmed.startsWith("http") ? trimmed : `https://${trimmed}`
+    );
+    return parsed.origin;
+  } catch {
+    return trimmed.replace(/\/+$/, "");
+  }
+}
+
+/**
+ * Resolve the browser origin claim for MapKit JS tokens.
+ *
+ * Priority:
+ *   1. `MAPKIT_ORIGIN` when explicitly configured
+ *   2. The caller's allowed request `Origin` (localhost, preview, self-host)
+ *   3. `APP_PUBLIC_ORIGIN` / `PUBLIC_APP_ORIGIN`
+ */
+export function resolveMapKitJsOrigin(
+  requestOrigin?: string | null
+): string | undefined {
+  const explicit = process.env.MAPKIT_ORIGIN?.trim();
+  if (explicit) {
+    return normalizeConfiguredOrigin(explicit);
+  }
+
+  if (requestOrigin && isAllowedOrigin(requestOrigin)) {
+    return normalizeConfiguredOrigin(requestOrigin);
+  }
+
+  const configuredPublicOrigin = getConfiguredPublicOrigin();
+  return configuredPublicOrigin ?? undefined;
+}
+
 /**
  * Sign a MapKit-style ES256 JWT.
  *
@@ -124,7 +163,8 @@ async function getPrivateKey(): Promise<CryptoKey> {
  */
 export async function signMapKitJwt(
   kind: MapKitJwtKind,
-  ttlSeconds: number
+  ttlSeconds: number,
+  options: { requestOrigin?: string | null } = {}
 ): Promise<MapKitSignedJwt> {
   const teamId = process.env.MAPKIT_TEAM_ID;
   const keyId = process.env.MAPKIT_KEY_ID;
@@ -135,9 +175,11 @@ export async function signMapKitJwt(
   const now = Math.floor(Date.now() / 1000);
   const exp = now + ttlSeconds;
 
-  const allowedOrigin = process.env.MAPKIT_ORIGIN?.trim();
-  const payload =
-    kind === "mapkit-js" && allowedOrigin ? { origin: allowedOrigin } : {};
+  const allowedOrigin =
+    kind === "mapkit-js"
+      ? resolveMapKitJsOrigin(options.requestOrigin)
+      : undefined;
+  const payload = allowedOrigin ? { origin: allowedOrigin } : {};
 
   const token = await new SignJWT(payload)
     .setProtectedHeader({ alg: "ES256", kid: keyId, typ: "JWT" })

--- a/api/mapkit-token.ts
+++ b/api/mapkit-token.ts
@@ -1,22 +1,89 @@
-import { createAppleJwtTokenHandler } from "./_utils/_apple-jwt-token-handler.js";
+import { apiHandler } from "./_utils/api-handler.js";
 import {
   listMapKitMissingEnv,
   parseMapKitPrivateKey,
+  resolveMapKitJsOrigin,
   signMapKitJwt,
+  type MapKitSignedJwt,
 } from "./_utils/_mapkit-jwt.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 10;
 
-export default createAppleJwtTokenHandler({
-  label: "MapKit",
-  notConfiguredError: "MapKit not configured",
-  privateKeyEnvKey: "MAPKIT_PRIVATE_KEY",
-  tokenTtlSeconds: 30 * 60, // 30 minutes
-  responseCacheSeconds: 5 * 60, // 5 minutes — clients may reuse the same JWT
-  safetyBufferMs: 60_000, // refresh if <60s remaining
-  listMissingEnv: listMapKitMissingEnv,
-  hasPrivateKeyEnv: () => Boolean(process.env.MAPKIT_PRIVATE_KEY),
-  parsePrivateKey: parseMapKitPrivateKey,
-  sign: (ttlSeconds) => signMapKitJwt("mapkit-js", ttlSeconds),
+const TOKEN_TTL_SECONDS = 30 * 60;
+const RESPONSE_CACHE_SECONDS = 5 * 60;
+const SAFETY_BUFFER_MS = 60_000;
+
+const tokenCache = new Map<string, MapKitSignedJwt>();
+
+function cacheKeyForOrigin(origin: string | undefined): string {
+  return origin ?? "__default__";
+}
+
+export default apiHandler({ methods: ["GET"] }, async ({ res, logger, startTime, origin }) => {
+  const missing = listMapKitMissingEnv();
+  if (missing.length > 0) {
+    const keyDiagnostics =
+      missing.includes("MAPKIT_PRIVATE_KEY") &&
+      Boolean(process.env.MAPKIT_PRIVATE_KEY)
+        ? parseMapKitPrivateKey()
+        : undefined;
+    logger.warn("MapKit token endpoint missing env vars", {
+      missing,
+      keyDiagnostics,
+    });
+    logger.response(500, Date.now() - startTime);
+    res.status(500).json({
+      error: "MapKit not configured",
+      missing,
+      ...(keyDiagnostics
+        ? {
+            privateKey: {
+              reason: keyDiagnostics.reason,
+              rawLength: keyDiagnostics.rawLength,
+              bodyLength: keyDiagnostics.bodyLength,
+              hasBeginMarker: keyDiagnostics.hasBeginMarker,
+              hasEndMarker: keyDiagnostics.hasEndMarker,
+              invalidCharSample: keyDiagnostics.invalidCharSample,
+            },
+          }
+        : {}),
+    });
+    return;
+  }
+
+  try {
+    const resolvedOrigin = resolveMapKitJsOrigin(origin);
+    const cacheKey = cacheKeyForOrigin(resolvedOrigin);
+    const now = Date.now();
+    let cachedToken = tokenCache.get(cacheKey);
+
+    if (!cachedToken || cachedToken.expiresAt - now < SAFETY_BUFFER_MS) {
+      cachedToken = await signMapKitJwt("mapkit-js", TOKEN_TTL_SECONDS, {
+        requestOrigin: origin,
+      });
+      tokenCache.set(cacheKey, cachedToken);
+      logger.info("Signed new MapKit JWT", {
+        expiresAt: new Date(cachedToken.expiresAt).toISOString(),
+        origin: resolvedOrigin ?? null,
+      });
+    }
+
+    res.setHeader(
+      "Cache-Control",
+      `private, max-age=${RESPONSE_CACHE_SECONDS}`
+    );
+    logger.response(200, Date.now() - startTime);
+    res.status(200).json({
+      token: cachedToken.token,
+      expiresAt: cachedToken.expiresAt,
+    });
+  } catch (error) {
+    logger.error("Failed to sign MapKit token", error);
+    logger.response(500, Date.now() - startTime);
+    res.status(500).json({
+      error: "Failed to sign MapKit token",
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
 });

--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -173,6 +173,18 @@ function TextEditContent({
       },
       [editor, setCurrentFilePath, setHasUnsavedChanges, setContentJson]
     ),
+    onLoadFailure: useCallback(
+      (filePath: string) => {
+        log.debug("Clearing stale TextEdit file path after failed restore", {
+          path: filePath,
+          instanceId,
+        });
+        setCurrentFilePath(null);
+        setHasUnsavedChanges(false);
+        setContentJson(editor?.getJSON() || null);
+      },
+      [editor, instanceId, setCurrentFilePath, setContentJson, setHasUnsavedChanges]
+    ),
   });
 
   const { isDraggingOver, dragHandlers } = useDragAndDrop({
@@ -281,7 +293,7 @@ function TextEditContent({
       log.debug("Restoring instance content from DB", {
         path: currentFilePath,
       });
-      handleLoadFromDatabase(currentFilePath);
+      void handleLoadFromDatabase(currentFilePath);
     }
   }, [
     editor,

--- a/src/apps/textedit/hooks/useFileOperations.ts
+++ b/src/apps/textedit/hooks/useFileOperations.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { Editor } from "@tiptap/core";
 import { useVfsFileOperations } from "@/services/vfs/useVfsFileOperations";
 import { readDocumentTextContent } from "@/services/vfs/FileContentRepository";
+import { getFileMetadata } from "@/services/vfs/FileMetadataService";
 import {
   htmlToMarkdown,
   htmlToPlainText,
@@ -27,6 +28,7 @@ interface UseFileOperationsProps {
   customTitle?: string;
   onSaveSuccess?: (filePath: string) => void;
   onLoadSuccess?: (filePath: string) => void;
+  onLoadFailure?: (filePath: string) => void;
 }
 
 export function useFileOperations({
@@ -35,6 +37,7 @@ export function useFileOperations({
   customTitle,
   onSaveSuccess,
   onLoadSuccess,
+  onLoadFailure,
 }: UseFileOperationsProps) {
   const { saveFile } = useVfsFileOperations("/Documents");
 
@@ -259,16 +262,27 @@ export function useFileOperations({
             log.debug("Loaded content from file", { path: filePath });
             return true;
           }
-        } else {
-          console.warn("Document not found or empty:", filePath);
         }
+
+        const fileMetadata = getFileMetadata(filePath);
+        if (!fileMetadata || fileMetadata.status !== "active") {
+          log.debug("Skipping load for missing or inactive document", {
+            path: filePath,
+          });
+        } else {
+          log.debug("Document metadata exists but content is empty", {
+            path: filePath,
+          });
+        }
+        onLoadFailure?.(filePath);
       } catch (err) {
         console.error("Error loading file content from DB:", err);
+        onLoadFailure?.(filePath);
       }
 
       return false;
     },
-    [editor, onLoadSuccess]
+    [editor, onLoadSuccess, onLoadFailure]
   );
 
   const generateSuggestedFileName = useCallback((): string => {

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -10,7 +10,7 @@ import { APP_ANALYTICS, track } from "@/utils/analytics";
 import { requestCloudSyncCheck } from "@/utils/cloudSyncEvents";
 import { shouldRequestCloudSyncOnAppLaunch } from "@/utils/cloudSyncLaunch";
 import { createClientLogger } from "@/utils/logger";
-import { getRestorablePreviewInitialData } from "@/types/appInitialData";
+import { getRestorablePreviewInitialData, getRestorableTextEditInitialData } from "@/types/appInitialData";
 export type { AIModel } from "@/types/aiModels";
 
 // ---------------- Types ---------------------------------------------------------
@@ -858,6 +858,13 @@ const createUseAppStore = () =>
                 acc.push([id, {
                   ...instWithoutRuntimeState,
                   initialData: getRestorablePreviewInitialData(inst.initialData),
+                } as AppInstance]);
+                return acc;
+              }
+              if (inst.appId === "textedit") {
+                acc.push([id, {
+                  ...instWithoutRuntimeState,
+                  initialData: getRestorableTextEditInitialData(inst.initialData),
                 } as AppInstance]);
                 return acc;
               }

--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -488,6 +488,27 @@ export async function ensureFileContentLoaded(
       }
     }
     if (!pendingFile?.assetPath) {
+      // Bundled documents ship inline content in filesystem.json instead of an
+      // assetPath. Recover those bytes when metadata exists but IndexedDB was
+      // cleared or never seeded.
+      if (storeName === STORES.DOCUMENTS) {
+        const data = await loadDefaultFiles();
+        const defaultFile = data.files.find((file) => file.path === filePath);
+        if (defaultFile?.content) {
+          await new Promise<void>((resolve, reject) => {
+            const tx = db!.transaction(storeName, "readwrite");
+            const store = tx.objectStore(storeName);
+            const putReq = store.put(
+              { name: defaultFile.name, content: defaultFile.content } as StoredContent,
+              uuid
+            );
+            putReq.onsuccess = () => resolve();
+            putReq.onerror = () => reject(putReq.error);
+            tx.onerror = () => reject(tx.error);
+          });
+          return true;
+        }
+      }
       return false;
     }
 

--- a/src/types/appInitialData.ts
+++ b/src/types/appInitialData.ts
@@ -13,6 +13,26 @@ export interface TextEditInitialData {
   content?: string;
 }
 
+/**
+ * Keep only the VFS path needed to restore a TextEdit window.
+ * Inline content can be large and is loaded from IndexedDB on restore.
+ */
+export function getRestorableTextEditInitialData(
+  data: unknown,
+): TextEditInitialData | undefined {
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    !("path" in data) ||
+    typeof data.path !== "string" ||
+    data.path.length === 0
+  ) {
+    return undefined;
+  }
+
+  return { path: data.path };
+}
+
 /** Paint initial data - for opening image files */
 export interface PaintInitialData {
   path: string;

--- a/tests/test-mapkit-jwt.test.ts
+++ b/tests/test-mapkit-jwt.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { jwtVerify } from "jose";
+
+import { resolveMapKitJsOrigin } from "../api/_utils/_mapkit-jwt";
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe("resolveMapKitJsOrigin", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.MAPKIT_ORIGIN;
+    delete process.env.APP_PUBLIC_ORIGIN;
+    delete process.env.PUBLIC_APP_ORIGIN;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test("prefers MAPKIT_ORIGIN when configured", () => {
+    process.env.MAPKIT_ORIGIN = "https://maps.example.com";
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    expect(resolveMapKitJsOrigin("http://localhost:5173")).toBe(
+      "https://maps.example.com"
+    );
+  });
+
+  test("uses an allowed request origin before APP_PUBLIC_ORIGIN", () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    expect(resolveMapKitJsOrigin("http://localhost:5173")).toBe(
+      "http://localhost:5173"
+    );
+  });
+
+  test("falls back to APP_PUBLIC_ORIGIN when request origin is absent", () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    expect(resolveMapKitJsOrigin(null)).toBe("https://os.example.com");
+  });
+});
+
+describe("MapKit JWT signer", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.MAPKIT_ORIGIN;
+    delete process.env.APP_PUBLIC_ORIGIN;
+    delete process.env.PUBLIC_APP_ORIGIN;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test("includes the resolved origin claim for mapkit-js tokens", async () => {
+    const moduleSpec = "../api/_utils/_mapkit-jwt";
+    const url = new URL(`${moduleSpec}.ts?cacheBust=${Date.now()}`, import.meta.url).href;
+    const fresh = (await import(url)) as typeof import("../api/_utils/_mapkit-jwt");
+
+    const { privateKey: privKey, publicKey: pubKey } = generateKeyPairSync("ec", {
+      namedCurve: "P-256",
+    });
+    process.env.MAPKIT_TEAM_ID = "TEAM1234AB";
+    process.env.MAPKIT_KEY_ID = "KEY1234567";
+    process.env.MAPKIT_PRIVATE_KEY = privKey
+      .export({ format: "pem", type: "pkcs8" })
+      .toString();
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const signed = await fresh.signMapKitJwt("mapkit-js", 60, {
+      requestOrigin: "http://localhost:5173",
+    });
+    const verified = await jwtVerify(signed.token, pubKey);
+
+    expect(verified.payload.origin).toBe("http://localhost:5173");
+    expect(verified.payload.iss).toBe("TEAM1234AB");
+  });
+});

--- a/tests/test-textedit-restore-wiring.test.ts
+++ b/tests/test-textedit-restore-wiring.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { getRestorableTextEditInitialData } from "../src/types/appInitialData";
+
+describe("TextEdit restore wiring", () => {
+  test("persists only the document path needed to restore a window", () => {
+    expect(
+      getRestorableTextEditInitialData({
+        path: "/Documents/notes.md",
+        content: "# Notes",
+      }),
+    ).toEqual({ path: "/Documents/notes.md" });
+    expect(getRestorableTextEditInitialData({ content: "# Notes" })).toBeUndefined();
+    expect(getRestorableTextEditInitialData({ path: "" })).toBeUndefined();
+  });
+
+  test("app store strips inline TextEdit content on persist", async () => {
+    const appStore = await Bun.file("src/stores/useAppStore.ts").text();
+    expect(appStore).toContain(
+      "getRestorableTextEditInitialData(inst.initialData)",
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two warnings surfaced in the in-app debug console:

- **`[MapKit] Authorization token without origin restriction`** — MapKit JS tokens are now signed with an `origin` claim derived from `MAPKIT_ORIGIN`, the allowed request `Origin`, or `APP_PUBLIC_ORIGIN`.
- **`Document not found or empty: /Documents/when software had a soul.md`** — TextEdit no longer emits a console warning when a restored window points at a document with missing IndexedDB content. Stale paths are cleared quietly, bundled default markdown can be re-seeded from `filesystem.json`, and persisted TextEdit windows store only the VFS path (not inline content).

## Changes

### MapKit
- Added `resolveMapKitJsOrigin()` in `api/_utils/_mapkit-jwt.ts`
- Reworked `/api/mapkit-token` to cache JWTs per resolved origin and pass the request `Origin` into signing

### TextEdit / VFS
- Recover bundled document inline content from `filesystem.json` when IndexedDB is empty
- Add `onLoadFailure` handling to clear stale restored file paths
- Add `getRestorableTextEditInitialData()` and use it in app-store persistence (mirrors Preview)

## Testing

- `bun test tests/test-mapkit-jwt.test.ts` — origin resolution + JWT claim verification
- `bun test tests/test-textedit-restore-wiring.test.ts` — restore persistence wiring
- Manual API check: `curl -H 'Origin: http://localhost:5173' http://localhost:3000/api/mapkit-token` returns a JWT whose payload includes `"origin": "http://localhost:5173"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d51dc9a-bfd8-4f6c-ba79-681bea46da1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d51dc9a-bfd8-4f6c-ba79-681bea46da1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

