### PR TITLE
Unlock assistant TTS from any interaction and recover dropped replies on iOS

### DIFF
--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -59,7 +59,11 @@ import {
   type AssistantBubbleRect,
 } from "./assistantBubblePlacement";
 import { useAssistantBubbleAutoClose } from "./useAssistantBubbleAutoClose";
-import { speakAssistantText, stopAssistantSpeech } from "./assistantSpeech";
+import {
+  primeAssistantSpeech,
+  speakAssistantText,
+  stopAssistantSpeech,
+} from "./assistantSpeech";
 import { useAssistantSpeech } from "./useAssistantSpeech";
 import {
   Streamdown,
@@ -576,6 +580,9 @@ function AssistantOverlayInner() {
   const handlePointerDown = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       markAssistantSoundInteraction();
+      // Tapping the assistant is a user gesture: unlock TTS (iOS Safari) and
+      // catch up on a reply that was silently dropped outside a gesture.
+      if (useAssistantStore.getState().speechEnabled) primeAssistantSpeech();
       if (event.pointerType === "mouse" && event.button !== 0) return;
       if (contextMenuPos) return;
       lastActiveAtRef.current = Date.now();
@@ -922,6 +929,7 @@ function AssistantOverlayInner() {
   const handleCharacterActivate = useCallback(() => {
     cancelBubbleAutoClose();
     markAssistantSoundInteraction();
+    if (useAssistantStore.getState().speechEnabled) primeAssistantSpeech();
     lastActiveAtRef.current = Date.now();
     const willOpen = !bubbleOpen;
     setBubbleOpen(willOpen);
@@ -1088,9 +1096,13 @@ function AssistantOverlayInner() {
       return;
     }
     // Speak the current reply inside the menu-click gesture: it audibly
-    // confirms the setting and unlocks synthesis on iOS Safari.
+    // confirms the setting and unlocks synthesis on iOS Safari. With no
+    // reply to speak yet, still unlock silently so the upcoming reply is
+    // audible.
     if (latestAssistantText && !isLoading) {
       speakAssistantText(latestAssistantText, { locale: i18n.language });
+    } else {
+      primeAssistantSpeech();
     }
   }, [
     cancelBubbleAutoClose,
@@ -1324,6 +1336,9 @@ function AssistantOverlayInner() {
     (event: React.FormEvent) => {
       event.preventDefault();
       markAssistantSoundInteraction();
+      // Submitting counts as a gesture even when triggered by the virtual
+      // keyboard's Go key, which may not dispatch pointer/key events.
+      if (useAssistantStore.getState().speechEnabled) primeAssistantSpeech();
       const text = input.trim();
       if (!text || isLoading) return;
       setInput("");

--- a/src/components/assistant/assistantSpeech.ts
+++ b/src/components/assistant/assistantSpeech.ts
@@ -37,7 +37,22 @@ export function prepareAssistantSpeechTexts(text: string): string[] {
 // reply (or a stop) never lets stale `onend` handlers keep speaking.
 let generation = 0;
 let voicesWarmed = false;
-let synthesisPrimed = false;
+/**
+ * True once an utterance has actually started playing, which proves the
+ * engine accepted a `speak()` (on iOS Safari that only happens after a call
+ * made inside a user gesture). Until then every gesture retries the unlock:
+ * iOS grants user activation to `touchend`/`keydown` but not `pointerdown`,
+ * so the first attempt of a tap can fail while a later one succeeds.
+ */
+let synthesisUnlocked = false;
+/**
+ * The most recent reply handed to `speakAssistantText` that has not audibly
+ * started. On iOS Safari a `speak()` outside a user gesture is silently
+ * dropped (no events, no error); the next gesture re-speaks this reply so
+ * the user actually hears it in addition to unlocking synthesis.
+ */
+let droppedSpeech: { text: string; options?: AssistantSpeechOptions } | null =
+  null;
 
 /** Warm the async voice list (Chrome loads it lazily). Never blocks speech. */
 function warmVoices(synth: SpeechSynthesis) {
@@ -57,23 +72,51 @@ export interface AssistantSpeechOptions {
  * other engines) ignore `speechSynthesis.speak()` until the page's first
  * `speak()` happens inside a gesture handler. When Speech was enabled in a
  * previous session, replies finish asynchronously — outside any gesture — so
- * without priming they are silently dropped. Call this from gesture handlers
- * (pointer down, submit); it speaks one muted, empty utterance the first time.
+ * without priming they are silently dropped.
+ *
+ * Call this from gesture handlers (tapping the assistant, submitting a
+ * message, any pointer/key gesture). If the latest reply was dropped it is
+ * re-spoken inside the gesture (which both unlocks synthesis and finally
+ * makes the reply audible); otherwise a muted utterance unlocks silently.
+ * Attempts keep retrying on subsequent gestures until an utterance verifiably
+ * starts — iOS silently drops blocked `speak()` calls with no event or error,
+ * so a single fire-and-forget attempt can latch a failed unlock forever.
  */
 export function primeAssistantSpeech(): void {
-  if (synthesisPrimed) return;
   const synth = getBrowserSpeechSynthesis();
   if (!synth) return;
-  synthesisPrimed = true;
+  if (synthesisUnlocked && !droppedSpeech) return;
 
   warmVoices(synth);
   synth.resume();
-  // Never clobber speech that is already audible (it also proves synthesis
-  // is unlocked).
-  if (synth.speaking || synth.pending) return;
+
+  // Audible speech proves synthesis is unlocked, and a reply dropped earlier
+  // is stale once something else is speaking — never barge in over it.
+  if (synth.speaking) {
+    synthesisUnlocked = true;
+    droppedSpeech = null;
+    return;
+  }
+
+  // Re-speak the dropped reply inside this gesture. speakAssistantText
+  // cancels first, which also clears any utterances stuck in the queue from
+  // the blocked attempt.
+  if (droppedSpeech) {
+    const { text, options } = droppedSpeech;
+    speakAssistantText(text, options);
+    return;
+  }
+
+  // A queued-but-not-started utterance either belongs to another feature
+  // (never clobber it, and don't pile on) or is about to start; retry on the
+  // next gesture instead.
+  if (synth.pending) return;
 
   const utterance = new SpeechSynthesisUtterance(" ");
   utterance.volume = 0;
+  utterance.onstart = () => {
+    synthesisUnlocked = true;
+  };
   synth.speak(utterance);
 }
 
@@ -93,7 +136,15 @@ export function speakAssistantText(
   synth.cancel();
 
   const texts = prepareAssistantSpeechTexts(text);
-  if (texts.length === 0) return;
+  if (texts.length === 0) {
+    droppedSpeech = null;
+    return;
+  }
+
+  // Until an utterance verifiably starts, assume this reply may have been
+  // dropped (iOS Safari blocks out-of-gesture speak() calls silently) so the
+  // next user gesture can re-speak it via primeAssistantSpeech.
+  droppedSpeech = { text, options };
 
   warmVoices(synth);
   synth.resume();
@@ -111,6 +162,13 @@ export function speakAssistantText(
       useAudioSettingsStore.getState().browserTtsVoiceURI
     );
     if (voice) utterance.voice = voice;
+
+    utterance.onstart = () => {
+      // An audible start proves the engine accepted the speak() (i.e.
+      // synthesis is unlocked) and that this reply was not dropped.
+      synthesisUnlocked = true;
+      if (currentGeneration === generation) droppedSpeech = null;
+    };
 
     let advanced = false;
     const advance = () => {
@@ -135,6 +193,7 @@ export function speakAssistantText(
 /** Stop assistant speech and drop any queued utterances. */
 export function stopAssistantSpeech(): void {
   generation++;
+  droppedSpeech = null;
   getBrowserSpeechSynthesis()?.cancel();
 }
 
@@ -142,5 +201,6 @@ export function stopAssistantSpeech(): void {
 export function __resetAssistantSpeechStateForTests(): void {
   generation++;
   voicesWarmed = false;
-  synthesisPrimed = false;
+  synthesisUnlocked = false;
+  droppedSpeech = null;
 }

--- a/src/components/assistant/useAssistantSpeech.ts
+++ b/src/components/assistant/useAssistantSpeech.ts
@@ -40,10 +40,11 @@ export function useAssistantSpeech({
 
   // When Speech was already on from a previous session, replies finish
   // outside any user gesture and iOS Safari drops the `speak()` call. Prime
-  // synthesis from the first gesture of the session so those asynchronous
-  // replies are audible. (Toggling Speech on manually primes as a side
-  // effect of speaking inside the menu click, which is why that path
-  // already worked.)
+  // synthesis from any gesture (tapping the assistant, typing, any tap on
+  // the page) so those asynchronous replies are audible; a reply that was
+  // already dropped is re-spoken by the priming gesture. primeAssistantSpeech
+  // keeps retrying until an utterance verifiably starts, then becomes a
+  // no-op, so leaving these listeners attached is cheap.
   useEffect(() => {
     if (!speechEnabled) return;
     if (typeof document === "undefined") return;

--- a/tests/test-assistant-speech.test.ts
+++ b/tests/test-assistant-speech.test.ts
@@ -57,6 +57,7 @@ class FakeUtterance {
   rate = 1;
   volume = 1;
   voice: unknown = null;
+  onstart: (() => void) | null = null;
   onend: (() => void) | null = null;
   onerror: (() => void) | null = null;
   constructor(text: string) {
@@ -172,13 +173,35 @@ describe("assistant speech playback", () => {
     expect((spoken[0].voice as SpeechSynthesisVoice).name).toBe("English UK");
   });
 
-  test("primeAssistantSpeech speaks one muted utterance, once", () => {
-    primeAssistantSpeech();
+  test("primeAssistantSpeech retries the muted unlock until an utterance starts", () => {
     primeAssistantSpeech();
     expect(spoken).toHaveLength(1);
     expect(spoken[0].volume).toBe(0);
     // Priming must not cancel anything (it runs on arbitrary gestures).
     expect(cancelCount).toBe(0);
+
+    // The engine never confirmed a start (iOS drops blocked speak() calls
+    // silently, with no event), so the next gesture retries the unlock.
+    primeAssistantSpeech();
+    expect(spoken).toHaveLength(2);
+    expect(spoken[1].volume).toBe(0);
+
+    // A started utterance proves synthesis is unlocked; priming becomes a
+    // no-op from then on.
+    spoken[1].onstart?.();
+    primeAssistantSpeech();
+    expect(spoken).toHaveLength(2);
+  });
+
+  test("primeAssistantSpeech never piles onto a pending queue", () => {
+    synth.pending = true;
+    primeAssistantSpeech();
+    expect(spoken).toHaveLength(0);
+    expect(cancelCount).toBe(0);
+    // The queue draining re-enables the unlock attempt on the next gesture.
+    synth.pending = false;
+    primeAssistantSpeech();
+    expect(spoken).toHaveLength(1);
   });
 
   test("primeAssistantSpeech skips the muted utterance while speech is active", () => {
@@ -200,6 +223,68 @@ describe("assistant speech playback", () => {
       "Hello there!",
     ]);
     expect(spoken[1].volume).toBe(1);
+  });
+
+  test("a reply dropped outside a gesture is re-spoken by the next priming gesture", () => {
+    speakAssistantText("Hello there!", { locale: "en" });
+    expect(spoken).toHaveLength(1);
+
+    // The engine never started the utterance (iOS blocked the speak() made
+    // outside a gesture), so the priming gesture re-speaks the reply at full
+    // volume instead of a muted unlock utterance.
+    primeAssistantSpeech();
+    expect(spoken.map((utterance) => utterance.text)).toEqual([
+      "Hello there!",
+      "Hello there!",
+    ]);
+    expect(spoken[1].volume).toBe(1);
+
+    // Once it audibly starts, later gestures stop re-speaking it.
+    spoken[1].onstart?.();
+    primeAssistantSpeech();
+    expect(spoken).toHaveLength(2);
+  });
+
+  test("a reply that already started is not re-spoken by later gestures", () => {
+    speakAssistantText("Hello there!", { locale: "en" });
+    spoken[0].onstart?.();
+    primeAssistantSpeech();
+    expect(spoken).toHaveLength(1);
+  });
+
+  test("priming re-speaks only the newest dropped reply", () => {
+    speakAssistantText("Old reply.", { locale: "en" });
+    speakAssistantText("New reply.", { locale: "en" });
+    primeAssistantSpeech();
+    expect(spoken.map((utterance) => utterance.text)).toEqual([
+      "Old reply.",
+      "New reply.",
+      "New reply.",
+    ]);
+  });
+
+  test("stopping speech clears the dropped reply", () => {
+    speakAssistantText("Hello there!", { locale: "en" });
+    stopAssistantSpeech();
+    primeAssistantSpeech();
+    expect(spoken).toHaveLength(2);
+    // The priming gesture unlocks silently instead of resurrecting the
+    // stopped reply.
+    expect(spoken[1].volume).toBe(0);
+  });
+
+  test("audible speech unlocks synthesis and drops the stale reply", () => {
+    speakAssistantText("Hello there!", { locale: "en" });
+    // Another feature's speech is audible (e.g. Books read-aloud): priming
+    // must not barge in over it with the stale assistant reply.
+    synth.speaking = true;
+    primeAssistantSpeech();
+    expect(spoken).toHaveLength(1);
+    expect(cancelCount).toBe(1);
+
+    synth.speaking = false;
+    primeAssistantSpeech();
+    expect(spoken).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On iOS Safari, assistant TTS only worked when Speech was toggled on via the character's context menu, because that toggle speaks inside the menu-click gesture. With Speech already enabled (e.g. persisted from a previous session), replies finish outside any gesture and iOS silently drops the `speak()` call — and the existing one-shot priming latch could permanently mark synthesis as "primed" even when the unlock utterance was never actually played (iOS gives no event or error for blocked calls, and a stuck pending queue made the primer bail before speaking).

## Changes

- `assistantSpeech.ts`
  - Replaced the fire-and-forget `synthesisPrimed` latch with a `synthesisUnlocked` flag that is only set when an utterance verifiably starts (`onstart`). Until then, every user gesture retries the unlock.
  - Track the latest reply that never audibly started as `droppedSpeech`; the next gesture re-speaks it at full volume (which unlocks synthesis, clears any stuck queue via the pre-speak `cancel()`, and finally makes the reply audible) instead of a muted unlock utterance.
  - Dropped-reply tracking is cleared when the reply starts playing, when a newer reply replaces it, on `stopAssistantSpeech()`, and when other speech is already audible (never barge in over e.g. Books read-aloud).
- `AssistantOverlay.tsx`
  - Tapping the assistant character, activating it (click/Enter), and submitting a message now prime TTS when Speech is enabled — so any interaction with the assistant enables speech on iOS, not just the menu toggle.
  - Enabling Speech via the context menu with no reply to speak yet still unlocks synthesis silently inside the gesture.
- `useAssistantSpeech.ts` — updated the document-level gesture listener comments to match the retry semantics (unchanged behavior: any pointerdown/touchend/keydown primes while Speech is on).
- `tests/test-assistant-speech.test.ts` — updated priming tests for retry-until-started semantics and added coverage for dropped-reply re-speak, newest-reply-wins, stop clearing the dropped reply, and not clobbering audible speech.

## Testing

- ✅ `bun test tests/test-assistant-speech.test.ts` (23 pass)
- ✅ `bun run test:unit` (2206 pass across 289 files)
- ✅ `bunx tsc -b --force`
- ✅ `bunx eslint` on changed files

iOS Safari's gesture-gated speech synthesis cannot be reproduced in the Linux cloud VM, so the unlock/retry/re-speak logic is verified with unit tests against a fake `speechSynthesis` engine modeling the blocked-speak behavior (no events, no error).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2ef4-9303-7f08-879d-756ab7b25d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2ef4-9303-7f08-879d-756ab7b25d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

