### PR TITLE
Extract shared log summarizer for client and API

### DIFF
--- a/api/_utils/_logging.ts
+++ b/api/_utils/_logging.ts
@@ -5,6 +5,8 @@
  * Node.js runtime - All logs go directly to terminal
  */
 
+import { summarizeForStructuredLog } from "../../src/shared/logSummarize.js";
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -41,13 +43,7 @@ const C = {
 // ============================================================================
 
 const COMPACT_JSON = true;
-const REDACTED = "[redacted]";
-const MAX_STRING_LENGTH = 240;
-const MAX_STACK_LENGTH = 4000;
-const MAX_ARRAY_ITEMS = 8;
-const MAX_DEPTH = 3;
-const SENSITIVE_KEY_RE =
-  /(password|token|secret|authorization|cookie|message|prompt|content|html|markdown|base64|blob|dataurl|transcript|body|text|lyrics|deviceid|useragent)$/i;
+const API_LOG_OPTIONS = { maxStringLength: 240 } as const;
 
 // ============================================================================
 // Helper Functions
@@ -61,97 +57,13 @@ function getTimestamp(): string {
   return `${C.dim}${now.toTimeString().slice(0, 8)}${C.reset}`;
 }
 
-function truncateString(value: string, maxLength = MAX_STRING_LENGTH): string {
-  if (value.length <= maxLength) return value;
-  return `${value.slice(0, maxLength)}... (truncated, length=${value.length})`;
-}
-
-function isSerializedErrorRecord(record: Record<string, unknown>): boolean {
-  if (record.kind === "Error" || record.kind === "DOMException") {
-    return true;
-  }
-  return (
-    typeof record.name === "string" &&
-    typeof record.message === "string" &&
-    typeof record.stack === "string"
-  );
-}
-
-function shouldRedactKey(
-  key: string,
-  record: Record<string, unknown>
-): boolean {
-  if (!SENSITIVE_KEY_RE.test(key)) return false;
-  if (isSerializedErrorRecord(record) && key === "message") return false;
-  return true;
-}
-
 export function summarizeForApiLog(
   value: unknown,
   depth = 0,
   seen = new WeakSet<object>(),
   key?: string
 ): unknown {
-  if (value === null || value === undefined) return value;
-
-  if (typeof value === "string") {
-    return truncateString(value, key === "stack" ? MAX_STACK_LENGTH : MAX_STRING_LENGTH);
-  }
-  if (typeof value === "number" || typeof value === "boolean") return value;
-  if (typeof value === "bigint") return `${value}n`;
-  if (typeof value === "function") return `[Function ${value.name || "anonymous"}]`;
-
-  if (value instanceof Error) {
-    if (seen.has(value)) return "[Circular]";
-    seen.add(value);
-    return {
-      kind: "Error",
-      name: value.name,
-      message: truncateString(value.message),
-      stack: value.stack ? truncateString(value.stack, MAX_STACK_LENGTH) : undefined,
-      cause:
-        "cause" in value && value.cause !== undefined
-          ? summarizeForApiLog(value.cause, depth + 1, seen, "cause")
-          : undefined,
-    };
-  }
-
-  if (value instanceof ArrayBuffer) {
-    return `ArrayBuffer(byteLength=${value.byteLength})`;
-  }
-
-  if (ArrayBuffer.isView(value)) {
-    return `${value.constructor.name}(byteLength=${value.byteLength})`;
-  }
-
-  if (typeof value !== "object") return String(value);
-  if (seen.has(value)) return "[Circular]";
-  seen.add(value);
-
-  if (depth >= MAX_DEPTH) {
-    return Array.isArray(value)
-      ? `array(length=${value.length})`
-      : `object(keys=${Object.keys(value as Record<string, unknown>).join(",") || "none"})`;
-  }
-
-  if (Array.isArray(value)) {
-    const items = value
-      .slice(0, MAX_ARRAY_ITEMS)
-      .map((item) => summarizeForApiLog(item, depth + 1, seen));
-    if (value.length > MAX_ARRAY_ITEMS) {
-      items.push(`... (${value.length - MAX_ARRAY_ITEMS} more)`);
-    }
-    return items;
-  }
-
-  const record = value as Record<string, unknown>;
-  const safe: Record<string, unknown> = {};
-  for (const [recordKey, item] of Object.entries(record)) {
-    safe[recordKey] = shouldRedactKey(recordKey, record)
-      ? REDACTED
-      : summarizeForApiLog(item, depth + 1, seen, recordKey);
-  }
-  return safe;
+  return summarizeForStructuredLog(value, depth, seen, key, API_LOG_OPTIONS);
 }
 
 export function isApiDebugLoggingEnabled(): boolean {

--- a/src/shared/logSummarize.ts
+++ b/src/shared/logSummarize.ts
@@ -1,0 +1,212 @@
+const REDACTED = "[redacted]";
+const DEFAULT_MAX_STRING_LENGTH = 160;
+const DEFAULT_MAX_STACK_LENGTH = 4000;
+const MAX_ARRAY_ITEMS = 8;
+const MAX_DEPTH = 3;
+
+const SENSITIVE_KEY_RE =
+  /(password|token|secret|authorization|cookie|message|prompt|content|html|markdown|base64|blob|dataurl|transcript|body|text|lyrics|deviceid|useragent)$/i;
+
+export interface LogSummarizeOptions {
+  maxStringLength?: number;
+  maxStackLength?: number;
+  /** Serialize DOM/Blob browser types (client logger). */
+  includeBrowserTypes?: boolean;
+  /** Include non-standard Error own-properties under `props`. */
+  includeErrorProps?: boolean;
+}
+
+function truncateString(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}... (truncated, length=${value.length})`;
+}
+
+function isSerializedErrorRecord(record: Record<string, unknown>): boolean {
+  if (
+    record.kind === "Error" ||
+    record.kind === "DOMException" ||
+    record.kind === "ErrorEvent" ||
+    record.kind === "PromiseRejectionEvent"
+  ) {
+    return true;
+  }
+  return (
+    typeof record.name === "string" &&
+    typeof record.message === "string" &&
+    typeof record.stack === "string"
+  );
+}
+
+function shouldRedactKey(
+  key: string,
+  record: Record<string, unknown>
+): boolean {
+  if (!SENSITIVE_KEY_RE.test(key)) return false;
+  if (isSerializedErrorRecord(record) && key === "message") return false;
+  return true;
+}
+
+function ownErrorProperties(
+  error: Error,
+  depth: number,
+  seen: WeakSet<object>,
+  summarize: (
+    value: unknown,
+    depth: number,
+    seen: WeakSet<object>,
+    key?: string
+  ) => unknown,
+  options: Required<LogSummarizeOptions>
+): Record<string, unknown> | undefined {
+  const props: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(error)) {
+    if (key === "name" || key === "message" || key === "stack" || key === "cause") {
+      continue;
+    }
+    props[key] = shouldRedactKey(key, error as unknown as Record<string, unknown>)
+      ? REDACTED
+      : summarize(item, depth + 1, seen, key);
+  }
+  return Object.keys(props).length ? props : undefined;
+}
+
+export function summarizeForStructuredLog(
+  value: unknown,
+  depth = 0,
+  seen = new WeakSet<object>(),
+  key?: string,
+  options: LogSummarizeOptions = {}
+): unknown {
+  const resolved: Required<LogSummarizeOptions> = {
+    maxStringLength: options.maxStringLength ?? DEFAULT_MAX_STRING_LENGTH,
+    maxStackLength: options.maxStackLength ?? DEFAULT_MAX_STACK_LENGTH,
+    includeBrowserTypes: options.includeBrowserTypes ?? false,
+    includeErrorProps: options.includeErrorProps ?? false,
+  };
+
+  const summarize = (
+    nextValue: unknown,
+    nextDepth: number,
+    nextSeen: WeakSet<object>,
+    nextKey?: string
+  ) => summarizeForStructuredLog(nextValue, nextDepth, nextSeen, nextKey, options);
+
+  if (value === null || value === undefined) return value;
+
+  if (typeof value === "string") {
+    return truncateString(
+      value,
+      key === "stack" ? resolved.maxStackLength : resolved.maxStringLength
+    );
+  }
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (typeof value === "bigint") return `${value}n`;
+  if (typeof value === "function") {
+    return `[Function ${value.name || "anonymous"}]`;
+  }
+
+  if (value instanceof Error) {
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+    const cause = "cause" in value ? value.cause : undefined;
+    const props = resolved.includeErrorProps
+      ? ownErrorProperties(value, depth, seen, summarize, resolved)
+      : undefined;
+    return {
+      kind: "Error",
+      name: value.name,
+      message: truncateString(value.message, resolved.maxStringLength),
+      stack: value.stack
+        ? truncateString(value.stack, resolved.maxStackLength)
+        : undefined,
+      cause:
+        cause === undefined ? undefined : summarize(cause, depth + 1, seen, "cause"),
+      ...(props ? { props } : {}),
+    };
+  }
+
+  if (
+    resolved.includeBrowserTypes &&
+    typeof DOMException !== "undefined" &&
+    value instanceof DOMException
+  ) {
+    if (seen.has(value)) return "[Circular]";
+    seen.add(value);
+    return {
+      kind: "DOMException",
+      name: value.name,
+      message: truncateString(value.message, resolved.maxStringLength),
+      code: value.code,
+      stack: value.stack
+        ? truncateString(value.stack, resolved.maxStackLength)
+        : undefined,
+    };
+  }
+
+  if (
+    resolved.includeBrowserTypes &&
+    typeof ErrorEvent !== "undefined" &&
+    value instanceof ErrorEvent
+  ) {
+    return {
+      kind: "ErrorEvent",
+      message: truncateString(value.message, resolved.maxStringLength),
+      filename: value.filename,
+      lineno: value.lineno,
+      colno: value.colno,
+      error: summarize(value.error, depth + 1, seen, "error"),
+    };
+  }
+
+  if (
+    resolved.includeBrowserTypes &&
+    typeof PromiseRejectionEvent !== "undefined" &&
+    value instanceof PromiseRejectionEvent
+  ) {
+    return {
+      kind: "PromiseRejectionEvent",
+      reason: summarize(value.reason, depth + 1, seen, "reason"),
+    };
+  }
+
+  if (resolved.includeBrowserTypes && typeof Blob !== "undefined" && value instanceof Blob) {
+    return `Blob(size=${value.size}, type=${value.type || "unknown"})`;
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return `ArrayBuffer(byteLength=${value.byteLength})`;
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return `${value.constructor.name}(byteLength=${value.byteLength})`;
+  }
+
+  if (typeof value !== "object") return String(value);
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+
+  if (depth >= MAX_DEPTH) {
+    return Array.isArray(value)
+      ? `array(length=${value.length})`
+      : `object(keys=${Object.keys(value as Record<string, unknown>).join(",") || "none"})`;
+  }
+
+  if (Array.isArray(value)) {
+    const items = value
+      .slice(0, MAX_ARRAY_ITEMS)
+      .map((item) => summarize(item, depth + 1, seen));
+    if (value.length > MAX_ARRAY_ITEMS) {
+      items.push(`... (${value.length - MAX_ARRAY_ITEMS} more)`);
+    }
+    return items;
+  }
+
+  const record = value as Record<string, unknown>;
+  const safe: Record<string, unknown> = {};
+  for (const [recordKey, item] of Object.entries(record)) {
+    safe[recordKey] = shouldRedactKey(recordKey, record)
+      ? REDACTED
+      : summarize(item, depth + 1, seen, recordKey);
+  }
+  return safe;
+}

--- a/src/shared/logSummarize.ts
+++ b/src/shared/logSummarize.ts
@@ -55,8 +55,7 @@ function ownErrorProperties(
     depth: number,
     seen: WeakSet<object>,
     key?: string
-  ) => unknown,
-  options: Required<LogSummarizeOptions>
+  ) => unknown
 ): Record<string, unknown> | undefined {
   const props: Record<string, unknown> = {};
   for (const [key, item] of Object.entries(error)) {
@@ -110,7 +109,7 @@ export function summarizeForStructuredLog(
     seen.add(value);
     const cause = "cause" in value ? value.cause : undefined;
     const props = resolved.includeErrorProps
-      ? ownErrorProperties(value, depth, seen, summarize, resolved)
+      ? ownErrorProperties(value, depth, seen, summarize)
       : undefined;
     return {
       kind: "Error",

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,62 +1,13 @@
 import { isDebugEnabled } from "@/utils/debug";
+import { summarizeForStructuredLog } from "@/shared/logSummarize";
 
 export type LogContext = Record<string, unknown>;
 
-const REDACTED = "[redacted]";
-const MAX_STRING_LENGTH = 160;
-const MAX_STACK_LENGTH = 4000;
-const MAX_ARRAY_ITEMS = 8;
-const MAX_DEPTH = 3;
-
-const SENSITIVE_KEY_RE =
-  /(password|token|secret|authorization|cookie|message|prompt|content|html|markdown|base64|blob|dataurl|transcript|body|text|lyrics|deviceid|useragent)$/i;
-
-function truncateString(value: string, maxLength = MAX_STRING_LENGTH): string {
-  if (value.length <= maxLength) return value;
-  return `${value.slice(0, maxLength)}... (truncated, length=${value.length})`;
-}
-
-function isSerializedErrorRecord(record: Record<string, unknown>): boolean {
-  if (
-    record.kind === "Error" ||
-    record.kind === "DOMException" ||
-    record.kind === "ErrorEvent" ||
-    record.kind === "PromiseRejectionEvent"
-  ) {
-    return true;
-  }
-  return (
-    typeof record.name === "string" &&
-    typeof record.message === "string" &&
-    typeof record.stack === "string"
-  );
-}
-
-function shouldRedactKey(
-  key: string,
-  record: Record<string, unknown>
-): boolean {
-  if (!SENSITIVE_KEY_RE.test(key)) return false;
-  if (isSerializedErrorRecord(record) && key === "message") return false;
-  return true;
-}
-
-function ownErrorProperties(
-  error: Error,
-  depth: number,
-  seen: WeakSet<object>
-): Record<string, unknown> | undefined {
-  const props: Record<string, unknown> = {};
-  for (const [key, item] of Object.entries(error)) {
-    if (key === "name" || key === "message" || key === "stack" || key === "cause") {
-      continue;
-    }
-    props[key] = shouldRedactKey(key, error as unknown as Record<string, unknown>)
-      ? REDACTED
-      : summarizeForLog(item, depth + 1, seen, key);
-  }
-  return Object.keys(props).length ? props : undefined;
-}
+const CLIENT_LOG_OPTIONS = {
+  maxStringLength: 160,
+  includeBrowserTypes: true,
+  includeErrorProps: true,
+} as const;
 
 export function summarizeForLog(
   value: unknown,
@@ -64,108 +15,7 @@ export function summarizeForLog(
   seen = new WeakSet<object>(),
   key?: string
 ): unknown {
-  if (value === null || value === undefined) return value;
-
-  if (typeof value === "string") {
-    return truncateString(value, key === "stack" ? MAX_STACK_LENGTH : MAX_STRING_LENGTH);
-  }
-  if (typeof value === "number" || typeof value === "boolean") return value;
-  if (typeof value === "bigint") return `${value}n`;
-  if (typeof value === "function") {
-    return `[Function ${value.name || "anonymous"}]`;
-  }
-
-  if (value instanceof Error) {
-    if (seen.has(value)) return "[Circular]";
-    seen.add(value);
-    const cause = "cause" in value ? value.cause : undefined;
-    const props = ownErrorProperties(value, depth, seen);
-    return {
-      kind: "Error",
-      name: value.name,
-      message: truncateString(value.message),
-      stack: value.stack ? truncateString(value.stack, MAX_STACK_LENGTH) : undefined,
-      cause:
-        cause === undefined
-          ? undefined
-          : summarizeForLog(cause, depth + 1, seen, "cause"),
-      props,
-    };
-  }
-
-  if (typeof DOMException !== "undefined" && value instanceof DOMException) {
-    if (seen.has(value)) return "[Circular]";
-    seen.add(value);
-    return {
-      kind: "DOMException",
-      name: value.name,
-      message: truncateString(value.message),
-      code: value.code,
-      stack: value.stack ? truncateString(value.stack, MAX_STACK_LENGTH) : undefined,
-    };
-  }
-
-  if (typeof ErrorEvent !== "undefined" && value instanceof ErrorEvent) {
-    return {
-      kind: "ErrorEvent",
-      message: truncateString(value.message),
-      filename: value.filename,
-      lineno: value.lineno,
-      colno: value.colno,
-      error: summarizeForLog(value.error, depth + 1, seen, "error"),
-    };
-  }
-
-  if (
-    typeof PromiseRejectionEvent !== "undefined" &&
-    value instanceof PromiseRejectionEvent
-  ) {
-    return {
-      kind: "PromiseRejectionEvent",
-      reason: summarizeForLog(value.reason, depth + 1, seen, "reason"),
-    };
-  }
-
-  if (typeof Blob !== "undefined" && value instanceof Blob) {
-    return `Blob(size=${value.size}, type=${value.type || "unknown"})`;
-  }
-
-  if (value instanceof ArrayBuffer) {
-    return `ArrayBuffer(byteLength=${value.byteLength})`;
-  }
-
-  if (ArrayBuffer.isView(value)) {
-    return `${value.constructor.name}(byteLength=${value.byteLength})`;
-  }
-
-  if (typeof value !== "object") return String(value);
-  if (seen.has(value)) return "[Circular]";
-  seen.add(value);
-
-  if (depth >= MAX_DEPTH) {
-    return Array.isArray(value)
-      ? `array(length=${value.length})`
-      : `object(keys=${Object.keys(value as Record<string, unknown>).join(",") || "none"})`;
-  }
-
-  if (Array.isArray(value)) {
-    const items = value
-      .slice(0, MAX_ARRAY_ITEMS)
-      .map((item) => summarizeForLog(item, depth + 1, seen));
-    if (value.length > MAX_ARRAY_ITEMS) {
-      items.push(`... (${value.length - MAX_ARRAY_ITEMS} more)`);
-    }
-    return items;
-  }
-
-  const record = value as Record<string, unknown>;
-  const safe: Record<string, unknown> = {};
-  for (const [key, item] of Object.entries(record)) {
-    safe[key] = shouldRedactKey(key, record)
-      ? REDACTED
-      : summarizeForLog(item, depth + 1, seen, key);
-  }
-  return safe;
+  return summarizeForStructuredLog(value, depth, seen, key, CLIENT_LOG_OPTIONS);
 }
 
 function formatLogArgs(scope: string, message: string, context?: unknown): unknown[] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consolidates duplicated log summarization between client and API loggers.

- New `src/shared/logSummarize.ts` with `summarizeForStructuredLog()` and shared redaction/truncation rules
- `src/utils/logger.ts` and `api/_utils/_logging.ts` remain thin wrappers with the same public APIs

## Testing

- ✅ `bun test tests/test-client-logger.test.ts tests/test-api-logging.test.ts` (14 pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

