### PR TITLE
Deduplicate debug capture initial flag read

### DIFF
--- a/src/utils/consoleCapture.ts
+++ b/src/utils/consoleCapture.ts
@@ -13,7 +13,7 @@
  * to avoid render storms when something logs in a tight loop.
  */
 
-import { DEBUG_FLAG_KEY } from "./debug";
+import { readStoredDebugFlagEnabled } from "./debug";
 
 export type ConsoleLogLevel = "log" | "info" | "warn" | "error" | "debug";
 
@@ -76,21 +76,10 @@ let buffer: ConsoleLogEntry[] = [];
 let snapshot: ConsoleLogEntry[] = buffer;
 let nextId = 1;
 let installed = false;
-let captureEnabled = readInitialCaptureEnabled();
+let captureEnabled = readStoredDebugFlagEnabled();
 
 const listeners = new Set<() => void>();
 let flushScheduled = false;
-
-function readInitialCaptureEnabled(): boolean {
-  try {
-    return (
-      typeof localStorage !== "undefined" &&
-      localStorage.getItem(DEBUG_FLAG_KEY) === "1"
-    );
-  } catch {
-    return false;
-  }
-}
 
 function scheduleFlush(): void {
   if (flushScheduled) return;

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -81,6 +81,18 @@ export function refreshRuntimeDebugFlag(): void {
   runtimeDebugEnabled = null;
 }
 
+/** Whether debug mode was explicitly persisted via localStorage (ignores dev default). */
+export function readStoredDebugFlagEnabled(): boolean {
+  try {
+    return (
+      typeof localStorage !== "undefined" &&
+      localStorage.getItem(DEBUG_FLAG_KEY) === "1"
+    );
+  } catch {
+    return false;
+  }
+}
+
 /** Production-silent `console.log`. */
 export function debug(...args: unknown[]): void {
   if (isDebugEnabled()) console.log(...args);

--- a/src/utils/networkCapture.ts
+++ b/src/utils/networkCapture.ts
@@ -16,7 +16,7 @@
  * storms during bursts of requests.
  */
 
-import { DEBUG_FLAG_KEY } from "./debug";
+import { readStoredDebugFlagEnabled } from "./debug";
 
 export type NetworkRequestOutcome = "success" | "error" | "pending";
 
@@ -41,21 +41,10 @@ let buffer: NetworkRequestEntry[] = [];
 let snapshot: NetworkRequestEntry[] = buffer;
 let nextId = 1;
 let installed = false;
-let captureEnabled = readInitialCaptureEnabled();
+let captureEnabled = readStoredDebugFlagEnabled();
 
 const listeners = new Set<() => void>();
 let flushScheduled = false;
-
-function readInitialCaptureEnabled(): boolean {
-  try {
-    return (
-      typeof localStorage !== "undefined" &&
-      localStorage.getItem(DEBUG_FLAG_KEY) === "1"
-    );
-  } catch {
-    return false;
-  }
-}
 
 function scheduleFlush(): void {
   if (flushScheduled) return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deduplicates the identical localStorage bootstrap check used by debug overlay capture modules.

- Added `readStoredDebugFlagEnabled()` to `src/utils/debug.ts`
- `consoleCapture` and `networkCapture` now share that helper instead of private duplicates

Behavior is unchanged: capture starts enabled only when `localStorage["ryos:debug"] === "1"` (before Control Panels rehydrates runtime flags).

## Testing

- ✅ `bun run test:unit` (2228 pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

