### PR TITLE
Migration prep: docs, telemetry, and breadcrumb rewrite

### DIFF
--- a/api/_utils/html-entities.ts
+++ b/api/_utils/html-entities.ts
@@ -12,7 +12,8 @@ const NAMED_HTML_ENTITIES: Record<string, string> = {
  * Decode common named and numeric HTML entities exactly once.
  *
  * This intentionally avoids recursive decoding so `&amp;lt;` becomes `&lt;`,
- * not `<`.
+ * not `<`. For chat/UI strings that may include tags and need full decoding,
+ * use the client `decodeHtmlEntities()` helper instead.
  */
 export function decodeHtmlEntitiesOnce(text: string): string {
   return text.replace(

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -813,6 +813,10 @@ function sanitizePersistedIpodMenuBreadcrumb(
           VALID_IPOD_MENU_KINDS.has(entry.kind as IpodMenuKind) && {
             kind: entry.kind as IpodMenuKind,
           }),
+        ...(entry.title === "Radio" &&
+          !entry.kind && {
+            kind: "radio" as IpodMenuKind,
+          }),
         ...(typeof entry.id === "string" && { id: entry.id }),
         title: entry.title,
         ...(typeof entry.displayTitle === "string" && {

--- a/src/sync/stateStorage.ts
+++ b/src/sync/stateStorage.ts
@@ -316,6 +316,11 @@ export async function loadPersistedSyncState(
   }
   if (!raw) return createEmptyPersistedSyncState();
 
+  console.warn(
+    "[sync2] Loaded legacy localStorage sync state; migrating to IndexedDB",
+    { username: recordKey(username) }
+  );
+
   let migrated: PersistedSyncState;
   try {
     migrated = normalizePersistedSyncState(JSON.parse(raw));

--- a/src/utils/decodeHtmlEntities.ts
+++ b/src/utils/decodeHtmlEntities.ts
@@ -1,6 +1,10 @@
 /**
  * Safely decode HTML entities without using innerHTML.
  * Uses DOMParser which does not execute scripts.
+ *
+ * Fully decodes entities (including double-encoded values) and strips HTML tags.
+ * For API metadata that must decode only once, use `decodeHtmlEntitiesOnce` in
+ * `api/_utils/html-entities.ts` instead.
  */
 export function decodeHtmlEntities(text: string): string {
   if (!text) return text;

--- a/src/utils/storageKeys.ts
+++ b/src/utils/storageKeys.ts
@@ -1,3 +1,11 @@
+/**
+ * Canonical localStorage keys and legacy migration helpers.
+ *
+ * Removal criteria: keep `LEGACY_STORAGE_KEYS` / `migrateLocalStorageKey` until
+ * production telemetry shows zero legacy-key reads for 90+ days. IndexedDB
+ * `legacyNames` paths follow the same gate. `removeStaleStorageKeys()` is a
+ * cheap idempotent cleanup for keys with no remaining readers.
+ */
 export const STORAGE_KEYS = {
   dock: "ryos:dock",
   applet: "ryos:applet",

--- a/tests/test-ipod-breadcrumb-migration.test.ts
+++ b/tests/test-ipod-breadcrumb-migration.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizePersistedIpodStateForRehydrate } from "../src/stores/useIpodStore";
+
+describe("persisted iPod breadcrumb migration", () => {
+  test("rewrites legacy Radio title breadcrumbs to kind radio", () => {
+    const sanitized = sanitizePersistedIpodStateForRehydrate({
+      ipodMenuBreadcrumb: [{ title: "Radio", selectedIndex: 0 }],
+    });
+
+    expect(sanitized.ipodMenuBreadcrumb?.[0]?.kind).toBe("radio");
+    expect(sanitized.ipodMenuBreadcrumb?.[0]?.title).toBe("Radio");
+  });
+});

--- a/tests/test-listen-client-instance.test.ts
+++ b/tests/test-listen-client-instance.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import {
+  migrateSessionClientIds,
+  normalizeClientInstanceId,
+  userConnectionKey,
+} from "../api/listen/_helpers/_client-instance.js";
+import type { ListenSession } from "../api/listen/_helpers/_types.js";
+
+describe("listen client instance helpers", () => {
+  test("normalizeClientInstanceId accepts safe ids and falls back to legacy prefix", () => {
+    expect(normalizeClientInstanceId("Alice", "tab-1")).toBe("tab-1");
+    expect(normalizeClientInstanceId("Alice", " bad id ")).toBe("legacy:alice");
+    expect(normalizeClientInstanceId("Alice", "")).toBe("legacy:alice");
+  });
+
+  test("userConnectionKey includes clientInstanceId when present", () => {
+    expect(
+      userConnectionKey({
+        username: "Alice",
+        clientInstanceId: "tab-1",
+      })
+    ).toBe("alice|tab-1");
+    expect(
+      userConnectionKey({
+        username: "Alice",
+        clientInstanceId: "",
+      })
+    ).toBe("alice|legacy:alice");
+  });
+
+  test("migrateSessionClientIds backfills missing host and dj client ids", () => {
+    const session: ListenSession = {
+      id: "room-1",
+      hostUsername: "host",
+      djUsername: "dj",
+      hostClientInstanceId: "",
+      djClientInstanceId: "",
+      users: [
+        { username: "host", joinedAt: 1, isOnline: true, clientInstanceId: "" },
+        { username: "dj", joinedAt: 1, isOnline: true, clientInstanceId: "dj-tab" },
+        { username: "guest", joinedAt: 1, isOnline: true, clientInstanceId: "" },
+      ],
+      currentTrackId: null,
+      currentTrackMeta: null,
+      isPlaying: false,
+      positionMs: 0,
+      lastSyncAt: 1,
+      createdAt: 1,
+    };
+
+    migrateSessionClientIds(session);
+
+    expect(session.users[0]?.clientInstanceId).toBe("legacy:host");
+    expect(session.users[1]?.clientInstanceId).toBe("dj-tab");
+    expect(session.users[2]?.clientInstanceId).toBe("legacy:guest");
+    expect(session.hostClientInstanceId).toBe("legacy:host");
+    expect(session.djClientInstanceId).toBe("dj-tab");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares legacy migration cutovers without removing active dual-read paths yet.

- Documents HTML entity decoder semantics (client full decode vs API single-pass)
- Documents storage-key retirement criteria in `storageKeys.ts`
- Logs when sync v2 reads legacy localStorage before IndexedDB migration
- Rewrites persisted iPod `Radio` breadcrumbs to `kind: "radio"` on rehydrate
- Adds unit tests for Listen client-instance backfill and iPod breadcrumb migration

## Testing

- ✅ `bun run test:unit` (2232 pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

