### PR TITLE
refactor(redis): extract legacy scan patterns for migration CLI

### DIFF
--- a/scripts/lib/redis-key-migration.ts
+++ b/scripts/lib/redis-key-migration.ts
@@ -1,9 +1,11 @@
 import type { Redis, RedisSortedSetEntry } from "../../api/_utils/redis.js";
 import {
   LEGACY_REDIS_SCAN_PATTERNS,
+  type LegacyRedisScanPattern,
+} from "../../src/shared/redisLegacyPatterns.js";
+import {
   redisKeys,
   sha256RedisIdentifier,
-  type LegacyRedisScanPattern,
 } from "../../src/shared/redisKeys.js";
 
 export interface RedisLegacyPatternStatus {

--- a/scripts/redis-key-migration.ts
+++ b/scripts/redis-key-migration.ts
@@ -23,7 +23,7 @@
  */
 
 import { createRedis } from "../api/_utils/redis.js";
-import { LEGACY_REDIS_SCAN_PATTERNS } from "../src/shared/redisKeys.js";
+import { LEGACY_REDIS_SCAN_PATTERNS } from "../src/shared/redisLegacyPatterns.js";
 import {
   assertKnownLegacyRedisPattern,
   backfillRedisKeyScheme,

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -1,10 +1,13 @@
 /**
  * Canonical Redis key registry — the runtime reads and writes only these key shapes.
  *
- * {@link LEGACY_REDIS_SCAN_PATTERNS} lists residual legacy key patterns for the
- * standalone migration CLI (`scripts/redis-key-migration.ts`), which can inspect,
- * backfill, and delete historical keys. The app API does not expose migration.
+ * Legacy key patterns for the migration CLI live in `./redisLegacyPatterns.ts`.
  */
+
+export {
+  LEGACY_REDIS_SCAN_PATTERNS,
+  type LegacyRedisScanPattern,
+} from "./redisLegacyPatterns";
 
 export const REDIS_KEY_SEPARATOR = ":";
 
@@ -26,47 +29,6 @@ export const CANONICAL_REDIS_PREFIXES = [
 ] as const;
 
 export type CanonicalRedisPrefix = (typeof CANONICAL_REDIS_PREFIXES)[number];
-
-/**
- * Legacy key patterns that must be empty before the final no-compatibility
- * cutover. Patterns stay precise where a top-level prefix remains canonical
- * (for example, `chat:*` becomes only selected legacy subtrees).
- */
-export const LEGACY_REDIS_SCAN_PATTERNS = [
-  "airdrop:*",
-  "analytics:aiu:*",
-  "analytics:daily:*",
-  "analytics:ep:*",
-  "analytics:st:*",
-  "analytics:uv:*",
-  "apple:*",
-  "applet:*",
-  "chat:irc:*",
-  "chat:messages:*",
-  "chat:password:*",
-  "chat:presence:*",
-  "chat:presencez:*",
-  "chat:room:*",
-  "chat:rooms",
-  "chat:token:*",
-  "chat:users:*",
-  "cursor-sdk-agent:*",
-  "cursor-sdk-run:*",
-  "geoip:*",
-  "ie:*",
-  "listen:*",
-  "memory:user:*:processing_lock",
-  "rl:*",
-  "rt:*",
-  "ryos:presence:*",
-  "song:*",
-  "sync:pref:*",
-  "sync2:*",
-  "telegram:*",
-  "wayback:*",
-] as const;
-
-export type LegacyRedisScanPattern = (typeof LEGACY_REDIS_SCAN_PATTERNS)[number];
 
 export function normalizeRedisSegment(segment: string | number): string {
   return encodeURIComponent(String(segment).trim().toLowerCase());

--- a/src/shared/redisLegacyPatterns.ts
+++ b/src/shared/redisLegacyPatterns.ts
@@ -1,0 +1,41 @@
+/**
+ * Legacy Redis key scan patterns for the standalone migration CLI
+ * (`scripts/redis-key-migration.ts`). Runtime API handlers use only canonical
+ * keys from `redisKeys.ts`; these patterns exist for ops backfill/delete.
+ */
+
+export const LEGACY_REDIS_SCAN_PATTERNS = [
+  "airdrop:*",
+  "analytics:aiu:*",
+  "analytics:daily:*",
+  "analytics:ep:*",
+  "analytics:st:*",
+  "analytics:uv:*",
+  "apple:*",
+  "applet:*",
+  "chat:irc:*",
+  "chat:messages:*",
+  "chat:password:*",
+  "chat:presence:*",
+  "chat:presencez:*",
+  "chat:room:*",
+  "chat:rooms",
+  "chat:token:*",
+  "chat:users:*",
+  "cursor-sdk-agent:*",
+  "cursor-sdk-run:*",
+  "geoip:*",
+  "ie:*",
+  "listen:*",
+  "memory:user:*:processing_lock",
+  "rl:*",
+  "rt:*",
+  "ryos:presence:*",
+  "song:*",
+  "sync:pref:*",
+  "sync2:*",
+  "telegram:*",
+  "wayback:*",
+] as const;
+
+export type LegacyRedisScanPattern = (typeof LEGACY_REDIS_SCAN_PATTERNS)[number];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extracts `LEGACY_REDIS_SCAN_PATTERNS` from the canonical `redisKeys.ts` registry into a dedicated `redisLegacyPatterns.ts` module used by the migration CLI scripts.

- **`src/shared/redisLegacyPatterns.ts`** — legacy scan patterns + type (ops/migration only)
- **`src/shared/redisKeys.ts`** — re-exports patterns for backward compatibility; runtime docs clarify canonical keys live here
- **`scripts/redis-key-migration.ts`** and **`scripts/lib/redis-key-migration.ts`** — import directly from `redisLegacyPatterns`

This separates runtime canonical key shapes from ops-only legacy cleanup patterns without removing any patterns (no data-loss risk).

## Testing

- `bun test tests/test-redis-keys.test.ts` — 6 pass
- `bun run test:unit` — 2228 pass

Part of the follow-up cleanup series after #1793 (debug logger dedup).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2fb8-02fd-7899-9dc4-4d17d7c214bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

