### PR TITLE
Style assistant speech bubbles with per-character accent colors

### DIFF
--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -1682,7 +1682,11 @@ function AssistantOverlayInner() {
             )}
           >
             <div
-              className="relative rounded-[8px] border border-black bg-[#FFFFC8] px-3 pt-1.5 pb-1 shadow-[2px_2px_0_rgba(0,0,0,0.35)] font-geneva-12 text-[12px] leading-snug text-black"
+              className="relative rounded-[8px] border px-3 pt-1.5 pb-1 shadow-[2px_2px_0_rgba(0,0,0,0.35)] font-geneva-12 text-[12px] leading-snug text-black"
+              style={{
+                backgroundColor: character.accent.bubbleBg,
+                borderColor: character.accent.bubbleBorder,
+              }}
               role="log"
               aria-live="polite"
             >
@@ -1753,9 +1757,13 @@ function AssistantOverlayInner() {
               </form>
               {/* Bubble tail pointing at the character */}
               <div
-                style={bubbleTailStyle}
+                style={{
+                  ...bubbleTailStyle,
+                  backgroundColor: character.accent.bubbleBg,
+                  borderColor: character.accent.bubbleBorder,
+                }}
                 className={cn(
-                  "absolute size-2.5 rotate-45 border-black bg-[#FFFFC8]",
+                  "absolute size-2.5 rotate-45",
                   bubbleSide === "above" && "-bottom-[6px] border-b border-r",
                   bubbleSide === "below" && "-top-[6px] border-l border-t",
                   bubbleSide === "left" && "-right-[6px] border-r border-t",

--- a/src/components/assistant/characters.ts
+++ b/src/components/assistant/characters.ts
@@ -23,6 +23,18 @@ export type AssistantCharacterId =
   | "saeko"
   | "monkeyking";
 
+/**
+ * Speech-bubble accent for a character. Fills stay light pastels so the
+ * bubble's black text keeps classic-tooltip readability; borders are the same
+ * hue pulled near-black so they read as the original 1px outline with a tint.
+ */
+export interface AssistantCharacterAccent {
+  /** Bubble + tail fill. */
+  bubbleBg: string;
+  /** Bubble + tail 1px outline. */
+  bubbleBorder: string;
+}
+
 export interface AssistantCharacter {
   id: AssistantCharacterId;
   /** Canonical English name (fallback); use getAssistantCharacterName / t(nameKey) for display. */
@@ -35,13 +47,16 @@ export interface AssistantCharacter {
   /** Sprite sheet + animation data. */
   mapUrl: string;
   agentUrl: string;
+  /** Per-character speech-bubble colors (derived from the sprite palette). */
+  accent: AssistantCharacterAccent;
 }
 
 function spriteCharacter(
   id: AssistantCharacterId,
   name: string,
   width: number,
-  height: number
+  height: number,
+  accent: AssistantCharacterAccent
 ): AssistantCharacter {
   return {
     id,
@@ -51,22 +66,62 @@ function spriteCharacter(
     height,
     mapUrl: `/assets/assistant/${id}/map.png`,
     agentUrl: `/assets/assistant/${id}/agent.json`,
+    accent,
   };
 }
 
+// Accent hues are sampled from each character's sprite sheet (dominant
+// saturated color), then normalized to a light pastel fill + near-black
+// tinted outline. Clippy keeps the classic MS Agent balloon yellow.
 export const ASSISTANT_CHARACTERS: AssistantCharacter[] = [
-  spriteCharacter("clippy", "Clippy", 124, 93),
-  spriteCharacter("links", "Links", 124, 93),
-  spriteCharacter("rover", "Rover", 80, 80),
-  spriteCharacter("merlin", "Merlin", 128, 128),
-  spriteCharacter("genie", "Genie", 128, 128),
-  spriteCharacter("peedy", "Peedy", 160, 128),
-  spriteCharacter("genius", "Genius", 124, 93),
-  spriteCharacter("rocky", "Rocky", 124, 93),
-  spriteCharacter("f1", "F1", 124, 93),
-  spriteCharacter("officelogo", "Office Logo", 124, 93),
-  spriteCharacter("saeko", "Saeko Sensei", 98, 115),
-  spriteCharacter("monkeyking", "Monkey King", 124, 93),
+  spriteCharacter("clippy", "Clippy", 124, 93, {
+    bubbleBg: "#FFFFC8",
+    bubbleBorder: "#3F3E18",
+  }),
+  spriteCharacter("links", "Links", 124, 93, {
+    bubbleBg: "#FCE6BF",
+    bubbleBorder: "#413116",
+  }),
+  spriteCharacter("rover", "Rover", 80, 80, {
+    bubbleBg: "#FFECB8",
+    bubbleBorder: "#433614",
+  }),
+  spriteCharacter("merlin", "Merlin", 128, 128, {
+    bubbleBg: "#D3E0FD",
+    bubbleBorder: "#18243F",
+  }),
+  spriteCharacter("genie", "Genie", 128, 128, {
+    bubbleBg: "#C3E5FD",
+    bubbleBorder: "#162F41",
+  }),
+  spriteCharacter("peedy", "Peedy", 160, 128, {
+    bubbleBg: "#CAF6C6",
+    bubbleBorder: "#1D3D1A",
+  }),
+  spriteCharacter("genius", "Genius", 124, 93, {
+    bubbleBg: "#DEE6ED",
+    bubbleBorder: "#212B36",
+  }),
+  spriteCharacter("rocky", "Rocky", 124, 93, {
+    bubbleBg: "#F5EEC2",
+    bubbleBorder: "#3F3A18",
+  }),
+  spriteCharacter("f1", "F1", 124, 93, {
+    bubbleBg: "#FDD6CE",
+    bubbleBorder: "#411D16",
+  }),
+  spriteCharacter("officelogo", "Office Logo", 124, 93, {
+    bubbleBg: "#D9DCFD",
+    bubbleBorder: "#181B3F",
+  }),
+  spriteCharacter("saeko", "Saeko Sensei", 98, 115, {
+    bubbleBg: "#FDD9C9",
+    bubbleBorder: "#412316",
+  }),
+  spriteCharacter("monkeyking", "Monkey King", 124, 93, {
+    bubbleBg: "#FBDEC1",
+    bubbleBorder: "#412B16",
+  }),
 ];
 
 export const DEFAULT_ASSISTANT_CHARACTER_ID: AssistantCharacterId = "rover";

--- a/tests/test-assistant-character-accents.test.ts
+++ b/tests/test-assistant-character-accents.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ASSISTANT_CHARACTERS } from "../src/components/assistant/characters";
+
+const HEX_RE = /^#[0-9A-F]{6}$/;
+
+function relativeLuminance(hex: string): number {
+  const channel = (i: number) => {
+    const c = parseInt(hex.slice(1 + i * 2, 3 + i * 2), 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(0) + 0.7152 * channel(1) + 0.0722 * channel(2);
+}
+
+describe("assistant character bubble accents", () => {
+  test("every character defines valid hex bubble colors", () => {
+    for (const character of ASSISTANT_CHARACTERS) {
+      expect(character.accent.bubbleBg).toMatch(HEX_RE);
+      expect(character.accent.bubbleBorder).toMatch(HEX_RE);
+    }
+  });
+
+  test("fills stay light pastels and borders stay dark (black text readable)", () => {
+    for (const character of ASSISTANT_CHARACTERS) {
+      // Light fill keeps the bubble's black text/UI legible.
+      expect(relativeLuminance(character.accent.bubbleBg)).toBeGreaterThan(0.6);
+      // Dark border preserves the classic 1px tooltip outline.
+      expect(relativeLuminance(character.accent.bubbleBorder)).toBeLessThan(
+        0.1
+      );
+    }
+  });
+
+  test("clippy keeps the classic MS Agent balloon yellow", () => {
+    const clippy = ASSISTANT_CHARACTERS.find((c) => c.id === "clippy")!;
+    expect(clippy.accent.bubbleBg).toBe("#FFFFC8");
+  });
+
+  test("accents are distinct per character (no single shared bubble color)", () => {
+    const fills = new Set(
+      ASSISTANT_CHARACTERS.map((c) => c.accent.bubbleBg.toUpperCase())
+    );
+    expect(fills.size).toBeGreaterThan(1);
+  });
+});
+
+describe("assistant overlay bubble accent wiring", () => {
+  const overlaySource = readFileSync(
+    join(import.meta.dir, "../src/components/assistant/AssistantOverlay.tsx"),
+    "utf8"
+  );
+
+  test("bubble and tail read colors from the selected character's accent", () => {
+    expect(
+      overlaySource.match(/backgroundColor: character\.accent\.bubbleBg/g)
+        ?.length
+    ).toBe(2);
+    expect(
+      overlaySource.match(/borderColor: character\.accent\.bubbleBorder/g)
+        ?.length
+    ).toBe(2);
+  });
+
+  test("no hard-coded bubble color remains", () => {
+    expect(overlaySource).not.toContain("#FFFFC8");
+    expect(overlaySource).not.toContain("border-black bg-");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The floating desktop assistant's speech bubble was always the classic MS Agent pale yellow (`#FFFFC8`) regardless of the selected character. Each character now gets its own bubble accent, sampled from its sprite palette and normalized to a light pastel fill with a matching near-black tinted 1px outline, so black text stays readable in every case.

- `src/components/assistant/characters.ts` — adds an `accent` (`bubbleBg` + `bubbleBorder`) to `AssistantCharacter` with per-character colors (Clippy keeps the classic `#FFFFC8`; Rover is warm amber, Merlin navy-blue pastel, Genie sky blue, Peedy green, F1 red, Saeko peach, etc.).
- `src/components/assistant/AssistantOverlay.tsx` — the bubble shell and its rotated tail now read background/border colors from the selected character's accent instead of the hard-coded `border-black bg-[#FFFFC8]` classes.
- `tests/test-assistant-character-accents.test.ts` — new unit suite: valid hex, light fill / dark border luminance invariants, Clippy's classic yellow preserved, distinct fills, and overlay wiring for both bubble and tail.

## Screenshots

![Rover with amber bubble](https://cursor.com/artifacts/c/art-a308dad4-4254-4b8e-b81b-e09a772fcec8)
![Merlin with pastel blue bubble](https://cursor.com/artifacts/c/art-3a9aa272-6cb9-46d5-8049-8887e2ea4838)
![Peedy with pastel green bubble](https://cursor.com/artifacts/c/art-85c9d399-d518-4922-8770-b1689d9dff18)
![Clippy with classic pale yellow bubble](https://cursor.com/artifacts/c/art-87449b4c-edca-4a66-ad15-be1ed0d9ec07)

## Testing

- `bun run test:registration`
- `bun test tests/test-assistant-*.test.*` plus `test-sync-v2-codecs` and `test-wallpaper-accent-color` (170 pass, 0 fail)
- `bun run typecheck`
- Manual browser check: cycled Rover → Merlin → Peedy → Clippy via the sprite's right-click character menu; each bubble (and tail) rendered its own tint.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f30b1-c8bf-775c-a961-49639a20738c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f30b1-c8bf-775c-a961-49639a20738c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

