### PR TITLE
Remove duplicate debug loggers and legacy dead code

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -105,7 +105,7 @@ import type {
   BooksLibraryEntry,
   BookOriginRect,
 } from "../hooks/useBooksLogic";
-import { createClientLogger } from "@/utils/logger";
+import { createClientLogger, summarizeForLog } from "@/utils/logger";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { getApiUrl } from "@/utils/platform";
 import { Sounds, useSound } from "@/hooks/useSound";
@@ -427,69 +427,6 @@ function flattenBookChapters(
   });
 }
 
-function serializeDebugValue(
-  value: unknown,
-  seen = new WeakSet<object>()
-): unknown {
-  if (value instanceof Error) {
-    if (seen.has(value)) return "[Circular]";
-    seen.add(value);
-    const cause = "cause" in value ? value.cause : undefined;
-    return {
-      kind: "Error",
-      name: value.name,
-      message: value.message,
-      stack: value.stack,
-      cause: cause === undefined ? undefined : serializeDebugValue(cause, seen),
-    };
-  }
-  if (typeof DOMException !== "undefined" && value instanceof DOMException) {
-    if (seen.has(value)) return "[Circular]";
-    seen.add(value);
-    return {
-      kind: "DOMException",
-      name: value.name,
-      message: value.message,
-      code: value.code,
-      stack: value.stack,
-    };
-  }
-  if (value instanceof Blob) {
-    return {
-      kind: "Blob",
-      size: value.size,
-      type: value.type,
-      constructorName: value.constructor?.name,
-    };
-  }
-  if (value instanceof ArrayBuffer) {
-    return {
-      kind: "ArrayBuffer",
-      byteLength: value.byteLength,
-    };
-  }
-  if (ArrayBuffer.isView(value)) {
-    return {
-      kind: value.constructor?.name,
-      byteLength: value.byteLength,
-      length: "length" in value ? value.length : undefined,
-    };
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => serializeDebugValue(item, seen));
-  }
-  if (value && typeof value === "object") {
-    if (seen.has(value)) return "[Circular]";
-    seen.add(value);
-    const result: Record<string, unknown> = {};
-    for (const [key, nested] of Object.entries(value)) {
-      result[key] = serializeDebugValue(nested, seen);
-    }
-    return result;
-  }
-  return value;
-}
-
 function getBooksDebugEnvironment() {
   if (typeof window === "undefined") return {};
   return {
@@ -659,7 +596,7 @@ export const BooksReaderPane = forwardRef<
   const appendDebugEvent = useCallback(
     (step: string, data?: unknown, level: BooksDebugLevel = "info") => {
       if (!displayDebugModeRef.current) return;
-      const debugData = serializeDebugValue(data);
+      const debugData = summarizeForLog(data);
       if (level === "error") {
         booksLog.error(step, debugData);
       } else if (level === "warn") {

--- a/src/apps/chats/components/chats-app/useChatsAppController.tsx
+++ b/src/apps/chats/components/chats-app/useChatsAppController.tsx
@@ -28,9 +28,7 @@ import { useTelegramLink } from "@/hooks/useTelegramLink";
 import { useGlobalPresence } from "@/hooks/useGlobalPresence";
 import { useChatsStore } from "@/stores/useChatsStore";
 import { useMenuShortcuts } from "@/hooks/useMenuShortcuts";
-import { createClientLogger } from "@/utils/logger";
-
-const log = createClientLogger("ChatsApp");
+import { chatsAppLog as log } from "../../logging";
 
 export type UseChatsAppControllerArgs = AppProps;
 

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -21,7 +21,7 @@ import { useChatsStoreShallow } from "@/stores/useChatsStore";
 import i18n from "@/lib/i18n";
 import { useTranslation } from "react-i18next";
 import { abortableFetch } from "@/utils/abortableFetch";
-import { createClientLogger } from "@/utils/logger";
+import { aiChatLog as log } from "../logging";
 import { tryInvokeParentStartGrindPlanning } from "@/utils/parentGrindPlanning";
 import { showAiMessageNotification } from "@/utils/chatNotificationDisplay";
 import { shouldShowNativeToastNotification } from "@/utils/nativeToastNotifications";
@@ -32,7 +32,6 @@ import { getSystemState } from "../utils/systemState";
 import { dispatchToolCall } from "../tools/dispatchToolCall";
 import { SERVER_EXECUTED_TOOL_NAME_SET } from "@/shared/tools/serverExecuted";
 
-const log = createClientLogger("AIChat");
 
 // Helper to check if chats app is currently in the foreground
 const isChatsInForeground = (): boolean => {

--- a/src/apps/chats/hooks/useChatRoom.ts
+++ b/src/apps/chats/hooks/useChatRoom.ts
@@ -19,7 +19,7 @@ import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
 import { shouldShowNativeToastNotification } from "@/utils/nativeToastNotifications";
 import { getApiUrl } from "@/utils/platform";
 import { abortableFetch } from "@/utils/abortableFetch";
-import { createClientLogger } from "@/utils/logger";
+import { chatRoomLog as log } from "../logging";
 import { shouldSubscribeToForegroundRoomUpdates } from "@/utils/chatRoomSubscriptions";
 import {
   getChatRoomChannelName,
@@ -56,7 +56,6 @@ interface RoomHandlers {
 }
 
 const EMPTY_MESSAGES: ChatMessage[] = [];
-const log = createClientLogger("ChatRoom");
 
 export function useChatRoom(
   isWindowOpen: boolean,

--- a/src/apps/chats/hooks/useSyncedAiMessages.ts
+++ b/src/apps/chats/hooks/useSyncedAiMessages.ts
@@ -2,9 +2,7 @@ import { useEffect, useRef } from "react";
 import type { UIMessage } from "@ai-sdk/react";
 import type { AIChatMessage } from "@/types/chat";
 import { resolveAiMessageSync } from "../utils/proactiveGreetingApply";
-import { createClientLogger } from "@/utils/logger";
-
-const log = createClientLogger("AIChat");
+import { aiChatLog as log } from "../logging";
 
 interface UseSyncedAiMessagesOptions {
   aiMessages: AIChatMessage[];

--- a/src/apps/chats/logging.ts
+++ b/src/apps/chats/logging.ts
@@ -1,0 +1,6 @@
+import { createClientLogger } from "@/utils/logger";
+
+export const aiChatLog = createClientLogger("AIChat");
+export const chatToolsLog = createClientLogger("ChatTools");
+export const chatRoomLog = createClientLogger("ChatRoom");
+export const chatsAppLog = createClientLogger("ChatsApp");

--- a/src/apps/chats/tools/appHandlers.ts
+++ b/src/apps/chats/tools/appHandlers.ts
@@ -9,9 +9,7 @@ import type { AppId } from "@/config/appIds";
 import type { LaunchAppOptions } from "@/hooks/useLaunchApp";
 import i18n from "@/lib/i18n";
 import type { ToolContext } from "./types";
-import { createClientLogger } from "@/utils/logger";
-
-const log = createClientLogger("ChatTools");
+import { chatToolsLog as log } from "../logging";
 
 export interface LaunchAppInput {
   id: string;

--- a/src/apps/chats/tools/dispatchToolCall.ts
+++ b/src/apps/chats/tools/dispatchToolCall.ts
@@ -31,7 +31,7 @@ import { generateJsonFromHtml } from "@/utils/tiptapHtml";
 import i18n from "@/lib/i18n";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { getApiUrl } from "@/utils/platform";
-import { createClientLogger } from "@/utils/logger";
+import { aiChatLog as log } from "../logging";
 import { emitAppletUpdated, emitDocumentUpdated } from "@/utils/appEventBus";
 import {
   persistChatApplet,
@@ -64,7 +64,6 @@ import {
   type DispatchToolCallResult,
 } from "./toolOpenResult";
 
-const log = createClientLogger("AIChat");
 
 export interface SharedToolCall {
   toolName: string;

--- a/src/apps/chats/tools/mediaHandler.ts
+++ b/src/apps/chats/tools/mediaHandler.ts
@@ -47,10 +47,9 @@ import {
   handleTvChannelAction,
   type TvChannelAction,
 } from "./mediaTvChannels";
-import { createClientLogger } from "@/utils/logger";
+import { chatToolsLog as log } from "../logging";
 import { computeSequentialNavigation } from "@/shared/media/transport";
 
-const log = createClientLogger("ChatTools");
 
 export type MediaControlTarget = "music" | "karaoke" | "videos" | "tv";
 

--- a/src/apps/chats/tools/settingsHandler.ts
+++ b/src/apps/chats/tools/settingsHandler.ts
@@ -13,9 +13,7 @@ import type { OsThemeId } from "@/themes/types";
 import i18n from "@/lib/i18n";
 import { forceRefreshCache } from "@/utils/prefetch";
 import type { ToolContext } from "./types";
-import { createClientLogger } from "@/utils/logger";
-
-const log = createClientLogger("ChatTools");
+import { chatToolsLog as log } from "../logging";
 
 export interface SettingsInput {
   language?: string;

--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerUrlBar.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerUrlBar.tsx
@@ -10,9 +10,7 @@ import { ClockCounterClockwise, MagnifyingGlass } from "@phosphor-icons/react";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { checkOfflineAndShowError } from "@/utils/offline";
 import type { InternetExplorerSuggestionItem } from "./types";
-import { createClientLogger } from "@/utils/logger";
-
-const log = createClientLogger("InternetExplorer");
+import { internetExplorerLog as log } from "../../logging";
 
 export interface InternetExplorerUrlBarProps {
   urlInputRef: RefObject<HTMLInputElement | null>;

--- a/src/apps/internet-explorer/components/time-machine-view/TimeMachineViewPortal.tsx
+++ b/src/apps/internet-explorer/components/time-machine-view/TimeMachineViewPortal.tsx
@@ -14,9 +14,7 @@ import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import TimeNavigationControls from "../TimeNavigationControls";
 import type { ShaderOption } from "./types";
 import type { useTimeMachineView } from "./useTimeMachineView";
-import { createClientLogger } from "@/utils/logger";
-
-const log = createClientLogger("TimeMachine");
+import { timeMachineLog as log } from "../../logging";
 
 export type TimeMachineViewVm = ReturnType<typeof useTimeMachineView>;
 

--- a/src/apps/internet-explorer/components/time-machine-view/useTimeMachineView.ts
+++ b/src/apps/internet-explorer/components/time-machine-view/useTimeMachineView.ts
@@ -17,9 +17,7 @@ import { exitVariants, loadingBarVariants, pulsingAnimationVariants } from "./an
 import { getMaskStyle, getHostname, timeMachineGenerateShareUrl } from "./utils";
 import { initialState, timeMachineUiReducer } from "./time-machine-ui-reducer";
 import type { PreviewSource, TimeMachineViewProps } from "./types";
-import { createClientLogger } from "@/utils/logger";
-
-const log = createClientLogger("TimeMachine");
+import { timeMachineLog as log } from "../../logging";
 
 export function useTimeMachineView({
   isOpen,

--- a/src/apps/internet-explorer/hooks/useAiGeneration.ts
+++ b/src/apps/internet-explorer/hooks/useAiGeneration.ts
@@ -17,9 +17,7 @@ import {
   normalizeUrlForAnalytics,
   track,
 } from "@/utils/analytics";
-import { createClientLogger } from "@/utils/logger";
-
-const log = createClientLogger("InternetExplorer");
+import { internetExplorerLog as log } from "../logging";
 
 interface UseAiGenerationProps {
   onLoadingChange?: (isLoading: boolean) => void;

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -31,7 +31,7 @@ import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
 import { useAppHelpAboutDialogs } from "@/hooks/useAppHelpAboutDialogs";
 import { useInternetExplorerStoreShallow } from "@/stores/useInternetExplorerStore";
 import { abortableFetch } from "@/utils/abortableFetch";
-import { createClientLogger } from "@/utils/logger";
+import { internetExplorerLog as log } from "../logging";
 import { onAppUpdate } from "@/utils/appEventBus";
 import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
 import {
@@ -54,7 +54,6 @@ import {
   getFutureYears,
 } from "../components/ie-menu-bar/yearLists";
 
-const log = createClientLogger("InternetExplorer");
 
 // Debug helper to identify direct passthrough URLs
 const logDirectPassthrough = (url: string) => {

--- a/src/apps/internet-explorer/logging.ts
+++ b/src/apps/internet-explorer/logging.ts
@@ -1,0 +1,4 @@
+import { createClientLogger } from "@/utils/logger";
+
+export const internetExplorerLog = createClientLogger("InternetExplorer");
+export const timeMachineLog = createClientLogger("TimeMachine");

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -21,9 +21,7 @@ import {
   shouldFireEndedForPlaybackState,
   shouldSuppressPlaybackStateFanoutWhileQueueLoading,
 } from "./appleMusicPlayerBridgeUtils";
-import { createClientLogger } from "@/utils/logger";
-
-const appleMusicLog = createClientLogger("AppleMusic");
+import { appleMusicLog } from "../logging";
 
 /**
  * Apple Music playback bridge.

--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -18,9 +18,7 @@ import {
   saveAppleMusicTrackCollection,
   type AppleMusicTrackCollectionKey,
 } from "@/utils/appleMusicLibraryCache";
-import { createClientLogger } from "@/utils/logger";
-
-const appleMusicLog = createClientLogger("AppleMusic");
+import { appleMusicLog } from "../logging";
 
 /**
  * Apple Music library fetcher.

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -96,7 +96,7 @@ import {
 import { getMenuMemoryKey, isNowPlayingSongMenu } from "../utils/menuIdentity";
 import { shouldPlayIpodWheelSound } from "../utils/wheelSound";
 import { shouldEnableAppleMusicIntegration } from "../utils/appleMusicActivation";
-import { createClientLogger } from "@/utils/logger";
+import { ipodLog } from "../logging";
 
 // User-agent sniffing is constant for the document lifetime, so compute once
 // at module load instead of re-running these regexes on every render of the
@@ -107,7 +107,6 @@ const IS_IOS = /iP(hone|od|ad)/.test(UA);
 const IS_SAFARI =
   /Safari/.test(UA) && !/Chrome/.test(UA) && !/CriOS/.test(UA);
 const IS_IOS_SAFARI = IS_IOS && IS_SAFARI;
-const ipodLog = createClientLogger("iPod");
 
 /** Stable fallback so `rebuildMenuItems` never returns a fresh `[]` per call. */
 const EMPTY_IPOD_MENU_ITEMS: MenuItem[] = [];

--- a/src/apps/ipod/hooks/useIpodPlayback.ts
+++ b/src/apps/ipod/hooks/useIpodPlayback.ts
@@ -2,9 +2,7 @@ import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import type ReactPlayer from "react-player";
 import { useIpodStore } from "@/stores/useIpodStore";
 import { useTrackSwitchGuard } from "@/shared/media/useTrackSwitchGuard";
-import { createClientLogger } from "@/utils/logger";
-
-const ipodLog = createClientLogger("iPod");
+import { ipodLog } from "../logging";
 
 type MusicKitLike = {
   currentPlaybackTime?: number;

--- a/src/apps/ipod/logging.ts
+++ b/src/apps/ipod/logging.ts
@@ -1,0 +1,4 @@
+import { createClientLogger } from "@/utils/logger";
+
+export const ipodLog = createClientLogger("iPod");
+export const appleMusicLog = createClientLogger("AppleMusic");

--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -35,9 +35,7 @@ import { useMenuShortcuts } from "@/hooks/useMenuShortcuts";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { getTextAnalytics, TEXTEDIT_ANALYTICS, track } from "@/utils/analytics";
 import { openNativeFile } from "@/utils/nativeFileDialogs";
-import { createClientLogger } from "@/utils/logger";
-
-const log = createClientLogger("TextEdit");
+import { textEditLog as log } from "../logging";
 
 // Debounce window for mirroring the editor content into the persisted store on
 // each keystroke, plus a max wait so continuous typing still snapshots for

--- a/src/apps/textedit/hooks/useFileOperations.ts
+++ b/src/apps/textedit/hooks/useFileOperations.ts
@@ -17,9 +17,7 @@ import {
 } from "../utils/richMarkdown";
 import { TEXTEDIT_ANALYTICS, track } from "@/utils/analytics";
 import { saveBlobToDevice } from "@/utils/nativeFileDialogs";
-import { createClientLogger } from "@/utils/logger";
-
-const log = createClientLogger("TextEdit");
+import { textEditLog as log } from "../logging";
 
 interface UseFileOperationsProps {
   editor: Editor | null;

--- a/src/apps/textedit/logging.ts
+++ b/src/apps/textedit/logging.ts
@@ -1,0 +1,3 @@
+import { createClientLogger } from "@/utils/logger";
+
+export const textEditLog = createClientLogger("TextEdit");

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -84,7 +84,6 @@ import { createClientLogger } from "@/utils/logger";
  * Debug Mode (or sets `localStorage["ryos:debug"] = "1"`).
  */
 const assistantAnimLogger = createClientLogger("AssistantAnim");
-const animLog = (message: string): void => assistantAnimLogger.debug(message);
 
 /** Distance (px) within which the assistant snaps to an edge on release. */
 const SNAP_THRESHOLD = 32;
@@ -694,7 +693,7 @@ function AssistantOverlayInner() {
   const previousCharacterIdRef = useRef(character.id);
   useEffect(() => {
     if (previousCharacterIdRef.current === character.id) return;
-    animLog(
+    assistantAnimLogger.debug(
       `character switch ${previousCharacterIdRef.current} → ${character.id}; reset transient animation state`
     );
     previousCharacterIdRef.current = character.id;
@@ -731,7 +730,7 @@ function AssistantOverlayInner() {
 
   const playAnimation = useCallback((name: string, reason?: string) => {
     if (!name) return;
-    animLog(`play ${name}${reason ? ` — ${reason}` : ""}`);
+    assistantAnimLogger.debug(`play ${name}${reason ? ` — ${reason}` : ""}`);
     if (idleTimerRef.current) {
       clearTimeout(idleTimerRef.current);
       idleTimerRef.current = null;
@@ -774,7 +773,7 @@ function AssistantOverlayInner() {
         direction
       );
       if (!pointingAnimation) {
-        animLog(`pointing ${direction} skipped — no clip for direction`);
+        assistantAnimLogger.debug(`pointing ${direction} skipped — no clip for direction`);
         return;
       }
       playAnimation(pointingAnimation, `pointing ${direction} at window`);
@@ -802,7 +801,7 @@ function AssistantOverlayInner() {
     entranceSequenceRef.current = plan.followUp
       ? [plan.first, plan.followUp]
       : [plan.first];
-    animLog(
+    assistantAnimLogger.debug(
       `entrance ${character.id}: ${plan.first}${
         plan.followUp ? ` → ${plan.followUp}` : ""
       }`
@@ -973,7 +972,7 @@ function AssistantOverlayInner() {
     (endedAnimation: string) => {
       const data = agentDataRef.current;
       if (!data) return;
-      animLog(`ended ${endedAnimation}`);
+      assistantAnimLogger.debug(`ended ${endedAnimation}`);
 
       if (quittingAnimationRef.current) {
         if (endedAnimation === quittingAnimationRef.current) {
@@ -996,7 +995,7 @@ function AssistantOverlayInner() {
           return;
         }
         entranceSequenceRef.current = null;
-        animLog("entrance complete");
+        assistantAnimLogger.debug("entrance complete");
       }
 
       const currentIntent = activityIntentRef.current;

--- a/src/components/assistant/ClippySprite.tsx
+++ b/src/components/assistant/ClippySprite.tsx
@@ -8,8 +8,6 @@ import { createClientLogger } from "@/utils/logger";
  * Mode (or sets `localStorage["ryos:debug"] = "1"`).
  */
 const assistantSpriteLogger = createClientLogger("AssistantSprite");
-const spriteLog = (message: string): void =>
-  assistantSpriteLogger.debug(message);
 
 /**
  * Minimal player for Microsoft Agent animation data (clippy.js format).
@@ -221,7 +219,7 @@ export function ClippySprite({
       soundPlayerRef.current?.stopAll();
       const anim = dataRef.current.animations[name];
       if (!anim || anim.frames.length === 0) {
-        spriteLog(`missing clip "${name}" — falling back to base pose`);
+        assistantSpriteLogger.debug(`missing clip "${name}" — falling back to base pose`);
         setFrameImages([[0, 0]]);
         // Report the clip as ended so the overlay's state machine recovers
         // (otherwise a missing clip freezes the sprite at its base pose until
@@ -230,7 +228,7 @@ export function ClippySprite({
         return;
       }
 
-      spriteLog(
+      assistantSpriteLogger.debug(
         `start ${name} (${anim.frames.length} frames${
           anim.useExitBranching ? ", exit-branching" : ""
         })`
@@ -332,7 +330,7 @@ export function ClippySprite({
           nextIndex >= playback.anim.frames.length - 1
         ) {
           playback.waiting = true;
-          spriteLog(`hold ${playback.name} at exit-branch wait point`);
+          assistantSpriteLogger.debug(`hold ${playback.name} at exit-branch wait point`);
           onEndRef.current?.(playback.name);
           if (playbackRef.current !== playback) return;
           playback.timer = setTimeout(step, WAITING_POLL_MS);
@@ -377,7 +375,7 @@ export function ClippySprite({
       playback.anim.useExitBranching &&
       !(playback.name === animation && !playback.exiting && !playback.waiting)
     ) {
-      spriteLog(
+      assistantSpriteLogger.debug(
         `graceful exit of ${playback.name}, then ${animation} (exit-branch wind-down)`
       );
       playback.pendingName = animation;

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,16 +1,13 @@
 /**
- * Lightweight debug logger that is silent in production by default.
+ * Debug-mode flag helpers for client logging and capture overlays.
  *
- * Many stores/hooks emit `console.log` traces on routine actions (login, room
- * fetch, sync, library migration). These are useful in development but spam
- * the console in production. Route those debug-level traces through `debug()`
- * so they only print when:
+ * Feature code should route traces through `createClientLogger()` in
+ * `src/utils/logger.ts`, which consults `isDebugEnabled()` before emitting
+ * debug/info output. Warnings and errors always print.
  *
+ * Debug mode is enabled when:
  *  - running a dev build (`import.meta.env.DEV`), or
  *  - the user opts in at runtime via `localStorage.setItem("ryos:debug", "1")`.
- *
- * `console.warn` / `console.error` should keep using `console` directly — they
- * surface real problems and are always shown.
  */
 
 export const DEBUG_FLAG_KEY = "ryos:debug";
@@ -79,25 +76,4 @@ export function setRuntimeDebugEnabled(enabled: boolean): void {
 
 export function refreshRuntimeDebugFlag(): void {
   runtimeDebugEnabled = null;
-}
-
-/** Production-silent `console.log`. */
-export function debug(...args: unknown[]): void {
-  if (isDebugEnabled()) console.log(...args);
-}
-
-/**
- * Production-silent logger bound to a `[scope]` prefix.
- *
- * @example
- *   const log = createDebugLogger("ChatsStore");
- *   log("Fetching rooms…");
- */
-export function createDebugLogger(
-  scope: string
-): (...args: unknown[]) => void {
-  const prefix = `[${scope}]`;
-  return (...args: unknown[]): void => {
-    if (isDebugEnabled()) console.log(prefix, ...args);
-  };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleans up client-side logging after the migration to `createClientLogger()`.

- Removed unused legacy helpers from `src/utils/debug.ts` (`debug()` and `createDebugLogger()`), which were superseded by `createClientLogger()` and are guarded by existing tests.
- Added shared app-level logging modules so each scope is instantiated once:
  - `src/apps/chats/logging.ts`
  - `src/apps/internet-explorer/logging.ts`
  - `src/apps/ipod/logging.ts`
  - `src/apps/textedit/logging.ts`
- Replaced the bespoke `serializeDebugValue()` helper in `BooksReaderPane` with the shared `summarizeForLog()` utility.
- Removed thin `animLog` / `spriteLog` wrapper functions in assistant components.

## Testing

- ✅ `bun run test:unit` (2228 pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

