### PR TITLE
Remove dead exports and legacy theme aliases

### DIFF
--- a/src/apps/books/utils/booksSpeech.ts
+++ b/src/apps/books/utils/booksSpeech.ts
@@ -1005,8 +1005,8 @@ export function applyGeometricPageEndCut(chunk: BooksSpeechChunk): void {
 export const BOOKS_SPEECH_ACTIVE_CLASS = "ryos-books-speech-active";
 /** Spoken characters painted at full ink (CSS Custom Highlight API). */
 export const BOOKS_SPEECH_HIGHLIGHT_NAME = "ryos-books-speech-spoken";
-/** @deprecated No longer used (edge fade caused flicker). */
-export const BOOKS_SPEECH_EDGE_HIGHLIGHT_NAME = "ryos-books-speech-edge";
+/** @deprecated No longer used (edge fade caused flicker). Kept for highlight cleanup. */
+const BOOKS_SPEECH_EDGE_HIGHLIGHT_NAME = "ryos-books-speech-edge";
 /** Fallback class when the CSS Highlight API is unavailable. */
 export const BOOKS_SPEECH_HIGHLIGHT_BLOCK_CLASS = "ryos-books-speech-spoken-block";
 

--- a/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
@@ -19,6 +19,9 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
 
   const {
     isWindowsTheme,
+    isMacTheme,
+    isAquaGlass,
+    isDarkMode,
     containerRef,
     sidebarVisibleBool,
     isFrameNarrow,

--- a/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
@@ -18,10 +18,6 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
   const { t } = useTranslation();
 
   const {
-    isWindowsLegacyTheme,
-    isMacTheme,
-    isAquaGlass,
-    isDarkMode,
     isWindowsTheme,
     containerRef,
     sidebarVisibleBool,
@@ -100,7 +96,7 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
     <div
       ref={containerRef}
       className={`relative size-full ${
-        isWindowsLegacyTheme ? "border-t border-[#919b9c]" : ""
+        isWindowsTheme ? "border-t border-[#919b9c]" : ""
       }`}
     >
       <AnimatePresence>
@@ -202,7 +198,7 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
             } ${
               isMacTheme ? "" : "bg-neutral-200/90 backdrop-blur-lg"
             } ${
-              isWindowsLegacyTheme
+              isWindowsTheme
                 ? "border-[#919b9c]"
                 : isMacTheme
                   ? ""

--- a/src/apps/chats/components/chats-app/useChatsAppController.tsx
+++ b/src/apps/chats/components/chats-app/useChatsAppController.tsx
@@ -363,7 +363,6 @@ export function useChatsAppController({
     isAquaGlass,
     isDarkMode,
   } = useThemeFlags();
-  const isWindowsLegacyTheme = isWindowsTheme;
   const isOffline = useOffline();
   const {
     telegramLinkedAccount,
@@ -557,7 +556,6 @@ export function useChatsAppController({
     isMacTheme,
     isAquaGlass,
     isDarkMode,
-    isWindowsLegacyTheme,
     isOffline,
     menuBar,
     currentRoom,

--- a/src/apps/control-panels/hooks/useControlPanelsLogic.ts
+++ b/src/apps/control-panels/hooks/useControlPanelsLogic.ts
@@ -1204,8 +1204,6 @@ export function useControlPanelsLogic({
   };
 
   // Theme flags come from useThemeFlags() above (single source of truth).
-  const isWindowsLegacyTheme = isWindowsTheme;
-
   const tabStyles = getTabStyles(currentTheme);
   const defaultTab = normalizeControlPanelClassicTabId(initialData?.defaultTab);
   const windowTitle = getTranslatedAppName("control-panels");
@@ -1295,7 +1293,6 @@ export function useControlPanelsLogic({
     isWindowsTheme,
     isMacOSTheme,
     isClassicMacTheme,
-    isWindowsLegacyTheme,
     uiSoundsEnabled,
     handleUISoundsChange,
     speechEnabled,

--- a/src/apps/internet-explorer/components/time-machine-view/TimeMachineViewPortal.tsx
+++ b/src/apps/internet-explorer/components/time-machine-view/TimeMachineViewPortal.tsx
@@ -2,7 +2,8 @@ import { AnimatePresence, motion } from "motion/react";
 import { X, Sparkle, Export } from "@phosphor-icons/react";
 import HtmlPreview from "@/components/shared/HtmlPreview";
 import { Button } from "@/components/ui/button";
-import GalaxyBackground, { ShaderType } from "@/components/shared/GalaxyBackground";
+import GalaxyBackground from "@/components/shared/GalaxyBackground";
+import { ShaderType } from "@/types/shader";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/src/apps/internet-explorer/components/time-machine-view/types.ts
+++ b/src/apps/internet-explorer/components/time-machine-view/types.ts
@@ -30,5 +30,4 @@ export type TimeMachineUiAction =
   | { type: "setPreviewError"; value: string | null }
   | { type: "setIsIframeLoaded"; value: boolean };
 
-export type ShaderOption =
-  import("@/components/shared/GalaxyBackground").ShaderType | "off";
+export type ShaderOption = import("@/types/shader").ShaderType | "off";

--- a/src/apps/internet-explorer/components/time-machine-view/useTimeMachineView.ts
+++ b/src/apps/internet-explorer/components/time-machine-view/useTimeMachineView.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useReducer, useRef } from "react";
-import { ShaderType } from "@/components/shared/GalaxyBackground";
+import { ShaderType } from "@/types/shader";
 import { useInternetExplorerStore } from "@/stores/useInternetExplorerStore";
 import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import { useSound, Sounds } from "@/hooks/useSound";

--- a/src/components/shared/GalaxyBackground.tsx
+++ b/src/components/shared/GalaxyBackground.tsx
@@ -3,9 +3,6 @@ import * as THREE from "three";
 import { useShaderEffectsEnabled } from "@/hooks/useShaderEffectsEnabled";
 import { ShaderType } from "@/types/shader";
 
-// Re-export for backwards compatibility
-export { ShaderType };
-
 interface GalaxyBackgroundProps {
   shaderType?: ShaderType;
   /** When true, render regardless of the global shaderEffectEnabled setting */
@@ -22,19 +19,6 @@ const GalaxyBackground: React.FC<GalaxyBackgroundProps> = ({
 
   // Combined state for rendering condition - removed screen size check
   const shouldRender = forceRender || shaderEffectEnabled;
-
-  // Check initial screen width and add resize listener - REMOVED
-  // useEffect(() => {
-  //   const checkScreenWidth = () => {
-  //     // Use a common breakpoint like 768px (Tailwind 'md') or 640px ('sm')
-  //     setIsLargeScreen(window.innerWidth >= 640); // Update screen size state
-  //   };
-  //
-  //   checkScreenWidth(); // Initial check
-  //   window.addEventListener('resize', checkScreenWidth);
-  //
-  //   return () => window.removeEventListener('resize', checkScreenWidth);
-  // }, []);
 
   useEffect(() => {
     if (!shouldRender || !mountRef.current) return;

--- a/src/hooks/useFurigana.tsx
+++ b/src/hooks/useFurigana.tsx
@@ -49,8 +49,6 @@ interface UseFuriganaReturn {
   furiganaMap: Map<string, FuriganaSegment[]>;
   /** Map of startTimeMs -> SoramimiSegment[] (Chinese misheard lyrics) */
   soramimiMap: Map<string, FuriganaSegment[]>;
-  /** Whether currently fetching (furigana OR soramimi) */
-  isFetching: boolean;
   /** Whether currently fetching furigana specifically */
   isFetchingFurigana: boolean;
   /** Whether currently fetching soramimi specifically */
@@ -218,9 +216,6 @@ export function useFurigana({
   const setError = useCallback((value: string | undefined) => {
     dispatch({ type: "patch", payload: { error: value } });
   }, []);
-  
-  // Combined fetching state for backwards compatibility
-  const isFetching = isFetchingFurigana || isFetchingSoramimi;
   const furiganaCacheKeyRef = useRef<string>("");
   const soramimiCacheKeyRef = useRef<string>("");
   // Track current songId for race condition prevention
@@ -833,7 +828,6 @@ export function useFurigana({
   return {
     furiganaMap,
     soramimiMap,
-    isFetching,
     isFetchingFurigana,
     isFetchingSoramimi,
     progress,

--- a/src/utils/tabStyles.ts
+++ b/src/utils/tabStyles.ts
@@ -54,7 +54,3 @@ export function getTabStyles(currentTheme: OsThemeId): TabStyleConfig {
     separatorStyle: { borderColor: separatorColor },
   };
 }
-
-export function getWindowsLegacyTabMenuClasses() {
-  return "h-7! flex justify-start! p-0 -mt-1 -mb-[2px] bg-transparent shadow-none /* Windows XP/98 tab strip */";
-}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Low-risk dead-code cleanup after prior logging migration work.

- Removed unused `getWindowsLegacyTabMenuClasses()` export
- Dropped `isWindowsLegacyTheme` alias (identical to `isWindowsTheme`; also removed unused Control Panels export)
- Made deprecated `BOOKS_SPEECH_EDGE_HIGHLIGHT_NAME` module-private (still used for CSS highlight cleanup)
- Removed unused combined `isFetching` field from `useFurigana` (callers use `isFetchingFurigana` / `isFetchingSoramimi`)
- Pointed Time Machine at `@/types/shader` instead of re-export shim on `GalaxyBackground`
- Deleted commented-out screen-width gate in `GalaxyBackground`

## Testing

- ✅ `bun run test:unit` (2228 pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

