### PR TITLE
Fix MapKit origin JWT claim and TextEdit missing-document warnings

### DIFF
--- a/api/_utils/_apple-jwt-token-handler.ts
+++ b/api/_utils/_apple-jwt-token-handler.ts
@@ -29,7 +29,12 @@ export interface AppleJwtTokenHandlerConfig {
   /** Whether the private-key env var is actually present (drives diagnostics). */
   hasPrivateKeyEnv: () => boolean;
   parsePrivateKey: () => AppleJwtKeyDiagnostics;
-  sign: (ttlSeconds: number) => Promise<MapKitSignedJwt>;
+  sign: (
+    ttlSeconds: number,
+    requestOrigin?: string | null
+  ) => Promise<MapKitSignedJwt>;
+  /** When true, cache tokens per resolved request origin (MapKit JS). */
+  originAwareCache?: boolean;
 }
 
 /**
@@ -45,10 +50,11 @@ export function createAppleJwtTokenHandler(config: AppleJwtTokenHandlerConfig) {
   // token is re-signed well before expiry so the client never receives a
   // token that's about to expire.
   let cachedToken: MapKitSignedJwt | null = null;
+  const cachedTokensByOrigin = new Map<string, MapKitSignedJwt>();
 
   return apiHandler(
     { methods: ["GET"] },
-    async ({ res, logger, startTime }) => {
+    async ({ req, res, logger, startTime, origin }) => {
       const missing = config.listMissingEnv();
       if (missing.length > 0) {
         // When the only "missing" thing is the private key but the env var is
@@ -84,15 +90,31 @@ export function createAppleJwtTokenHandler(config: AppleJwtTokenHandlerConfig) {
 
       try {
         const now = Date.now();
-        if (
-          !cachedToken ||
-          cachedToken.expiresAt - now < config.safetyBufferMs
-        ) {
-          cachedToken = await config.sign(config.tokenTtlSeconds);
+        const cacheKey = config.originAwareCache
+          ? origin || "__default__"
+          : null;
+        const cached =
+          cacheKey !== null
+            ? cachedTokensByOrigin.get(cacheKey) ?? null
+            : cachedToken;
+
+        if (!cached || cached.expiresAt - now < config.safetyBufferMs) {
+          const signed = await config.sign(config.tokenTtlSeconds, origin);
+          if (cacheKey !== null) {
+            cachedTokensByOrigin.set(cacheKey, signed);
+          } else {
+            cachedToken = signed;
+          }
           logger.info(`Signed new ${config.label} JWT`, {
-            expiresAt: new Date(cachedToken.expiresAt).toISOString(),
+            expiresAt: new Date(signed.expiresAt).toISOString(),
+            ...(cacheKey !== null ? { origin: cacheKey } : {}),
           });
         }
+
+        const activeToken =
+          cacheKey !== null
+            ? cachedTokensByOrigin.get(cacheKey)!
+            : cachedToken!;
 
         res.setHeader(
           "Cache-Control",
@@ -100,8 +122,8 @@ export function createAppleJwtTokenHandler(config: AppleJwtTokenHandlerConfig) {
         );
         logger.response(200, Date.now() - startTime);
         res.status(200).json({
-          token: cachedToken.token,
-          expiresAt: cachedToken.expiresAt,
+          token: activeToken.token,
+          expiresAt: activeToken.expiresAt,
         });
       } catch (error) {
         logger.error(`Failed to sign ${config.label} token`, error);

--- a/api/_utils/_mapkit-jwt.ts
+++ b/api/_utils/_mapkit-jwt.ts
@@ -1,4 +1,6 @@
 import { SignJWT, importPKCS8, type CryptoKey } from "jose";
+import { isAllowedOrigin } from "./_cors.js";
+import { getConfiguredPublicOrigin } from "./runtime-config.js";
 
 /**
  * Shared utilities for parsing the MapKit `.p8` private key and signing the
@@ -115,6 +117,27 @@ async function getPrivateKey(): Promise<CryptoKey> {
 }
 
 /**
+ * Resolve the browser origin claim for MapKit JS tokens.
+ *
+ * Priority:
+ *   1. Explicit `MAPKIT_ORIGIN`
+ *   2. Allowed request `Origin` header (localhost, preview deploys, etc.)
+ *   3. Configured `APP_PUBLIC_ORIGIN` for production deployments
+ */
+export function resolveMapKitJsOrigin(
+  requestOrigin?: string | null
+): string | null {
+  const explicit = process.env.MAPKIT_ORIGIN?.trim();
+  if (explicit) return explicit;
+
+  if (requestOrigin && isAllowedOrigin(requestOrigin)) {
+    return requestOrigin;
+  }
+
+  return getConfiguredPublicOrigin();
+}
+
+/**
  * Sign a MapKit-style ES256 JWT.
  *
  * For `mapkit-js` we include an optional `origin` claim so that browsers must
@@ -124,7 +147,8 @@ async function getPrivateKey(): Promise<CryptoKey> {
  */
 export async function signMapKitJwt(
   kind: MapKitJwtKind,
-  ttlSeconds: number
+  ttlSeconds: number,
+  options: { requestOrigin?: string | null } = {}
 ): Promise<MapKitSignedJwt> {
   const teamId = process.env.MAPKIT_TEAM_ID;
   const keyId = process.env.MAPKIT_KEY_ID;
@@ -135,7 +159,10 @@ export async function signMapKitJwt(
   const now = Math.floor(Date.now() / 1000);
   const exp = now + ttlSeconds;
 
-  const allowedOrigin = process.env.MAPKIT_ORIGIN?.trim();
+  const allowedOrigin =
+    kind === "mapkit-js"
+      ? resolveMapKitJsOrigin(options.requestOrigin)
+      : null;
   const payload =
     kind === "mapkit-js" && allowedOrigin ? { origin: allowedOrigin } : {};
 

--- a/api/mapkit-token.ts
+++ b/api/mapkit-token.ts
@@ -18,5 +18,7 @@ export default createAppleJwtTokenHandler({
   listMissingEnv: listMapKitMissingEnv,
   hasPrivateKeyEnv: () => Boolean(process.env.MAPKIT_PRIVATE_KEY),
   parsePrivateKey: parseMapKitPrivateKey,
-  sign: (ttlSeconds) => signMapKitJwt("mapkit-js", ttlSeconds),
+  sign: (ttlSeconds, requestOrigin) =>
+    signMapKitJwt("mapkit-js", ttlSeconds, { requestOrigin }),
+  originAwareCache: true,
 });

--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -30,6 +30,7 @@ import {
 } from "../utils/mergeEditorContent";
 import { persistedContentToEditorContent } from "../utils/documentContent";
 import { readDocumentTextContent } from "@/services/vfs/FileContentRepository";
+import { getFileMetadata } from "@/services/vfs/FileMetadataService";
 import { useRegisterUndoRedo } from "@/hooks/useUndoRedo";
 import { useMenuShortcuts } from "@/hooks/useMenuShortcuts";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
@@ -281,7 +282,18 @@ function TextEditContent({
       log.debug("Restoring instance content from DB", {
         path: currentFilePath,
       });
-      handleLoadFromDatabase(currentFilePath);
+      void (async () => {
+        const loaded = await handleLoadFromDatabase(currentFilePath);
+        if (loaded) return;
+
+        const metadata = getFileMetadata(currentFilePath);
+        if (!metadata || metadata.status === "trashed") {
+          log.debug("Clearing stale TextEdit file path after failed restore", {
+            path: currentFilePath,
+          });
+          setCurrentFilePath(null);
+        }
+      })();
     }
   }, [
     editor,
@@ -290,6 +302,7 @@ function TextEditContent({
     contentJson,
     currentFilePath,
     handleLoadFromDatabase,
+    setCurrentFilePath,
   ]);
 
   // Reactively merge externally-sourced content (cloud sync, file sync, or AI

--- a/src/apps/textedit/hooks/useFileOperations.ts
+++ b/src/apps/textedit/hooks/useFileOperations.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { Editor } from "@tiptap/core";
 import { useVfsFileOperations } from "@/services/vfs/useVfsFileOperations";
 import { readDocumentTextContent } from "@/services/vfs/FileContentRepository";
+import { getFileMetadata } from "@/services/vfs/FileMetadataService";
 import {
   htmlToMarkdown,
   htmlToPlainText,
@@ -233,6 +234,14 @@ export function useFileOperations({
     async (filePath: string): Promise<boolean> => {
       if (!editor) return false;
 
+      const metadata = getFileMetadata(filePath);
+      if (!metadata || metadata.status === "trashed") {
+        log.debug("Skipping load for missing or trashed document", {
+          path: filePath,
+        });
+        return false;
+      }
+
       try {
         const contentStr = await readDocumentTextContent(filePath);
         if (contentStr) {
@@ -259,16 +268,22 @@ export function useFileOperations({
             log.debug("Loaded content from file", { path: filePath });
             return true;
           }
-        } else {
-          console.warn("Document not found or empty:", filePath);
         }
+
+        // Metadata exists but content is empty or not yet synced — open a blank
+        // document at the same path so the user can keep editing without noise.
+        log.debug("Document has no stored content yet; opening blank editor", {
+          path: filePath,
+        });
+        await handleLoadFromPath(filePath, "");
+        return true;
       } catch (err) {
         console.error("Error loading file content from DB:", err);
       }
 
       return false;
     },
-    [editor, onLoadSuccess]
+    [editor, handleLoadFromPath, onLoadSuccess]
   );
 
   const generateSuggestedFileName = useCallback((): string => {

--- a/tests/test-mapkit-jwt.test.ts
+++ b/tests/test-mapkit-jwt.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { generateKeyPairSync } from "node:crypto";
+import { generateKeyPairSync, randomUUID } from "node:crypto";
 import { jwtVerify } from "jose";
 
 import {
   parseMapKitPrivateKey,
   listMapKitMissingEnv,
+  resolveMapKitJsOrigin,
 } from "../api/_utils/_mapkit-jwt";
 
 function generateP8(): { pem: string; pkcs8: string } {
@@ -18,6 +19,18 @@ function generateP8(): { pem: string; pkcs8: string } {
 }
 
 const ORIGINAL_ENV = { ...process.env };
+
+async function loadFreshMapKitJwtModule() {
+  const moduleSpec = "../api/_utils/_mapkit-jwt";
+  const url = new URL(`${moduleSpec}.ts?cacheBust=${randomUUID()}`, import.meta.url)
+    .href;
+  return (await import(url)) as typeof import("../api/_utils/_mapkit-jwt");
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  const [, payloadB64] = token.split(".");
+  return JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
+}
 
 describe("MapKit JWT signer", () => {
   beforeEach(() => {
@@ -40,13 +53,27 @@ describe("MapKit JWT signer", () => {
     expect(missing).toContain("MAPKIT_PRIVATE_KEY");
   });
 
-  test("falls back to APP_PUBLIC_ORIGIN when MAPKIT_ORIGIN is unset", async () => {
-    const moduleSpec = "../api/_utils/_mapkit-jwt";
-    const url = new URL(
-      `${moduleSpec}.ts?cacheBust=${Date.now()}`,
-      import.meta.url
-    ).href;
-    const fresh = (await import(url)) as typeof import("../api/_utils/_mapkit-jwt");
+  test("resolveMapKitJsOrigin prefers MAPKIT_ORIGIN", () => {
+    process.env.MAPKIT_ORIGIN = "https://maps.example.com";
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    expect(resolveMapKitJsOrigin("http://localhost:5173")).toBe(
+      "https://maps.example.com"
+    );
+  });
+
+  test("resolveMapKitJsOrigin falls back to allowed request origin", () => {
+    expect(resolveMapKitJsOrigin("http://localhost:5173")).toBe(
+      "http://localhost:5173"
+    );
+  });
+
+  test("resolveMapKitJsOrigin falls back to APP_PUBLIC_ORIGIN", () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    expect(resolveMapKitJsOrigin(null)).toBe("https://os.example.com");
+  });
+
+  test("signs a mapkit-js token with verifiable origin claim", async () => {
+    const fresh = await loadFreshMapKitJwtModule();
 
     const { privateKey: privKey, publicKey: pubKey } = generateKeyPairSync(
       "ec",
@@ -62,70 +89,15 @@ describe("MapKit JWT signer", () => {
     const signed = await fresh.signMapKitJwt("mapkit-js", 60);
     const verified = await jwtVerify(signed.token, pubKey);
     expect(verified.payload.origin).toBe("https://os.example.com");
-  });
-
-  test("prefers MAPKIT_ORIGIN over APP_PUBLIC_ORIGIN", async () => {
-    const moduleSpec = "../api/_utils/_mapkit-jwt";
-    const url = new URL(
-      `${moduleSpec}.ts?cacheBust=${Date.now()}-2`,
-      import.meta.url
-    ).href;
-    const fresh = (await import(url)) as typeof import("../api/_utils/_mapkit-jwt");
-
-    const { privateKey: privKey, publicKey: pubKey } = generateKeyPairSync(
-      "ec",
-      { namedCurve: "P-256" }
-    );
-    process.env.MAPKIT_TEAM_ID = "TEAM1234AB";
-    process.env.MAPKIT_KEY_ID = "KEY1234567";
-    process.env.MAPKIT_PRIVATE_KEY = privKey
-      .export({ format: "pem", type: "pkcs8" })
-      .toString();
-    process.env.MAPKIT_ORIGIN = "https://maps.example.com";
-    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
-
-    const signed = await fresh.signMapKitJwt("mapkit-js", 60);
-    const verified = await jwtVerify(signed.token, pubKey);
-    expect(verified.payload.origin).toBe("https://maps.example.com");
-  });
-
-  test("uses allowed request origin when explicit env vars are unset", async () => {
-    const moduleSpec = "../api/_utils/_mapkit-jwt";
-    const url = new URL(
-      `${moduleSpec}.ts?cacheBust=${Date.now()}-3`,
-      import.meta.url
-    ).href;
-    const fresh = (await import(url)) as typeof import("../api/_utils/_mapkit-jwt");
-
-    const { privateKey: privKey, publicKey: pubKey } = generateKeyPairSync(
-      "ec",
-      { namedCurve: "P-256" }
-    );
-    process.env.MAPKIT_TEAM_ID = "TEAM1234AB";
-    process.env.MAPKIT_KEY_ID = "KEY1234567";
-    process.env.MAPKIT_PRIVATE_KEY = privKey
-      .export({ format: "pem", type: "pkcs8" })
-      .toString();
-
-    const signed = await fresh.signMapKitJwt("mapkit-js", 60, {
-      requestOrigin: "http://localhost:5173",
-    });
-    const verified = await jwtVerify(signed.token, pubKey);
-    expect(verified.payload.origin).toBe("http://localhost:5173");
+    expect(verified.payload.iss).toBe("TEAM1234AB");
   });
 
   test("omits the origin claim for maps-server-api tokens", async () => {
-    const moduleSpec = "../api/_utils/_mapkit-jwt";
-    const url = new URL(
-      `${moduleSpec}.ts?cacheBust=${Date.now()}-4`,
-      import.meta.url
-    ).href;
-    const fresh = (await import(url)) as typeof import("../api/_utils/_mapkit-jwt");
+    const fresh = await loadFreshMapKitJwtModule();
 
-    const { privateKey: privKey, publicKey: pubKey } = generateKeyPairSync(
-      "ec",
-      { namedCurve: "P-256" }
-    );
+    const { privateKey: privKey } = generateKeyPairSync("ec", {
+      namedCurve: "P-256",
+    });
     process.env.MAPKIT_TEAM_ID = "TEAM1234AB";
     process.env.MAPKIT_KEY_ID = "KEY1234567";
     process.env.MAPKIT_PRIVATE_KEY = privKey
@@ -136,8 +108,9 @@ describe("MapKit JWT signer", () => {
     const signed = await fresh.signMapKitJwt("maps-server-api", 60, {
       requestOrigin: "https://os.example.com",
     });
-    const verified = await jwtVerify(signed.token, pubKey);
-    expect(verified.payload.origin).toBeUndefined();
+    const payload = decodeJwtPayload(signed.token);
+    expect(payload.origin).toBeUndefined();
+    expect(payload.iss).toBe("TEAM1234AB");
   });
 
   test("parseMapKitPrivateKey accepts a valid PEM key", () => {

--- a/tests/test-mapkit-jwt.test.ts
+++ b/tests/test-mapkit-jwt.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import { jwtVerify } from "jose";
+
+import {
+  parseMapKitPrivateKey,
+  listMapKitMissingEnv,
+} from "../api/_utils/_mapkit-jwt";
+
+function generateP8(): { pem: string; pkcs8: string } {
+  const { privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+  });
+  const pkcs8 = privateKey
+    .export({ format: "pem", type: "pkcs8" })
+    .toString();
+  return { pem: pkcs8, pkcs8 };
+}
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe("MapKit JWT signer", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.MAPKIT_TEAM_ID;
+    delete process.env.MAPKIT_KEY_ID;
+    delete process.env.MAPKIT_PRIVATE_KEY;
+    delete process.env.MAPKIT_ORIGIN;
+    delete process.env.APP_PUBLIC_ORIGIN;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test("listMapKitMissingEnv reports every required field", () => {
+    const missing = listMapKitMissingEnv();
+    expect(missing).toContain("MAPKIT_TEAM_ID");
+    expect(missing).toContain("MAPKIT_KEY_ID");
+    expect(missing).toContain("MAPKIT_PRIVATE_KEY");
+  });
+
+  test("falls back to APP_PUBLIC_ORIGIN when MAPKIT_ORIGIN is unset", async () => {
+    const moduleSpec = "../api/_utils/_mapkit-jwt";
+    const url = new URL(
+      `${moduleSpec}.ts?cacheBust=${Date.now()}`,
+      import.meta.url
+    ).href;
+    const fresh = (await import(url)) as typeof import("../api/_utils/_mapkit-jwt");
+
+    const { privateKey: privKey, publicKey: pubKey } = generateKeyPairSync(
+      "ec",
+      { namedCurve: "P-256" }
+    );
+    process.env.MAPKIT_TEAM_ID = "TEAM1234AB";
+    process.env.MAPKIT_KEY_ID = "KEY1234567";
+    process.env.MAPKIT_PRIVATE_KEY = privKey
+      .export({ format: "pem", type: "pkcs8" })
+      .toString();
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const signed = await fresh.signMapKitJwt("mapkit-js", 60);
+    const verified = await jwtVerify(signed.token, pubKey);
+    expect(verified.payload.origin).toBe("https://os.example.com");
+  });
+
+  test("prefers MAPKIT_ORIGIN over APP_PUBLIC_ORIGIN", async () => {
+    const moduleSpec = "../api/_utils/_mapkit-jwt";
+    const url = new URL(
+      `${moduleSpec}.ts?cacheBust=${Date.now()}-2`,
+      import.meta.url
+    ).href;
+    const fresh = (await import(url)) as typeof import("../api/_utils/_mapkit-jwt");
+
+    const { privateKey: privKey, publicKey: pubKey } = generateKeyPairSync(
+      "ec",
+      { namedCurve: "P-256" }
+    );
+    process.env.MAPKIT_TEAM_ID = "TEAM1234AB";
+    process.env.MAPKIT_KEY_ID = "KEY1234567";
+    process.env.MAPKIT_PRIVATE_KEY = privKey
+      .export({ format: "pem", type: "pkcs8" })
+      .toString();
+    process.env.MAPKIT_ORIGIN = "https://maps.example.com";
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const signed = await fresh.signMapKitJwt("mapkit-js", 60);
+    const verified = await jwtVerify(signed.token, pubKey);
+    expect(verified.payload.origin).toBe("https://maps.example.com");
+  });
+
+  test("uses allowed request origin when explicit env vars are unset", async () => {
+    const moduleSpec = "../api/_utils/_mapkit-jwt";
+    const url = new URL(
+      `${moduleSpec}.ts?cacheBust=${Date.now()}-3`,
+      import.meta.url
+    ).href;
+    const fresh = (await import(url)) as typeof import("../api/_utils/_mapkit-jwt");
+
+    const { privateKey: privKey, publicKey: pubKey } = generateKeyPairSync(
+      "ec",
+      { namedCurve: "P-256" }
+    );
+    process.env.MAPKIT_TEAM_ID = "TEAM1234AB";
+    process.env.MAPKIT_KEY_ID = "KEY1234567";
+    process.env.MAPKIT_PRIVATE_KEY = privKey
+      .export({ format: "pem", type: "pkcs8" })
+      .toString();
+
+    const signed = await fresh.signMapKitJwt("mapkit-js", 60, {
+      requestOrigin: "http://localhost:5173",
+    });
+    const verified = await jwtVerify(signed.token, pubKey);
+    expect(verified.payload.origin).toBe("http://localhost:5173");
+  });
+
+  test("omits the origin claim for maps-server-api tokens", async () => {
+    const moduleSpec = "../api/_utils/_mapkit-jwt";
+    const url = new URL(
+      `${moduleSpec}.ts?cacheBust=${Date.now()}-4`,
+      import.meta.url
+    ).href;
+    const fresh = (await import(url)) as typeof import("../api/_utils/_mapkit-jwt");
+
+    const { privateKey: privKey, publicKey: pubKey } = generateKeyPairSync(
+      "ec",
+      { namedCurve: "P-256" }
+    );
+    process.env.MAPKIT_TEAM_ID = "TEAM1234AB";
+    process.env.MAPKIT_KEY_ID = "KEY1234567";
+    process.env.MAPKIT_PRIVATE_KEY = privKey
+      .export({ format: "pem", type: "pkcs8" })
+      .toString();
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const signed = await fresh.signMapKitJwt("maps-server-api", 60, {
+      requestOrigin: "https://os.example.com",
+    });
+    const verified = await jwtVerify(signed.token, pubKey);
+    expect(verified.payload.origin).toBeUndefined();
+  });
+
+  test("parseMapKitPrivateKey accepts a valid PEM key", () => {
+    const { pem } = generateP8();
+    process.env.MAPKIT_PRIVATE_KEY = pem;
+    const parsed = parseMapKitPrivateKey();
+    expect(parsed.pem).not.toBeNull();
+    expect(parsed.pem).toContain("BEGIN");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two console warnings reported during ryOS sessions:

1. **`Document not found or empty: /Documents/when software had a soul.md`** — TextEdit now handles restored/missing document paths gracefully instead of emitting a noisy `console.warn`.
2. **`[MapKit] Authorization token without origin restriction is not recommended in production environments.`** — MapKit JS tokens now include an `origin` claim derived from `MAPKIT_ORIGIN`, the allowed request `Origin`, or `APP_PUBLIC_ORIGIN`.

## Changes

### TextEdit
- `handleLoadFromDatabase` checks file metadata before loading
- Missing/trashed metadata: debug log + return false (caller clears stale persisted path)
- Metadata present but empty content: open a blank editor at the same path (matches Finder launch behavior)
- Restore effect clears stale `filePath` when metadata is gone

### MapKit
- Added `resolveMapKitJsOrigin()` with env/request/public-origin fallback chain
- MapKit token handler caches JWTs per request origin
- Added unit tests for origin resolution and signing

## Testing

- `bun test tests/test-mapkit-jwt.test.ts` — 7/7 pass
- `bun test tests/test-textedit-programmatic-updates.test.ts` — 6/6 pass
- Verified `/api/mapkit-token` returns JWT with `origin` claim (e.g. `http://localhost:5173` when requested with that Origin header)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-624b1819-af01-429f-8bfc-f4a16f0c0caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-624b1819-af01-429f-8bfc-f4a16f0c0caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

