### PR TITLE
Fix detached assistant bubble: slide by measured bubble size, not the estimate

### DIFF
--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -55,6 +56,7 @@ import { resolveAssistantSnapPoint } from "./assistantSnap";
 import {
   ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
   ASSISTANT_BUBBLE_WIDTH,
+  resolveAssistantBubbleCrossOffset,
   resolveAssistantBubblePlacement,
   type AssistantBubbleRect,
 } from "./assistantBubblePlacement";
@@ -114,14 +116,8 @@ const REST_ANIMATION = "RestPose";
 const BUBBLE_TAIL_INSET = 24;
 /** Keep the tail clear of the bubble's rounded corners. */
 const BUBBLE_TAIL_MIN_OFFSET = 10;
-/** Farthest the tail can sit from the aligned edge along the bubble width. */
-const BUBBLE_TAIL_MAX_OFFSET_X = ASSISTANT_BUBBLE_WIDTH - 34;
-/**
- * Farthest the tail can sit from the aligned edge along the bubble height.
- * Conservative because the rendered bubble can be much shorter than the
- * placement estimate; this keeps the tail attached even to a one-line bubble.
- */
-const BUBBLE_TAIL_MAX_OFFSET_Y = 56;
+/** Clearance (px) between the tail and the bubble edge opposite its anchor. */
+const BUBBLE_TAIL_EDGE_CLEARANCE = 34;
 
 /** Wait for the snap spring to mostly settle before pointing at a window. */
 const POINTING_DELAY_MS = 550;
@@ -1282,9 +1278,70 @@ function AssistantOverlayInner() {
   const bubbleSide = bubblePlacement.side;
   const bubbleAlignEnd = bubblePlacement.align === "end";
   const bubbleVertical = bubbleSide === "above" || bubbleSide === "below";
-  // Cross-axis slide keeping the bubble on screen; the tail counter-shifts
-  // by the same amount so it keeps pointing at the character.
-  const bubbleCrossOffset = bubblePlacement.crossOffset;
+
+  // Track the rendered bubble height. The placement above chooses the side
+  // with a worst-case estimated height (so it stays stable while a reply
+  // streams in), but the on-screen slide must use the real height: a short
+  // bubble slid by the estimate's overshoot ends up detached from the
+  // character (bubble floating away, tail pointing at nothing).
+  const [bubbleMeasuredHeight, setBubbleMeasuredHeight] = useState<
+    number | null
+  >(null);
+  useLayoutEffect(() => {
+    if (!bubbleOpen) {
+      setBubbleMeasuredHeight(null);
+      return;
+    }
+    // While dragging the bubble unmounts; keep the last measurement so the
+    // bubble reappears in place, and re-observe the new element afterwards.
+    if (isDragging) return;
+    const element = bubbleRef.current;
+    if (!element) return;
+    // offsetHeight ignores the open/close scale transform, unlike
+    // getBoundingClientRect().
+    const measure = () => setBubbleMeasuredHeight(element.offsetHeight);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [bubbleOpen, isDragging]);
+  const bubbleRenderHeight =
+    bubbleMeasuredHeight ?? ASSISTANT_BUBBLE_ESTIMATED_HEIGHT;
+
+  // Cross-axis slide keeping the bubble on screen, recomputed from the
+  // measured bubble size; the tail counter-shifts by the same amount so it
+  // keeps pointing at the character.
+  const bubbleCrossOffset = useMemo(() => {
+    const insets = computeInsets();
+    return resolveAssistantBubbleCrossOffset({
+      side: bubbleSide,
+      align: bubblePlacement.align,
+      anchor: {
+        x: position.x,
+        y: position.y,
+        width: character.width,
+        height: character.height,
+      },
+      bubbleSize: {
+        width: ASSISTANT_BUBBLE_WIDTH,
+        height: bubbleRenderHeight,
+      },
+      viewport: {
+        width: window.innerWidth,
+        height: window.innerHeight,
+        topInset: insets.topInset,
+        bottomInset: insets.bottomInset,
+      },
+    });
+  }, [
+    bubbleSide,
+    bubblePlacement.align,
+    position,
+    character.width,
+    character.height,
+    bubbleRenderHeight,
+    computeInsets,
+  ]);
   const bubblePositionStyle = bubbleVertical
     ? bubbleAlignEnd
       ? { right: -bubbleCrossOffset }
@@ -1298,7 +1355,11 @@ function AssistantOverlayInner() {
         (bubbleAlignEnd ? bubbleCrossOffset : -bubbleCrossOffset),
       BUBBLE_TAIL_MIN_OFFSET
     ),
-    bubbleVertical ? BUBBLE_TAIL_MAX_OFFSET_X : BUBBLE_TAIL_MAX_OFFSET_Y
+    Math.max(
+      BUBBLE_TAIL_MIN_OFFSET,
+      (bubbleVertical ? ASSISTANT_BUBBLE_WIDTH : bubbleRenderHeight) -
+        BUBBLE_TAIL_EDGE_CLEARANCE
+    )
   );
   const bubbleTailStyle = bubbleVertical
     ? bubbleAlignEnd

--- a/src/components/assistant/assistantBubblePlacement.ts
+++ b/src/components/assistant/assistantBubblePlacement.ts
@@ -117,6 +117,59 @@ function clampAxis(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
+interface ResolveAssistantBubbleCrossOffsetOptions {
+  side: AssistantBubbleSide;
+  align: AssistantBubbleAlign;
+  /** Character rect (viewport coordinates). */
+  anchor: AssistantBubbleRect;
+  bubbleSize: { width: number; height: number };
+  viewport: AssistantBubbleViewport;
+}
+
+/**
+ * Cross-axis slide (px) that keeps a bubble of the given size on screen for
+ * an already-chosen side/align: horizontal for above/below, vertical for
+ * left/right. The placement resolver picks the side using an estimated
+ * bubble size, but the rendered bubble is often much shorter, so the overlay
+ * recomputes the slide from the measured size — otherwise an estimate-based
+ * slide shifts the real bubble away from the character.
+ */
+export function resolveAssistantBubbleCrossOffset({
+  side,
+  align,
+  anchor,
+  bubbleSize,
+  viewport,
+}: ResolveAssistantBubbleCrossOffsetOptions): number {
+  if (side === "above" || side === "below") {
+    const naturalX =
+      align === "start"
+        ? anchor.x
+        : anchor.x + anchor.width - bubbleSize.width;
+    return (
+      clampAxis(
+        naturalX,
+        BUBBLE_VIEWPORT_MARGIN,
+        viewport.width - bubbleSize.width - BUBBLE_VIEWPORT_MARGIN
+      ) - naturalX
+    );
+  }
+  const naturalY =
+    align === "start"
+      ? anchor.y
+      : anchor.y + anchor.height - bubbleSize.height;
+  return (
+    clampAxis(
+      naturalY,
+      viewport.topInset + BUBBLE_VIEWPORT_MARGIN,
+      viewport.height -
+        viewport.bottomInset -
+        bubbleSize.height -
+        BUBBLE_VIEWPORT_MARGIN
+    ) - naturalY
+  );
+}
+
 export function resolveAssistantBubblePlacement({
   anchor,
   bubbleSize,
@@ -210,24 +263,18 @@ export function resolveAssistantBubblePlacement({
   const slideOnScreen = (
     candidate: PlacementCandidate
   ): { bounds: AssistantBubbleRect; crossOffset: number } => {
-    const { bounds, side } = candidate;
+    const { bounds, side, align } = candidate;
+    const crossOffset = resolveAssistantBubbleCrossOffset({
+      side,
+      align,
+      anchor,
+      bubbleSize,
+      viewport,
+    });
     if (side === "above" || side === "below") {
-      const x = clampAxis(
-        bounds.x,
-        BUBBLE_VIEWPORT_MARGIN,
-        viewport.width - bounds.width - BUBBLE_VIEWPORT_MARGIN
-      );
-      return { bounds: { ...bounds, x }, crossOffset: x - bounds.x };
+      return { bounds: { ...bounds, x: bounds.x + crossOffset }, crossOffset };
     }
-    const y = clampAxis(
-      bounds.y,
-      viewport.topInset + BUBBLE_VIEWPORT_MARGIN,
-      viewport.height -
-        viewport.bottomInset -
-        bounds.height -
-        BUBBLE_VIEWPORT_MARGIN
-    );
-    return { bounds: { ...bounds, y }, crossOffset: y - bounds.y };
+    return { bounds: { ...bounds, y: bounds.y + crossOffset }, crossOffset };
   };
 
   const scored = candidates.map((candidate) => {

--- a/tests/test-assistant-bubble-placement.test.ts
+++ b/tests/test-assistant-bubble-placement.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
   ASSISTANT_BUBBLE_WIDTH,
+  resolveAssistantBubbleCrossOffset,
   resolveAssistantBubblePlacement,
   type AssistantBubbleRect,
 } from "../src/components/assistant/assistantBubblePlacement";
@@ -178,5 +179,75 @@ describe("assistant bubble placement", () => {
     expect(placement.penalty).toBeLessThan(
       ASSISTANT_BUBBLE_WIDTH * ASSISTANT_BUBBLE_ESTIMATED_HEIGHT
     );
+  });
+});
+
+describe("assistant bubble cross offset", () => {
+  const viewport = { width: 393, height: 852, topInset: 26, bottomInset: 104 };
+  const bubbleWidth = ASSISTANT_BUBBLE_WIDTH;
+
+  test("a short measured bubble is not slid by the estimate's overshoot", () => {
+    // Regression: character near the top with a side pop hanging upward
+    // ("end" align). With the worst-case estimated height the bubble's top
+    // would poke above the menubar, so the estimate-based slide shoved it
+    // down — detaching the real (much shorter) bubble from the character.
+    const anchor = { x: 305, y: 60, width: 80, height: 80 };
+
+    const estimateBased = resolveAssistantBubbleCrossOffset({
+      side: "left",
+      align: "end",
+      anchor,
+      bubbleSize: { width: bubbleWidth, height: ASSISTANT_BUBBLE_ESTIMATED_HEIGHT },
+      viewport,
+    });
+    expect(estimateBased).toBeGreaterThan(0);
+
+    const measured = resolveAssistantBubbleCrossOffset({
+      side: "left",
+      align: "end",
+      anchor,
+      bubbleSize: { width: bubbleWidth, height: 104 },
+      viewport,
+    });
+    expect(measured).toBe(0);
+  });
+
+  test("still slides a measured bubble that would leave the viewport", () => {
+    // Character low on the screen with a top-aligned side pop: the measured
+    // bubble would dip into the dock area, so it slides up just enough.
+    const anchor = { x: 305, y: 700, width: 80, height: 80 };
+    const offset = resolveAssistantBubbleCrossOffset({
+      side: "left",
+      align: "start",
+      anchor,
+      bubbleSize: { width: bubbleWidth, height: 104 },
+      viewport,
+    });
+    // max top = 852 - 104 (bottom inset) - 104 (height) - 8 (margin) = 636
+    expect(offset).toBe(636 - 700);
+  });
+
+  test("matches the placement resolver's slide for vertical sides", () => {
+    // Above/below slide along x, where the bubble width is fixed, so the
+    // measured-size recompute must agree with the resolver's own offset.
+    const anchor = { x: 156, y: 640, width: 80, height: 80 };
+    const placement = resolveAssistantBubblePlacement({
+      anchor,
+      bubbleSize: {
+        width: bubbleWidth,
+        height: ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
+      },
+      viewport,
+      obstacles: [],
+    });
+    expect(placement.side).toBe("above");
+    const offset = resolveAssistantBubbleCrossOffset({
+      side: placement.side,
+      align: placement.align,
+      anchor,
+      bubbleSize: { width: bubbleWidth, height: 104 },
+      viewport,
+    });
+    expect(offset).toBe(placement.crossOffset);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Follow-up to #1788. At some character positions the bubble rendered detached from the character — floating away with the tail pointing at empty space (reported screenshots: character at the top-right with the bubble shoved downward; character at the bottom-right with the bubble floating above-left of it).

Root cause: the placement resolver computes its on-screen cross-axis slide with the **worst-case estimated bubble height (208px)**, but side pops (`left`/`right`) are rendered anchored to the character with the **actual** bubble height (~100px for a short reply). When the estimate overflowed the viewport, the slide compensated for a phantom overflow and shifted the real, much shorter bubble away from the character; the tail's counter-shift then hit its safety clamp and pointed at nothing.

## Fix

- `assistantBubblePlacement.ts`: extracted the cross-axis slide into `resolveAssistantBubbleCrossOffset(side, align, anchor, bubbleSize, viewport)`, reused by the resolver's candidate scoring.
- `AssistantOverlay.tsx`: measures the rendered bubble height (`ResizeObserver` + `offsetHeight`, which ignores the open/close scale transform) and recomputes the slide and tail offsets from the **measured** size. Side/align selection still uses the stable worst-case estimate so the bubble doesn't flip sides while a reply streams in. The tail clamp is now derived from the measured height instead of a blunt 56px constant.
- New unit tests covering the regression (short measured bubble must not inherit the estimate's overshoot), the still-needed slide when the measured bubble would leave the viewport, and consistency with the resolver for vertical sides.

## Verification (420px-wide viewport)

![Rover at top-right (the reported geometry): bubble adjacent to his left, tail pointing at him](https://cursor.com/artifacts/c/art-6f57dd77-13b0-4688-87d7-6bd6bcd5aa51)
![Rover at the bottom: bubble directly above him, tail pointing down at him, fully on screen](https://cursor.com/artifacts/c/art-592ac56c-e11d-47b3-b85b-f43e77614125)

- ✅ `bun test tests/test-assistant-bubble-placement.test.ts tests/test-assistant-window-snap.test.ts tests/test-assistant-bubble-auto-close.test.tsx tests/test-assistant-bubble-shimmer.test.ts` (36 pass)
- ✅ `bun run typecheck`
- ✅ `bunx eslint` on changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2ecc-b4fa-75a1-aec4-27db88ae4b97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2ecc-b4fa-75a1-aec4-27db88ae4b97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

