### PR TITLE
Make assistant bubble placement window-aware with 4-side popping

### DIFF
--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -47,6 +47,12 @@ import {
 } from "./assistantAnimation";
 import { markAssistantSoundInteraction } from "./assistantSounds";
 import { resolveAssistantSnapPoint } from "./assistantSnap";
+import {
+  ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
+  ASSISTANT_BUBBLE_WIDTH,
+  resolveAssistantBubblePlacement,
+  type AssistantBubbleRect,
+} from "./assistantBubblePlacement";
 import { useAssistantBubbleAutoClose } from "./useAssistantBubbleAutoClose";
 import { speakAssistantText, stopAssistantSpeech } from "./assistantSpeech";
 import { useAssistantSpeech } from "./useAssistantSpeech";
@@ -1008,11 +1014,64 @@ function AssistantOverlayInner() {
   );
 
   // --- Bubble placement --------------------------------------------------------
-  // Show the bubble above the character unless the character is near the top
-  // of the screen; keep the bubble inside the viewport horizontally.
-  const bubbleBelow = position.y < 220;
-  const bubbleAlignRight =
-    position.x + character.width / 2 > window.innerWidth / 2;
+  // Pick the side of the character (above/below/left/right) where the bubble
+  // stays inside the viewport and covers the least amount of open windows, so
+  // a character docked next to a window pops its bubble away from the window.
+  const windowInstances = useAppStore((state) => state.instances);
+  const bubblePlacement = useMemo(() => {
+    const insets = computeInsets();
+    const obstacles: AssistantBubbleRect[] = [];
+    for (const instance of Object.values(windowInstances)) {
+      if (!instance.isOpen || instance.isMinimized) continue;
+      if (!instance.position || !instance.size) continue;
+      obstacles.push({
+        x: instance.position.x,
+        y: instance.position.y,
+        width: instance.size.width,
+        height: instance.size.height,
+      });
+    }
+    return resolveAssistantBubblePlacement({
+      anchor: {
+        x: position.x,
+        y: position.y,
+        width: character.width,
+        height: character.height,
+      },
+      bubbleSize: {
+        width: ASSISTANT_BUBBLE_WIDTH,
+        height: ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
+      },
+      viewport: {
+        width: window.innerWidth,
+        height: window.innerHeight,
+        topInset: insets.topInset,
+        bottomInset: insets.bottomInset,
+      },
+      obstacles,
+    });
+  }, [
+    windowInstances,
+    position,
+    character.width,
+    character.height,
+    computeInsets,
+  ]);
+  const bubbleSide = bubblePlacement.side;
+  const bubbleAlignEnd = bubblePlacement.align === "end";
+  const bubbleVertical = bubbleSide === "above" || bubbleSide === "below";
+  // Slide the bubble from the character's side as it scales in/out.
+  const bubblePopOffset = {
+    x: bubbleSide === "left" ? 1 : bubbleSide === "right" ? -1 : 0,
+    y: bubbleSide === "above" ? 1 : bubbleSide === "below" ? -1 : 0,
+  };
+  const bubbleTransformOrigin = bubbleVertical
+    ? `${bubbleAlignEnd ? "right" : "left"} ${
+        bubbleSide === "below" ? "top" : "bottom"
+      }`
+    : `${bubbleSide === "left" ? "right" : "left"} ${
+        bubbleAlignEnd ? "bottom" : "top"
+      }`;
 
   const handleSubmit = useCallback(
     (event: React.FormEvent) => {
@@ -1091,24 +1150,35 @@ function AssistantOverlayInner() {
             onFocus={handleBubbleFocus}
             onPointerDown={handleBubblePointerDown}
             onWheel={handleBubbleWheel}
-            initial={{ opacity: 0, scale: 0.9, y: bubbleBelow ? -4 : 4 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
+            initial={{
+              opacity: 0,
+              scale: 0.9,
+              x: bubblePopOffset.x * 4,
+              y: bubblePopOffset.y * 4,
+            }}
+            animate={{ opacity: 1, scale: 1, x: 0, y: 0 }}
             exit={{
               opacity: 0,
               scale: 0.96,
-              y: bubbleBelow ? -2 : 2,
+              x: bubblePopOffset.x * 2,
+              y: bubblePopOffset.y * 2,
               transition: reduceMotion ? { duration: 0 } : BUBBLE_EXIT,
             }}
             transition={reduceMotion ? { duration: 0 } : BUBBLE_OPEN_SPRING}
-            style={{
-              transformOrigin: `${bubbleAlignRight ? "right" : "left"} ${
-                bubbleBelow ? "top" : "bottom"
-              }`,
-            }}
+            style={{ transformOrigin: bubbleTransformOrigin }}
             className={cn(
               "absolute w-64 pointer-events-auto",
-              bubbleBelow ? "top-full mt-2" : "bottom-full mb-2",
-              bubbleAlignRight ? "right-0" : "left-0"
+              bubbleSide === "above" && "bottom-full mb-2",
+              bubbleSide === "below" && "top-full mt-2",
+              bubbleSide === "left" && "right-full mr-2",
+              bubbleSide === "right" && "left-full ml-2",
+              bubbleVertical
+                ? bubbleAlignEnd
+                  ? "right-0"
+                  : "left-0"
+                : bubbleAlignEnd
+                ? "bottom-0"
+                : "top-0"
             )}
           >
             <div
@@ -1175,10 +1245,17 @@ function AssistantOverlayInner() {
               <div
                 className={cn(
                   "absolute size-2.5 rotate-45 border-black bg-[#FFFFC8]",
-                  bubbleBelow
-                    ? "-top-[6px] border-l border-t"
-                    : "-bottom-[6px] border-b border-r",
-                  bubbleAlignRight ? "right-6" : "left-6"
+                  bubbleSide === "above" && "-bottom-[6px] border-b border-r",
+                  bubbleSide === "below" && "-top-[6px] border-l border-t",
+                  bubbleSide === "left" && "-right-[6px] border-r border-t",
+                  bubbleSide === "right" && "-left-[6px] border-b border-l",
+                  bubbleVertical
+                    ? bubbleAlignEnd
+                      ? "right-6"
+                      : "left-6"
+                    : bubbleAlignEnd
+                    ? "bottom-6"
+                    : "top-6"
                 )}
               />
             </div>

--- a/src/components/assistant/assistantBubblePlacement.ts
+++ b/src/components/assistant/assistantBubblePlacement.ts
@@ -1,0 +1,213 @@
+/**
+ * Window-aware placement for the assistant's speech bubble.
+ *
+ * The bubble can pop on any of the four sides of the character (above, below,
+ * left, right) with two alignments per side. Candidates are scored by how much
+ * of the bubble would fall outside the viewport (worst) and how much would
+ * cover open windows, so a character docked next to a window pops its bubble
+ * away from the window instead of over it.
+ */
+
+export interface AssistantBubbleRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface AssistantBubbleViewport {
+  width: number;
+  height: number;
+  topInset: number;
+  bottomInset: number;
+}
+
+export type AssistantBubbleSide = "above" | "below" | "left" | "right";
+
+/**
+ * Alignment along the side's cross axis. For above/below: "start" aligns the
+ * bubble's left edge with the character (extends right), "end" aligns the
+ * right edge (extends left). For left/right: "start" aligns the top edge
+ * (extends down), "end" aligns the bottom edge (extends up).
+ */
+export type AssistantBubbleAlign = "start" | "end";
+
+export interface AssistantBubblePlacement {
+  side: AssistantBubbleSide;
+  align: AssistantBubbleAlign;
+  bounds: AssistantBubbleRect;
+  /** Weighted viewport-overflow + window-overlap area. 0 = fully clear. */
+  penalty: number;
+}
+
+export const ASSISTANT_BUBBLE_WIDTH = 256;
+export const ASSISTANT_BUBBLE_ESTIMATED_HEIGHT = 208;
+export const ASSISTANT_BUBBLE_GAP = 8;
+
+/** Covering a window is bad; pushing the bubble offscreen is worse. */
+const OVERFLOW_WEIGHT = 4;
+
+interface ResolveAssistantBubblePlacementOptions {
+  /** Character rect (viewport coordinates). */
+  anchor: AssistantBubbleRect;
+  bubbleSize: { width: number; height: number };
+  viewport: AssistantBubbleViewport;
+  /** Rects the bubble should avoid covering (open windows). */
+  obstacles: AssistantBubbleRect[];
+}
+
+function getRight(rect: AssistantBubbleRect): number {
+  return rect.x + rect.width;
+}
+
+function getBottom(rect: AssistantBubbleRect): number {
+  return rect.y + rect.height;
+}
+
+function getIntersectionArea(
+  a: AssistantBubbleRect,
+  b: AssistantBubbleRect
+): number {
+  const width = Math.max(
+    0,
+    Math.min(getRight(a), getRight(b)) - Math.max(a.x, b.x)
+  );
+  const height = Math.max(
+    0,
+    Math.min(getBottom(a), getBottom(b)) - Math.max(a.y, b.y)
+  );
+  return width * height;
+}
+
+function getOverflowArea(
+  rect: AssistantBubbleRect,
+  viewport: AssistantBubbleViewport
+): number {
+  const visibleWidth = Math.max(
+    0,
+    Math.min(getRight(rect), viewport.width) - Math.max(rect.x, 0)
+  );
+  const visibleHeight = Math.max(
+    0,
+    Math.min(getBottom(rect), viewport.height) - Math.max(rect.y, 0)
+  );
+  return rect.width * rect.height - visibleWidth * visibleHeight;
+}
+
+interface PlacementCandidate {
+  side: AssistantBubbleSide;
+  align: AssistantBubbleAlign;
+  bounds: AssistantBubbleRect;
+  priority: number;
+}
+
+export function resolveAssistantBubblePlacement({
+  anchor,
+  bubbleSize,
+  viewport,
+  obstacles,
+}: ResolveAssistantBubblePlacementOptions): AssistantBubblePlacement {
+  const anchorRight = getRight(anchor);
+  const anchorBottom = getBottom(anchor);
+  const anchorCenterX = anchor.x + anchor.width / 2;
+  const anchorCenterY = anchor.y + anchor.height / 2;
+
+  // Prefer extending toward the middle of the screen (classic behavior).
+  const hAlign: AssistantBubbleAlign =
+    anchorCenterX > viewport.width / 2 ? "end" : "start";
+  const vAlign: AssistantBubbleAlign =
+    anchorCenterY > viewport.height / 2 ? "end" : "start";
+  const nearSide: AssistantBubbleSide =
+    anchorCenterX > viewport.width / 2 ? "left" : "right";
+  const farSide: AssistantBubbleSide = nearSide === "left" ? "right" : "left";
+
+  const flip = (align: AssistantBubbleAlign): AssistantBubbleAlign =>
+    align === "start" ? "end" : "start";
+
+  const xFor = (align: AssistantBubbleAlign): number =>
+    align === "start" ? anchor.x : anchorRight - bubbleSize.width;
+  const yFor = (align: AssistantBubbleAlign): number =>
+    align === "start" ? anchor.y : anchorBottom - bubbleSize.height;
+
+  const boundsFor = (
+    side: AssistantBubbleSide,
+    align: AssistantBubbleAlign
+  ): AssistantBubbleRect => {
+    switch (side) {
+      case "above":
+        return {
+          x: xFor(align),
+          y: anchor.y - ASSISTANT_BUBBLE_GAP - bubbleSize.height,
+          width: bubbleSize.width,
+          height: bubbleSize.height,
+        };
+      case "below":
+        return {
+          x: xFor(align),
+          y: anchorBottom + ASSISTANT_BUBBLE_GAP,
+          width: bubbleSize.width,
+          height: bubbleSize.height,
+        };
+      case "left":
+        return {
+          x: anchor.x - ASSISTANT_BUBBLE_GAP - bubbleSize.width,
+          y: yFor(align),
+          width: bubbleSize.width,
+          height: bubbleSize.height,
+        };
+      case "right":
+        return {
+          x: anchorRight + ASSISTANT_BUBBLE_GAP,
+          y: yFor(align),
+          width: bubbleSize.width,
+          height: bubbleSize.height,
+        };
+    }
+  };
+
+  // Priority breaks ties between equally clear placements: above first, then
+  // below, then beside the character (toward the screen center first).
+  const order: Array<[AssistantBubbleSide, AssistantBubbleAlign]> = [
+    ["above", hAlign],
+    ["above", flip(hAlign)],
+    ["below", hAlign],
+    ["below", flip(hAlign)],
+    [nearSide, vAlign],
+    [nearSide, flip(vAlign)],
+    [farSide, vAlign],
+    [farSide, flip(vAlign)],
+  ];
+
+  const candidates: PlacementCandidate[] = order.map(
+    ([side, align], priority) => ({
+      side,
+      align,
+      bounds: boundsFor(side, align),
+      priority,
+    })
+  );
+
+  const scored = candidates.map((candidate) => {
+    const overlap = obstacles.reduce(
+      (total, obstacle) =>
+        total + getIntersectionArea(candidate.bounds, obstacle),
+      0
+    );
+    return {
+      ...candidate,
+      penalty:
+        getOverflowArea(candidate.bounds, viewport) * OVERFLOW_WEIGHT +
+        overlap,
+    };
+  });
+
+  scored.sort((a, b) => a.penalty - b.penalty || a.priority - b.priority);
+
+  const best = scored[0];
+  return {
+    side: best.side,
+    align: best.align,
+    bounds: best.bounds,
+    penalty: best.penalty,
+  };
+}

--- a/src/components/assistant/assistantSnap.ts
+++ b/src/components/assistant/assistantSnap.ts
@@ -1,11 +1,12 @@
 import type { AssistantPosition } from "@/stores/useAssistantStore";
+import {
+  ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
+  ASSISTANT_BUBBLE_WIDTH,
+  resolveAssistantBubblePlacement,
+} from "./assistantBubblePlacement";
 
 const SNAP_MARGIN = 8;
 const WINDOW_GAP = 8;
-const BUBBLE_GAP = 8;
-const BUBBLE_WIDTH = 256;
-const ESTIMATED_BUBBLE_HEIGHT = 208;
-const BUBBLE_BELOW_THRESHOLD = 220;
 
 export interface AssistantSnapRect {
   x: number;
@@ -69,42 +70,6 @@ function getIntersectionArea(a: AssistantSnapRect, b: AssistantSnapRect): number
     Math.min(getBottom(a), getBottom(b)) - Math.max(a.y, b.y)
   );
   return width * height;
-}
-
-function getBubbleBounds(
-  position: AssistantPosition,
-  assistantSize: AssistantSnapSize,
-  viewportWidth: number
-): AssistantSnapRect {
-  const below = position.y < BUBBLE_BELOW_THRESHOLD;
-  const alignRight =
-    position.x + assistantSize.width / 2 > viewportWidth / 2;
-
-  return {
-    x: alignRight
-      ? position.x + assistantSize.width - BUBBLE_WIDTH
-      : position.x,
-    y: below
-      ? position.y + assistantSize.height + BUBBLE_GAP
-      : position.y - ESTIMATED_BUBBLE_HEIGHT - BUBBLE_GAP,
-    width: BUBBLE_WIDTH,
-    height: ESTIMATED_BUBBLE_HEIGHT,
-  };
-}
-
-function getOverflowArea(
-  rect: AssistantSnapRect,
-  viewport: AssistantSnapViewport
-): number {
-  const visibleWidth = Math.max(
-    0,
-    Math.min(getRight(rect), viewport.width) - Math.max(rect.x, 0)
-  );
-  const visibleHeight = Math.max(
-    0,
-    Math.min(getBottom(rect), viewport.height) - Math.max(rect.y, 0)
-  );
-  return rect.width * rect.height - visibleWidth * visibleHeight;
 }
 
 function getDistanceSquared(
@@ -270,16 +235,21 @@ export function resolveAssistantSnapPoint({
 
   return valid
     .map((candidate) => {
-      const bubbleBounds = getBubbleBounds(
-        candidate.position,
-        assistantSize,
-        viewport.width
-      );
+      // Score with the same window-aware resolver the bubble UI uses, so the
+      // chosen dock point is one where the bubble can pop without covering
+      // the target window or the viewport edges.
+      const bubblePlacement = resolveAssistantBubblePlacement({
+        anchor: getRect(candidate.position, assistantSize),
+        bubbleSize: {
+          width: ASSISTANT_BUBBLE_WIDTH,
+          height: ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
+        },
+        viewport,
+        obstacles: [targetBounds],
+      });
       return {
         ...candidate,
-        bubblePenalty:
-          getOverflowArea(bubbleBounds, viewport) +
-          getIntersectionArea(bubbleBounds, targetBounds),
+        bubblePenalty: bubblePlacement.penalty,
         distance: getDistanceSquared(currentPosition, candidate.position),
       };
     })

--- a/tests/test-assistant-bubble-placement.test.ts
+++ b/tests/test-assistant-bubble-placement.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
+  ASSISTANT_BUBBLE_WIDTH,
+  resolveAssistantBubblePlacement,
+  type AssistantBubbleRect,
+} from "../src/components/assistant/assistantBubblePlacement";
+
+const bubbleSize = {
+  width: ASSISTANT_BUBBLE_WIDTH,
+  height: ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
+};
+
+const desktopViewport = {
+  width: 1440,
+  height: 900,
+  topInset: 24,
+  bottomInset: 80,
+};
+
+const character = { width: 80, height: 80 };
+
+function place(
+  anchor: { x: number; y: number },
+  obstacles: AssistantBubbleRect[] = [],
+  viewport = desktopViewport
+) {
+  return resolveAssistantBubblePlacement({
+    anchor: { ...anchor, ...character },
+    bubbleSize,
+    viewport,
+    obstacles,
+  });
+}
+
+describe("assistant bubble placement", () => {
+  test("defaults to above, extending toward screen center", () => {
+    const left = place({ x: 100, y: 600 });
+    expect(left.side).toBe("above");
+    expect(left.align).toBe("start");
+    expect(left.penalty).toBe(0);
+
+    const right = place({ x: 1300, y: 600 });
+    expect(right.side).toBe("above");
+    expect(right.align).toBe("end");
+    expect(right.penalty).toBe(0);
+  });
+
+  test("flips below when the character is near the top of the screen", () => {
+    const placement = place({ x: 700, y: 60 });
+    expect(placement.side).toBe("below");
+    expect(placement.penalty).toBe(0);
+  });
+
+  test("does not cover a window the character is docked under", () => {
+    // Mobile-like layout: window fills the top, character snapped below the
+    // window's bottom-right corner. The bubble must pop down and extend left.
+    const viewport = { width: 390, height: 844, topInset: 26, bottomInset: 40 };
+    const window: AssistantBubbleRect = { x: 0, y: 26, width: 390, height: 500 };
+    const placement = place({ x: 302, y: 534 }, [window], viewport);
+
+    expect(placement.side).toBe("below");
+    expect(placement.align).toBe("end");
+    expect(placement.penalty).toBe(0);
+    // Entirely below the window and inside the viewport.
+    expect(placement.bounds.y).toBeGreaterThanOrEqual(534 + 80);
+    expect(placement.bounds.y + placement.bounds.height).toBeLessThanOrEqual(
+      844
+    );
+  });
+
+  test("extends away from a window when docked at its bottom-right corner", () => {
+    // Character sits just right of the window, aligned with its bottom edge.
+    const window: AssistantBubbleRect = { x: 100, y: 80, width: 600, height: 500 };
+    const placement = place({ x: 708, y: 500 }, [window]);
+
+    expect(placement.side).toBe("above");
+    // Extending left ("end") would cover the window; extend right instead.
+    expect(placement.align).toBe("start");
+    expect(placement.penalty).toBe(0);
+  });
+
+  test("pops sideways when above and below are both blocked", () => {
+    // Short viewport: no room for the bubble above or below the character,
+    // but a side pop extending downward fits fully.
+    const viewport = { width: 1440, height: 400, topInset: 24, bottomInset: 40 };
+    const placement = place({ x: 8, y: 140 }, [], viewport);
+
+    expect(placement.side).toBe("right");
+    expect(placement.align).toBe("start");
+    expect(placement.penalty).toBe(0);
+    expect(placement.bounds.y).toBe(140);
+  });
+
+  test("side pop anchors toward the top or bottom of the character", () => {
+    // Character low in a short viewport: the side bubble should hang upward,
+    // bottom-aligned with the character.
+    const viewport = { width: 1440, height: 400, topInset: 24, bottomInset: 40 };
+    const placement = place({ x: 8, y: 180 }, [], viewport);
+
+    expect(placement.side).toBe("right");
+    expect(placement.align).toBe("end");
+    expect(placement.penalty).toBe(0);
+    expect(placement.bounds.y + placement.bounds.height).toBe(180 + 80);
+  });
+
+  test("keeps the classic default when nothing can be fully clear", () => {
+    // Maximized window: every placement overlaps it equally, so the classic
+    // above-toward-center default wins the tie.
+    const window: AssistantBubbleRect = {
+      x: 0,
+      y: 24,
+      width: 1440,
+      height: 796,
+    };
+    const placement = place({ x: 600, y: 500 }, [window]);
+    expect(placement.side).toBe("above");
+    expect(placement.align).toBe("start");
+  });
+
+  test("stays on screen and minimizes window coverage when boxed in", () => {
+    // Character at the bottom-right of the screen with a window filling the
+    // desktop above: the bubble stays fully on screen and picks the placement
+    // covering the least of the window (tucked left, hanging below it).
+    const window: AssistantBubbleRect = {
+      x: 0,
+      y: 24,
+      width: 1440,
+      height: 700,
+    };
+    const placement = place({ x: 1352, y: 740 }, [window]);
+    expect(placement.side).toBe("left");
+    expect(placement.align).toBe("end");
+    const { bounds } = placement;
+    expect(bounds.x).toBeGreaterThanOrEqual(0);
+    expect(bounds.x + bounds.width).toBeLessThanOrEqual(1440);
+    expect(bounds.y).toBeGreaterThanOrEqual(0);
+    expect(bounds.y + bounds.height).toBeLessThanOrEqual(900);
+    // Covering part of the window beats popping offscreen, and the side pop
+    // covers less of the window than popping above would.
+    expect(placement.penalty).toBeLessThan(
+      ASSISTANT_BUBBLE_WIDTH * ASSISTANT_BUBBLE_ESTIMATED_HEIGHT
+    );
+  });
+});

--- a/tests/test-assistant-window-snap.test.ts
+++ b/tests/test-assistant-window-snap.test.ts
@@ -23,7 +23,9 @@ describe("assistant window snap point", () => {
     ).toEqual({ x: 708, y: 487 });
   });
 
-  test("uses an upper edge when the bottom edge has no room", () => {
+  test("keeps the bottom-right corner when the bubble can pop away from the window", () => {
+    // The window reaches low, but the bubble can still pop up-and-right from
+    // the bottom-right corner without covering the window.
     expect(
       resolveAssistantSnapPoint({
         currentPosition: { x: 1200, y: 700 },
@@ -31,10 +33,12 @@ describe("assistant window snap point", () => {
         viewport,
         targetBounds: { x: 100, y: 400, width: 600, height: 400 },
       })
-    ).toEqual({ x: 576, y: 299 });
+    ).toEqual({ x: 708, y: 707 });
   });
 
-  test("moves to the left when the target is against the right edge", () => {
+  test("tucks under the bottom edge when the target is against the right edge", () => {
+    // No room to the right: the assistant sits under the bottom-right corner
+    // and the bubble pops sideways to the left, clear of the window.
     expect(
       resolveAssistantSnapPoint({
         currentPosition: { x: 1200, y: 500 },
@@ -42,7 +46,7 @@ describe("assistant window snap point", () => {
         viewport,
         targetBounds: { x: 1000, y: 100, width: 400, height: 500 },
       })
-    ).toEqual({ x: 868, y: 507 });
+    ).toEqual({ x: 1276, y: 608 });
   });
 
   test("does not cover a window with no available outside point", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the desktop assistant's speech bubble pop smarter:

- **Window-aware popping** — the bubble now picks the side of the character (above/below/left/right, with start/end alignment = 8 candidate placements) that stays fully inside the viewport and covers the least amount of open windows. When the character is docked next to or below a window, the bubble pops away from the window instead of over it.
- **Left/right side pops** — the bubble can now pop beside the character (anchored toward its top or bottom) when there's no room above or below, e.g. on short viewports, or extend downwards-and-leftwards when the character snaps under a window's bottom-right corner (the mobile case).
- New `assistantBubblePlacement.ts` resolver scores candidates by weighted viewport-overflow + window-overlap area, with tie-breaking priorities that preserve the classic default (above the character, extending toward screen center).
- `assistantSnap.ts` (auto-relocation next to windows opened by AI tools) now scores dock points with the same resolver, so the assistant prefers dock spots where its bubble can open without covering the target window.
- The bubble tail, transform origin, and open/close motion offsets follow the chosen side.

## Screenshots

Character docked under a window's bottom-right corner — bubble pops below, extending left, keeping the window clear (previously it popped up over the window):

![Bubble pops below when docked under a window](https://cursor.com/artifacts/c/art-eb925b28-95cb-4427-8a4d-0b3cb1fbf465)

Short viewport with the character vertically centered — no room above or below, so the bubble pops beside the character with the tail on its left edge:

![Side pop beside the character](https://cursor.com/artifacts/c/art-5444f817-ceff-40a1-aa2b-7e7ec02c5f80)

## Testing

- New unit suite `tests/test-assistant-bubble-placement.test.ts` (8 tests) covering defaults, window avoidance, side pops, and boxed-in fallbacks.
- Updated `tests/test-assistant-window-snap.test.ts` expectations for the shared bubble-penalty scoring.
- `bun test` (both suites), `bunx tsc --noEmit`, `bunx eslint`, `bun run test:registration`, and `bun run build` all pass.
- Manually verified in the browser (screenshots above): below-window pop when docked under a window, and sideways pop in a short viewport.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2e81-41e1-7ce5-a399-2cf09f1055f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2e81-41e1-7ce5-a399-2cf09f1055f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

