### PR TITLE
Never clip the assistant speech bubble; pop to the top when boxed in

### DIFF
--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -110,6 +110,19 @@ const BUBBLE_EXIT: Transition = {
 
 const REST_ANIMATION = "RestPose";
 
+/** Default distance (px) of the bubble tail from its aligned bubble edge. */
+const BUBBLE_TAIL_INSET = 24;
+/** Keep the tail clear of the bubble's rounded corners. */
+const BUBBLE_TAIL_MIN_OFFSET = 10;
+/** Farthest the tail can sit from the aligned edge along the bubble width. */
+const BUBBLE_TAIL_MAX_OFFSET_X = ASSISTANT_BUBBLE_WIDTH - 34;
+/**
+ * Farthest the tail can sit from the aligned edge along the bubble height.
+ * Conservative because the rendered bubble can be much shorter than the
+ * placement estimate; this keeps the tail attached even to a one-line bubble.
+ */
+const BUBBLE_TAIL_MAX_OFFSET_Y = 56;
+
 /** Wait for the snap spring to mostly settle before pointing at a window. */
 const POINTING_DELAY_MS = 550;
 
@@ -1192,9 +1205,31 @@ function AssistantOverlayInner() {
   const windowInstances = useAppStore((state) => state.instances);
   const bubblePlacement = useMemo(() => {
     const insets = computeInsets();
+    // Prefer the rendered window frames: on mobile the store keeps numeric
+    // sizes while windows actually render full-width, so store rects can
+    // misreport what the bubble would cover.
+    const frameByInstanceId = new Map<string, HTMLElement>();
+    for (const element of document.querySelectorAll<HTMLElement>(
+      "[data-window-instance-id]"
+    )) {
+      const instanceId = element.dataset.windowInstanceId;
+      if (instanceId) frameByInstanceId.set(instanceId, element);
+    }
     const obstacles: AssistantBubbleRect[] = [];
-    for (const instance of Object.values(windowInstances)) {
+    for (const [instanceId, instance] of Object.entries(windowInstances)) {
       if (!instance.isOpen || instance.isMinimized) continue;
+      const frameBounds = frameByInstanceId
+        .get(instanceId)
+        ?.getBoundingClientRect();
+      if (frameBounds && frameBounds.width > 0 && frameBounds.height > 0) {
+        obstacles.push({
+          x: frameBounds.left,
+          y: frameBounds.top,
+          width: frameBounds.width,
+          height: frameBounds.height,
+        });
+        continue;
+      }
       if (!instance.position || !instance.size) continue;
       obstacles.push({
         x: instance.position.x,
@@ -1232,6 +1267,31 @@ function AssistantOverlayInner() {
   const bubbleSide = bubblePlacement.side;
   const bubbleAlignEnd = bubblePlacement.align === "end";
   const bubbleVertical = bubbleSide === "above" || bubbleSide === "below";
+  // Cross-axis slide keeping the bubble on screen; the tail counter-shifts
+  // by the same amount so it keeps pointing at the character.
+  const bubbleCrossOffset = bubblePlacement.crossOffset;
+  const bubblePositionStyle = bubbleVertical
+    ? bubbleAlignEnd
+      ? { right: -bubbleCrossOffset }
+      : { left: bubbleCrossOffset }
+    : bubbleAlignEnd
+    ? { bottom: -bubbleCrossOffset }
+    : { top: bubbleCrossOffset };
+  const bubbleTailOffset = Math.min(
+    Math.max(
+      BUBBLE_TAIL_INSET +
+        (bubbleAlignEnd ? bubbleCrossOffset : -bubbleCrossOffset),
+      BUBBLE_TAIL_MIN_OFFSET
+    ),
+    bubbleVertical ? BUBBLE_TAIL_MAX_OFFSET_X : BUBBLE_TAIL_MAX_OFFSET_Y
+  );
+  const bubbleTailStyle = bubbleVertical
+    ? bubbleAlignEnd
+      ? { right: bubbleTailOffset }
+      : { left: bubbleTailOffset }
+    : bubbleAlignEnd
+    ? { bottom: bubbleTailOffset }
+    : { top: bubbleTailOffset };
   // Slide the bubble from the character's side as it scales in/out.
   const bubblePopOffset = {
     x: bubbleSide === "left" ? 1 : bubbleSide === "right" ? -1 : 0,
@@ -1344,20 +1404,16 @@ function AssistantOverlayInner() {
               transition: reduceMotion ? { duration: 0 } : BUBBLE_EXIT,
             }}
             transition={reduceMotion ? { duration: 0 } : BUBBLE_OPEN_SPRING}
-            style={{ transformOrigin: bubbleTransformOrigin }}
+            style={{
+              transformOrigin: bubbleTransformOrigin,
+              ...bubblePositionStyle,
+            }}
             className={cn(
               "absolute w-64 pointer-events-auto",
               bubbleSide === "above" && "bottom-full mb-2",
               bubbleSide === "below" && "top-full mt-2",
               bubbleSide === "left" && "right-full mr-2",
-              bubbleSide === "right" && "left-full ml-2",
-              bubbleVertical
-                ? bubbleAlignEnd
-                  ? "right-0"
-                  : "left-0"
-                : bubbleAlignEnd
-                ? "bottom-0"
-                : "top-0"
+              bubbleSide === "right" && "left-full ml-2"
             )}
           >
             <div
@@ -1422,19 +1478,13 @@ function AssistantOverlayInner() {
               </form>
               {/* Bubble tail pointing at the character */}
               <div
+                style={bubbleTailStyle}
                 className={cn(
                   "absolute size-2.5 rotate-45 border-black bg-[#FFFFC8]",
                   bubbleSide === "above" && "-bottom-[6px] border-b border-r",
                   bubbleSide === "below" && "-top-[6px] border-l border-t",
                   bubbleSide === "left" && "-right-[6px] border-r border-t",
-                  bubbleSide === "right" && "-left-[6px] border-b border-l",
-                  bubbleVertical
-                    ? bubbleAlignEnd
-                      ? "right-6"
-                      : "left-6"
-                    : bubbleAlignEnd
-                    ? "bottom-6"
-                    : "top-6"
+                  bubbleSide === "right" && "-left-[6px] border-b border-l"
                 )}
               />
             </div>

--- a/src/components/assistant/assistantBubblePlacement.ts
+++ b/src/components/assistant/assistantBubblePlacement.ts
@@ -2,10 +2,12 @@
  * Window-aware placement for the assistant's speech bubble.
  *
  * The bubble can pop on any of the four sides of the character (above, below,
- * left, right) with two alignments per side. Candidates are scored by how much
- * of the bubble would fall outside the viewport (worst) and how much would
- * cover open windows, so a character docked next to a window pops its bubble
- * away from the window instead of over it.
+ * left, right) with two alignments per side. Each candidate is first slid
+ * along its side's cross axis so it stays inside the viewport, then scored:
+ * staying fully on screen is a hard constraint (a clipped bubble never beats
+ * an on-screen one), and among on-screen candidates the one covering the
+ * least amount of open windows wins, so a character docked next to a window
+ * pops its bubble away from the window instead of over it.
  */
 
 export interface AssistantBubbleRect {
@@ -36,6 +38,12 @@ export interface AssistantBubblePlacement {
   side: AssistantBubbleSide;
   align: AssistantBubbleAlign;
   bounds: AssistantBubbleRect;
+  /**
+   * Cross-axis shift (px) applied to the natural edge-aligned position to
+   * keep the bubble inside the viewport: horizontal for above/below,
+   * vertical for left/right. 0 when the bubble fits without sliding.
+   */
+  crossOffset: number;
   /** Weighted viewport-overflow + window-overlap area. 0 = fully clear. */
   penalty: number;
 }
@@ -46,6 +54,9 @@ export const ASSISTANT_BUBBLE_GAP = 8;
 
 /** Covering a window is bad; pushing the bubble offscreen is worse. */
 const OVERFLOW_WEIGHT = 4;
+
+/** Preferred clearance (px) between the bubble and the viewport edges. */
+const BUBBLE_VIEWPORT_MARGIN = 8;
 
 interface ResolveAssistantBubblePlacementOptions {
   /** Character rect (viewport coordinates). */
@@ -99,6 +110,11 @@ interface PlacementCandidate {
   align: AssistantBubbleAlign;
   bounds: AssistantBubbleRect;
   priority: number;
+}
+
+function clampAxis(value: number, min: number, max: number): number {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
 }
 
 export function resolveAssistantBubblePlacement({
@@ -187,27 +203,69 @@ export function resolveAssistantBubblePlacement({
     })
   );
 
+  // Slide each candidate along its side's cross axis so it stays inside the
+  // viewport. The main axis (the offset away from the character) is never
+  // adjusted — that would cover the character — so any remaining overflow
+  // there still disqualifies the candidate against fully visible ones.
+  const slideOnScreen = (
+    candidate: PlacementCandidate
+  ): { bounds: AssistantBubbleRect; crossOffset: number } => {
+    const { bounds, side } = candidate;
+    if (side === "above" || side === "below") {
+      const x = clampAxis(
+        bounds.x,
+        BUBBLE_VIEWPORT_MARGIN,
+        viewport.width - bounds.width - BUBBLE_VIEWPORT_MARGIN
+      );
+      return { bounds: { ...bounds, x }, crossOffset: x - bounds.x };
+    }
+    const y = clampAxis(
+      bounds.y,
+      viewport.topInset + BUBBLE_VIEWPORT_MARGIN,
+      viewport.height -
+        viewport.bottomInset -
+        bounds.height -
+        BUBBLE_VIEWPORT_MARGIN
+    );
+    return { bounds: { ...bounds, y }, crossOffset: y - bounds.y };
+  };
+
   const scored = candidates.map((candidate) => {
+    const { bounds, crossOffset } = slideOnScreen(candidate);
+    const overflow = getOverflowArea(bounds, viewport);
     const overlap = obstacles.reduce(
-      (total, obstacle) =>
-        total + getIntersectionArea(candidate.bounds, obstacle),
+      (total, obstacle) => total + getIntersectionArea(bounds, obstacle),
       0
     );
     return {
-      ...candidate,
-      penalty:
-        getOverflowArea(candidate.bounds, viewport) * OVERFLOW_WEIGHT +
-        overlap,
+      side: candidate.side,
+      align: candidate.align,
+      priority: candidate.priority,
+      bounds,
+      crossOffset,
+      overflow,
+      overlap,
     };
   });
 
-  scored.sort((a, b) => a.penalty - b.penalty || a.priority - b.priority);
+  // Never clip: any placement that stays fully on screen beats any placement
+  // that overflows, no matter how much of a window it covers. Among equally
+  // visible candidates, cover as little of the open windows as possible,
+  // slide as little as possible, then fall back to the classic side order.
+  scored.sort(
+    (a, b) =>
+      a.overflow - b.overflow ||
+      a.overlap - b.overlap ||
+      Math.abs(a.crossOffset) - Math.abs(b.crossOffset) ||
+      a.priority - b.priority
+  );
 
   const best = scored[0];
   return {
     side: best.side,
     align: best.align,
     bounds: best.bounds,
-    penalty: best.penalty,
+    crossOffset: best.crossOffset,
+    penalty: best.overflow * OVERFLOW_WEIGHT + best.overlap,
   };
 }

--- a/tests/test-assistant-bubble-placement.test.ts
+++ b/tests/test-assistant-bubble-placement.test.ts
@@ -39,11 +39,13 @@ describe("assistant bubble placement", () => {
     expect(left.side).toBe("above");
     expect(left.align).toBe("start");
     expect(left.penalty).toBe(0);
+    expect(left.crossOffset).toBe(0);
 
     const right = place({ x: 1300, y: 600 });
     expect(right.side).toBe("above");
     expect(right.align).toBe("end");
     expect(right.penalty).toBe(0);
+    expect(right.crossOffset).toBe(0);
   });
 
   test("flips below when the character is near the top of the screen", () => {
@@ -116,6 +118,41 @@ describe("assistant bubble placement", () => {
     const placement = place({ x: 600, y: 500 }, [window]);
     expect(placement.side).toBe("above");
     expect(placement.align).toBe("start");
+  });
+
+  test("slides along the cross axis instead of clipping on a narrow viewport", () => {
+    // Character horizontally centered on a phone: neither left- nor
+    // right-aligned above placement fits, so the bubble slides sideways to
+    // stay fully on screen instead of hanging off the edge.
+    const viewport = { width: 393, height: 852, topInset: 26, bottomInset: 90 };
+    const placement = place({ x: 156, y: 640 }, [], viewport);
+
+    expect(placement.side).toBe("above");
+    expect(placement.penalty).toBe(0);
+    expect(placement.crossOffset).toBe(-27);
+    expect(placement.bounds.x).toBe(129);
+    expect(placement.bounds.x + placement.bounds.width).toBeLessThanOrEqual(
+      393 - 8
+    );
+  });
+
+  test("pops to the top instead of clipping beside a full-width window", () => {
+    // Regression: character docked at the bottom of a phone viewport with a
+    // window filling the screen above it. Side pops hang off the viewport and
+    // must never win just because they cover less of the window — the bubble
+    // pops above (sliding on-screen), accepting the window overlap.
+    const viewport = { width: 393, height: 852, topInset: 26, bottomInset: 90 };
+    const window: AssistantBubbleRect = { x: 0, y: 26, width: 393, height: 560 };
+    const placement = place({ x: 150, y: 640 }, [window], viewport);
+
+    expect(placement.side).toBe("above");
+    const { bounds } = placement;
+    expect(bounds.x).toBeGreaterThanOrEqual(0);
+    expect(bounds.x + bounds.width).toBeLessThanOrEqual(393);
+    expect(bounds.y).toBeGreaterThanOrEqual(0);
+    expect(bounds.y + bounds.height).toBeLessThanOrEqual(852);
+    // Slid left so the right-extending bubble stays on screen.
+    expect(placement.crossOffset).toBe(-21);
   });
 
   test("stays on screen and minimizes window coverage when boxed in", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile-width viewports the assistant's speech bubble could pop beside the character and hang off the viewport edge, clipping the text (reported screenshot: bubble clipped at the left edge next to a full-width Control Panels window — it should have popped above the character).

Two causes:

1. Viewport overflow was only a *weighted* penalty (4×), so a placement that clipped could still beat an on-screen placement that covered more of an open window.
2. Candidates were rigidly edge-aligned to the character, so on narrow viewports (256px bubble on a ~393px phone) every candidate could overflow when the character sits away from an edge.

## Fix

- `assistantBubblePlacement.ts`: every candidate now **slides along its side's cross axis** to stay inside the viewport (8px margin; side pops also respect menubar/dock insets), and scoring is lexicographic: staying fully on screen is a **hard constraint** — a clipped placement never beats a visible one — then least window overlap, least slide, then the classic side order. The resolver returns the applied `crossOffset`.
- `AssistantOverlay.tsx`: applies the cross-axis offset to the bubble position and counter-shifts the tail by the same amount (clamped) so it keeps pointing at the character. Obstacle rects now prefer the rendered window frames (`[data-window-instance-id]` bounding rects) over store geometry, which diverges on mobile where windows render full-width.
- New regression tests for the narrow-viewport slide and the "pop to the top instead of clipping beside a full-width window" scenario.

## Verification (420px-wide viewport, full-width System Preferences window open)

![Rover at bottom-left: bubble pops above, fully on screen](https://cursor.com/artifacts/c/art-51602615-8e7d-4628-af4e-126d84ccea1b)
![Rover at bottom-right: bubble pops above and slides left to stay on screen, tail still pointing at Rover](https://cursor.com/artifacts/c/art-71524d04-640a-4489-8879-10da3e9892c5)

- ✅ `bun test tests/test-assistant-bubble-placement.test.ts` (10 pass)
- ✅ `bun test tests/test-assistant-window-snap.test.ts tests/test-assistant-bubble-auto-close.test.tsx tests/test-assistant-animation.test.tsx tests/test-assistant-bubble-shimmer.test.ts` (57 pass)
- ✅ `bun run typecheck`
- ✅ `bunx eslint` on changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2ecc-b4fa-75a1-aec4-27db88ae4b97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2ecc-b4fa-75a1-aec4-27db88ae4b97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

