### PR TITLE
Remove HtmlPreview display settings wrapper functions

### DIFF
--- a/src/components/shared/html-preview/HtmlPreview.tsx
+++ b/src/components/shared/html-preview/HtmlPreview.tsx
@@ -2,10 +2,7 @@ import { useState, useRef, useEffect, useCallback, memo } from "react";
 import { motion, AnimatePresence, useDragControls } from "motion/react";
 import { ArrowsIn, Copy, Check, DownloadSimple, Code, Export, DotsSixVertical, Plus } from "@phosphor-icons/react";
 import { createPortal } from "react-dom";
-import {
-  loadHtmlPreviewSplit,
-  saveHtmlPreviewSplit,
-} from "@/stores/useDisplaySettingsStore";
+import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
@@ -48,7 +45,10 @@ function HtmlPreview({
   const [isFullScreen, setIsFullScreen] = useState(initialFullScreen);
   const [copySuccess, setCopySuccess] = useState(false);
   const [showCode, setShowCode] = useState(false);
-  const [isSplitView, setIsSplitView] = useState(loadHtmlPreviewSplit());
+  const isSplitView = useDisplaySettingsStore((state) => state.htmlPreviewSplit);
+  const setHtmlPreviewSplit = useDisplaySettingsStore(
+    (state) => state.setHtmlPreviewSplit
+  );
   const [originalHeight, setOriginalHeight] = useState<string | null>(null);
   const isMobile = useMediaQuery("(max-width: 767px)");
   const [isDragging, setIsDragging] = useState(false);
@@ -117,10 +117,6 @@ function HtmlPreview({
     getProcessedHtmlContent,
     getProcessedHtmlContentForSave
   );
-
-  useEffect(() => {
-    saveHtmlPreviewSplit(isSplitView);
-  }, [isSplitView]);
 
   useEffect(() => {
     if (isFullScreen && previewRef.current && !originalHeight) {
@@ -726,7 +722,7 @@ function HtmlPreview({
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
-                              setIsSplitView(!isSplitView);
+                              setHtmlPreviewSplit(!isSplitView);
                               if (!isSplitView) {
                                 minimizeSound.play();
                               } else {
@@ -748,11 +744,11 @@ function HtmlPreview({
                             e.stopPropagation();
                             if (!showCode) {
                               setShowCode(true);
-                              setIsSplitView(true);
+                              setHtmlPreviewSplit(true);
                               maximizeSound.play();
                             } else {
                               setShowCode(false);
-                              setIsSplitView(false);
+                              setHtmlPreviewSplit(false);
                               minimizeSound.play();
                             }
                           }}

--- a/src/stores/useDisplaySettingsStore.ts
+++ b/src/stores/useDisplaySettingsStore.ts
@@ -427,12 +427,6 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
   )
 );
 
-// Helper functions for backward compatibility
-export const loadHtmlPreviewSplit = () =>
-  useDisplaySettingsStore.getState().htmlPreviewSplit;
-export const saveHtmlPreviewSplit = (v: boolean) =>
-  useDisplaySettingsStore.getState().setHtmlPreviewSplit(v);
-
 /**
  * Shallow-equality selector hook for this store. Co-located with the store
  * (rather than a central helpers barrel) so importing it doesn't pull other


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes backward-compat wrappers around the HTML preview split-view preference.

- `HtmlPreview` now reads/writes `htmlPreviewSplit` on `useDisplaySettingsStore` directly
- Deleted unused `loadHtmlPreviewSplit` / `saveHtmlPreviewSplit` exports

## Testing

- ✅ `bun run test:unit` (2228 pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

