### PR TITLE
Unify duration formatting behind formatSeconds

### DIFF
--- a/src/utils/formatDuration.ts
+++ b/src/utils/formatDuration.ts
@@ -1,15 +1,31 @@
+export interface FormatSecondsOptions {
+  /** When true, zero-pad the minutes segment (`01:05`). Default false (`1:05`). */
+  padMinutes?: boolean;
+}
+
+/**
+ * Format a duration in seconds as `m:ss` or `MM:SS`.
+ * Fractional seconds are floored; negative values clamp to zero.
+ */
+export function formatSeconds(
+  totalSeconds: number,
+  options: FormatSecondsOptions = {}
+): string {
+  const safeSeconds = Math.max(0, Math.floor(totalSeconds));
+  const minutes = Math.floor(safeSeconds / 60);
+  const seconds = safeSeconds % 60;
+  const minuteText = options.padMinutes
+    ? String(minutes).padStart(2, "0")
+    : String(minutes);
+  return `${minuteText}:${String(seconds).padStart(2, "0")}`;
+}
+
 /**
  * Format a duration in seconds as zero-padded `MM:SS` (e.g. `04:05`).
  * Fractional seconds are floored; negative values clamp to `00:00`.
  */
 export function formatSecondsMmSs(totalSeconds: number): string {
-  const safeSeconds = Math.max(0, Math.floor(totalSeconds));
-  const minutes = Math.floor(safeSeconds / 60);
-  const seconds = safeSeconds % 60;
-  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(
-    2,
-    "0"
-  )}`;
+  return formatSeconds(totalSeconds, { padMinutes: true });
 }
 
 /**

--- a/src/utils/timeFormat.ts
+++ b/src/utils/timeFormat.ts
@@ -1,7 +1,6 @@
+import { formatSeconds } from "./formatDuration";
+
+/** Unpadded minutes playback label (e.g. `1:05`, `60:00`). */
 export function formatSecondsAsMinutesSeconds(totalSeconds: number): string {
-  const safeSeconds = Math.max(0, Math.floor(totalSeconds));
-  return `${Math.floor(safeSeconds / 60)}:${String(safeSeconds % 60).padStart(
-    2,
-    "0"
-  )}`;
+  return formatSeconds(totalSeconds);
 }

--- a/tests/test-time-format.test.ts
+++ b/tests/test-time-format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { formatSecondsAsMinutesSeconds } from "../src/utils/timeFormat";
+import { formatSeconds, formatSecondsMmSs } from "../src/utils/formatDuration";
 
 describe("formatSecondsAsMinutesSeconds", () => {
   test("formats whole and fractional seconds as m:ss", () => {
@@ -11,5 +12,13 @@ describe("formatSecondsAsMinutesSeconds", () => {
 
   test("clamps negative values to zero", () => {
     expect(formatSecondsAsMinutesSeconds(-5)).toBe("0:00");
+  });
+});
+
+describe("formatSeconds", () => {
+  test("supports padded and unpadded minute segments", () => {
+    expect(formatSeconds(65)).toBe("1:05");
+    expect(formatSeconds(65, { padMinutes: true })).toBe("01:05");
+    expect(formatSecondsMmSs(65)).toBe("01:05");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unifies playback duration formatting without changing existing UI output.

- Added `formatSeconds(totalSeconds, { padMinutes })` in `formatDuration.ts`
- `formatSecondsMmSs` and `formatSecondsAsMinutesSeconds` delegate to it
- Extended `test-time-format.test.ts` with padded/unpadded cases

## Testing

- ✅ `bun test tests/test-time-format.test.ts` (3 pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

