### PR TITLE
Fix assistant bubble misplacement during thinking on left/right sides

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -2608,7 +2608,7 @@ export const BooksReaderPane = forwardRef<
           }}
         >
           <motion.div
-            role="toolbar"
+            role={barOpen ? "toolbar" : "button"}
             aria-label={
               askRyoActive
                 ? t("apps.books.selection.askRyo")
@@ -2620,7 +2620,7 @@ export const BooksReaderPane = forwardRef<
                       defaultValue: "Read-aloud controls",
                     })
             }
-            aria-expanded={barOpen}
+            aria-expanded={barOpen ? undefined : false}
             className={cn(
               "books-speech-overlay flex items-center justify-center overflow-hidden",
               // The reply bubble squares off; the control pill (including the

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -1337,9 +1337,10 @@ function AssistantOverlayInner() {
   // measured bubble size; the tail counter-shifts by the same amount so it
   // keeps pointing at the character.
   const bubbleCrossOffset = useMemo(() => {
-    // Side pops stay edge-aligned with the character while a reply is in flight;
-    // cross-axis sliding uses estimated heights and detaches the thinking bubble.
-    if (!bubbleVertical && isLoading) {
+    // Side pops stay edge-aligned with the character for the whole turn
+    // (thinking → streaming → finished reply). Recomputing cross-offset when
+    // isLoading flips false uses the tall final height and jumps the bubble.
+    if (!bubbleVertical && (isLoading || showTyping || Boolean(bubbleText))) {
       return 0;
     }
     const insets = computeInsets();
@@ -1368,6 +1369,8 @@ function AssistantOverlayInner() {
     bubblePlacement.align,
     bubbleVertical,
     isLoading,
+    showTyping,
+    bubbleText,
     position,
     character.width,
     character.height,

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -60,6 +60,7 @@ import {
   resolveAssistantBubblePlacement,
   resolveAssistantBubbleRenderHeight,
   readAssistantBubbleViewport,
+  clampAssistantAnchorToVisibleBand,
   type AssistantBubbleRect,
   type AssistantBubbleViewport,
 } from "./assistantBubblePlacement";
@@ -1248,6 +1249,18 @@ function AssistantOverlayInner() {
   // Pick the side of the character (above/below/left/right) where the bubble
   // stays inside the viewport and covers the least amount of open windows, so
   // a character docked next to a window pops its bubble away from the window.
+  const renderPosition = useMemo(
+    () =>
+      clampAssistantAnchorToVisibleBand({
+        position,
+        characterSize: {
+          width: character.width,
+          height: character.height,
+        },
+        viewport: bubbleViewport,
+      }),
+    [position, character.width, character.height, bubbleViewport]
+  );
   const windowInstances = useAppStore((state) => state.instances);
   const bubblePlacement = useMemo(() => {
     // Prefer the rendered window frames: on mobile the store keeps numeric
@@ -1285,8 +1298,8 @@ function AssistantOverlayInner() {
     }
     return resolveAssistantBubblePlacement({
       anchor: {
-        x: position.x,
-        y: position.y,
+        x: renderPosition.x,
+        y: renderPosition.y,
         width: character.width,
         height: character.height,
       },
@@ -1299,7 +1312,7 @@ function AssistantOverlayInner() {
     });
   }, [
     windowInstances,
-    position,
+    renderPosition,
     character.width,
     character.height,
     bubbleViewport,
@@ -1347,8 +1360,8 @@ function AssistantOverlayInner() {
       side: bubbleSide,
       align: bubblePlacement.align,
       anchor: {
-        x: position.x,
-        y: position.y,
+        x: renderPosition.x,
+        y: renderPosition.y,
         width: character.width,
         height: character.height,
       },
@@ -1361,7 +1374,7 @@ function AssistantOverlayInner() {
   }, [
     bubbleSide,
     bubblePlacement.align,
-    position,
+    renderPosition,
     character.width,
     character.height,
     bubbleRenderHeight,
@@ -1474,7 +1487,10 @@ function AssistantOverlayInner() {
     <motion.div
       ref={overlayRef}
       initial={false}
-      animate={{ x: position.x, y: position.y }}
+      animate={{
+        x: isDragging ? position.x : renderPosition.x,
+        y: isDragging ? position.y : renderPosition.y,
+      }}
       transition={
         isDragging || reduceMotion ? { duration: 0 } : SNAP_SPRING
       }

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -237,6 +237,15 @@ function clampToViewport(
   };
 }
 
+/** Layout viewport size; prefers visualViewport for mobile keyboard changes. */
+function readAssistantViewportSize(): { width: number; height: number } {
+  const viewport = window.visualViewport;
+  return {
+    width: Math.round(viewport?.width ?? window.innerWidth),
+    height: Math.round(viewport?.height ?? window.innerHeight),
+  };
+}
+
 export function AssistantOverlay() {
   const enabled = useAssistantStore((state) => state.enabled);
   if (!enabled) return null;
@@ -351,6 +360,7 @@ function AssistantOverlayInner() {
         )
       : defaultPosition();
   });
+  const [viewportSize, setViewportSize] = useState(readAssistantViewportSize);
   const [isDragging, setIsDragging] = useState(false);
 
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -460,17 +470,27 @@ function AssistantOverlayInner() {
     setStoredPosition,
   ]);
 
-  // Keep the assistant on-screen when the viewport or character size changes.
+  // Keep the assistant on-screen and refresh bubble placement when the
+  // viewport changes (mobile soft-keyboard open/close only updates
+  // visualViewport, not always window.innerHeight).
   useEffect(() => {
-    const clamp = () => {
+    const syncViewport = () => {
+      setViewportSize(readAssistantViewportSize());
       const insets = computeInsets();
       setPosition((prev) =>
         clampToViewport(prev, character.width, character.height, insets.topInset)
       );
     };
-    clamp();
-    window.addEventListener("resize", clamp);
-    return () => window.removeEventListener("resize", clamp);
+    syncViewport();
+    window.addEventListener("resize", syncViewport);
+    const visualViewport = window.visualViewport;
+    visualViewport?.addEventListener("resize", syncViewport);
+    visualViewport?.addEventListener("scroll", syncViewport);
+    return () => {
+      window.removeEventListener("resize", syncViewport);
+      visualViewport?.removeEventListener("resize", syncViewport);
+      visualViewport?.removeEventListener("scroll", syncViewport);
+    };
   }, [computeInsets, character.width, character.height]);
 
   const dragStateRef = useRef<{
@@ -1282,8 +1302,8 @@ function AssistantOverlayInner() {
         height: ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
       },
       viewport: {
-        width: window.innerWidth,
-        height: window.innerHeight,
+        width: viewportSize.width,
+        height: viewportSize.height,
         topInset: insets.topInset,
         bottomInset: insets.bottomInset,
       },
@@ -1295,6 +1315,8 @@ function AssistantOverlayInner() {
     character.width,
     character.height,
     computeInsets,
+    viewportSize.width,
+    viewportSize.height,
   ]);
   const bubbleSide = bubblePlacement.side;
   const bubbleAlignEnd = bubblePlacement.align === "end";
@@ -1325,7 +1347,7 @@ function AssistantOverlayInner() {
     const observer = new ResizeObserver(measure);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [bubbleOpen, isDragging, bubbleContentMeasureKey]);
+  }, [bubbleOpen, isDragging, bubbleContentMeasureKey, viewportSize.height]);
   const bubbleRenderHeight = resolveAssistantBubbleRenderHeight({
     measuredHeight: bubbleMeasuredHeight,
     isThinking: showTyping,
@@ -1350,8 +1372,8 @@ function AssistantOverlayInner() {
         height: bubbleRenderHeight,
       },
       viewport: {
-        width: window.innerWidth,
-        height: window.innerHeight,
+        width: viewportSize.width,
+        height: viewportSize.height,
         topInset: insets.topInset,
         bottomInset: insets.bottomInset,
       },
@@ -1364,6 +1386,8 @@ function AssistantOverlayInner() {
     character.height,
     bubbleRenderHeight,
     computeInsets,
+    viewportSize.width,
+    viewportSize.height,
   ]);
   const bubblePositionStyle = bubbleVertical
     ? bubbleAlignEnd

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -58,6 +58,7 @@ import {
   ASSISTANT_BUBBLE_WIDTH,
   resolveAssistantBubbleCrossOffset,
   resolveAssistantBubblePlacement,
+  resolveAssistantBubbleRenderHeight,
   type AssistantBubbleRect,
 } from "./assistantBubblePlacement";
 import { useAssistantBubbleAutoClose } from "./useAssistantBubbleAutoClose";
@@ -271,6 +272,14 @@ function AssistantOverlayInner() {
     greetIfStale,
     clearConversation,
   } = chatHandle;
+
+  const bubbleText = errorText ?? latestAssistantText;
+  const showTyping = isAwaitingReply && !errorText;
+  const bubbleContentMeasureKey = showTyping
+    ? `thinking:${statusLabels.join("\0")}`
+    : errorText
+      ? `error:${errorText}`
+      : `reply:${bubbleText.length}:${isLoading}`;
 
   // Speak finished replies aloud (browser TTS) when Speech is enabled.
   useAssistantSpeech({ latestAssistantText, isLoading });
@@ -1316,9 +1325,11 @@ function AssistantOverlayInner() {
     const observer = new ResizeObserver(measure);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [bubbleOpen, isDragging]);
-  const bubbleRenderHeight =
-    bubbleMeasuredHeight ?? ASSISTANT_BUBBLE_ESTIMATED_HEIGHT;
+  }, [bubbleOpen, isDragging, bubbleContentMeasureKey]);
+  const bubbleRenderHeight = resolveAssistantBubbleRenderHeight({
+    measuredHeight: bubbleMeasuredHeight,
+    isThinking: showTyping,
+  });
 
   // Cross-axis slide keeping the bubble on screen, recomputed from the
   // measured bubble size; the tail counter-shifts by the same amount so it
@@ -1407,9 +1418,6 @@ function AssistantOverlayInner() {
     },
     [input, isLoading, sendUserMessage]
   );
-
-  const bubbleText = errorText ?? latestAssistantText;
-  const showTyping = isAwaitingReply && !errorText;
 
   const characterVisual = useMemo(() => {
     if (!agentData) {

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -59,10 +59,7 @@ import {
   resolveAssistantBubbleCrossOffset,
   resolveAssistantBubblePlacement,
   resolveAssistantBubbleRenderHeight,
-  readAssistantBubbleViewport,
-  clampAssistantAnchorToVisibleBand,
   type AssistantBubbleRect,
-  type AssistantBubbleViewport,
 } from "./assistantBubblePlacement";
 import { useAssistantBubbleAutoClose } from "./useAssistantBubbleAutoClose";
 import {
@@ -354,9 +351,6 @@ function AssistantOverlayInner() {
         )
       : defaultPosition();
   });
-  const [bubbleViewport, setBubbleViewport] = useState<AssistantBubbleViewport>(
-    () => readAssistantBubbleViewport({ topInset: 0, bottomInset: 0 })
-  );
   const [isDragging, setIsDragging] = useState(false);
 
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -466,26 +460,19 @@ function AssistantOverlayInner() {
     setStoredPosition,
   ]);
 
-  // Keep the assistant on-screen and refresh bubble placement when the
-  // layout or visual viewport changes (soft keyboard shifts offsetTop/height).
+  // Keep the assistant on-screen when the viewport or character size changes.
+  // Do not track visualViewport or shrink the layout on iOS keyboard open —
+  // that lifts the character and input out of the visible band.
   useEffect(() => {
-    const syncViewport = () => {
-      setBubbleViewport(readAssistantBubbleViewport(computeInsets()));
+    const clamp = () => {
       const insets = computeInsets();
       setPosition((prev) =>
         clampToViewport(prev, character.width, character.height, insets.topInset)
       );
     };
-    syncViewport();
-    window.addEventListener("resize", syncViewport);
-    const visualViewport = window.visualViewport;
-    visualViewport?.addEventListener("resize", syncViewport);
-    visualViewport?.addEventListener("scroll", syncViewport);
-    return () => {
-      window.removeEventListener("resize", syncViewport);
-      visualViewport?.removeEventListener("resize", syncViewport);
-      visualViewport?.removeEventListener("scroll", syncViewport);
-    };
+    clamp();
+    window.addEventListener("resize", clamp);
+    return () => window.removeEventListener("resize", clamp);
   }, [computeInsets, character.width, character.height]);
 
   const dragStateRef = useRef<{
@@ -1249,20 +1236,9 @@ function AssistantOverlayInner() {
   // Pick the side of the character (above/below/left/right) where the bubble
   // stays inside the viewport and covers the least amount of open windows, so
   // a character docked next to a window pops its bubble away from the window.
-  const renderPosition = useMemo(
-    () =>
-      clampAssistantAnchorToVisibleBand({
-        position,
-        characterSize: {
-          width: character.width,
-          height: character.height,
-        },
-        viewport: bubbleViewport,
-      }),
-    [position, character.width, character.height, bubbleViewport]
-  );
   const windowInstances = useAppStore((state) => state.instances);
   const bubblePlacement = useMemo(() => {
+    const insets = computeInsets();
     // Prefer the rendered window frames: on mobile the store keeps numeric
     // sizes while windows actually render full-width, so store rects can
     // misreport what the bubble would cover.
@@ -1298,8 +1274,8 @@ function AssistantOverlayInner() {
     }
     return resolveAssistantBubblePlacement({
       anchor: {
-        x: renderPosition.x,
-        y: renderPosition.y,
+        x: position.x,
+        y: position.y,
         width: character.width,
         height: character.height,
       },
@@ -1307,15 +1283,20 @@ function AssistantOverlayInner() {
         width: ASSISTANT_BUBBLE_WIDTH,
         height: ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
       },
-      viewport: bubbleViewport,
+      viewport: {
+        width: window.innerWidth,
+        height: window.innerHeight,
+        topInset: insets.topInset,
+        bottomInset: insets.bottomInset,
+      },
       obstacles,
     });
   }, [
     windowInstances,
-    renderPosition,
+    position,
     character.width,
     character.height,
-    bubbleViewport,
+    computeInsets,
   ]);
   const bubbleSide = bubblePlacement.side;
   const bubbleAlignEnd = bubblePlacement.align === "end";
@@ -1346,7 +1327,7 @@ function AssistantOverlayInner() {
     const observer = new ResizeObserver(measure);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [bubbleOpen, isDragging, bubbleContentMeasureKey, bubbleViewport]);
+  }, [bubbleOpen, isDragging, bubbleContentMeasureKey]);
   const bubbleRenderHeight = resolveAssistantBubbleRenderHeight({
     measuredHeight: bubbleMeasuredHeight,
     isThinking: showTyping,
@@ -1356,12 +1337,18 @@ function AssistantOverlayInner() {
   // measured bubble size; the tail counter-shifts by the same amount so it
   // keeps pointing at the character.
   const bubbleCrossOffset = useMemo(() => {
+    // Side pops stay edge-aligned with the character while a reply is in flight;
+    // cross-axis sliding uses estimated heights and detaches the thinking bubble.
+    if (!bubbleVertical && isLoading) {
+      return 0;
+    }
+    const insets = computeInsets();
     return resolveAssistantBubbleCrossOffset({
       side: bubbleSide,
       align: bubblePlacement.align,
       anchor: {
-        x: renderPosition.x,
-        y: renderPosition.y,
+        x: position.x,
+        y: position.y,
         width: character.width,
         height: character.height,
       },
@@ -1369,16 +1356,23 @@ function AssistantOverlayInner() {
         width: ASSISTANT_BUBBLE_WIDTH,
         height: bubbleRenderHeight,
       },
-      viewport: bubbleViewport,
+      viewport: {
+        width: window.innerWidth,
+        height: window.innerHeight,
+        topInset: insets.topInset,
+        bottomInset: insets.bottomInset,
+      },
     });
   }, [
     bubbleSide,
     bubblePlacement.align,
-    renderPosition,
+    bubbleVertical,
+    isLoading,
+    position,
     character.width,
     character.height,
     bubbleRenderHeight,
-    bubbleViewport,
+    computeInsets,
   ]);
   const bubblePositionStyle = bubbleVertical
     ? bubbleAlignEnd
@@ -1487,10 +1481,7 @@ function AssistantOverlayInner() {
     <motion.div
       ref={overlayRef}
       initial={false}
-      animate={{
-        x: isDragging ? position.x : renderPosition.x,
-        y: isDragging ? position.y : renderPosition.y,
-      }}
+      animate={{ x: position.x, y: position.y }}
       transition={
         isDragging || reduceMotion ? { duration: 0 } : SNAP_SPRING
       }

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -59,7 +59,9 @@ import {
   resolveAssistantBubbleCrossOffset,
   resolveAssistantBubblePlacement,
   resolveAssistantBubbleRenderHeight,
+  readAssistantBubbleViewport,
   type AssistantBubbleRect,
+  type AssistantBubbleViewport,
 } from "./assistantBubblePlacement";
 import { useAssistantBubbleAutoClose } from "./useAssistantBubbleAutoClose";
 import {
@@ -237,15 +239,6 @@ function clampToViewport(
   };
 }
 
-/** Layout viewport size; prefers visualViewport for mobile keyboard changes. */
-function readAssistantViewportSize(): { width: number; height: number } {
-  const viewport = window.visualViewport;
-  return {
-    width: Math.round(viewport?.width ?? window.innerWidth),
-    height: Math.round(viewport?.height ?? window.innerHeight),
-  };
-}
-
 export function AssistantOverlay() {
   const enabled = useAssistantStore((state) => state.enabled);
   if (!enabled) return null;
@@ -360,7 +353,9 @@ function AssistantOverlayInner() {
         )
       : defaultPosition();
   });
-  const [viewportSize, setViewportSize] = useState(readAssistantViewportSize);
+  const [bubbleViewport, setBubbleViewport] = useState<AssistantBubbleViewport>(
+    () => readAssistantBubbleViewport({ topInset: 0, bottomInset: 0 })
+  );
   const [isDragging, setIsDragging] = useState(false);
 
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -471,11 +466,10 @@ function AssistantOverlayInner() {
   ]);
 
   // Keep the assistant on-screen and refresh bubble placement when the
-  // viewport changes (mobile soft-keyboard open/close only updates
-  // visualViewport, not always window.innerHeight).
+  // layout or visual viewport changes (soft keyboard shifts offsetTop/height).
   useEffect(() => {
     const syncViewport = () => {
-      setViewportSize(readAssistantViewportSize());
+      setBubbleViewport(readAssistantBubbleViewport(computeInsets()));
       const insets = computeInsets();
       setPosition((prev) =>
         clampToViewport(prev, character.width, character.height, insets.topInset)
@@ -1256,7 +1250,6 @@ function AssistantOverlayInner() {
   // a character docked next to a window pops its bubble away from the window.
   const windowInstances = useAppStore((state) => state.instances);
   const bubblePlacement = useMemo(() => {
-    const insets = computeInsets();
     // Prefer the rendered window frames: on mobile the store keeps numeric
     // sizes while windows actually render full-width, so store rects can
     // misreport what the bubble would cover.
@@ -1301,12 +1294,7 @@ function AssistantOverlayInner() {
         width: ASSISTANT_BUBBLE_WIDTH,
         height: ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
       },
-      viewport: {
-        width: viewportSize.width,
-        height: viewportSize.height,
-        topInset: insets.topInset,
-        bottomInset: insets.bottomInset,
-      },
+      viewport: bubbleViewport,
       obstacles,
     });
   }, [
@@ -1314,9 +1302,7 @@ function AssistantOverlayInner() {
     position,
     character.width,
     character.height,
-    computeInsets,
-    viewportSize.width,
-    viewportSize.height,
+    bubbleViewport,
   ]);
   const bubbleSide = bubblePlacement.side;
   const bubbleAlignEnd = bubblePlacement.align === "end";
@@ -1347,7 +1333,7 @@ function AssistantOverlayInner() {
     const observer = new ResizeObserver(measure);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [bubbleOpen, isDragging, bubbleContentMeasureKey, viewportSize.height]);
+  }, [bubbleOpen, isDragging, bubbleContentMeasureKey, bubbleViewport]);
   const bubbleRenderHeight = resolveAssistantBubbleRenderHeight({
     measuredHeight: bubbleMeasuredHeight,
     isThinking: showTyping,
@@ -1357,7 +1343,6 @@ function AssistantOverlayInner() {
   // measured bubble size; the tail counter-shifts by the same amount so it
   // keeps pointing at the character.
   const bubbleCrossOffset = useMemo(() => {
-    const insets = computeInsets();
     return resolveAssistantBubbleCrossOffset({
       side: bubbleSide,
       align: bubblePlacement.align,
@@ -1371,12 +1356,7 @@ function AssistantOverlayInner() {
         width: ASSISTANT_BUBBLE_WIDTH,
         height: bubbleRenderHeight,
       },
-      viewport: {
-        width: viewportSize.width,
-        height: viewportSize.height,
-        topInset: insets.topInset,
-        bottomInset: insets.bottomInset,
-      },
+      viewport: bubbleViewport,
     });
   }, [
     bubbleSide,
@@ -1385,9 +1365,7 @@ function AssistantOverlayInner() {
     character.width,
     character.height,
     bubbleRenderHeight,
-    computeInsets,
-    viewportSize.width,
-    viewportSize.height,
+    bubbleViewport,
   ]);
   const bubblePositionStyle = bubbleVertical
     ? bubbleAlignEnd

--- a/src/components/assistant/assistantBubblePlacement.ts
+++ b/src/components/assistant/assistantBubblePlacement.ts
@@ -18,10 +18,59 @@ export interface AssistantBubbleRect {
 }
 
 export interface AssistantBubbleViewport {
+  /** Layout viewport width (`window.innerWidth`). */
   width: number;
+  /** Layout viewport height (`window.innerHeight`). */
   height: number;
   topInset: number;
   bottomInset: number;
+  /**
+   * Layout Y of the visible viewport top (`visualViewport.offsetTop`). When
+   * omitted, 0. Required for correct side-pop sliding while the soft keyboard
+   * is up — anchor positions use layout coordinates, so using only
+   * `visualViewport.height` as the layout bottom over-slides the bubble.
+   */
+  visibleTop?: number;
+  /** Layout Y of the visible viewport bottom (`offsetTop + height`). */
+  visibleBottom?: number;
+}
+
+/** Build a viewport snapshot for bubble placement from layout + visualViewport. */
+export function readAssistantBubbleViewport(insets: {
+  topInset: number;
+  bottomInset: number;
+}): AssistantBubbleViewport {
+  const visual = window.visualViewport;
+  const height = window.innerHeight;
+  const width = window.innerWidth;
+  return {
+    width,
+    height,
+    topInset: insets.topInset,
+    bottomInset: insets.bottomInset,
+    visibleTop: visual ? Math.round(visual.offsetTop) : 0,
+    visibleBottom: visual
+      ? Math.round(visual.offsetTop + visual.height)
+      : height,
+  };
+}
+
+/** Preferred clearance (px) between the bubble and the viewport edges. */
+const BUBBLE_VIEWPORT_MARGIN = 8;
+
+function getVerticalSlideBounds(
+  viewport: AssistantBubbleViewport,
+  bubbleHeight: number
+): { minY: number; maxY: number } {
+  const bandTop = viewport.visibleTop ?? 0;
+  const bandBottom = viewport.visibleBottom ?? viewport.height;
+  const minY = Math.max(bandTop, viewport.topInset + BUBBLE_VIEWPORT_MARGIN);
+  const maxY =
+    Math.min(bandBottom, viewport.height) -
+    viewport.bottomInset -
+    bubbleHeight -
+    BUBBLE_VIEWPORT_MARGIN;
+  return { minY, maxY: Math.max(minY, maxY) };
 }
 
 export type AssistantBubbleSide = "above" | "below" | "left" | "right";
@@ -87,9 +136,6 @@ export function resolveAssistantBubbleRenderHeight({
 
 /** Covering a window is bad; pushing the bubble offscreen is worse. */
 const OVERFLOW_WEIGHT = 4;
-
-/** Preferred clearance (px) between the bubble and the viewport edges. */
-const BUBBLE_VIEWPORT_MARGIN = 8;
 
 interface ResolveAssistantBubblePlacementOptions {
   /** Character rect (viewport coordinates). */
@@ -191,16 +237,8 @@ export function resolveAssistantBubbleCrossOffset({
     align === "start"
       ? anchor.y
       : anchor.y + anchor.height - bubbleSize.height;
-  return (
-    clampAxis(
-      naturalY,
-      viewport.topInset + BUBBLE_VIEWPORT_MARGIN,
-      viewport.height -
-        viewport.bottomInset -
-        bubbleSize.height -
-        BUBBLE_VIEWPORT_MARGIN
-    ) - naturalY
-  );
+  const { minY, maxY } = getVerticalSlideBounds(viewport, bubbleSize.height);
+  return clampAxis(naturalY, minY, maxY) - naturalY;
 }
 
 export function resolveAssistantBubblePlacement({

--- a/src/components/assistant/assistantBubblePlacement.ts
+++ b/src/components/assistant/assistantBubblePlacement.ts
@@ -18,41 +18,10 @@ export interface AssistantBubbleRect {
 }
 
 export interface AssistantBubbleViewport {
-  /** Layout viewport width (`window.innerWidth`). */
   width: number;
-  /** Layout viewport height (`window.innerHeight`). */
   height: number;
   topInset: number;
   bottomInset: number;
-  /**
-   * Layout Y of the visible viewport top (`visualViewport.offsetTop`). When
-   * omitted, 0. Required for correct side-pop sliding while the soft keyboard
-   * is up — anchor positions use layout coordinates, so using only
-   * `visualViewport.height` as the layout bottom over-slides the bubble.
-   */
-  visibleTop?: number;
-  /** Layout Y of the visible viewport bottom (`offsetTop + height`). */
-  visibleBottom?: number;
-}
-
-/** Build a viewport snapshot for bubble placement from layout + visualViewport. */
-export function readAssistantBubbleViewport(insets: {
-  topInset: number;
-  bottomInset: number;
-}): AssistantBubbleViewport {
-  const visual = window.visualViewport;
-  const height = window.innerHeight;
-  const width = window.innerWidth;
-  return {
-    width,
-    height,
-    topInset: insets.topInset,
-    bottomInset: insets.bottomInset,
-    visibleTop: visual ? Math.round(visual.offsetTop) : 0,
-    visibleBottom: visual
-      ? Math.round(visual.offsetTop + visual.height)
-      : height,
-  };
 }
 
 /** Preferred clearance (px) between the bubble and the viewport edges. */
@@ -232,41 +201,6 @@ export function resolveAssistantBubbleCrossOffset({
         BUBBLE_VIEWPORT_MARGIN
     ) - naturalY
   );
-}
-
-interface ClampAssistantAnchorToVisibleBandOptions {
-  position: { x: number; y: number };
-  characterSize: { width: number; height: number };
-  viewport: AssistantBubbleViewport;
-}
-
-/**
- * Lift/shift the assistant anchor into the visible layout band while the soft
- * keyboard is up. Stored drag position stays in layout coordinates; this is
- * the render-time position fed to the overlay and bubble anchor math.
- */
-export function clampAssistantAnchorToVisibleBand({
-  position,
-  characterSize,
-  viewport,
-}: ClampAssistantAnchorToVisibleBandOptions): { x: number; y: number } {
-  const visibleTop = viewport.visibleTop ?? 0;
-  const visibleBottom = viewport.visibleBottom ?? viewport.height;
-  const keyboardCompressed = visibleBottom < viewport.height - 48;
-  const bottomInset = keyboardCompressed
-    ? BUBBLE_VIEWPORT_MARGIN
-    : viewport.bottomInset;
-  const minY = visibleTop + viewport.topInset + BUBBLE_VIEWPORT_MARGIN;
-  const maxY =
-    visibleBottom - bottomInset - characterSize.height - BUBBLE_VIEWPORT_MARGIN;
-  const minX = BUBBLE_VIEWPORT_MARGIN;
-  const maxX =
-    viewport.width - characterSize.width - BUBBLE_VIEWPORT_MARGIN;
-
-  return {
-    x: clampAxis(position.x, minX, Math.max(minX, maxX)),
-    y: clampAxis(position.y, minY, Math.max(minY, maxY)),
-  };
 }
 
 export function resolveAssistantBubblePlacement({

--- a/src/components/assistant/assistantBubblePlacement.ts
+++ b/src/components/assistant/assistantBubblePlacement.ts
@@ -50,7 +50,40 @@ export interface AssistantBubblePlacement {
 
 export const ASSISTANT_BUBBLE_WIDTH = 256;
 export const ASSISTANT_BUBBLE_ESTIMATED_HEIGHT = 208;
+/** Compact thinking/sending bubble (ticker + input) before streamed text arrives. */
+export const ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT = 104;
 export const ASSISTANT_BUBBLE_GAP = 8;
+
+interface ResolveAssistantBubbleRenderHeightOptions {
+  measuredHeight: number | null;
+  /** True while the bubble shows the thinking ticker instead of reply text. */
+  isThinking: boolean;
+}
+
+/**
+ * Height used for on-screen cross-axis sliding. Falls back to a compact
+ * thinking estimate while awaiting a reply so a stale measurement from the
+ * previous long reply does not detach a short thinking bubble on left/right
+ * sides; otherwise uses the streaming worst-case estimate.
+ */
+export function resolveAssistantBubbleRenderHeight({
+  measuredHeight,
+  isThinking,
+}: ResolveAssistantBubbleRenderHeightOptions): number {
+  const fallback = isThinking
+    ? ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT
+    : ASSISTANT_BUBBLE_ESTIMATED_HEIGHT;
+  if (measuredHeight === null) return fallback;
+  // ResizeObserver updates one frame after the ticker replaces a long reply;
+  // ignore the prior reply's tall measurement while thinking.
+  if (
+    isThinking &&
+    measuredHeight > ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT + 16
+  ) {
+    return ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT;
+  }
+  return measuredHeight;
+}
 
 /** Covering a window is bad; pushing the bubble offscreen is worse. */
 const OVERFLOW_WEIGHT = 4;

--- a/src/components/assistant/assistantBubblePlacement.ts
+++ b/src/components/assistant/assistantBubblePlacement.ts
@@ -58,21 +58,6 @@ export function readAssistantBubbleViewport(insets: {
 /** Preferred clearance (px) between the bubble and the viewport edges. */
 const BUBBLE_VIEWPORT_MARGIN = 8;
 
-function getVerticalSlideBounds(
-  viewport: AssistantBubbleViewport,
-  bubbleHeight: number
-): { minY: number; maxY: number } {
-  const bandTop = viewport.visibleTop ?? 0;
-  const bandBottom = viewport.visibleBottom ?? viewport.height;
-  const minY = Math.max(bandTop, viewport.topInset + BUBBLE_VIEWPORT_MARGIN);
-  const maxY =
-    Math.min(bandBottom, viewport.height) -
-    viewport.bottomInset -
-    bubbleHeight -
-    BUBBLE_VIEWPORT_MARGIN;
-  return { minY, maxY: Math.max(minY, maxY) };
-}
-
 export type AssistantBubbleSide = "above" | "below" | "left" | "right";
 
 /**
@@ -237,8 +222,51 @@ export function resolveAssistantBubbleCrossOffset({
     align === "start"
       ? anchor.y
       : anchor.y + anchor.height - bubbleSize.height;
-  const { minY, maxY } = getVerticalSlideBounds(viewport, bubbleSize.height);
-  return clampAxis(naturalY, minY, maxY) - naturalY;
+  return (
+    clampAxis(
+      naturalY,
+      viewport.topInset + BUBBLE_VIEWPORT_MARGIN,
+      viewport.height -
+        viewport.bottomInset -
+        bubbleSize.height -
+        BUBBLE_VIEWPORT_MARGIN
+    ) - naturalY
+  );
+}
+
+interface ClampAssistantAnchorToVisibleBandOptions {
+  position: { x: number; y: number };
+  characterSize: { width: number; height: number };
+  viewport: AssistantBubbleViewport;
+}
+
+/**
+ * Lift/shift the assistant anchor into the visible layout band while the soft
+ * keyboard is up. Stored drag position stays in layout coordinates; this is
+ * the render-time position fed to the overlay and bubble anchor math.
+ */
+export function clampAssistantAnchorToVisibleBand({
+  position,
+  characterSize,
+  viewport,
+}: ClampAssistantAnchorToVisibleBandOptions): { x: number; y: number } {
+  const visibleTop = viewport.visibleTop ?? 0;
+  const visibleBottom = viewport.visibleBottom ?? viewport.height;
+  const keyboardCompressed = visibleBottom < viewport.height - 48;
+  const bottomInset = keyboardCompressed
+    ? BUBBLE_VIEWPORT_MARGIN
+    : viewport.bottomInset;
+  const minY = visibleTop + viewport.topInset + BUBBLE_VIEWPORT_MARGIN;
+  const maxY =
+    visibleBottom - bottomInset - characterSize.height - BUBBLE_VIEWPORT_MARGIN;
+  const minX = BUBBLE_VIEWPORT_MARGIN;
+  const maxX =
+    viewport.width - characterSize.width - BUBBLE_VIEWPORT_MARGIN;
+
+  return {
+    x: clampAxis(position.x, minX, Math.max(minX, maxX)),
+    y: clampAxis(position.y, minY, Math.max(minY, maxY)),
+  };
 }
 
 export function resolveAssistantBubblePlacement({

--- a/src/components/dialogs/BootScreen.tsx
+++ b/src/components/dialogs/BootScreen.tsx
@@ -75,8 +75,6 @@ export function BootScreen({
 
   useEffect(() => {
     let progressInterval: number | undefined;
-    let bootTimer: number | undefined;
-    let soundTimer: number | undefined;
     let completeTimer: number | undefined;
 
     if (!isOpen) {
@@ -89,7 +87,7 @@ export function BootScreen({
       return undefined;
     }
 
-    soundTimer = window.setTimeout(() => {
+    const soundTimer = window.setTimeout(() => {
       play();
     }, 100);
 
@@ -97,7 +95,7 @@ export function BootScreen({
       dispatch({ type: "increment", amount: Math.random() * 10 });
     }, 100);
 
-    bootTimer = window.setTimeout(() => {
+    const bootTimer = window.setTimeout(() => {
       window.clearInterval(progressInterval);
       progressInterval = undefined;
       dispatch({ type: "setProgress", value: 100 });

--- a/src/hooks/useChatSynth.ts
+++ b/src/hooks/useChatSynth.ts
@@ -393,7 +393,6 @@ export function useChatSynth() {
         // This catch might be less necessary with the active voice check, but kept for safety
         log.debug("Skipping note due to timing or error", error);
       }
-    } else {
     }
   }, [isAudioReady, vibrate, initializeAudio, currentPresetKey]); // Add initializeAudio dependency
 

--- a/tests/test-assistant-bubble-placement.test.ts
+++ b/tests/test-assistant-bubble-placement.test.ts
@@ -310,5 +310,8 @@ describe("assistant bubble render height", () => {
     });
     expect(estimateOffset).toBeGreaterThan(0);
     expect(thinkingOffset).toBe(0);
+    // A tall finished reply would also slide (estimateOffset); the overlay
+    // keeps side-pop cross-offset at 0 for the whole turn so it does not jump
+    // when isLoading flips false after streaming.
   });
 });

--- a/tests/test-assistant-bubble-placement.test.ts
+++ b/tests/test-assistant-bubble-placement.test.ts
@@ -312,43 +312,45 @@ describe("assistant bubble render height", () => {
     expect(thinkingOffset).toBe(0);
   });
 
-  test("side pop cross offset relaxes when the viewport grows after keyboard dismiss", () => {
-    // Regression: with the soft keyboard up the visual viewport is short, so a
-    // left/right bubble slides far up to stay on screen. After dismiss the
-    // placement math must rerun with the taller viewport or the bubble stays
-    // detached from the character.
+  test("visible viewport band keeps a bottom character anchored with keyboard up", () => {
+    // Regression: treating visualViewport.height as the layout bottom while the
+    // character stays in layout coordinates slides the bubble far above the
+    // visible area (even before the keyboard dismisses).
     const anchor = { x: 305, y: 600, width: 80, height: 80 };
     const bubbleSize = {
       width: ASSISTANT_BUBBLE_WIDTH,
       height: ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT,
     };
-    const keyboardUp = {
+    const layoutViewport = {
       width: 393,
+      height: 844,
+      topInset: 26,
+      bottomInset: 104,
+    };
+    const buggyKeyboardViewport = {
+      ...layoutViewport,
       height: 500,
-      topInset: 26,
-      bottomInset: 104,
     };
-    const keyboardDown = {
-      width: 393,
-      height: 852,
-      topInset: 26,
-      bottomInset: 104,
+    const keyboardUpViewport = {
+      ...layoutViewport,
+      visibleTop: 340,
+      visibleBottom: 840,
     };
-    const whileKeyboardUp = resolveAssistantBubbleCrossOffset({
+    const buggyOffset = resolveAssistantBubbleCrossOffset({
       side: "left",
       align: "end",
       anchor,
       bubbleSize,
-      viewport: keyboardUp,
+      viewport: buggyKeyboardViewport,
     });
-    const afterKeyboardDown = resolveAssistantBubbleCrossOffset({
+    const anchoredOffset = resolveAssistantBubbleCrossOffset({
       side: "left",
       align: "end",
       anchor,
       bubbleSize,
-      viewport: keyboardDown,
+      viewport: keyboardUpViewport,
     });
-    expect(whileKeyboardUp).toBeLessThan(afterKeyboardDown);
-    expect(afterKeyboardDown).toBeGreaterThan(-40);
+    expect(buggyOffset).toBeLessThan(-200);
+    expect(anchoredOffset).toBe(0);
   });
 });

--- a/tests/test-assistant-bubble-placement.test.ts
+++ b/tests/test-assistant-bubble-placement.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
+  ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT,
   ASSISTANT_BUBBLE_WIDTH,
   resolveAssistantBubbleCrossOffset,
   resolveAssistantBubblePlacement,
+  resolveAssistantBubbleRenderHeight,
   type AssistantBubbleRect,
 } from "../src/components/assistant/assistantBubblePlacement";
 
@@ -249,5 +251,64 @@ describe("assistant bubble cross offset", () => {
       viewport,
     });
     expect(offset).toBe(placement.crossOffset);
+  });
+});
+
+describe("assistant bubble render height", () => {
+  test("thinking state ignores a stale tall measurement from the prior reply", () => {
+    expect(
+      resolveAssistantBubbleRenderHeight({
+        measuredHeight: ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
+        isThinking: true,
+      })
+    ).toBe(ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT);
+  });
+
+  test("thinking state falls back to the compact estimate when unmeasured", () => {
+    expect(
+      resolveAssistantBubbleRenderHeight({
+        measuredHeight: null,
+        isThinking: true,
+      })
+    ).toBe(ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT);
+  });
+
+  test("streaming keeps the measured height once text is visible", () => {
+    expect(
+      resolveAssistantBubbleRenderHeight({
+        measuredHeight: 160,
+        isThinking: false,
+      })
+    ).toBe(160);
+  });
+
+  test("thinking cross offset stays anchored with the compact height", () => {
+    const viewport = { width: 393, height: 852, topInset: 26, bottomInset: 104 };
+    const anchor = { x: 305, y: 60, width: 80, height: 80 };
+    const estimateOffset = resolveAssistantBubbleCrossOffset({
+      side: "left",
+      align: "end",
+      anchor,
+      bubbleSize: {
+        width: ASSISTANT_BUBBLE_WIDTH,
+        height: ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
+      },
+      viewport,
+    });
+    const thinkingOffset = resolveAssistantBubbleCrossOffset({
+      side: "left",
+      align: "end",
+      anchor,
+      bubbleSize: {
+        width: ASSISTANT_BUBBLE_WIDTH,
+        height: resolveAssistantBubbleRenderHeight({
+          measuredHeight: ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
+          isThinking: true,
+        }),
+      },
+      viewport,
+    });
+    expect(estimateOffset).toBeGreaterThan(0);
+    expect(thinkingOffset).toBe(0);
   });
 });

--- a/tests/test-assistant-bubble-placement.test.ts
+++ b/tests/test-assistant-bubble-placement.test.ts
@@ -3,7 +3,6 @@ import {
   ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
   ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT,
   ASSISTANT_BUBBLE_WIDTH,
-  clampAssistantAnchorToVisibleBand,
   resolveAssistantBubbleCrossOffset,
   resolveAssistantBubblePlacement,
   resolveAssistantBubbleRenderHeight,
@@ -311,51 +310,5 @@ describe("assistant bubble render height", () => {
     });
     expect(estimateOffset).toBeGreaterThan(0);
     expect(thinkingOffset).toBe(0);
-  });
-
-  test("lifts a bottom anchor into the visible band while the keyboard is up", () => {
-    const layoutViewport = {
-      width: 393,
-      height: 844,
-      topInset: 26,
-      bottomInset: 104,
-      visibleTop: 0,
-      visibleBottom: 400,
-    };
-    const lifted = clampAssistantAnchorToVisibleBand({
-      position: { x: 305, y: 600 },
-      characterSize: { width: 80, height: 80 },
-      viewport: layoutViewport,
-    });
-    expect(lifted.y).toBe(400 - 8 - 80 - 8);
-    expect(lifted.x).toBe(305);
-  });
-
-  test("thinking bubble stays anchored after the anchor is lifted", () => {
-    const layoutViewport = {
-      width: 393,
-      height: 844,
-      topInset: 26,
-      bottomInset: 104,
-      visibleTop: 0,
-      visibleBottom: 400,
-    };
-    const anchorY = clampAssistantAnchorToVisibleBand({
-      position: { x: 305, y: 600 },
-      characterSize: { width: 80, height: 80 },
-      viewport: layoutViewport,
-    }).y;
-    const anchor = { x: 305, y: anchorY, width: 80, height: 80 };
-    const offset = resolveAssistantBubbleCrossOffset({
-      side: "left",
-      align: "end",
-      anchor,
-      bubbleSize: {
-        width: ASSISTANT_BUBBLE_WIDTH,
-        height: ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT,
-      },
-      viewport: layoutViewport,
-    });
-    expect(offset).toBe(0);
   });
 });

--- a/tests/test-assistant-bubble-placement.test.ts
+++ b/tests/test-assistant-bubble-placement.test.ts
@@ -311,4 +311,44 @@ describe("assistant bubble render height", () => {
     expect(estimateOffset).toBeGreaterThan(0);
     expect(thinkingOffset).toBe(0);
   });
+
+  test("side pop cross offset relaxes when the viewport grows after keyboard dismiss", () => {
+    // Regression: with the soft keyboard up the visual viewport is short, so a
+    // left/right bubble slides far up to stay on screen. After dismiss the
+    // placement math must rerun with the taller viewport or the bubble stays
+    // detached from the character.
+    const anchor = { x: 305, y: 600, width: 80, height: 80 };
+    const bubbleSize = {
+      width: ASSISTANT_BUBBLE_WIDTH,
+      height: ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT,
+    };
+    const keyboardUp = {
+      width: 393,
+      height: 500,
+      topInset: 26,
+      bottomInset: 104,
+    };
+    const keyboardDown = {
+      width: 393,
+      height: 852,
+      topInset: 26,
+      bottomInset: 104,
+    };
+    const whileKeyboardUp = resolveAssistantBubbleCrossOffset({
+      side: "left",
+      align: "end",
+      anchor,
+      bubbleSize,
+      viewport: keyboardUp,
+    });
+    const afterKeyboardDown = resolveAssistantBubbleCrossOffset({
+      side: "left",
+      align: "end",
+      anchor,
+      bubbleSize,
+      viewport: keyboardDown,
+    });
+    expect(whileKeyboardUp).toBeLessThan(afterKeyboardDown);
+    expect(afterKeyboardDown).toBeGreaterThan(-40);
+  });
 });

--- a/tests/test-assistant-bubble-placement.test.ts
+++ b/tests/test-assistant-bubble-placement.test.ts
@@ -3,6 +3,7 @@ import {
   ASSISTANT_BUBBLE_ESTIMATED_HEIGHT,
   ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT,
   ASSISTANT_BUBBLE_WIDTH,
+  clampAssistantAnchorToVisibleBand,
   resolveAssistantBubbleCrossOffset,
   resolveAssistantBubblePlacement,
   resolveAssistantBubbleRenderHeight,
@@ -312,45 +313,49 @@ describe("assistant bubble render height", () => {
     expect(thinkingOffset).toBe(0);
   });
 
-  test("visible viewport band keeps a bottom character anchored with keyboard up", () => {
-    // Regression: treating visualViewport.height as the layout bottom while the
-    // character stays in layout coordinates slides the bubble far above the
-    // visible area (even before the keyboard dismisses).
-    const anchor = { x: 305, y: 600, width: 80, height: 80 };
-    const bubbleSize = {
-      width: ASSISTANT_BUBBLE_WIDTH,
-      height: ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT,
-    };
+  test("lifts a bottom anchor into the visible band while the keyboard is up", () => {
     const layoutViewport = {
       width: 393,
       height: 844,
       topInset: 26,
       bottomInset: 104,
+      visibleTop: 0,
+      visibleBottom: 400,
     };
-    const buggyKeyboardViewport = {
-      ...layoutViewport,
-      height: 500,
+    const lifted = clampAssistantAnchorToVisibleBand({
+      position: { x: 305, y: 600 },
+      characterSize: { width: 80, height: 80 },
+      viewport: layoutViewport,
+    });
+    expect(lifted.y).toBe(400 - 8 - 80 - 8);
+    expect(lifted.x).toBe(305);
+  });
+
+  test("thinking bubble stays anchored after the anchor is lifted", () => {
+    const layoutViewport = {
+      width: 393,
+      height: 844,
+      topInset: 26,
+      bottomInset: 104,
+      visibleTop: 0,
+      visibleBottom: 400,
     };
-    const keyboardUpViewport = {
-      ...layoutViewport,
-      visibleTop: 340,
-      visibleBottom: 840,
-    };
-    const buggyOffset = resolveAssistantBubbleCrossOffset({
+    const anchorY = clampAssistantAnchorToVisibleBand({
+      position: { x: 305, y: 600 },
+      characterSize: { width: 80, height: 80 },
+      viewport: layoutViewport,
+    }).y;
+    const anchor = { x: 305, y: anchorY, width: 80, height: 80 };
+    const offset = resolveAssistantBubbleCrossOffset({
       side: "left",
       align: "end",
       anchor,
-      bubbleSize,
-      viewport: buggyKeyboardViewport,
+      bubbleSize: {
+        width: ASSISTANT_BUBBLE_WIDTH,
+        height: ASSISTANT_BUBBLE_THINKING_ESTIMATED_HEIGHT,
+      },
+      viewport: layoutViewport,
     });
-    const anchoredOffset = resolveAssistantBubbleCrossOffset({
-      side: "left",
-      align: "end",
-      anchor,
-      bubbleSize,
-      viewport: keyboardUpViewport,
-    });
-    expect(buggyOffset).toBeLessThan(-200);
-    expect(anchoredOffset).toBe(0);
+    expect(offset).toBe(0);
   });
 });

--- a/tests/test-assistant-bubble-shimmer.test.ts
+++ b/tests/test-assistant-bubble-shimmer.test.ts
@@ -34,4 +34,12 @@ describe("assistant bubble loading shimmer", () => {
     expect(toolInvocationDefaultSource).toContain("leading-snug");
     expect(toolInvocationDefaultSource).not.toContain("py-0.5");
   });
+
+  test("side pops skip cross-axis slide while a reply is in flight", () => {
+    expect(assistantOverlaySource).toContain("!bubbleVertical && isLoading");
+    expect(assistantOverlaySource).not.toContain(
+      "clampAssistantAnchorToVisibleBand"
+    );
+    expect(assistantOverlaySource).not.toContain("visualViewport?.addEventListener");
+  });
 });

--- a/tests/test-assistant-bubble-shimmer.test.ts
+++ b/tests/test-assistant-bubble-shimmer.test.ts
@@ -36,7 +36,9 @@ describe("assistant bubble loading shimmer", () => {
   });
 
   test("side pops skip cross-axis slide while a reply is in flight", () => {
-    expect(assistantOverlaySource).toContain("!bubbleVertical && isLoading");
+    expect(assistantOverlaySource).toContain(
+      "!bubbleVertical && (isLoading || showTyping || Boolean(bubbleText))"
+    );
     expect(assistantOverlaySource).not.toContain(
       "clampAssistantAnchorToVisibleBand"
     );

--- a/tests/test-assistant-character-names.test.ts
+++ b/tests/test-assistant-character-names.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { ASSISTANT_CHARACTERS } from "../src/components/assistant/characters";
-import en from "../src/lib/locales/en/translation.json";
 
 const LOCALES = [
   "en",
@@ -38,7 +37,7 @@ describe("assistant character name localization", () => {
   });
 
   test("English catalog names match the canonical character names", () => {
-    const names = (en as Record<string, any>).common.assistant.characters;
+    const names = getCharacterNames("en") as Record<string, string>;
     for (const character of ASSISTANT_CHARACTERS) {
       expect(names[character.id]).toBe(character.name);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes left/right assistant bubble detaching from the character during thinking/sending and again when streaming finishes.

## Root cause

Side-pop cross-axis sliding uses bubble height. Two failure modes:

1. **Thinking** — stale tall `bubbleMeasuredHeight` from the previous reply slid the short thinking bubble away.
2. **Stream complete** — cross-offset was locked to `0` only while `isLoading`; when streaming ended, the lock released and the tall final height re-applied slide, jumping the bubble off the character.

## Fix

- **`resolveAssistantBubbleRenderHeight()`** — compact thinking fallback; ignores stale tall measurements while `isThinking`
- **Content-transition remeasure** — `bubbleContentMeasureKey` drives remeasure on thinking ↔ reply ↔ error transitions
- **Side-pop anchor pin for the whole turn** — `!bubbleVertical && (isLoading || showTyping || Boolean(bubbleText))` keeps cross-offset at `0` through thinking, streaming, and the finished reply

## iOS

Removed earlier `visualViewport` / anchor-lift / `interactive-widget=resizes-content` experiments that jumped the character when the keyboard opened.

## Testing

- `bun test tests/test-assistant-bubble-placement.test.ts` — 17/17 pass
- `bun test tests/test-assistant-bubble-shimmer.test.ts` — 4/4 pass
- `bun run typecheck` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d4dab30-dac1-415c-8730-d8854fc98ba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d4dab30-dac1-415c-8730-d8854fc98ba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

