### PR TITLE
Unify browser TTS voice handling; default voices per assistant character

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -95,11 +95,10 @@ import {
   useBooksSpeechBarVisibility,
 } from "../hooks/useBooksSpeechBarVisibility";
 import {
+  createSpeechUtterance,
   getBrowserSpeechSynthesis,
-  resolveSpeechVoice,
   ryOSLocaleToSpeechLanguage,
 } from "@/utils/browserSpeech";
-import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useBookCover } from "../utils/useBookCover";
 import { BookCover } from "./BookCover";
 import type {
@@ -2157,15 +2156,11 @@ export const BooksReaderPane = forwardRef<
     // The reply follows the question's language (book language falling back
     // to the UI locale), so reuse the read-aloud language + voice resolution.
     const lang = getSpeechLanguage();
-    const utterance = new SpeechSynthesisUtterance(reply);
-    utterance.lang = lang;
-    utterance.rate = normalizeBooksSpeechRate(speechRateRef.current);
-    const voice = resolveSpeechVoice(
-      synth.getVoices(),
+    const utterance = createSpeechUtterance(reply, {
       lang,
-      useAudioSettingsStore.getState().browserTtsVoiceURI
-    );
-    if (voice) utterance.voice = voice;
+      rate: normalizeBooksSpeechRate(speechRateRef.current),
+      voices: synth.getVoices(),
+    });
     utterance.onend = () => {
       askSpeechStartedRef.current = false;
       setIsSpeakingAskReply(false);

--- a/src/apps/books/hooks/useBooksSpeech.ts
+++ b/src/apps/books/hooks/useBooksSpeech.ts
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  createSpeechUtterance,
   getBrowserSpeechSynthesis,
-  resolveSpeechVoice,
 } from "@/utils/browserSpeech";
-import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import {
   applySpeechSpokenHighlight,
   applyCarryOverSpokenHits,
@@ -301,15 +300,11 @@ export function useBooksSpeech({
 
       const lang = optionsRef.current.getSpeechLanguage();
       const rate = optionsRef.current.getSpeechRate();
-      const utterance = new SpeechSynthesisUtterance(chunk.text);
-      utterance.lang = lang;
-      utterance.rate = rate;
-      const voice = resolveSpeechVoice(
-        synth.getVoices(),
+      const utterance = createSpeechUtterance(chunk.text, {
         lang,
-        useAudioSettingsStore.getState().browserTtsVoiceURI
-      );
-      if (voice) utterance.voice = voice;
+        rate,
+        voices: synth.getVoices(),
+      });
       activeUtteranceRef.current = utterance;
 
       let settled = false;

--- a/src/apps/calculator/utils/calculatorSpeech.ts
+++ b/src/apps/calculator/utils/calculatorSpeech.ts
@@ -1,9 +1,8 @@
 import {
+  createSpeechUtterance,
   getBrowserSpeechSynthesis,
-  resolveSpeechVoice,
   ryOSLocaleToSpeechLanguage,
 } from "@/utils/browserSpeech";
-import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 
 const KEY_TRANSLATION_KEYS: Record<string, string> = {
   "+": "apps.calculator.speech.keys.plus",
@@ -214,18 +213,11 @@ function drainSpeechQueue(adapter: SpeechSynthAdapter) {
   // (subsequent queued items drain from onend handlers).
   adapter.resume();
 
-  const utterance = new SpeechSynthesisUtterance(text);
-  utterance.lang = lang;
-  utterance.rate = rate;
-
-  const voice = resolveSpeechVoice(
-    adapter.getVoices(),
+  const utterance = createSpeechUtterance(text, {
     lang,
-    useAudioSettingsStore.getState().browserTtsVoiceURI
-  );
-  if (voice) {
-    utterance.voice = voice;
-  }
+    rate,
+    voices: adapter.getVoices(),
+  });
 
   let finished = false;
   const finish = () => {

--- a/src/components/assistant/assistantSpeech.ts
+++ b/src/components/assistant/assistantSpeech.ts
@@ -7,13 +7,14 @@
  */
 
 import {
+  createSpeechUtterance,
   getBrowserSpeechSynthesis,
-  resolveSpeechVoice,
   ryOSLocaleToSpeechLanguage,
 } from "@/utils/browserSpeech";
 import { cleanTextForSpeech } from "@/apps/chats/utils/textForSpeech";
 import { splitTextIntoSpeechSegments } from "@/apps/books/utils/booksSpeech";
-import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
+import { useAssistantStore } from "@/stores/useAssistantStore";
+import { getAssistantVoiceProfile } from "./assistantVoices";
 
 /** Safety net for engines that never fire `end`/`error` on an utterance. */
 export const ASSISTANT_SPEECH_UTTERANCE_TIMEOUT_MS = 30_000;
@@ -150,18 +151,20 @@ export function speakAssistantText(
   synth.resume();
 
   const lang = ryOSLocaleToSpeechLanguage(options?.locale);
+  // The active character's persona defaults (voice, pitch, rate); the user's
+  // preferred browser TTS voice still wins inside createSpeechUtterance.
+  const profile = getAssistantVoiceProfile(
+    useAssistantStore.getState().characterId
+  );
 
   const speakAt = (index: number) => {
     if (currentGeneration !== generation || index >= texts.length) return;
 
-    const utterance = new SpeechSynthesisUtterance(texts[index]);
-    utterance.lang = lang;
-    const voice = resolveSpeechVoice(
-      synth.getVoices(),
+    const utterance = createSpeechUtterance(texts[index], {
       lang,
-      useAudioSettingsStore.getState().browserTtsVoiceURI
-    );
-    if (voice) utterance.voice = voice;
+      profile,
+      voices: synth.getVoices(),
+    });
 
     utterance.onstart = () => {
       // An audible start proves the engine accepted the speak() (i.e.

--- a/src/components/assistant/assistantVoices.ts
+++ b/src/components/assistant/assistantVoices.ts
@@ -1,0 +1,124 @@
+/**
+ * Default browser-TTS voice profiles for the desktop assistant characters.
+ *
+ * Web Speech voice lists differ per OS/browser, so each persona lists
+ * preferred voice names across the common platforms (macOS/iOS system
+ * voices, Chrome's "Google …" network voices, Windows' "Microsoft …"
+ * voices, Edge's "… Online (Natural)" voices). Resolution is language-gated
+ * (see resolveSpeechVoice), so profiles can mix languages: Saeko prefers
+ * Kyoko when speaking Japanese and a female English voice otherwise.
+ *
+ * Pitch/rate apply on every platform and language, so a character keeps its
+ * personality even when none of its preferred voices exist on the device.
+ * A user-selected voice (Control Panels → Sound) always wins over these.
+ */
+
+import type { SpeechVoiceProfile } from "@/utils/browserSpeech";
+import type { AssistantCharacterId } from "./characters";
+
+/** Bright standard female voices (macOS, Chrome, Windows, Edge). */
+const FEMALE_VOICES = [
+  "Samantha", // macOS/iOS en-US default
+  "Google US English", // Chrome network (female)
+  "Microsoft Aria", // Edge natural / Windows 11
+  "Microsoft Jenny",
+  "Microsoft Zira", // Windows en-US female
+  "Karen", // macOS en-AU
+  "Moira", // macOS en-IE
+  "Google UK English Female",
+  "Microsoft Hazel", // Windows en-GB
+] as const;
+
+/** Standard male voices (macOS, Chrome, Windows, Edge). */
+const MALE_VOICES = [
+  "Alex", // macOS en-US (when installed)
+  "Aaron", // macOS/iOS en-US
+  "Microsoft Guy", // Edge natural
+  "Microsoft Andrew",
+  "Microsoft David", // Windows en-US male
+  "Microsoft Mark",
+  "Google UK English Male",
+  "Daniel", // macOS en-GB
+  "Rishi", // macOS en-IN
+] as const;
+
+/** Deeper, statelier male voices — UK/authoritative first. */
+const DEEP_MALE_VOICES = [
+  "Daniel", // macOS en-GB
+  "Google UK English Male",
+  "Microsoft Ryan", // Edge natural en-GB
+  "Microsoft George", // Windows en-GB
+  "Microsoft Guy",
+  "Microsoft David",
+  "Alex",
+  "Aaron",
+] as const;
+
+/** Japanese voices first (Saeko Sensei), female English fallbacks after. */
+const JAPANESE_FEMALE_VOICES = [
+  "Kyoko", // macOS/iOS ja-JP
+  "Google 日本語", // Chrome network ja-JP
+  "Microsoft Nanami", // Edge natural ja-JP
+  "Microsoft Haruka", // Windows ja-JP
+  "Microsoft Ayumi",
+  ...FEMALE_VOICES,
+] as const;
+
+/** Chinese voices first (Monkey King), male English fallbacks after. */
+const CHINESE_VOICES = [
+  "Ting-Ting", // macOS zh-CN (also listed as "Tingting")
+  "Tingting",
+  "Mei-Jia", // macOS zh-TW (also "Meijia")
+  "Meijia",
+  "Google 普通话", // Chrome network zh-CN
+  "Google 國語", // Chrome network zh-TW
+  "Microsoft Xiaoxiao", // Edge natural zh-CN
+  "Microsoft Huihui", // Windows zh-CN
+  "Microsoft Hanhan", // Windows zh-TW
+  ...MALE_VOICES,
+] as const;
+
+/**
+ * Persona voice defaults per assistant character. Pitch/rate keep each
+ * character distinct even on devices where only one voice exists.
+ */
+const ASSISTANT_VOICE_PROFILES: Record<AssistantCharacterId, SpeechVoiceProfile> = {
+  // Chipper, springy paperclip.
+  clippy: { preferredVoiceNames: MALE_VOICES, pitch: 1.2, rate: 1.05 },
+  // Playful cat — light and quick.
+  links: { preferredVoiceNames: FEMALE_VOICES, pitch: 1.4, rate: 1.05 },
+  // Friendly dog — warm, a touch bright.
+  rover: { preferredVoiceNames: MALE_VOICES, pitch: 1.15 },
+  // Old wizard — deep and unhurried.
+  merlin: { preferredVoiceNames: DEEP_MALE_VOICES, pitch: 0.8, rate: 0.95 },
+  // Smooth, theatrical genie.
+  genie: { preferredVoiceNames: DEEP_MALE_VOICES, pitch: 0.85 },
+  // Squawky parrot — high and fast.
+  peedy: { preferredVoiceNames: FEMALE_VOICES, pitch: 1.5, rate: 1.1 },
+  // The professor — measured, slightly low.
+  genius: { preferredVoiceNames: MALE_VOICES, pitch: 0.9, rate: 0.95 },
+  // Gruff dog.
+  rocky: { preferredVoiceNames: MALE_VOICES, pitch: 0.7, rate: 0.95 },
+  // Robot — flat and low.
+  f1: { preferredVoiceNames: MALE_VOICES, pitch: 0.5 },
+  // Neutral narrator.
+  officelogo: { preferredVoiceNames: FEMALE_VOICES },
+  // Japanese teacher — Kyoko/Nanami when speaking Japanese.
+  saeko: { preferredVoiceNames: JAPANESE_FEMALE_VOICES, pitch: 1.1 },
+  // Energetic Monkey King — Chinese voices when speaking Chinese.
+  monkeyking: { preferredVoiceNames: CHINESE_VOICES, pitch: 1.25, rate: 1.1 },
+};
+
+const DEFAULT_PROFILE: SpeechVoiceProfile = {
+  preferredVoiceNames: MALE_VOICES,
+};
+
+/** Voice profile for an assistant character (default profile when unknown). */
+export function getAssistantVoiceProfile(
+  characterId: string | null | undefined
+): SpeechVoiceProfile {
+  return (
+    ASSISTANT_VOICE_PROFILES[characterId as AssistantCharacterId] ??
+    DEFAULT_PROFILE
+  );
+}

--- a/src/stores/useAudioSettingsStore.ts
+++ b/src/stores/useAudioSettingsStore.ts
@@ -29,9 +29,12 @@ interface AudioSettingsState {
   ttsVoice: string | null;
   /**
    * Preferred browser speechSynthesis voice (voiceURI) used by all
-   * browser-based TTS (Calculator speech, Books read-aloud). `null` picks a
-   * voice automatically from the utterance language. Device-local: voice
-   * lists differ per browser/OS, so this is intentionally not cloud-synced.
+   * browser-based TTS (desktop assistant, Calculator speech, Books
+   * read-aloud). `null` picks a voice automatically: the assistant falls
+   * back to its character's default voices, everything else to the best
+   * voice for the utterance language (see utils/browserSpeech). Device-
+   * local: voice lists differ per browser/OS, so this is intentionally not
+   * cloud-synced.
    */
   browserTtsVoiceURI: string | null;
   synthPreset: string;

--- a/src/utils/browserSpeech.ts
+++ b/src/utils/browserSpeech.ts
@@ -1,8 +1,19 @@
 /**
  * Shared helpers for the browser's native SpeechSynthesis API (browser TTS).
- * Used by apps that speak locally without the AI `/api/speech` endpoint
- * (Calculator key/result speech, Books read-aloud).
+ *
+ * This is the single home for web-speech voice selection and utterance
+ * configuration, used by every feature that speaks locally without the AI
+ * `/api/speech` endpoint: the desktop assistant, Calculator key/result
+ * speech, and Books read-aloud (page speech + Ask Ryo replies).
+ *
+ * Voice resolution priority (see {@link resolveSpeechVoice}):
+ *   1. the user's preferred voice from Control Panels → Sound (language-gated)
+ *   2. the caller's voice profile (e.g. an assistant character's default
+ *      voices), tried in order and language-gated
+ *   3. an automatic quality-ranked pick for the utterance language
  */
+
+import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 
 /** Map ryOS i18n codes to BCP 47 tags for SpeechSynthesisUtterance.lang */
 export function ryOSLocaleToSpeechLanguage(locale: string | undefined): string {
@@ -38,6 +49,170 @@ export function ryOSLocaleToSpeechLanguage(locale: string | undefined): string {
   return withRegion[primary] ?? primary;
 }
 
+/**
+ * Persona defaults for browser TTS (e.g. an assistant character). Voice
+ * names are tried in order against the voices available on this device and
+ * only apply when they speak the utterance's language; pitch/rate always
+ * apply.
+ */
+export interface SpeechVoiceProfile {
+  /**
+   * Ordered, case-insensitive substrings matched against voice names
+   * (e.g. "Daniel" matches "Daniel (English (United Kingdom))"). List names
+   * across platforms and languages — resolution is language-gated, so a
+   * profile can mix "Samantha" (en), "Kyoko" (ja) and "Microsoft Zira" (en).
+   */
+  preferredVoiceNames?: readonly string[];
+  /** Utterance pitch (0–2, engine default 1). */
+  pitch?: number;
+  /** Utterance rate (engine default 1); callers may override per feature. */
+  rate?: number;
+}
+
+/**
+ * macOS/iOS novelty and effect voices (plus the low-quality Eloquence pack)
+ * that speak in sound effects or robot-like tones. They dominate Apple's
+ * ~100+ entry voice list, so the automatic pick ranks them last. A profile
+ * or the user can still select them explicitly.
+ */
+const NOVELTY_VOICE_NAMES = new Set([
+  "albert",
+  "bad news",
+  "bahh",
+  "bells",
+  "boing",
+  "bubbles",
+  "cellos",
+  "deranged",
+  "good news",
+  "hysterical",
+  "jester",
+  "junior",
+  "kathy",
+  "organ",
+  "pipe organ",
+  "princess",
+  "ralph",
+  "superstar",
+  "trinoids",
+  "whisper",
+  "wobble",
+  "zarvox",
+  // Eloquence pack (shipped on recent macOS/iOS; robotic, low quality).
+  "eddy",
+  "flo",
+  "grandma",
+  "grandpa",
+  "reed",
+  "rocko",
+  "sandy",
+  "shelley",
+  "fred",
+]);
+
+/**
+ * Well-known good Apple system voices (macOS/iOS expose them to Safari and
+ * Chrome). Windows needs no equivalent list: every "Microsoft …" voice is a
+ * standard voice and is ranked by prefix instead.
+ */
+const KNOWN_GOOD_APPLE_VOICE_NAMES = new Set([
+  // English
+  "samantha",
+  "alex",
+  "aaron",
+  "daniel",
+  "karen",
+  "moira",
+  "rishi",
+  "tessa",
+  "fiona",
+  "arthur",
+  "martha",
+  // Japanese / Chinese / Korean
+  "kyoko",
+  "otoya",
+  "hattori",
+  "ting-ting",
+  "tingting",
+  "mei-jia",
+  "meijia",
+  "sin-ji",
+  "sinji",
+  "yuna",
+  // European languages
+  "thomas",
+  "amelie",
+  "amélie",
+  "audrey",
+  "anna",
+  "petra",
+  "markus",
+  "monica",
+  "mónica",
+  "paulina",
+  "alice",
+  "federica",
+  "luciana",
+  "joana",
+  "milena",
+  "zosia",
+  "ellen",
+  "xander",
+]);
+
+/** Voice name up to the first parenthesis/dash qualifier, lowercased —
+ * "Samantha (Enhanced)" and "Microsoft David - English (United States)"
+ * become "samantha" and "microsoft david". */
+function voiceBaseName(name: string): string {
+  return name.split("(")[0].split(" - ")[0].trim().toLowerCase();
+}
+
+/**
+ * Rank a voice for the automatic per-language pick. Higher is better;
+ * novelty voices rank below everything else.
+ */
+export function scoreSpeechVoiceQuality(voice: SpeechSynthesisVoice): number {
+  const name = voice.name.toLowerCase();
+  const base = voiceBaseName(voice.name);
+  if (NOVELTY_VOICE_NAMES.has(base)) return -1;
+
+  let score = 0;
+  if (name.includes("natural")) {
+    // Edge's "Microsoft … Online (Natural)" neural voices.
+    score += 8;
+  } else if (name.startsWith("microsoft")) {
+    // Windows standard voices (David, Zira, Mark, Haruka, …).
+    score += 6;
+  }
+  if (KNOWN_GOOD_APPLE_VOICE_NAMES.has(base)) score += 6;
+  if (name.startsWith("google")) score += 5; // Chrome network voices.
+  if (/enhanced|premium/.test(name)) score += 2;
+  if (voice.default) score += 1;
+  return score;
+}
+
+function pickBestVoice(
+  voices: SpeechSynthesisVoice[]
+): SpeechSynthesisVoice | null {
+  let best: SpeechSynthesisVoice | null = null;
+  let bestScore = -Infinity;
+  for (const voice of voices) {
+    const score = scoreSpeechVoiceQuality(voice);
+    if (score > bestScore) {
+      best = voice;
+      bestScore = score;
+    }
+  }
+  return best;
+}
+
+/**
+ * Automatic voice pick for a language: exact region match beats other
+ * regions of the same language; within a tier the highest quality-ranked
+ * voice wins (avoiding macOS novelty voices, preferring platform defaults
+ * like Samantha, Microsoft David/Zira, Google US English, and Edge's
+ * Natural voices).
+ */
 export function pickSpeechVoiceForLanguage(
   voices: SpeechSynthesisVoice[],
   lang: string
@@ -45,44 +220,80 @@ export function pickSpeechVoiceForLanguage(
   if (voices.length === 0) return null;
 
   const target = lang.toLowerCase();
-  const exact = voices.find((voice) => voice.lang.toLowerCase() === target);
-  if (exact) return exact;
+  const exact = voices.filter((voice) => voice.lang.toLowerCase() === target);
+  if (exact.length > 0) return pickBestVoice(exact);
 
   const targetPrimary = target.split("-")[0];
   const prefixMatches = voices.filter((voice) =>
     voice.lang.toLowerCase().startsWith(`${targetPrimary}-`)
   );
-  if (prefixMatches.length > 0) return prefixMatches[0];
+  if (prefixMatches.length > 0) return pickBestVoice(prefixMatches);
 
-  const primaryMatch = voices.find(
+  const primaryMatches = voices.filter(
     (voice) => voice.lang.toLowerCase().split("-")[0] === targetPrimary
   );
-  return primaryMatch ?? null;
+  return primaryMatches.length > 0 ? pickBestVoice(primaryMatches) : null;
 }
 
 /**
- * Resolve the voice for an utterance, honoring the user's preferred browser
- * TTS voice (Control Panels → Sound). The preference only applies when the
- * preferred voice speaks the same primary language as the utterance —
- * otherwise (e.g. an English voice while reading a Japanese book) we fall
- * back to the automatic per-language pick so speech stays intelligible.
+ * First voice matching one of the preferred names (in preference order)
+ * that speaks the target language. Names are case-insensitive substrings of
+ * the voice name, so "Daniel" matches "Daniel (English (United Kingdom))".
+ */
+export function pickSpeechVoiceByName(
+  voices: SpeechSynthesisVoice[],
+  lang: string,
+  preferredNames: readonly string[]
+): SpeechSynthesisVoice | null {
+  const targetPrimary = lang.toLowerCase().split("-")[0];
+  const candidates = targetPrimary
+    ? voices.filter(
+        (voice) => voice.lang.toLowerCase().split("-")[0] === targetPrimary
+      )
+    : voices;
+  for (const preferred of preferredNames) {
+    const needle = preferred.toLowerCase();
+    const match = candidates.find((voice) =>
+      voice.name.toLowerCase().includes(needle)
+    );
+    if (match) return match;
+  }
+  return null;
+}
+
+/**
+ * Resolve the voice for an utterance:
+ *   1. the user's preferred browser TTS voice (Control Panels → Sound),
+ *   2. the caller's preferred voice names (e.g. an assistant character's
+ *      default voices),
+ *   3. the automatic quality-ranked per-language pick.
+ *
+ * Every step is language-gated: a preference only applies when the voice
+ * speaks the same primary language as the utterance — otherwise (e.g. an
+ * English voice while reading a Japanese book) we fall back so speech stays
+ * intelligible.
  */
 export function resolveSpeechVoice(
   voices: SpeechSynthesisVoice[],
   lang: string,
-  preferredVoiceURI?: string | null
+  preferredVoiceURI?: string | null,
+  preferredVoiceNames?: readonly string[]
 ): SpeechSynthesisVoice | null {
+  const targetPrimary = lang.toLowerCase().split("-")[0];
   if (preferredVoiceURI) {
     const preferred = voices.find(
       (voice) => voice.voiceURI === preferredVoiceURI
     );
     if (preferred) {
-      const targetPrimary = lang.toLowerCase().split("-")[0];
       const voicePrimary = preferred.lang.toLowerCase().split("-")[0];
       if (!targetPrimary || voicePrimary === targetPrimary) {
         return preferred;
       }
     }
+  }
+  if (preferredVoiceNames && preferredVoiceNames.length > 0) {
+    const named = pickSpeechVoiceByName(voices, lang, preferredVoiceNames);
+    if (named) return named;
   }
   return pickSpeechVoiceForLanguage(voices, lang);
 }
@@ -90,4 +301,49 @@ export function resolveSpeechVoice(
 export function getBrowserSpeechSynthesis(): SpeechSynthesis | null {
   if (typeof window === "undefined") return null;
   return window.speechSynthesis ?? null;
+}
+
+export interface CreateSpeechUtteranceOptions {
+  /** BCP 47 utterance language (see {@link ryOSLocaleToSpeechLanguage}). */
+  lang: string;
+  /** Feature rate override (e.g. Books speech rate); beats the profile rate. */
+  rate?: number;
+  /** Persona defaults (voice names, pitch, rate). */
+  profile?: SpeechVoiceProfile;
+  /**
+   * Voice list to resolve against. Defaults to the live synthesis voice
+   * list; pass explicitly when the caller already holds a synth reference.
+   */
+  voices?: SpeechSynthesisVoice[];
+}
+
+/**
+ * Unified browser-TTS utterance factory: sets the language, resolves the
+ * voice (user setting → profile preference → automatic pick) and applies
+ * profile pitch/rate. All web-speech features create utterances here so
+ * voice/settings handling stays consistent.
+ */
+export function createSpeechUtterance(
+  text: string,
+  options: CreateSpeechUtteranceOptions
+): SpeechSynthesisUtterance {
+  const { lang, profile } = options;
+  const utterance = new SpeechSynthesisUtterance(text);
+  utterance.lang = lang;
+
+  const rate = options.rate ?? profile?.rate;
+  if (rate !== undefined) utterance.rate = rate;
+  if (profile?.pitch !== undefined) utterance.pitch = profile.pitch;
+
+  const voices =
+    options.voices ?? getBrowserSpeechSynthesis()?.getVoices() ?? [];
+  const voice = resolveSpeechVoice(
+    voices,
+    lang,
+    useAudioSettingsStore.getState().browserTtsVoiceURI,
+    profile?.preferredVoiceNames
+  );
+  if (voice) utterance.voice = voice;
+
+  return utterance;
 }

--- a/tests/test-assistant-speech.test.ts
+++ b/tests/test-assistant-speech.test.ts
@@ -55,6 +55,7 @@ class FakeUtterance {
   text: string;
   lang = "";
   rate = 1;
+  pitch = 1;
   volume = 1;
   voice: unknown = null;
   onstart: (() => void) | null = null;
@@ -113,6 +114,7 @@ describe("assistant speech playback", () => {
     spoken.forEach((utterance) => utterance.onend?.());
     __resetAssistantSpeechStateForTests();
     useAudioSettingsStore.setState({ browserTtsVoiceURI: null });
+    useAssistantStore.setState({ characterId: "rover" });
     g.window = originalWindow;
     g.SpeechSynthesisUtterance = originalUtterance;
     delete g.speechSynthesis;
@@ -159,6 +161,61 @@ describe("assistant speech playback", () => {
     speakAssistantText("こんにちは。", { locale: "ja" });
     expect(spoken).toHaveLength(1);
     expect(spoken[0].lang).toBe("ja-JP");
+  });
+
+  test("applies the character's default voice profile (voice, pitch, rate)", () => {
+    fakeVoices = [
+      { voiceURI: "sam", lang: "en-US", name: "Samantha" },
+      {
+        voiceURI: "dan",
+        lang: "en-GB",
+        name: "Daniel (English (United Kingdom))",
+      },
+    ] as SpeechSynthesisVoice[];
+    useAssistantStore.setState({ characterId: "merlin" });
+
+    speakAssistantText("Behold!", { locale: "en" });
+    expect(spoken).toHaveLength(1);
+    // Merlin defaults to a deep UK male voice, lowered pitch, slower rate.
+    expect((spoken[0].voice as SpeechSynthesisVoice).name).toBe(
+      "Daniel (English (United Kingdom))"
+    );
+    expect(spoken[0].pitch).toBe(0.8);
+    expect(spoken[0].rate).toBe(0.95);
+  });
+
+  test("character voice preferences are language-gated", () => {
+    fakeVoices = [
+      { voiceURI: "sam", lang: "en-US", name: "Samantha" },
+      { voiceURI: "kyoko", lang: "ja-JP", name: "Kyoko" },
+    ] as SpeechSynthesisVoice[];
+    useAssistantStore.setState({ characterId: "saeko" });
+
+    // Speaking Japanese, Saeko prefers the Japanese voice…
+    speakAssistantText("こんにちは。", { locale: "ja" });
+    expect((spoken[0].voice as SpeechSynthesisVoice).name).toBe("Kyoko");
+
+    // …and falls back to a female English voice for English replies.
+    speakAssistantText("Hello.", { locale: "en" });
+    expect((spoken[1].voice as SpeechSynthesisVoice).name).toBe("Samantha");
+  });
+
+  test("the user's preferred voice overrides the character default", () => {
+    fakeVoices = [
+      { voiceURI: "sam", lang: "en-US", name: "Samantha" },
+      {
+        voiceURI: "dan",
+        lang: "en-GB",
+        name: "Daniel (English (United Kingdom))",
+      },
+    ] as SpeechSynthesisVoice[];
+    useAssistantStore.setState({ characterId: "merlin" });
+    useAudioSettingsStore.setState({ browserTtsVoiceURI: "sam" });
+
+    speakAssistantText("Behold!", { locale: "en" });
+    expect((spoken[0].voice as SpeechSynthesisVoice).name).toBe("Samantha");
+    // Persona pitch/rate still apply — only the voice choice is overridden.
+    expect(spoken[0].pitch).toBe(0.8);
   });
 
   test("honors the preferred browser TTS voice from audio settings", () => {

--- a/tests/test-browser-speech-voices.test.ts
+++ b/tests/test-browser-speech-voices.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for the unified browser TTS voice handling in
+ * src/utils/browserSpeech.ts: quality-ranked automatic picks, profile
+ * preferred-name resolution, the user-setting > profile > automatic
+ * priority, and the createSpeechUtterance factory.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  createSpeechUtterance,
+  pickSpeechVoiceByName,
+  pickSpeechVoiceForLanguage,
+  resolveSpeechVoice,
+  scoreSpeechVoiceQuality,
+} from "../src/utils/browserSpeech";
+import { useAudioSettingsStore } from "../src/stores/useAudioSettingsStore";
+
+function voice(
+  name: string,
+  lang: string,
+  extra?: Partial<SpeechSynthesisVoice>
+): SpeechSynthesisVoice {
+  return {
+    name,
+    lang,
+    voiceURI: name,
+    localService: true,
+    default: false,
+    ...extra,
+  } as SpeechSynthesisVoice;
+}
+
+describe("scoreSpeechVoiceQuality", () => {
+  test("ranks novelty/effect voices below everything else", () => {
+    expect(scoreSpeechVoiceQuality(voice("Zarvox", "en-US"))).toBe(-1);
+    expect(scoreSpeechVoiceQuality(voice("Bad News", "en-US"))).toBe(-1);
+    expect(
+      scoreSpeechVoiceQuality(voice("Grandma (English (US))", "en-US"))
+    ).toBe(-1);
+    expect(
+      scoreSpeechVoiceQuality(voice("Samantha", "en-US"))
+    ).toBeGreaterThan(0);
+  });
+
+  test("prefers Natural (Edge) > Microsoft/Apple system > Google voices", () => {
+    const natural = scoreSpeechVoiceQuality(
+      voice("Microsoft Aria Online (Natural) - English (United States)", "en-US")
+    );
+    const microsoft = scoreSpeechVoiceQuality(
+      voice("Microsoft Zira - English (United States)", "en-US")
+    );
+    const apple = scoreSpeechVoiceQuality(voice("Samantha", "en-US"));
+    const google = scoreSpeechVoiceQuality(voice("Google US English", "en-US"));
+    const unknown = scoreSpeechVoiceQuality(voice("Mystery Voice", "en-US"));
+    expect(natural).toBeGreaterThan(microsoft);
+    expect(microsoft).toBeGreaterThan(google);
+    expect(apple).toBeGreaterThan(google);
+    expect(google).toBeGreaterThan(unknown);
+  });
+});
+
+describe("pickSpeechVoiceForLanguage (quality-ranked automatic pick)", () => {
+  test("never auto-picks a macOS novelty voice when a real one exists", () => {
+    const voices = [
+      voice("Albert", "en-US"),
+      voice("Bells", "en-US"),
+      voice("Samantha", "en-US"),
+    ];
+    expect(pickSpeechVoiceForLanguage(voices, "en-US")?.name).toBe("Samantha");
+  });
+
+  test("exact region match still beats a better-quality other region", () => {
+    const voices = [
+      voice("Google UK English Female", "en-GB"),
+      voice("Mystery Voice", "en-US"),
+    ];
+    expect(pickSpeechVoiceForLanguage(voices, "en-US")?.name).toBe(
+      "Mystery Voice"
+    );
+  });
+
+  test("prefers the platform's known-good voice within a language", () => {
+    const voices = [
+      voice("Some Random Voice", "en-US"),
+      voice("Microsoft David - English (United States)", "en-US"),
+      voice("Google US English", "en-US"),
+    ];
+    expect(pickSpeechVoiceForLanguage(voices, "en-US")?.name).toBe(
+      "Microsoft David - English (United States)"
+    );
+  });
+
+  test("falls back to the only voice for a language even if novelty", () => {
+    const voices = [voice("Zarvox", "en-US"), voice("Kyoko", "ja-JP")];
+    expect(pickSpeechVoiceForLanguage(voices, "en-US")?.name).toBe("Zarvox");
+  });
+});
+
+describe("pickSpeechVoiceByName (profile preferences)", () => {
+  const voices = [
+    voice("Samantha", "en-US"),
+    voice("Daniel (English (United Kingdom))", "en-GB"),
+    voice("Kyoko", "ja-JP"),
+  ];
+
+  test("matches names as case-insensitive substrings, in order", () => {
+    expect(
+      pickSpeechVoiceByName(voices, "en-US", ["daniel", "Samantha"])?.name
+    ).toBe("Daniel (English (United Kingdom))");
+    expect(
+      pickSpeechVoiceByName(voices, "en-US", ["Samantha", "Daniel"])?.name
+    ).toBe("Samantha");
+  });
+
+  test("is language-gated: skips preferred names in another language", () => {
+    expect(pickSpeechVoiceByName(voices, "ja-JP", ["Samantha", "Kyoko"])?.name).toBe(
+      "Kyoko"
+    );
+    expect(pickSpeechVoiceByName(voices, "de-DE", ["Samantha"])).toBeNull();
+  });
+});
+
+describe("resolveSpeechVoice priority", () => {
+  const voices = [
+    voice("Samantha", "en-US"),
+    voice("Daniel (English (United Kingdom))", "en-GB"),
+    voice("Kyoko", "ja-JP"),
+  ];
+
+  test("user-selected voice wins over profile preferred names", () => {
+    expect(
+      resolveSpeechVoice(voices, "en-US", "Samantha", ["Daniel"])?.name
+    ).toBe("Samantha");
+  });
+
+  test("profile preferred names win over the automatic pick", () => {
+    expect(resolveSpeechVoice(voices, "en-US", null, ["Daniel"])?.name).toBe(
+      "Daniel (English (United Kingdom))"
+    );
+  });
+
+  test("language-mismatched user voice falls back to profile names", () => {
+    expect(
+      resolveSpeechVoice(voices, "ja-JP", "Samantha", ["Kyoko"])?.name
+    ).toBe("Kyoko");
+  });
+
+  test("falls back to the automatic pick when nothing matches", () => {
+    expect(resolveSpeechVoice(voices, "en-US", "missing", ["Nadia"])?.name).toBe(
+      "Samantha"
+    );
+  });
+});
+
+describe("createSpeechUtterance", () => {
+  class FakeUtterance {
+    text: string;
+    lang = "";
+    rate = 1;
+    pitch = 1;
+    volume = 1;
+    voice: SpeechSynthesisVoice | null = null;
+    constructor(text: string) {
+      this.text = text;
+    }
+  }
+
+  const g = globalThis as Record<string, unknown>;
+  const originalUtterance = g.SpeechSynthesisUtterance;
+  const voices = [
+    voice("Samantha", "en-US"),
+    voice("Daniel (English (United Kingdom))", "en-GB"),
+  ];
+
+  beforeEach(() => {
+    g.SpeechSynthesisUtterance = FakeUtterance;
+    useAudioSettingsStore.setState({ browserTtsVoiceURI: null });
+  });
+
+  afterEach(() => {
+    g.SpeechSynthesisUtterance = originalUtterance;
+    useAudioSettingsStore.setState({ browserTtsVoiceURI: null });
+  });
+
+  test("applies profile voice, pitch, and rate", () => {
+    const utterance = createSpeechUtterance("Greetings!", {
+      lang: "en-US",
+      voices,
+      profile: { preferredVoiceNames: ["Daniel"], pitch: 0.8, rate: 0.95 },
+    }) as unknown as FakeUtterance;
+    expect(utterance.lang).toBe("en-US");
+    expect(utterance.voice?.name).toBe("Daniel (English (United Kingdom))");
+    expect(utterance.pitch).toBe(0.8);
+    expect(utterance.rate).toBe(0.95);
+  });
+
+  test("explicit rate overrides the profile rate", () => {
+    const utterance = createSpeechUtterance("Fast.", {
+      lang: "en-US",
+      voices,
+      rate: 1.5,
+      profile: { rate: 0.9 },
+    }) as unknown as FakeUtterance;
+    expect(utterance.rate).toBe(1.5);
+  });
+
+  test("the user's preferred voice from settings beats the profile", () => {
+    useAudioSettingsStore.setState({ browserTtsVoiceURI: "Samantha" });
+    const utterance = createSpeechUtterance("Hello.", {
+      lang: "en-US",
+      voices,
+      profile: { preferredVoiceNames: ["Daniel"] },
+    }) as unknown as FakeUtterance;
+    expect(utterance.voice?.name).toBe("Samantha");
+  });
+
+  test("without profile or setting, uses the automatic language pick", () => {
+    const utterance = createSpeechUtterance("Hello.", {
+      lang: "en-US",
+      voices,
+    }) as unknown as FakeUtterance;
+    expect(utterance.voice?.name).toBe("Samantha");
+    expect(utterance.pitch).toBe(1);
+    expect(utterance.rate).toBe(1);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

- Makes `src/utils/browserSpeech.ts` the single home for Web Speech (browser TTS) voice selection and utterance configuration via a new `createSpeechUtterance` factory: sets language, resolves the voice, and applies persona pitch/rate in one place, reading the user's preferred voice (Control Panels → Sound) from the audio settings store itself.
- All four web-speech call sites now go through the unified factory instead of hand-rolling `SpeechSynthesisUtterance` + store reads: desktop assistant (`assistantSpeech.ts`), Calculator speech (`calculatorSpeech.ts`), Books read-aloud (`useBooksSpeech.ts`), and Books Ask Ryo replies (`BooksReaderPane.tsx`).
- Voice resolution priority (each step language-gated): user-selected voice → caller's voice profile (preferred names, in order) → automatic quality-ranked pick.
- The automatic per-language pick is now quality-ranked instead of "first match": macOS novelty/Eloquence voices (Zarvox, Bells, Grandma, Eddy, …) rank last, while platform staples rank first — Edge "(Natural)" neural voices, "Microsoft …" system voices (David/Zira/Mark), well-known Apple voices (Samantha, Daniel, Karen, Kyoko, …), then Chrome's "Google …" network voices.
- New `assistantVoices.ts` gives each assistant character a default browser-TTS voice profile — preferred voice names spanning macOS/Chrome/Windows/Edge plus persona pitch/rate (e.g. Merlin: deep UK male, pitch 0.8; Links: bright female, pitch 1.4; Saeko: Kyoko/Nanami when speaking Japanese; Monkey King: Ting-Ting/Google 普通话 when speaking Chinese). Pitch/rate keep the persona even when no preferred voice exists on the device; a user-selected voice always wins.

### Testing

- ✅ `bun run test:unit` (2225 pass, 0 fail across 290 files)
- ✅ New suite `tests/test-browser-speech-voices.test.ts` (quality ranking, name preferences, resolution priority, `createSpeechUtterance`)
- ✅ Extended `tests/test-assistant-speech.test.ts` (character profile voice/pitch/rate, language gating, user override)
- ✅ `bun run test:registration`
- ✅ `bun run build`
- ⚠️ `bun run lint` (178 problems / 5 errors — identical to base branch, all pre-existing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2f35-d160-777b-bdc0-50e622e26a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2f35-d160-777b-bdc0-50e622e26a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

