### PR TITLE
Improve AI tool system: expanded settings tool, VFS handler extraction, tool-call repair, per-tool rate limits

### DIFF
--- a/.cursor/skills/add-ai-chat-tool/SKILL.md
+++ b/.cursor/skills/add-ai-chat-tool/SKILL.md
@@ -153,8 +153,8 @@ Handler conventions (match existing handlers like `stickiesHandler.ts`):
 
 ## E. Wire the Client Dispatch
 
-1. In `src/apps/chats/tools/index.ts`, export the handler/type and (optionally) `registerToolHandler("myFeatureControl", handleMyFeatureControl)`.
-2. In `src/apps/chats/hooks/useAiChat.ts`, import the handler and add a `case` to the `switch (toolCall.toolName)` inside `handleSharedToolCall`:
+1. In `src/apps/chats/tools/index.ts`, export the handler and its input type.
+2. In `src/apps/chats/tools/dispatchToolCall.ts` (shared by the Chats app and the desktop assistant), add a `case` to the `switch (toolCall.toolName)`:
 
 ```typescript
 case "myFeatureControl": {
@@ -168,7 +168,7 @@ case "myFeatureControl": {
 }
 ```
 
-> The registry (`registerToolHandler`/`getToolHandler`) exists for automatic dispatch, but `useAiChat` currently dispatches via the explicit `switch`. Add the `case` — otherwise the tool falls through to the `default` branch and reports "Unhandled tool". Set `result = ""` when the handler emits its own output (return a non-empty string only for trivial tools that don't call `addToolOutput`).
+> Dispatch is an explicit `switch` — there is no handler registry. Add the `case`, otherwise the tool falls through to the `default` branch and reports "Unhandled tool". Set `result = ""` when the handler emits its own output (return a non-empty string only for trivial tools that don't call `addToolOutput`). VFS tools (`list`/`open`/`read`/`write`/`edit`) live in `vfsHandlers.ts` and receive a `VfsToolContext` with `saveFile` + `recordOpenedInstance`.
 
 ## F. Server Executor (server-executed / dual tools)
 

--- a/api/_utils/_aiPrompts.ts
+++ b/api/_utils/_aiPrompts.ts
@@ -324,11 +324,12 @@ You're chatting with a linked ryOS user in a private Telegram DM.
 - Only include a plain URL when the user explicitly asks for the source or direct link.
 - Never use markdown link syntax, parenthetical citation blocks, or a separate sources/references list.
 
-## Calendar & Stickies
-You can manage the user's calendar events, todos, and sticky notes directly from Telegram.
+## Calendar, Stickies & Contacts
+You can manage the user's calendar events, todos, sticky notes, contacts, and documents directly from Telegram.
 - Use calendarControl to list/create/update/delete events and todos. Dates are YYYY-MM-DD, times are HH:MM.
 - When listing todos with 'listTodos', do NOT pass a 'date' parameter unless the user specifically asks for todos due on a certain date — most todos have no due date and would be filtered out.
 - Use stickiesControl to list/create/update/delete sticky notes.
+- Use contactsControl to list/get/create/update/delete contacts. Use 'list' with a query to find someone before updating.
 - Use documentsControl to list, read, write, and edit synced markdown files under /Documents. List results include document names and exact /Documents/*.md paths.
 - These changes sync to ryOS automatically — the user will see them next time the browser polls.
 - If the user hasn't enabled cloud sync yet, these tools will let you know.

--- a/api/_utils/_rate-limit.ts
+++ b/api/_utils/_rate-limit.ts
@@ -6,8 +6,16 @@ import { makeKey, makeCanonicalRateKey } from "./_rate-limit-key.js";
 // importing them from this module.
 export { makeKey, makeCanonicalRateKey } from "./_rate-limit-key.js";
 
-// Set up Redis client
-const redis = createRedis();
+// Lazily create the Redis client on first use. Creating it at module load
+// would throw in environments without Redis configuration (e.g. unit tests
+// importing chat tools), breaking every module in the import chain.
+let redisClient: RedisClient | null = null;
+function getRedis(): RedisClient {
+  if (!redisClient) {
+    redisClient = createRedis();
+  }
+  return redisClient;
+}
 
 // Constants for rate limiting
 export const AI_LIMIT_PER_5_HOURS = 15;
@@ -49,7 +57,7 @@ export async function checkAndIncrementAIMessageCount(
   // If authenticated, validate the token
   if (isAuthenticated && authToken) {
     const lower = identifier.toLowerCase();
-    const validation = await validateAuth(redis, lower, authToken);
+    const validation = await validateAuth(getRedis(), lower, authToken);
     if (!validation.valid) {
       // Invalid token for this user – treat as unauthenticated (use anon limit)
       return {
@@ -61,7 +69,7 @@ export async function checkAndIncrementAIMessageCount(
 
     // If the request is from ryo **and** the token is valid, bypass rate limits entirely
     if (isRyo) {
-      const currentCount = await redis.get<string>(key);
+      const currentCount = await getRedis().get<string>(key);
       const count = currentCount ? parseInt(currentCount, 10) : 0;
       return { allowed: true, count, limit };
     }
@@ -78,11 +86,11 @@ export async function checkAndIncrementAIMessageCount(
 
   // ATOMIC rate limit check: increment first, then check
   // This prevents race conditions where two requests read the same count
-  const newCount = await redis.incr(key);
+  const newCount = await getRedis().incr(key);
 
   // Set TTL only if this is the first increment (count became 1)
   if (newCount === 1) {
-    await redis.expire(key, ttlSeconds);
+    await getRedis().expire(key, ttlSeconds);
   }
 
   // Check if the NEW count exceeds the limit
@@ -126,8 +134,9 @@ export async function checkCounterLimit({
   key,
   windowSeconds,
   limit,
-  redis: client = redis,
+  redis: injectedClient,
 }: CounterLimitArgs): Promise<CounterLimitResult> {
+  const client = injectedClient ?? getRedis();
   // ATOMIC approach: increment first, then check
   // This prevents race conditions where two concurrent requests both read
   // the same count and both pass the limit check

--- a/api/_utils/_rate-limit.ts
+++ b/api/_utils/_rate-limit.ts
@@ -1,4 +1,4 @@
-import { createRedis } from "./redis.js";
+import { createRedis, type Redis as RedisClient } from "./redis.js";
 import { validateAuth } from "./auth/index.js";
 import { makeKey, makeCanonicalRateKey } from "./_rate-limit-key.js";
 
@@ -103,6 +103,8 @@ interface CounterLimitArgs {
   key: string;
   windowSeconds: number;
   limit: number;
+  /** Redis client to use; defaults to this module's shared client. */
+  redis?: RedisClient;
 }
 
 export interface CounterLimitResult {
@@ -124,19 +126,20 @@ export async function checkCounterLimit({
   key,
   windowSeconds,
   limit,
+  redis: client = redis,
 }: CounterLimitArgs): Promise<CounterLimitResult> {
   // ATOMIC approach: increment first, then check
   // This prevents race conditions where two concurrent requests both read
   // the same count and both pass the limit check
-  const newCount = await redis.incr(key);
+  const newCount = await client.incr(key);
 
   // Set TTL only if this is the first increment (count became 1)
   // This is safe because INCR is atomic - only one request will see newCount === 1
   if (newCount === 1) {
-    await redis.expire(key, windowSeconds);
+    await client.expire(key, windowSeconds);
   }
 
-  const ttl = await redis.ttl(key);
+  const ttl = await client.ttl(key);
   const resetSeconds = typeof ttl === "number" && ttl > 0 ? ttl : windowSeconds;
 
   // Check if the NEW count exceeds the limit

--- a/api/_utils/ryo-agent.ts
+++ b/api/_utils/ryo-agent.ts
@@ -1,11 +1,60 @@
 import {
+  NoSuchToolError,
   ToolLoopAgent,
   stepCountIs,
   type TextStreamPart,
+  type ToolCallRepairFunction,
   type ToolSet,
 } from "ai";
 import { getOpenAIProviderOptions } from "./_aiModels.js";
 import type { PreparedRyoConversation } from "./ryo-conversation.js";
+
+/**
+ * Deterministic tool-call repair for malformed inputs.
+ *
+ * Models occasionally emit tool arguments as double-encoded JSON or wrapped
+ * in markdown fences, which fails schema parsing and surfaces as a tool
+ * error the model must burn a step recovering from. This repairs the common
+ * encoding mistakes without an extra LLM round-trip; anything else (including
+ * calls to unknown tools) is left to the SDK's normal error path.
+ */
+export const repairRyoToolCall: ToolCallRepairFunction<ToolSet> = async ({
+  toolCall,
+  error,
+}) => {
+  if (NoSuchToolError.isInstance(error)) {
+    return null;
+  }
+
+  const raw = toolCall.input;
+  if (typeof raw !== "string") return null;
+
+  let candidate = raw.trim();
+
+  // Strip markdown code fences (```json ... ```)
+  const fenceMatch = candidate.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  if (fenceMatch) {
+    candidate = fenceMatch[1].trim();
+  }
+
+  try {
+    let parsed: unknown = JSON.parse(candidate);
+    // Unwrap double-encoded JSON ("{\"a\":1}" parsed to a string)
+    if (typeof parsed === "string") {
+      parsed = JSON.parse(parsed);
+    }
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const repairedInput = JSON.stringify(parsed);
+      if (repairedInput !== raw) {
+        return { ...toolCall, input: repairedInput };
+      }
+    }
+  } catch {
+    // Not repairable deterministically; let the SDK surface the error.
+  }
+
+  return null;
+};
 
 export const RYO_AGENT_PRESETS = {
   chat: {
@@ -54,6 +103,7 @@ export function createRyoToolLoopAgent({
     temperature,
     maxOutputTokens: agentPreset.maxOutputTokens,
     stopWhen: stepCountIs(agentPreset.stopAfterSteps),
+    experimental_repairToolCall: repairRyoToolCall,
     ...(headers ? { headers } : {}),
     ...(providerOptions ? { providerOptions } : {}),
   });

--- a/api/chat/tools/_tool-rate-limit.ts
+++ b/api/chat/tools/_tool-rate-limit.ts
@@ -12,6 +12,7 @@
  * available in the tool context.
  */
 
+import type { Redis } from "../../_utils/redis.js";
 import { checkCounterLimit } from "../../_utils/_rate-limit.js";
 
 export type RateLimitedToolName =
@@ -36,9 +37,14 @@ export interface ToolRateLimitResult {
 
 export async function checkToolRateLimit(
   tool: RateLimitedToolName,
-  username: string | null | undefined,
-  logError: (...args: unknown[]) => void
+  context: {
+    username?: string | null;
+    /** Reuse the tool context's Redis client when available (also keeps unit tests offline). */
+    redis?: Redis;
+    logError: (...args: unknown[]) => void;
+  }
 ): Promise<ToolRateLimitResult> {
+  const { username, redis, logError } = context;
   if (!username) return { allowed: true };
 
   const { limit, windowSeconds } = TOOL_RATE_LIMITS[tool];
@@ -47,6 +53,7 @@ export async function checkToolRateLimit(
       key: `ratelimit:tool:${tool}:${username.toLowerCase()}`,
       windowSeconds,
       limit,
+      ...(redis ? { redis } : {}),
     });
     if (!result.allowed) {
       const minutes = Math.max(1, Math.ceil(result.resetSeconds / 60));

--- a/api/chat/tools/_tool-rate-limit.ts
+++ b/api/chat/tools/_tool-rate-limit.ts
@@ -1,0 +1,64 @@
+/**
+ * Lightweight per-user rate limiting for server-executed chat tools.
+ *
+ * The chat endpoint already rate limits messages (per IP for anonymous users,
+ * per username for authenticated ones), but a single message can trigger up
+ * to `stopAfterSteps` tool calls. These per-tool counters bound how much
+ * external quota (YouTube API, Apple Maps, arbitrary web fetches) one user
+ * can burn through tool loops.
+ *
+ * Anonymous users are not tracked here: their chat budget (3 messages/day
+ * per IP) already caps tool usage, and there is no stable identifier
+ * available in the tool context.
+ */
+
+import { checkCounterLimit } from "../../_utils/_rate-limit.js";
+
+export type RateLimitedToolName =
+  | "webFetch"
+  | "searchSongs"
+  | "mapsSearchPlaces";
+
+const TOOL_RATE_LIMITS: Record<
+  RateLimitedToolName,
+  { limit: number; windowSeconds: number }
+> = {
+  webFetch: { limit: 50, windowSeconds: 60 * 60 },
+  searchSongs: { limit: 30, windowSeconds: 60 * 60 },
+  mapsSearchPlaces: { limit: 50, windowSeconds: 60 * 60 },
+};
+
+export interface ToolRateLimitResult {
+  allowed: boolean;
+  /** Human/model-readable failure message when not allowed. */
+  message?: string;
+}
+
+export async function checkToolRateLimit(
+  tool: RateLimitedToolName,
+  username: string | null | undefined,
+  logError: (...args: unknown[]) => void
+): Promise<ToolRateLimitResult> {
+  if (!username) return { allowed: true };
+
+  const { limit, windowSeconds } = TOOL_RATE_LIMITS[tool];
+  try {
+    const result = await checkCounterLimit({
+      key: `ratelimit:tool:${tool}:${username.toLowerCase()}`,
+      windowSeconds,
+      limit,
+    });
+    if (!result.allowed) {
+      const minutes = Math.max(1, Math.ceil(result.resetSeconds / 60));
+      return {
+        allowed: false,
+        message: `Rate limit reached for ${tool} (${limit} calls/hour). Try again in about ${minutes} minute${minutes === 1 ? "" : "s"}.`,
+      };
+    }
+    return { allowed: true };
+  } catch (error) {
+    // Fail open: a Redis hiccup should not take down tool execution.
+    logError(`[${tool}] rate limit check failed`, error);
+    return { allowed: true };
+  }
+}

--- a/api/chat/tools/executors.ts
+++ b/api/chat/tools/executors.ts
@@ -37,6 +37,7 @@ import {
 } from "../../sync/v2/_tool-state.js";
 import { getAppPublicOrigin } from "../../_utils/runtime-config.js";
 import { extractMetadata, stripHtmlToText } from "./htmlExtract.js";
+import { checkToolRateLimit } from "./_tool-rate-limit.js";
 import {
   getYouTubeApiKeys,
   toSearchSongsResult,
@@ -94,11 +95,20 @@ export async function executeGenerateHtml(
  */
 export async function executeSearchSongs(
   input: SearchSongsInput,
-  context: ServerToolContext
+  context: ServerToolContext & { username?: string | null }
 ): Promise<SearchSongsOutput> {
   const { query, maxResults = 5 } = input;
   
   context.log(`[searchSongs] Searching for: "${query}" (max ${maxResults} results)`);
+
+  const rateLimit = await checkToolRateLimit(
+    "searchSongs",
+    context.username,
+    context.logError
+  );
+  if (!rateLimit.allowed) {
+    return { results: [], message: rateLimit.message! };
+  }
 
   const apiKeys = getYouTubeApiKeys(context.env);
 
@@ -192,11 +202,27 @@ const WEB_FETCH_BROWSER_HEADERS: Record<string, string> = {
 
 export async function executeWebFetch(
   input: WebFetchInput,
-  context: ServerToolContext
+  context: ServerToolContext & { username?: string | null }
 ): Promise<WebFetchOutput> {
   const { url, selector } = input;
 
   context.log(`[webFetch] Fetching: ${url}${selector ? ` (selector: ${selector})` : ""}`);
+
+  const rateLimit = await checkToolRateLimit(
+    "webFetch",
+    context.username,
+    context.logError
+  );
+  if (!rateLimit.allowed) {
+    return {
+      success: false,
+      url,
+      content: "",
+      contentLength: 0,
+      truncated: false,
+      message: rateLimit.message!,
+    };
+  }
 
   try {
     await validatePublicUrl(url);

--- a/api/chat/tools/executors.ts
+++ b/api/chat/tools/executors.ts
@@ -95,17 +95,13 @@ export async function executeGenerateHtml(
  */
 export async function executeSearchSongs(
   input: SearchSongsInput,
-  context: ServerToolContext & { username?: string | null }
+  context: ServerToolContext & { username?: string | null; redis?: Redis }
 ): Promise<SearchSongsOutput> {
   const { query, maxResults = 5 } = input;
   
   context.log(`[searchSongs] Searching for: "${query}" (max ${maxResults} results)`);
 
-  const rateLimit = await checkToolRateLimit(
-    "searchSongs",
-    context.username,
-    context.logError
-  );
+  const rateLimit = await checkToolRateLimit("searchSongs", context);
   if (!rateLimit.allowed) {
     return { results: [], message: rateLimit.message! };
   }
@@ -202,17 +198,13 @@ const WEB_FETCH_BROWSER_HEADERS: Record<string, string> = {
 
 export async function executeWebFetch(
   input: WebFetchInput,
-  context: ServerToolContext & { username?: string | null }
+  context: ServerToolContext & { username?: string | null; redis?: Redis }
 ): Promise<WebFetchOutput> {
   const { url, selector } = input;
 
   context.log(`[webFetch] Fetching: ${url}${selector ? ` (selector: ${selector})` : ""}`);
 
-  const rateLimit = await checkToolRateLimit(
-    "webFetch",
-    context.username,
-    context.logError
-  );
+  const rateLimit = await checkToolRateLimit("webFetch", context);
   if (!rateLimit.allowed) {
     return {
       success: false,

--- a/api/chat/tools/index.ts
+++ b/api/chat/tools/index.ts
@@ -184,7 +184,7 @@ export const TOOL_DESCRIPTIONS = {
     "For 'add', pass the chosen YouTube result's videoId and title/channel when available. Results include canonical ryOS links for iPod and Karaoke share URLs.",
   
   settings:
-    "Change system settings in ryOS. Use this tool when the user asks to change language, theme, volume, enable/disable speech, or check for updates. Multiple settings can be changed in a single call.",
+    "Change system settings in ryOS. Use this tool when the user asks to change language, theme, wallpaper, accent color, volume, enable/disable speech or UI sounds, or check for updates. Multiple settings can be changed in a single call.",
   
   stickiesControl:
     "Manage sticky notes in ryOS. Actions: 'list' returns all stickies with their IDs, content, and colors; 'create' makes a new sticky note with optional content/text, color (yellow/blue/green/pink/purple/orange), position, size; 'update' modifies an existing sticky by ID - use this to set/replace text content, change color, or move it; 'delete' removes a sticky by ID; 'clear' removes all stickies. The Stickies app opens automatically when creating notes.",
@@ -500,6 +500,18 @@ export function createChatTools(
   const profile = options.profile || "all";
 
   if (profile === "all") {
+    if (!context.username) {
+      // Anonymous users have no persistent memory storage, so the memory
+      // tools always fail for them. Omit them entirely to save prompt
+      // tokens and avoid dead-end tool calls.
+      const {
+        memoryWrite: _memoryWrite,
+        memoryRead: _memoryRead,
+        memoryDelete: _memoryDelete,
+        ...anonymousTools
+      } = allTools;
+      return anonymousTools;
+    }
     return allTools;
   }
 

--- a/api/chat/tools/maps-executor.ts
+++ b/api/chat/tools/maps-executor.ts
@@ -11,6 +11,7 @@ import {
   type MapKitSearchPlace,
 } from "../../_utils/_mapkit-server.js";
 import { listMapKitMissingEnv } from "../../_utils/_mapkit-jwt.js";
+import { checkToolRateLimit } from "./_tool-rate-limit.js";
 import type {
   MapsSearchPlaceResult,
   MapsSearchPlacesInput,
@@ -114,9 +115,25 @@ function resolveFallbackNear(
 
 export async function executeMapsSearchPlaces(
   input: MapsSearchPlacesInput,
-  context: ServerToolContext
+  context: ServerToolContext & { username?: string | null }
 ): Promise<MapsSearchPlacesOutput> {
   const query = input.query.trim();
+
+  const rateLimit = await checkToolRateLimit(
+    "mapsSearchPlaces",
+    context.username,
+    context.logError
+  );
+  if (!rateLimit.allowed) {
+    return {
+      success: false,
+      query,
+      results: [],
+      message: rateLimit.message!,
+      error: "rate_limited",
+    };
+  }
+
   const explicitNear = input.near ?? null;
   const fallbackNear = explicitNear ? null : resolveFallbackNear(context);
   const effectiveNear = explicitNear ?? fallbackNear;

--- a/api/chat/tools/maps-executor.ts
+++ b/api/chat/tools/maps-executor.ts
@@ -11,6 +11,7 @@ import {
   type MapKitSearchPlace,
 } from "../../_utils/_mapkit-server.js";
 import { listMapKitMissingEnv } from "../../_utils/_mapkit-jwt.js";
+import type { Redis } from "../../_utils/redis.js";
 import { checkToolRateLimit } from "./_tool-rate-limit.js";
 import type {
   MapsSearchPlaceResult,
@@ -115,15 +116,11 @@ function resolveFallbackNear(
 
 export async function executeMapsSearchPlaces(
   input: MapsSearchPlacesInput,
-  context: ServerToolContext & { username?: string | null }
+  context: ServerToolContext & { username?: string | null; redis?: Redis }
 ): Promise<MapsSearchPlacesOutput> {
   const query = input.query.trim();
 
-  const rateLimit = await checkToolRateLimit(
-    "mapsSearchPlaces",
-    context.username,
-    context.logError
-  );
+  const rateLimit = await checkToolRateLimit("mapsSearchPlaces", context);
   if (!rateLimit.allowed) {
     return {
       success: false,

--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { appIds } from "../../../src/config/appIds.js";
 import {
   THEME_IDS,
+  ACCENT_IDS,
   LANGUAGE_CODES,
   VFS_PATHS,
   MEMORY_TYPES,
@@ -415,6 +416,19 @@ export const settingsSchema = z.object({
     .describe(
       'Change the OS theme. One of "system7" (Mac OS 7), "macosx" (Mac OS X), "xp" (Windows XP), "win98" (Windows 98).'
     ),
+  wallpaper: z
+    .string()
+    .max(120)
+    .optional()
+    .describe(
+      "Change the desktop wallpaper by name. Fuzzy-matched against the built-in tiles, photos, and video wallpapers (e.g. 'aurora', 'clouds', 'red tile')."
+    ),
+  accent: z
+    .enum(ACCENT_IDS)
+    .optional()
+    .describe(
+      "Change the accent color (Mac OS X and System 7 themes only). 'default' restores the theme's classic look; 'wallpaper' samples the color from the current wallpaper."
+    ),
   masterVolume: z
     .number()
     .min(0)
@@ -428,6 +442,12 @@ export const settingsSchema = z.object({
     .optional()
     .describe(
       "Enable or disable text-to-speech for AI responses. When enabled, the AI's responses will be read aloud."
+    ),
+  uiSoundsEnabled: z
+    .boolean()
+    .optional()
+    .describe(
+      "Enable or disable UI sound effects (window sounds, clicks, and other interface feedback)."
     ),
   checkForUpdates: z
     .boolean()
@@ -646,6 +666,11 @@ export const calendarControlSchema = z.object({
     .max(500)
     .optional()
     .describe("Optional notes for the event."),
+  location: z
+    .string()
+    .max(200)
+    .optional()
+    .describe("For 'create' and 'update': optional event location (shown under the title)."),
   completed: z
     .boolean()
     .optional()
@@ -839,12 +864,14 @@ export const documentsControlSchema = z
       ),
     path: z
       .string()
+      .max(300)
       .optional()
       .describe(
         "For 'read', 'write', and 'edit': full document path under /Documents, e.g. '/Documents/notes.md'."
       ),
     content: z
       .string()
+      .max(100_000)
       .optional()
       .describe("For 'write': markdown content to save. Required for writes."),
     mode: z
@@ -856,11 +883,16 @@ export const documentsControlSchema = z
       ),
     old_string: z
       .string()
+      .max(20_000)
       .optional()
       .describe(
         "For 'edit': exact text to replace. Must match uniquely within the document."
       ),
-    new_string: z.string().optional().describe("For 'edit': replacement text."),
+    new_string: z
+      .string()
+      .max(20_000)
+      .optional()
+      .describe("For 'edit': replacement text."),
   })
   .superRefine((data, ctx) => {
     const path = data.path?.trim();
@@ -887,6 +919,20 @@ export const documentsControlSchema = z
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "Document paths must end with .md.",
+          path: ["path"],
+        });
+      }
+      const fileName = path.slice("/Documents/".length);
+      if (
+        fileName.includes("/") ||
+        fileName.includes("\\") ||
+        fileName.includes("..") ||
+        fileName.trim().length === 0
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "Document paths must point at a single file directly under /Documents (no subdirectories or '..').",
           path: ["path"],
         });
       }

--- a/api/chat/tools/types.ts
+++ b/api/chat/tools/types.ts
@@ -36,6 +36,22 @@ export {
 export const THEME_IDS = ["system7", "macosx", "xp", "win98"] as const;
 export type ThemeId = typeof THEME_IDS[number];
 
+// Accent color IDs (mirrors AccentId in src/themes/accents.ts)
+export const ACCENT_IDS = [
+  "default",
+  "wallpaper",
+  "graphite",
+  "blue",
+  "purple",
+  "pink",
+  "red",
+  "orange",
+  "yellow",
+  "green",
+  "teal",
+] as const;
+export type AccentId = typeof ACCENT_IDS[number];
+
 // Supported language codes
 export const LANGUAGE_CODES = [
   "en",
@@ -265,8 +281,11 @@ export interface SongLibraryControlOutput {
 export interface SettingsInput {
   language?: LanguageCode;
   theme?: ThemeId;
+  wallpaper?: string;
+  accent?: AccentId;
   masterVolume?: number;
   speechEnabled?: boolean;
+  uiSoundsEnabled?: boolean;
   checkForUpdates?: boolean;
 }
 

--- a/src/apps/chats/tools/appHandlers.ts
+++ b/src/apps/chats/tools/appHandlers.ts
@@ -8,6 +8,7 @@ import { requestCloseWindow } from "@/utils/windowUtils";
 import type { AppId } from "@/config/appIds";
 import type { LaunchAppOptions } from "@/hooks/useLaunchApp";
 import i18n from "@/lib/i18n";
+import { getTranslatedAppName } from "@/utils/i18n";
 import type { ToolContext } from "./types";
 import { chatToolsLog as log } from "../logging";
 
@@ -43,7 +44,9 @@ export const handleLaunchApp = (
     return "";
   }
 
-  const appName = appRegistry[id as AppId]?.name || id;
+  const appName = appRegistry[id as AppId]
+    ? getTranslatedAppName(id as AppId)
+    : id;
   log.debug("launchApp", { id, hasUrl: Boolean(url), year });
 
   const launchOptions: LaunchAppOptions = {};
@@ -53,11 +56,12 @@ export const handleLaunchApp = (
 
   context.launchApp(id as AppId, launchOptions);
 
-  let result = `Launched ${appName}`;
-  if (id === "internet-explorer") {
-    const urlPart = url ? ` to ${url}` : "";
-    const yearPart = year && year !== "current" ? ` in ${year}` : "";
-    result += `${urlPart}${yearPart}`;
+  let result = i18n.t("apps.chats.toolCalls.launchedApp", { appName });
+  if (id === "internet-explorer" && url) {
+    result =
+      year && year !== "current"
+        ? i18n.t("apps.chats.toolCalls.launchedWithUrlAndYear", { url, year })
+        : i18n.t("apps.chats.toolCalls.launchedWithUrl", { url });
   }
   log.debug("launchApp result", { appId: id });
   return result;
@@ -85,7 +89,9 @@ export const handleCloseApp = (
     return "";
   }
 
-  const appName = appRegistry[id as AppId]?.name || id;
+  const appName = appRegistry[id as AppId]
+    ? getTranslatedAppName(id as AppId)
+    : id;
   log.debug("closeApp", { id });
 
   // Close all instances of the specified app
@@ -95,7 +101,7 @@ export const handleCloseApp = (
 
   if (openInstances.length === 0) {
     log.debug("closeApp target not running", { id });
-    return `${appName} is not running`;
+    return i18n.t("apps.chats.toolCalls.appNotRunning", { appName });
   }
 
   // Close all open instances of this app (with animation and sound)
@@ -105,5 +111,5 @@ export const handleCloseApp = (
 
   log.debug("Closed app windows", { id, windowCount: openInstances.length });
 
-  return `Closed ${appName}`;
+  return i18n.t("apps.chats.toolCalls.closed", { appName });
 };

--- a/src/apps/chats/tools/calendarHandler.ts
+++ b/src/apps/chats/tools/calendarHandler.ts
@@ -1,26 +1,51 @@
 import type { ToolHandler } from "./types";
 import { useCalendarStore } from "@/stores/useCalendarStore";
-import type { EventColor } from "@/stores/useCalendarStore";
-import { calendarEventOccursOnDate } from "@/shared/calendarEventDates";
+import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
+import {
+  applyCalendarToolAction,
+  serializeCalendarEvent,
+  serializeCalendarTodo,
+  type CalendarControlInput,
+  type CalendarEventToolRecord,
+  type CalendarTodoToolRecord,
+} from "@/shared/tools/calendar";
+import type { CalendarSnapshotData } from "@/shared/domains/calendar";
 import i18n from "@/lib/i18n";
+import { createShortIdMap, resolveId, type ShortIdMap } from "./helpers";
 
-export interface CalendarControlInput {
-  action: "list" | "create" | "update" | "delete" | "listTodos" | "createTodo" | "toggleTodo" | "deleteTodo";
-  id?: string;
-  title?: string;
-  date?: string;
-  endDate?: string;
-  startTime?: string;
-  endTime?: string;
-  color?: EventColor;
-  notes?: string;
-  completed?: boolean;
-  calendarId?: string;
-}
+export type { CalendarControlInput } from "@/shared/tools/calendar";
 
 const tc = (key: string, opts?: Record<string, unknown>) =>
   i18n.t(`apps.chats.toolCalls.calendar.${key}`, opts);
 
+/**
+ * Module-level short-ID maps (events + todos) built on list actions and
+ * resolved on mutations, mirroring the stickies/contacts handlers. They
+ * intentionally persist across dispatches so the model can list once and
+ * mutate in later steps or messages.
+ */
+let eventIdMap: ShortIdMap | undefined;
+let todoIdMap: ShortIdMap | undefined;
+
+const withShortEventId = (
+  record: CalendarEventToolRecord
+): CalendarEventToolRecord => ({
+  ...record,
+  id: eventIdMap?.fullToShort.get(record.id) || record.id,
+});
+
+const withShortTodoId = (
+  record: CalendarTodoToolRecord
+): CalendarTodoToolRecord => ({
+  ...record,
+  id: todoIdMap?.fullToShort.get(record.id) || record.id,
+});
+
+/**
+ * Client calendar tool handler. Runs the same `applyCalendarToolAction`
+ * reducer as the server (Telegram) executor, then bridges the resulting
+ * snapshot back into the Zustand store + cloud-sync deletion markers.
+ */
 export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
   input,
   toolCallId,
@@ -29,309 +54,187 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
   const store = useCalendarStore.getState();
   const { action } = input;
 
-  switch (action) {
-    case "list": {
-      let events = store.events;
-      if (input.date) {
-        events = events.filter((ev) => calendarEventOccursOnDate(ev, input.date!));
+  const emitError = (errorText: string) => {
+    context.addToolOutput({
+      state: "output-error",
+      tool: "calendarControl",
+      toolCallId,
+      errorText,
+    });
+  };
+
+  const snapshot: CalendarSnapshotData = {
+    events: store.events,
+    calendars: store.calendars,
+    todos: store.todos,
+  };
+
+  // Resolve short IDs (e1/t1) from previous list outputs to full UUIDs.
+  const resolvedInput: CalendarControlInput = input.id
+    ? {
+        ...input,
+        id:
+          action === "toggleTodo" || action === "deleteTodo"
+            ? resolveId(input.id, todoIdMap)
+            : resolveId(input.id, eventIdMap),
       }
-      const formatted = events.map((ev) => ({
-        id: ev.id,
-        title: ev.title,
-        date: ev.date,
-        endDate: ev.endDate,
-        startTime: ev.startTime,
-        endTime: ev.endTime,
-        color: ev.color,
-        notes: ev.notes,
-      }));
+    : input;
+
+  const result = applyCalendarToolAction(snapshot, resolvedInput, {
+    generateId: () => crypto.randomUUID(),
+    now: () => Date.now(),
+    deletedAt: () => new Date().toISOString(),
+  });
+
+  if (!result.ok) {
+    switch (result.error) {
+      case "missing_fields":
+        emitError(
+          action === "createTodo"
+            ? tc("createTodoMissingTitle")
+            : tc("createEventMissingFields")
+        );
+        return;
+      case "missing_id": {
+        const keys: Partial<Record<CalendarControlInput["action"], string>> = {
+          update: "updateEventMissingId",
+          delete: "deleteEventMissingId",
+          toggleTodo: "toggleTodoMissingId",
+          deleteTodo: "deleteTodoMissingId",
+        };
+        emitError(tc(keys[action] || "updateEventMissingId"));
+        return;
+      }
+      case "not_found":
+        emitError(
+          action === "toggleTodo" || action === "deleteTodo"
+            ? tc("todoNotFound", { id: input.id })
+            : tc("eventNotFound", { id: input.id })
+        );
+        return;
+      default:
+        emitError(tc("unknownAction", { action }));
+        return;
+    }
+  }
+
+  const emitOutput = (output: unknown) => {
+    context.addToolOutput({ tool: "calendarControl", toolCallId, output });
+  };
+
+  switch (result.kind) {
+    case "list": {
+      eventIdMap = createShortIdMap(
+        result.events.map((event) => event.id),
+        "e"
+      );
+      const formatted = result.events.map(withShortEventId);
       const count = formatted.length;
       const message = input.date
-        ? tc(count === 1 ? "foundEventsForDate" : "foundEventsForDatePlural", { count, date: input.date })
-        : tc(count === 1 ? "foundEventsTotal" : "foundEventsTotalPlural", { count });
-      context.addToolOutput({
-        tool: "calendarControl",
-        toolCallId,
-        output: {
-          success: true,
-          message,
-          events: formatted,
-        },
-      });
-      break;
+        ? tc(count === 1 ? "foundEventsForDate" : "foundEventsForDatePlural", {
+            count,
+            date: input.date,
+          })
+        : tc(count === 1 ? "foundEventsTotal" : "foundEventsTotalPlural", {
+            count,
+          });
+      emitOutput({ success: true, message, events: formatted });
+      return;
     }
 
     case "create": {
-      if (!input.title || !input.date) {
-        context.addToolOutput({
-          state: "output-error",
-          tool: "calendarControl",
-          toolCallId,
-          errorText: tc("createEventMissingFields"),
-        });
-        return;
-      }
-
-      const eventId = store.addEvent({
-        title: input.title,
-        date: input.date,
-        endDate: input.endDate,
-        startTime: input.startTime,
-        endTime: input.endTime,
-        color: input.color || "blue",
-        notes: input.notes,
-      });
-
-      store.setSelectedDate(input.date);
+      useCalendarStore.setState({ events: result.state.events });
+      store.setSelectedDate(result.event.date);
       context.launchApp("calendar");
-
-      context.addToolOutput({
-        tool: "calendarControl",
-        toolCallId,
-        output: {
-          success: true,
-          message: tc("createdEvent", { title: input.title, date: input.date }),
-          event: {
-            id: eventId,
-            title: input.title,
-            date: input.date,
-            endDate: input.endDate,
-            startTime: input.startTime,
-            endTime: input.endTime,
-            color: input.color || "blue",
-            notes: input.notes,
-          },
-        },
+      emitOutput({
+        success: true,
+        message: tc("createdEvent", {
+          title: result.event.title,
+          date: result.event.date,
+        }),
+        event: serializeCalendarEvent(result.event),
       });
-      break;
+      return;
     }
 
     case "update": {
-      if (!input.id) {
-        context.addToolOutput({
-          state: "output-error",
-          tool: "calendarControl",
-          toolCallId,
-          errorText: tc("updateEventMissingId"),
-        });
-        return;
-      }
-
-      const existing = store.events.find((ev) => ev.id === input.id);
-      if (!existing) {
-        context.addToolOutput({
-          state: "output-error",
-          tool: "calendarControl",
-          toolCallId,
-          errorText: tc("eventNotFound", { id: input.id }),
-        });
-        return;
-      }
-
-      const updates: Record<string, unknown> = {};
-      if (input.title !== undefined) updates.title = input.title;
-      if (input.date !== undefined) updates.date = input.date;
-      if (input.endDate !== undefined) updates.endDate = input.endDate;
-      if (input.startTime !== undefined) updates.startTime = input.startTime;
-      if (input.endTime !== undefined) updates.endTime = input.endTime;
-      if (input.color !== undefined) updates.color = input.color;
-      if (input.notes !== undefined) updates.notes = input.notes;
-
-      store.updateEvent(input.id, updates);
-
-      context.addToolOutput({
-        tool: "calendarControl",
-        toolCallId,
-        output: {
-          success: true,
-          message: tc("updatedEventMsg", { title: existing.title }),
-        },
+      useCalendarStore.setState({ events: result.state.events });
+      emitOutput({
+        success: true,
+        message: tc("updatedEventMsg", { title: result.event.title }),
+        event: withShortEventId(serializeCalendarEvent(result.event)),
       });
-      break;
+      return;
     }
 
     case "delete": {
-      if (!input.id) {
-        context.addToolOutput({
-          state: "output-error",
-          tool: "calendarControl",
-          toolCallId,
-          errorText: tc("deleteEventMissingId"),
-        });
-        return;
-      }
-
-      const toDelete = store.events.find((ev) => ev.id === input.id);
-      if (!toDelete) {
-        context.addToolOutput({
-          state: "output-error",
-          tool: "calendarControl",
-          toolCallId,
-          errorText: tc("eventNotFound", { id: input.id }),
-        });
-        return;
-      }
-
-      store.deleteEvent(input.id);
-
-      context.addToolOutput({
-        tool: "calendarControl",
-        toolCallId,
-        output: {
-          success: true,
-          message: tc("deletedEventMsg", { title: toDelete.title }),
-        },
+      useCalendarStore.setState({ events: result.state.events });
+      useCloudSyncStore
+        .getState()
+        .markDeletedKeys("calendarEventIds", [result.event.id]);
+      emitOutput({
+        success: true,
+        message: tc("deletedEventMsg", { title: result.event.title }),
       });
-      break;
+      return;
     }
 
     case "listTodos": {
-      let todos = store.todos;
-      if (input.completed === true) {
-        todos = todos.filter((t) => t.completed);
-      }
-      const formatted = todos.map((t) => ({
-        id: t.id,
-        title: t.title,
-        completed: t.completed,
-        dueDate: t.dueDate,
-        calendarId: t.calendarId,
-      }));
+      todoIdMap = createShortIdMap(
+        result.todos.map((todo) => todo.id),
+        "t"
+      );
+      const formatted = result.todos.map(withShortTodoId);
       const count = formatted.length;
-      context.addToolOutput({
-        tool: "calendarControl",
-        toolCallId,
-        output: {
-          success: true,
-          message: tc(count === 1 ? "foundTodosMsg" : "foundTodosMsgPlural", { count }),
-          todos: formatted,
-        },
+      emitOutput({
+        success: true,
+        message: tc(count === 1 ? "foundTodosMsg" : "foundTodosMsgPlural", {
+          count,
+        }),
+        todos: formatted,
       });
-      break;
+      return;
     }
 
     case "createTodo": {
-      if (!input.title) {
-        context.addToolOutput({
-          state: "output-error",
-          tool: "calendarControl",
-          toolCallId,
-          errorText: tc("createTodoMissingTitle"),
-        });
-        return;
-      }
-
-      const calendarId = input.calendarId || store.calendars[0]?.id || "home";
-      const todoId = store.addTodo(input.title, calendarId, input.date);
-
+      useCalendarStore.setState({ todos: result.state.todos });
       store.setShowTodoSidebar(true);
       context.launchApp("calendar");
-
-      context.addToolOutput({
-        tool: "calendarControl",
-        toolCallId,
-        output: {
-          success: true,
-          message: input.date
-            ? tc("createdTodoDue", { title: input.title, date: input.date })
-            : tc("createdTodo", { title: input.title }),
-          todo: {
-            id: todoId,
-            title: input.title,
-            completed: false,
-            dueDate: input.date || null,
-            calendarId,
-          },
-        },
+      emitOutput({
+        success: true,
+        message: result.todo.dueDate
+          ? tc("createdTodoDue", {
+              title: result.todo.title,
+              date: result.todo.dueDate,
+            })
+          : tc("createdTodo", { title: result.todo.title }),
+        todo: serializeCalendarTodo(result.todo),
       });
-      break;
+      return;
     }
 
     case "toggleTodo": {
-      if (!input.id) {
-        context.addToolOutput({
-          state: "output-error",
-          tool: "calendarControl",
-          toolCallId,
-          errorText: tc("toggleTodoMissingId"),
-        });
-        return;
-      }
-
-      const todoToToggle = store.todos.find((t) => t.id === input.id);
-      if (!todoToToggle) {
-        context.addToolOutput({
-          state: "output-error",
-          tool: "calendarControl",
-          toolCallId,
-          errorText: tc("todoNotFound", { id: input.id }),
-        });
-        return;
-      }
-
-      store.toggleTodo(input.id);
-
-      context.addToolOutput({
-        tool: "calendarControl",
-        toolCallId,
-        output: {
-          success: true,
-          message: !todoToToggle.completed
-            ? tc("markedTodoCompleted", { title: todoToToggle.title })
-            : tc("markedTodoPending", { title: todoToToggle.title }),
-          todo: {
-            id: todoToToggle.id,
-            title: todoToToggle.title,
-            completed: !todoToToggle.completed,
-            dueDate: todoToToggle.dueDate,
-            calendarId: todoToToggle.calendarId,
-          },
-        },
+      useCalendarStore.setState({ todos: result.state.todos });
+      emitOutput({
+        success: true,
+        message: result.todo.completed
+          ? tc("markedTodoCompleted", { title: result.todo.title })
+          : tc("markedTodoPending", { title: result.todo.title }),
+        todo: withShortTodoId(serializeCalendarTodo(result.todo)),
       });
-      break;
+      return;
     }
 
     case "deleteTodo": {
-      if (!input.id) {
-        context.addToolOutput({
-          state: "output-error",
-          tool: "calendarControl",
-          toolCallId,
-          errorText: tc("deleteTodoMissingId"),
-        });
-        return;
-      }
-
-      const todoToDelete = store.todos.find((t) => t.id === input.id);
-      if (!todoToDelete) {
-        context.addToolOutput({
-          state: "output-error",
-          tool: "calendarControl",
-          toolCallId,
-          errorText: tc("todoNotFound", { id: input.id }),
-        });
-        return;
-      }
-
-      store.deleteTodo(input.id);
-
-      context.addToolOutput({
-        tool: "calendarControl",
-        toolCallId,
-        output: {
-          success: true,
-          message: tc("deletedTodoMsg", { title: todoToDelete.title }),
-        },
+      useCalendarStore.setState({ todos: result.state.todos });
+      useCloudSyncStore
+        .getState()
+        .markDeletedKeys("calendarTodoIds", [result.todo.id]);
+      emitOutput({
+        success: true,
+        message: tc("deletedTodoMsg", { title: result.todo.title }),
       });
-      break;
+      return;
     }
-
-    default:
-      context.addToolOutput({
-        state: "output-error",
-        tool: "calendarControl",
-        toolCallId,
-        errorText: tc("unknownAction", { action }),
-      });
   }
 };

--- a/src/apps/chats/tools/dispatchToolCall.ts
+++ b/src/apps/chats/tools/dispatchToolCall.ts
@@ -7,37 +7,9 @@
  * AI surfaces share one implementation.
  */
 
-import { useAppStore } from "@/stores/useAppStore";
-import { AppId } from "@/config/appIds";
-import { appRegistry } from "@/config/appRegistry";
-import { getTranslatedAppName } from "@/utils/i18n";
-import { getDefaultFileApp } from "@/utils/fileAssociations";
-import type { DocumentContent } from "@/apps/finder/hooks/useFileSystem";
-import { STORES, dbOperations } from "@/utils/indexedDB";
-import {
-  normalizeSearchText,
-  computeMatchScore,
-  deriveScoreThreshold,
-} from "@/apps/chats/utils/fuzzySearch";
-import { useTextEditStore } from "@/stores/useTextEditStore";
-import { useFilesStore } from "@/stores/useFilesStore";
-import {
-  getIpodTracksForLibrary,
-  type IpodLibrarySelection,
-  useIpodStore,
-} from "@/stores/useIpodStore";
-import { markdownToHtml } from "@/utils/markdown";
-import { generateJsonFromHtml } from "@/utils/tiptapHtml";
 import i18n from "@/lib/i18n";
-import { abortableFetch } from "@/utils/abortableFetch";
-import { getApiUrl } from "@/utils/platform";
 import { aiChatLog as log } from "../logging";
-import { emitAppletUpdated, emitDocumentUpdated } from "@/utils/appEventBus";
-import {
-  persistChatApplet,
-  persistChatDocument,
-  type SaveFileHandler,
-} from "../utils/chatFilePersistence";
+import { type SaveFileHandler } from "../utils/chatFilePersistence";
 import {
   handleLaunchApp,
   handleCloseApp,
@@ -58,12 +30,25 @@ import {
   type CalendarControlInput,
   type ContactsControlInput,
 } from "./index";
+import {
+  handleVfsList,
+  handleVfsOpen,
+  handleVfsRead,
+  handleVfsWrite,
+  handleVfsEdit,
+  type VfsToolContext,
+  type VfsListInput,
+  type VfsPathInput,
+  type VfsWriteInput,
+  type VfsEditInput,
+} from "./vfsHandlers";
 import { SERVER_EXECUTED_TOOL_NAME_SET } from "@/shared/tools/serverExecuted";
 import {
   createToolOpenResultTracker,
   type DispatchToolCallResult,
 } from "./toolOpenResult";
 
+export { trackNewTextEditInstance } from "./vfsHandlers";
 
 export interface SharedToolCall {
   toolName: string;
@@ -77,58 +62,6 @@ export interface DispatchToolCallContext {
   saveFile: SaveFileHandler;
   onOpenAttempt?: (instanceId: string) => void;
 }
-
-async function storedContentToText(
-  content: DocumentContent["content"]
-): Promise<string> {
-  if (typeof content === "string") return content;
-  if (content instanceof Blob) return content.text();
-  return new TextDecoder().decode(content);
-}
-
-const recentlyCreatedTextEditInstances = new Map<
-  string,
-  { instanceId: string; path: string; timestamp: number }
->();
-
-// Helper to add a newly created instance to tracking
-export const trackNewTextEditInstance = (instanceId: string, path: string) => {
-  recentlyCreatedTextEditInstances.set(instanceId, {
-    instanceId,
-    path,
-    timestamp: Date.now(),
-  });
-  // Clean up old entries (older than 5 minutes)
-  const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
-  for (const [id, data] of recentlyCreatedTextEditInstances.entries()) {
-    if (data.timestamp < fiveMinutesAgo) {
-      recentlyCreatedTextEditInstances.delete(id);
-    }
-  }
-};
-
-const getRecentTextEditInstanceForPath = (path: string): string | null => {
-  const appStore = useAppStore.getState();
-  let newestMatch: { instanceId: string; timestamp: number } | null = null;
-
-  for (const [id, tracked] of recentlyCreatedTextEditInstances.entries()) {
-    if (tracked.path !== path) {
-      continue;
-    }
-
-    const instance = appStore.instances[id];
-    if (!instance || !instance.isOpen || instance.appId !== "textedit") {
-      recentlyCreatedTextEditInstances.delete(id);
-      continue;
-    }
-
-    if (!newestMatch || tracked.timestamp > newestMatch.timestamp) {
-      newestMatch = { instanceId: id, timestamp: tracked.timestamp };
-    }
-  }
-
-  return newestMatch?.instanceId ?? null;
-};
 
 /**
  * Execute one client-side tool call and report its output back through
@@ -163,6 +96,12 @@ export async function dispatchToolCall(
   const toolContext: ToolContext = {
     launchApp,
     addToolOutput,
+  };
+
+  const vfsContext: VfsToolContext = {
+    ...toolContext,
+    saveFile,
+    recordOpenedInstance: openResultTracker.recordOpenedInstance,
   };
 
   try {
@@ -208,939 +147,57 @@ export async function dispatchToolCall(
         break;
       }
       case "list": {
-        const { path, query, limit, librarySource } = toolCall.input as {
-          path: string;
-          query?: string;
-          limit?: number;
-          librarySource?: IpodLibrarySelection;
-        };
-
-        if (!path) {
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: i18n.t("apps.chats.toolCalls.noPathProvided"),
-          });
-          result = "";
-          break;
-        }
-
-        log.debug("Tool list", { path, query, limit });
-
-        try {
-          // Route based on path
-          if (path === "/Music") {
-            // List the selected iPod library. Karaoke asks for the YouTube
-            // slice even when the iPod UI is currently showing Apple Music.
-            const ipodStore = useIpodStore.getState();
-            const selectedLibrary = librarySource ?? "active";
-            const normalizedQuery = query
-              ? normalizeSearchText(query.trim())
-              : "";
-            const queryTokens = normalizedQuery
-              ? normalizedQuery.split(/\s+/).filter(Boolean)
-              : [];
-            const hasQuery = normalizedQuery.length > 0;
-            const maxResults = limit
-              ? Math.min(Math.max(limit, 1), 50)
-              : 25;
-            const activeTracks = getIpodTracksForLibrary(ipodStore, selectedLibrary);
-            const scoredTracks = activeTracks.map((track) => {
-              const fields = [
-                track.id,
-                track.title,
-                track.artist ?? "",
-                track.album ?? "",
-              ].map(normalizeSearchText);
-              const score = hasQuery
-                ? fields.reduce(
-                    (best, field) =>
-                      Math.max(
-                        best,
-                        computeMatchScore(field, normalizedQuery, queryTokens)
-                      ),
-                    0
-                  )
-                : 1;
-              return { track, score };
-            });
-            const scoreThreshold = hasQuery
-              ? deriveScoreThreshold(normalizedQuery.length)
-              : 0;
-            const matchingTracks = scoredTracks
-              .filter(({ score }) => score >= scoreThreshold)
-              .sort((a, b) => (hasQuery ? b.score - a.score : 0));
-            const library = matchingTracks
-              .slice(0, maxResults)
-              .map(({ track }) => ({
-                path: `/Music/${track.id}`,
-                id: track.id,
-                title: track.title,
-                artist: track.artist,
-                source:
-                  track.source ??
-                  (selectedLibrary === "active"
-                    ? ipodStore.librarySource
-                    : selectedLibrary),
-              }));
-            const hiddenCount = Math.max(matchingTracks.length - library.length, 0);
-            const resolvedLibrary =
-              selectedLibrary === "active" ? ipodStore.librarySource : selectedLibrary;
-            const libraryName =
-              resolvedLibrary === "appleMusic" ? "Apple Music" : "YouTube";
-
-            const resultMessage =
-              library.length > 0
-                ? `${library.length === 1 
-                    ? i18n.t("apps.chats.toolCalls.foundSongsInMusic", { count: library.length })
-                    : i18n.t("apps.chats.toolCalls.foundSongsInMusicPlural", { count: library.length })} (${libraryName})${
-                    hiddenCount > 0
-                      ? `; showing ${library.length} of ${matchingTracks.length}. Use query or limit to narrow results.`
-                      : ""
-                  }:\n${JSON.stringify(library, null, 2)}`
-                : hasQuery
-                  ? `No songs matched "${query}" in ${libraryName}.`
-                  : i18n.t("apps.chats.toolCalls.musicLibraryEmpty");
-
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: resultMessage,
-            });
-            result = "";
-          } else if (path === "/Applets Store") {
-            // List shared applets from store
-            const normalizedKeyword = query
-              ? normalizeSearchText(query.trim())
-              : "";
-            const keywordTokens = normalizedKeyword
-              ? normalizedKeyword.split(/\s+/).filter(Boolean)
-              : [];
-            const hasKeyword = normalizedKeyword.length > 0;
-            const maxResults = limit
-              ? Math.min(Math.max(limit, 1), 100)
-              : 50;
-
-            const response = await abortableFetch(
-              getApiUrl("/api/share-applet?list=true"),
-              {
-                timeout: 15000,
-                retry: { maxAttempts: 2, initialDelayMs: 500 },
-              }
-            );
-
-            const data = await response.json();
-            const allApplets: Array<{
-              id: string;
-              title?: string;
-              name?: string;
-              icon?: string;
-              createdAt?: number;
-              createdBy?: string;
-            }> = Array.isArray(data?.applets) ? data.applets : [];
-
-            const scoreThreshold = hasKeyword
-              ? deriveScoreThreshold(normalizedKeyword.length)
-              : 0;
-
-            const scoredApplets = allApplets.map((applet) => {
-              const normalizedFields = [
-                typeof applet.title === "string" ? normalizeSearchText(applet.title) : "",
-                typeof applet.name === "string" ? normalizeSearchText(applet.name) : "",
-                typeof applet.createdBy === "string" ? normalizeSearchText(applet.createdBy) : "",
-              ].filter((value) => value.length > 0);
-
-              const score = hasKeyword
-                ? normalizedFields.reduce((best, field) => {
-                    const fieldScore = computeMatchScore(field, normalizedKeyword, keywordTokens);
-                    return fieldScore > best ? fieldScore : best;
-                  }, 0)
-                : 1;
-
-              return { applet, score };
-            });
-
-            const filteredApplets = hasKeyword
-              ? scoredApplets.filter(({ score }) => score >= scoreThreshold)
-              : scoredApplets;
-
-            filteredApplets.sort((a, b) => {
-              if (hasKeyword && b.score !== a.score) return b.score - a.score;
-              return (b.applet.createdAt ?? 0) - (a.applet.createdAt ?? 0);
-            });
-
-            const limitedApplets = filteredApplets.slice(0, maxResults).map(({ applet }) => ({
-              path: `/Applets Store/${applet.id}`,
-              id: applet.id,
-              title: applet.title ?? applet.name ?? "Untitled",
-              name: applet.name,
-            }));
-
-            const resultMessage = limitedApplets.length > 0
-              ? `${limitedApplets.length === 1
-                  ? i18n.t("apps.chats.toolCalls.foundSharedApplets", { count: limitedApplets.length })
-                  : i18n.t("apps.chats.toolCalls.foundSharedAppletsPlural", { count: limitedApplets.length })}:\n${JSON.stringify(limitedApplets, null, 2)}`
-              : hasKeyword
-                ? i18n.t("apps.chats.toolCalls.noSharedAppletsMatched", { query })
-                : i18n.t("apps.chats.toolCalls.noSharedAppletsAvailable");
-
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: resultMessage,
-            });
-            result = "";
-          } else if (path === "/Applications") {
-            // List installed applications
-            const apps = Object.entries(appRegistry).reduce<
-              { path: string; name: string }[]
-            >((acc, [id, app]) => {
-              if (id !== "finder") {
-                acc.push({
-                  path: `/Applications/${id}`,
-                  name: app.name,
-                });
-              }
-              return acc;
-            }, []);
-
-            const appsMessage = apps.length === 1
-              ? i18n.t("apps.chats.toolCalls.foundApplicationsList", { count: apps.length })
-              : i18n.t("apps.chats.toolCalls.foundApplicationsListPlural", { count: apps.length });
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: `${appsMessage}:\n${JSON.stringify(apps, null, 2)}`,
-            });
-            result = "";
-          } else if (path === "/Applets" || path === "/Documents") {
-            // List files from file system
-            const filesStore = useFilesStore.getState();
-            const allItems = Object.values(filesStore.items);
-
-            const files = allItems.filter(
-              (item) =>
-                item.status === "active" &&
-                item.path.startsWith(`${path}/`) &&
-                !item.isDirectory &&
-                item.path !== `${path}/`,
-            );
-
-            const fileList = files.map((file) => ({
-              path: file.path,
-              name: file.name,
-              type: file.type,
-            }));
-
-            const fileType = path === "/Applets" ? "applet" : "document";
-            const resultMessage = fileList.length > 0
-              ? `${fileList.length === 1
-                  ? i18n.t("apps.chats.toolCalls.foundFileType", { count: fileList.length, fileType })
-                  : i18n.t("apps.chats.toolCalls.foundFileTypePlural", { count: fileList.length, fileType })}:\n${JSON.stringify(fileList, null, 2)}`
-              : i18n.t("apps.chats.toolCalls.noFileTypeFound", { fileType, path });
-
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: resultMessage,
-            });
-            result = "";
-          } else {
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              state: "output-error",
-              errorText: i18n.t("apps.chats.toolCalls.invalidPathForList", { path }),
-            });
-            result = "";
-          }
-        } catch (err) {
-          console.error("list error:", err);
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: err instanceof Error ? err.message : i18n.t("apps.chats.toolCalls.failedToListItems"),
-          });
-          result = "";
-        }
+        await handleVfsList(
+          toolCall.input as VfsListInput,
+          toolCall.toolName,
+          toolCall.toolCallId,
+          vfsContext
+        );
+        result = "";
         break;
       }
       case "open": {
-        const { path } = toolCall.input as { path: string };
-
-        if (!path) {
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: i18n.t("apps.chats.toolCalls.noPathProvided"),
-          });
-          result = "";
-          break;
-        }
-
-        log.debug("Tool open", { path });
-
-        try {
-          // Route based on path prefix
-          if (path.startsWith("/Music/")) {
-            const songId = path.replace("/Music/", "");
-            await handleMediaControl(
-              {
-                target: "music",
-                action: "playKnown",
-                id: songId,
-              },
-              toolCall.toolCallId,
-              toolContext,
-              toolCall.toolName
-            );
-            result = "";
-          } else if (path.startsWith("/Applets Store/")) {
-            // Open shared applet preview
-            const shareId = path.replace("/Applets Store/", "");
-            
-            // Fetch applet metadata to get the name
-            let appletName = shareId;
-            try {
-              const response = await abortableFetch(
-                getApiUrl(`/api/share-applet?id=${encodeURIComponent(shareId)}`),
-                {
-                  timeout: 15000,
-                  retry: { maxAttempts: 1, initialDelayMs: 250 },
-                }
-              );
-              const data = await response.json();
-              appletName = data.title || data.name || shareId;
-            } catch {
-              // Fall back to shareId if fetch fails
-            }
-            
-            launchApp("applet-viewer", {
-              initialData: { path: "", content: "", shareCode: shareId },
-            });
-
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: i18n.t("apps.chats.toolCalls.openedApplet", { appletName }),
-            });
-            result = "";
-          } else if (path.startsWith("/Applications/")) {
-            // Launch application
-            const appId = path.replace("/Applications/", "") as AppId;
-            if (!appRegistry[appId]) {
-              throw new Error(`Application not found: ${appId}`);
-            }
-
-            launchApp(appId);
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: i18n.t("apps.chats.toolCalls.launchedApp", { appName: getTranslatedAppName(appId) }),
-            });
-            result = "";
-          } else if (path.startsWith("/Applets/")) {
-            // Open applet in viewer
-            const filesStore = useFilesStore.getState();
-            const fileItem = filesStore.items[path];
-
-            if (!fileItem || fileItem.status !== "active") {
-              throw new Error(`Applet not found: ${path}`);
-            }
-
-            if (!fileItem.uuid) {
-              throw new Error(`Applet missing content: ${path}`);
-            }
-
-            const contentData = await dbOperations.get<DocumentContent>(
-              STORES.APPLETS,
-              fileItem.uuid,
-            );
-
-            if (!contentData || !contentData.content) {
-              throw new Error(`Failed to read applet content: ${path}`);
-            }
-
-            const content = await storedContentToText(contentData.content);
-
-            launchApp("applet-viewer", {
-              initialData: { path, content },
-            });
-
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: i18n.t("apps.chats.toolCalls.openedFile", { fileName: fileItem.name }),
-            });
-            result = "";
-          } else if (path.startsWith("/Documents/")) {
-            // Open document in TextEdit
-            const filesStore = useFilesStore.getState();
-            const fileItem = filesStore.items[path];
-            const appStore = useAppStore.getState();
-            const textEditStore = useTextEditStore.getState();
-
-            if (!fileItem || fileItem.status !== "active") {
-              throw new Error(`Document not found: ${path}`);
-            }
-
-            if (getDefaultFileApp(fileItem) === "preview") {
-              launchApp("preview", {
-                initialData: { path },
-              });
-              addToolOutput({
-                tool: toolCall.toolName,
-                toolCallId: toolCall.toolCallId,
-                output: i18n.t("apps.chats.toolCalls.openedDocument", {
-                  fileName: fileItem.name,
-                }),
-              });
-              result = "";
-              break;
-            }
-
-            const existingInstanceId = textEditStore.getInstanceIdByPath(path);
-            if (existingInstanceId) {
-              if (appStore.instances[existingInstanceId]) {
-                appStore.bringInstanceToForeground(existingInstanceId);
-                openResultTracker.recordOpenedInstance(existingInstanceId);
-                addToolOutput({
-                  tool: toolCall.toolName,
-                  toolCallId: toolCall.toolCallId,
-                  output: i18n.t("apps.chats.toolCalls.openedDocument", {
-                    fileName: fileItem.name,
-                  }),
-                });
-                result = "";
-                break;
-              }
-
-              // Stale reference in TextEdit store; clean it up and continue.
-              textEditStore.removeInstance(existingInstanceId);
-            }
-
-            // Fallback for write->open races: a freshly launched TextEdit window
-            // may not have registered its file path yet.
-            const recentInstanceId = getRecentTextEditInstanceForPath(path);
-            if (recentInstanceId) {
-              appStore.bringInstanceToForeground(recentInstanceId);
-              openResultTracker.recordOpenedInstance(recentInstanceId);
-              addToolOutput({
-                tool: toolCall.toolName,
-                toolCallId: toolCall.toolCallId,
-                output: i18n.t("apps.chats.toolCalls.openedDocument", {
-                  fileName: fileItem.name,
-                }),
-              });
-              result = "";
-              break;
-            }
-
-            if (!fileItem.uuid) {
-              throw new Error(`Document missing content: ${path}`);
-            }
-
-            const contentData = await dbOperations.get<DocumentContent>(
-              STORES.DOCUMENTS,
-              fileItem.uuid,
-            );
-
-            if (!contentData || !contentData.content) {
-              throw new Error(`Failed to read document content: ${path}`);
-            }
-
-            const content = await storedContentToText(contentData.content);
-
-            // Pass initialData directly to launchApp (consistent with Terminal/Finder approach).
-            // TextEdit handles markdown-to-HTML conversion internally.
-            launchApp("textedit", {
-              multiWindow: true,
-              initialData: { path, content },
-            });
-
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: i18n.t("apps.chats.toolCalls.openedDocument", { fileName: fileItem.name }),
-            });
-            result = "";
-          } else {
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              state: "output-error",
-              errorText: i18n.t("apps.chats.toolCalls.invalidPath", { path }),
-            });
-            result = "";
-          }
-        } catch (err) {
-          console.error("open error:", err);
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: err instanceof Error ? err.message : i18n.t("apps.chats.toolCalls.failedToOpen"),
-          });
-          result = "";
-        }
+        await handleVfsOpen(
+          toolCall.input as VfsPathInput,
+          toolCall.toolName,
+          toolCall.toolCallId,
+          vfsContext
+        );
+        result = "";
         break;
       }
       case "read": {
-        const { path } = toolCall.input as { path: string };
-
-        if (!path) {
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: i18n.t("apps.chats.toolCalls.noPathProvided"),
-          });
-          result = "";
-          break;
-        }
-
-        log.debug("Tool read", { path });
-
-        try {
-          if (path.startsWith("/Applets Store/")) {
-            // Fetch shared applet content
-            const shareId = path.replace("/Applets Store/", "");
-            const response = await abortableFetch(
-              getApiUrl(`/api/share-applet?id=${encodeURIComponent(shareId)}`),
-              {
-                timeout: 15000,
-                retry: { maxAttempts: 2, initialDelayMs: 500 },
-              }
-            );
-
-            const data = await response.json();
-            const filesStore = useFilesStore.getState();
-            const installedEntry = Object.values(filesStore.items).find(
-              (item) =>
-                item.status === "active" &&
-                typeof item.shareId === "string" &&
-                item.shareId.toLowerCase() === shareId.toLowerCase(),
-            );
-
-            const payload = {
-              id: shareId,
-              title: data?.title ?? null,
-              name: data?.name ?? null,
-              icon: data?.icon ?? null,
-              createdBy: data?.createdBy ?? null,
-              installedPath: installedEntry?.path ?? null,
-              content: typeof data?.content === "string" ? data.content : "",
-            };
-
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: JSON.stringify(payload, null, 2),
-            });
-            result = "";
-          } else if (path.startsWith("/Applets/") || path.startsWith("/Documents/")) {
-            // Read local file content
-            const isApplet = path.startsWith("/Applets/");
-            const filesStore = useFilesStore.getState();
-            const fileItem = filesStore.items[path];
-
-            if (!fileItem || fileItem.status !== "active") {
-              throw new Error(`File not found: ${path}`);
-            }
-
-            if (!fileItem.uuid) {
-              throw new Error(`File missing content: ${path}`);
-            }
-
-            const storeName = isApplet ? STORES.APPLETS : STORES.DOCUMENTS;
-            const contentData = await dbOperations.get<DocumentContent>(storeName, fileItem.uuid);
-
-            if (!contentData || contentData.content == null) {
-              throw new Error(`Failed to read file content: ${path}`);
-            }
-
-            const content = await storedContentToText(contentData.content);
-
-            const fileLabel = isApplet ? i18n.t("apps.chats.toolCalls.applet") : i18n.t("apps.chats.toolCalls.document");
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: i18n.t("apps.chats.toolCalls.fileContent", { fileLabel, fileName: fileItem.name, charCount: content.length }) + `\n\n${content}`,
-            });
-            result = "";
-          } else {
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              state: "output-error",
-              errorText: i18n.t("apps.chats.toolCalls.invalidPathForRead", { path }),
-            });
-            result = "";
-          }
-        } catch (err) {
-          console.error("read error:", err);
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: err instanceof Error ? err.message : i18n.t("apps.chats.toolCalls.failedToReadFile"),
-          });
-          result = "";
-        }
+        await handleVfsRead(
+          toolCall.input as VfsPathInput,
+          toolCall.toolName,
+          toolCall.toolCallId,
+          vfsContext
+        );
+        result = "";
         break;
       }
       case "write": {
-        const { path, content, mode = "overwrite" } = toolCall.input as {
-          path: string;
-          content: string;
-          mode?: "overwrite" | "append" | "prepend";
-        };
-
-        if (!path) {
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: i18n.t("apps.chats.toolCalls.noPathProvided"),
-          });
-          result = "";
-          break;
-        }
-
-        // Validate path format for documents
-        if (!path.startsWith("/Documents/")) {
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: i18n.t("apps.chats.toolCalls.invalidPathForWrite", { path }),
-          });
-          result = "";
-          break;
-        }
-
-        // Validate filename has .md extension
-        const fileName = path.split("/").pop() || "";
-        if (!fileName.endsWith(".md")) {
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: i18n.t("apps.chats.toolCalls.invalidFilename", { fileName }),
-          });
-          result = "";
-          break;
-        }
-
-        if (!content && mode === "overwrite") {
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: i18n.t("apps.chats.toolCalls.noContentProvided"),
-          });
-          result = "";
-          break;
-        }
-
-        log.debug("Tool write", { path, mode, contentLength: content?.length });
-
-        try {
-          const appStore = useAppStore.getState();
-          const textEditStore = useTextEditStore.getState();
-
-          // Check if file exists for append/prepend modes
-          const existingItem = useFilesStore.getState().items[path];
-          const isNewFile = !existingItem || existingItem.status !== "active";
-
-          // Determine final content based on mode
-          let finalContent = content || "";
-          if (!isNewFile && mode !== "overwrite" && existingItem?.uuid) {
-            const existingData = await dbOperations.get<DocumentContent>(STORES.DOCUMENTS, existingItem.uuid);
-            if (existingData?.content) {
-              const existingContent = await storedContentToText(
-                existingData.content
-              );
-              finalContent = mode === "prepend"
-                ? content + existingContent
-                : existingContent + content;
-            }
-          }
-
-          await persistChatDocument({
-            saveFile,
-            path,
-            fileName,
-            content: finalContent,
-            icon: existingItem?.icon || "📄",
-          });
-
-          // Find existing TextEdit instance for this file
-          let targetInstanceId: string | null = null;
-          for (const [instanceId, instance] of Object.entries(textEditStore.instances)) {
-            if (instance.filePath === path) {
-              // Verify instance actually exists in AppStore
-              if (appStore.instances[instanceId]) {
-                targetInstanceId = instanceId;
-              } else {
-                // Stale instance reference - clean it up
-                textEditStore.removeInstance(instanceId);
-              }
-              break;
-            }
-          }
-
-          if (targetInstanceId) {
-            // Update existing TextEdit instance with content
-            const htmlFragment = markdownToHtml(finalContent);
-            const contentJson = await generateJsonFromHtml(htmlFragment);
-
-            textEditStore.updateInstance(targetInstanceId, {
-              filePath: path,
-              contentJson,
-              hasUnsavedChanges: false, // Already saved to disk
-            });
-
-            // Dispatch event to update the editor content
-            emitDocumentUpdated({
-              path,
-              content: JSON.stringify(contentJson),
-            });
-
-            appStore.bringInstanceToForeground(targetInstanceId);
-          } else {
-            // Create new TextEdit instance with initialData (same pattern as Finder)
-            const windowTitle = fileName.replace(/\.md$/, "") || "Untitled";
-            targetInstanceId = appStore.launchApp(
-              "textedit",
-              { path, content: finalContent },
-              windowTitle,
-              true
-            );
-            trackNewTextEditInstance(targetInstanceId, path);
-          }
-
-          openResultTracker.recordOpenedInstance(targetInstanceId);
-          const outputKey = isNewFile ? "createdDocument" : "updatedDocument";
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            output: i18n.t(`apps.chats.toolCalls.${outputKey}`, { path }),
-          });
-          result = "";
-        } catch (err) {
-          console.error("write error:", err);
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: err instanceof Error ? err.message : i18n.t("apps.chats.toolCalls.failedToWriteFile"),
-          });
-          result = "";
-        }
+        await handleVfsWrite(
+          toolCall.input as VfsWriteInput,
+          toolCall.toolName,
+          toolCall.toolCallId,
+          vfsContext
+        );
+        result = "";
         break;
       }
       case "edit": {
-        const { path, old_string, new_string } = toolCall.input as {
-          path: string;
-          old_string: string;
-          new_string: string;
-        };
-
-        if (!path || typeof old_string !== "string" || typeof new_string !== "string") {
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: i18n.t("apps.chats.toolCalls.missingEditParameters"),
-          });
-          result = "";
-          break;
-        }
-
-        log.debug("Tool edit", {
-          path,
-          oldStringLength: old_string.length,
-          newStringLength: new_string.length,
-        });
-
-        // Normalize line endings
-        const normalizedOldString = old_string.replace(/\r\n?/g, "\n");
-        const normalizedNewString = new_string.replace(/\r\n?/g, "\n");
-
-        try {
-          if (path.startsWith("/Documents/")) {
-            // Edit document - read directly from file system (independent of TextEdit instances)
-            const filesStore = useFilesStore.getState();
-            const fileItem = filesStore.items[path];
-
-            if (!fileItem || fileItem.status !== "active" || !fileItem.uuid) {
-              throw new Error(`Document not found: ${path}. Use write tool to create new documents, or list({ path: "/Documents" }) to see available files.`);
-            }
-
-            // Read existing content from IndexedDB
-            const contentData = await dbOperations.get<DocumentContent>(STORES.DOCUMENTS, fileItem.uuid);
-            if (!contentData?.content) {
-              throw new Error(`Failed to read document content: ${path}`);
-            }
-
-            const existingContent = await storedContentToText(
-              contentData.content
-            );
-
-            // Normalize existing content
-            const normalizedExisting = existingContent.replace(/\r\n?/g, "\n");
-
-            // Check for uniqueness - count occurrences
-            const occurrences = normalizedExisting.split(normalizedOldString).length - 1;
-            
-            if (occurrences === 0) {
-              addToolOutput({
-                tool: toolCall.toolName,
-                toolCallId: toolCall.toolCallId,
-                state: "output-error",
-                errorText: i18n.t("apps.chats.toolCalls.oldStringNotFound"),
-              });
-              result = "";
-              break;
-            }
-
-            if (occurrences > 1) {
-              addToolOutput({
-                tool: toolCall.toolName,
-                toolCallId: toolCall.toolCallId,
-                state: "output-error",
-                errorText: i18n.t("apps.chats.toolCalls.oldStringMultipleMatches", { count: occurrences }),
-              });
-              result = "";
-              break;
-            }
-
-            // Replace exactly one occurrence
-            const updatedContent = normalizedExisting.replace(normalizedOldString, normalizedNewString);
-
-            await persistChatDocument({
-              saveFile,
-              path,
-              fileName: fileItem.name,
-              content: updatedContent,
-              icon: fileItem.icon || "📄",
-            });
-
-            // Also update any open TextEdit instance showing this file
-            const textEditState = useTextEditStore.getState();
-            for (const [instanceId, instance] of Object.entries(textEditState.instances)) {
-              if (instance.filePath === path) {
-                const updatedHtml = markdownToHtml(updatedContent);
-                const updatedJson = await generateJsonFromHtml(updatedHtml);
-
-                textEditState.updateInstance(instanceId, {
-                  contentJson: updatedJson,
-                  hasUnsavedChanges: false, // Already saved to disk
-                });
-                break;
-              }
-            }
-
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: i18n.t("apps.chats.toolCalls.editedDocument", { path }),
-            });
-            result = "";
-          } else if (path.startsWith("/Applets/")) {
-            // Edit applet HTML
-            const filesStore = useFilesStore.getState();
-            const fileItem = filesStore.items[path];
-
-            if (!fileItem || fileItem.status !== "active" || !fileItem.uuid) {
-              throw new Error(`Applet not found: ${path}. Use generateHtml tool to create new applets, or list({ path: "/Applets" }) to see available files.`);
-            }
-
-            const contentData = await dbOperations.get<DocumentContent>(STORES.APPLETS, fileItem.uuid);
-            if (!contentData?.content) {
-              throw new Error(`Failed to read applet content: ${path}`);
-            }
-
-            const existingContent = await storedContentToText(
-              contentData.content
-            );
-
-            // Normalize existing content
-            const normalizedExisting = existingContent.replace(/\r\n?/g, "\n");
-
-            // Check for uniqueness - count occurrences
-            const occurrences = normalizedExisting.split(normalizedOldString).length - 1;
-            
-            if (occurrences === 0) {
-              addToolOutput({
-                tool: toolCall.toolName,
-                toolCallId: toolCall.toolCallId,
-                state: "output-error",
-                errorText: i18n.t("apps.chats.toolCalls.oldStringNotFound"),
-              });
-              result = "";
-              break;
-            }
-
-            if (occurrences > 1) {
-              addToolOutput({
-                tool: toolCall.toolName,
-                toolCallId: toolCall.toolCallId,
-                state: "output-error",
-                errorText: i18n.t("apps.chats.toolCalls.oldStringMultipleMatches", { count: occurrences }),
-              });
-              result = "";
-              break;
-            }
-
-            // Replace exactly one occurrence
-            const updatedContent = normalizedExisting.replace(normalizedOldString, normalizedNewString);
-
-            await persistChatApplet({
-              saveFile,
-              fileItem,
-              content: updatedContent,
-            });
-
-            // Let any open applet viewers hot-reload this edited applet.
-            emitAppletUpdated({
-              path,
-              content: updatedContent,
-            });
-
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              output: i18n.t("apps.chats.toolCalls.editedApplet", { path }),
-            });
-            result = "";
-          } else {
-            addToolOutput({
-              tool: toolCall.toolName,
-              toolCallId: toolCall.toolCallId,
-              state: "output-error",
-              errorText: i18n.t("apps.chats.toolCalls.invalidPathForEdit", { path }),
-            });
-            result = "";
-          }
-        } catch (err) {
-          console.error("edit error:", err);
-          addToolOutput({
-            tool: toolCall.toolName,
-            toolCallId: toolCall.toolCallId,
-            state: "output-error",
-            errorText: err instanceof Error ? err.message : i18n.t("apps.chats.toolCalls.failedToEditFile"),
-          });
-          result = "";
-        }
+        await handleVfsEdit(
+          toolCall.input as VfsEditInput,
+          toolCall.toolName,
+          toolCall.toolCallId,
+          vfsContext
+        );
+        result = "";
         break;
       }
       case "settings": {
-        handleSettings(
+        await handleSettings(
           toolCall.input as SettingsInput,
           toolCall.toolCallId,
           toolContext
@@ -1192,7 +249,9 @@ export async function dispatchToolCall(
           tool: toolCall.toolName,
           toolCallId: toolCall.toolCallId,
           state: "output-error",
-          errorText: `Unhandled tool: ${toolCall.toolName}`,
+          errorText: i18n.t("apps.chats.toolCalls.unhandledTool", {
+            toolName: toolCall.toolName,
+          }),
         });
         result = "";
         break;
@@ -1217,7 +276,10 @@ export async function dispatchToolCall(
       tool: toolCall.toolName,
       toolCallId: toolCall.toolCallId,
       state: "output-error",
-      errorText: err instanceof Error ? err.message : i18n.t("apps.chats.toolCalls.unknownError"),
+      errorText:
+        err instanceof Error
+          ? err.message
+          : i18n.t("apps.chats.toolCalls.unknownError"),
     });
     return openResultTracker.getResult();
   }

--- a/src/apps/chats/tools/mediaHandler.ts
+++ b/src/apps/chats/tools/mediaHandler.ts
@@ -846,7 +846,8 @@ const handlePlayKnown = (
     context.addToolOutput({
       tool: emitToolName,
       toolCallId,
-      output: adapter.messages.notFound(),
+      state: "output-error",
+      errorText: adapter.messages.notFound(),
     });
     log.debug("playKnown found no matching item", { target: input.target });
     return;
@@ -859,7 +860,8 @@ const handlePlayKnown = (
     context.addToolOutput({
       tool: emitToolName,
       toolCallId,
-      output: adapter.messages.notFound(),
+      state: "output-error",
+      errorText: adapter.messages.notFound(),
     });
     return;
   }
@@ -916,7 +918,8 @@ const handleAddAndPlay = async (
     context.addToolOutput({
       tool: emitToolName,
       toolCallId,
-      output: errorMsg,
+      state: "output-error",
+      errorText: errorMsg,
     });
     console.error(`[ToolCall] ${errorMsg}`);
     return;
@@ -928,7 +931,8 @@ const handleAddAndPlay = async (
     context.addToolOutput({
       tool: emitToolName,
       toolCallId,
-      output: result.error,
+      state: "output-error",
+      errorText: result.error,
     });
     console.error(`[ToolCall] ${result.error}`);
     return;

--- a/src/apps/chats/tools/settingsHandler.ts
+++ b/src/apps/chats/tools/settingsHandler.ts
@@ -8,8 +8,16 @@ import {
   type LanguageCode,
 } from "@/stores/useLanguageStore";
 import { useThemeStore } from "@/stores/useThemeStore";
+import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import { themes } from "@/themes";
 import type { OsThemeId } from "@/themes/types";
+import { getAccentChrome, isValidAccent, type AccentId } from "@/themes/accents";
+import { loadWallpaperManifest } from "@/utils/wallpapers";
+import {
+  normalizeSearchText,
+  computeMatchScore,
+  deriveScoreThreshold,
+} from "@/apps/chats/utils/fuzzySearch";
 import i18n from "@/lib/i18n";
 import { forceRefreshCache } from "@/utils/prefetch";
 import type { ToolContext } from "./types";
@@ -18,8 +26,11 @@ import { chatToolsLog as log } from "../logging";
 export interface SettingsInput {
   language?: string;
   theme?: OsThemeId;
+  wallpaper?: string;
+  accent?: string;
   masterVolume?: number;
   speechEnabled?: boolean;
+  uiSoundsEnabled?: boolean;
   checkForUpdates?: boolean;
 }
 
@@ -49,17 +60,86 @@ const getLanguageDisplayName = (langCode: string): string => {
   return langCode;
 };
 
+/** Human-readable label for a manifest-relative wallpaper path. */
+const wallpaperLabelFromPath = (relPath: string): string => {
+  const fileName = relPath.split("/").pop() || relPath;
+  return fileName.replace(/\.[^.]+$/, "").replace(/[-_]+/g, " ");
+};
+
+/**
+ * Fuzzy-match a requested wallpaper name against the built-in manifest
+ * (tiles, photos across all categories, and video wallpapers). Returns the
+ * absolute wallpaper path to feed `setWallpaper`, or null when nothing
+ * matches well enough.
+ */
+const resolveWallpaperPath = async (
+  query: string
+): Promise<{ path: string; label: string } | null> => {
+  const manifest = await loadWallpaperManifest();
+  const candidates: string[] = [
+    ...(manifest.tiles || []),
+    ...Object.values(manifest.photos || {}).flat(),
+    ...(manifest.videos || []),
+  ];
+
+  const normalizedQuery = normalizeSearchText(query.trim());
+  if (!normalizedQuery) return null;
+  const queryTokens = normalizedQuery.split(/\s+/).filter(Boolean);
+
+  let best: { relPath: string; score: number } | null = null;
+  for (const relPath of candidates) {
+    const label = wallpaperLabelFromPath(relPath);
+    // Match against both the bare name and the categorized path
+    // ("photos/nature/aurora") so category words like "nature" also hit.
+    const fields = [label, relPath.replace(/\.[^.]+$/, "").replace(/[/_-]+/g, " ")];
+    const score = fields.reduce(
+      (bestScore, field) =>
+        Math.max(
+          bestScore,
+          computeMatchScore(
+            normalizeSearchText(field),
+            normalizedQuery,
+            queryTokens
+          )
+        ),
+      0
+    );
+    if (!best || score > best.score) {
+      best = { relPath, score };
+    }
+  }
+
+  if (!best || best.score < deriveScoreThreshold(normalizedQuery.length)) {
+    return null;
+  }
+
+  return {
+    path: `/wallpapers/${best.relPath}`,
+    label: wallpaperLabelFromPath(best.relPath),
+  };
+};
+
 /**
  * Handle settings tool call
  */
-export const handleSettings = (
+export const handleSettings = async (
   input: SettingsInput,
   toolCallId: string,
   context: ToolContext
-): void => {
-  const { language, theme, masterVolume, speechEnabled, checkForUpdates } = input;
+): Promise<void> => {
+  const {
+    language,
+    theme,
+    wallpaper,
+    accent,
+    masterVolume,
+    speechEnabled,
+    uiSoundsEnabled,
+    checkForUpdates,
+  } = input;
 
   const changes: string[] = [];
+  const failures: string[] = [];
   const audioSettingsStore = useAudioSettingsStore.getState();
   const langStore = useLanguageStore.getState();
   const themeStore = useThemeStore.getState();
@@ -89,6 +169,57 @@ export const handleSettings = (
     }
   }
 
+  // Wallpaper change (fuzzy-matched against built-in manifest)
+  if (wallpaper !== undefined) {
+    try {
+      const match = await resolveWallpaperPath(wallpaper);
+      if (match) {
+        await useDisplaySettingsStore.getState().setWallpaper(match.path);
+        changes.push(
+          i18n.t("apps.chats.toolCalls.settingsWallpaperChanged", {
+            name: match.label,
+          })
+        );
+        log.debug("Wallpaper changed", { wallpaper: match.path });
+      } else {
+        failures.push(
+          i18n.t("apps.chats.toolCalls.settingsWallpaperNotFound", {
+            query: wallpaper,
+          })
+        );
+      }
+    } catch (error) {
+      log.debug("Wallpaper change failed", { error });
+      failures.push(
+        i18n.t("apps.chats.toolCalls.settingsWallpaperNotFound", {
+          query: wallpaper,
+        })
+      );
+    }
+  }
+
+  // Accent color (Aqua / System 7 chromes only). Applied after any theme
+  // change so "switch to macosx with a purple accent" works in one call.
+  if (accent !== undefined) {
+    const activeTheme = useThemeStore.getState().current;
+    const chrome = getAccentChrome(activeTheme);
+    if (chrome && isValidAccent(chrome, accent)) {
+      useThemeStore.getState().setAccent(accent as AccentId, activeTheme);
+      changes.push(
+        i18n.t("apps.chats.toolCalls.settingsAccentChanged", {
+          accent,
+        })
+      );
+      log.debug("Accent changed", { accent, theme: activeTheme });
+    } else {
+      failures.push(
+        i18n.t("apps.chats.toolCalls.settingsAccentNotSupported", {
+          theme: themes[activeTheme]?.name || activeTheme,
+        })
+      );
+    }
+  }
+
   // Master volume
   if (masterVolume !== undefined) {
     audioSettingsStore.setMasterVolume(masterVolume);
@@ -112,6 +243,17 @@ export const handleSettings = (
     log.debug("Speech setting changed", { speechEnabled });
   }
 
+  // UI sounds enabled
+  if (uiSoundsEnabled !== undefined) {
+    audioSettingsStore.setUiSoundsEnabled(uiSoundsEnabled);
+    changes.push(
+      uiSoundsEnabled
+        ? i18n.t("apps.chats.toolCalls.settingsUiSoundsEnabled")
+        : i18n.t("apps.chats.toolCalls.settingsUiSoundsDisabled")
+    );
+    log.debug("UI sounds setting changed", { uiSoundsEnabled });
+  }
+
   // Check for updates
   if (checkForUpdates) {
     forceRefreshCache();
@@ -120,14 +262,23 @@ export const handleSettings = (
   }
 
   // Build result message
-  if (changes.length > 0) {
-    const resultMessage =
-      changes.length === 1 ? changes[0] : changes.join(". ") + ".";
-    context.addToolOutput({
-      tool: "settings",
-      toolCallId,
-      output: resultMessage,
-    });
+  const parts = [...changes, ...failures];
+  if (parts.length > 0) {
+    const resultMessage = parts.length === 1 ? parts[0] : parts.join(". ") + ".";
+    if (changes.length === 0) {
+      context.addToolOutput({
+        tool: "settings",
+        toolCallId,
+        state: "output-error",
+        errorText: resultMessage,
+      });
+    } else {
+      context.addToolOutput({
+        tool: "settings",
+        toolCallId,
+        output: resultMessage,
+      });
+    }
   } else {
     context.addToolOutput({
       tool: "settings",

--- a/src/apps/chats/tools/stickiesHandler.ts
+++ b/src/apps/chats/tools/stickiesHandler.ts
@@ -3,19 +3,17 @@
  */
 
 import type { ToolContext } from "./types";
-import { useStickiesStore, type StickyColor } from "@/stores/useStickiesStore";
+import { useStickiesStore, type StickyNote } from "@/stores/useStickiesStore";
 import { useAppStore } from "@/stores/useAppStore";
 import i18n from "@/lib/i18n";
+import {
+  buildStickyPatch,
+  serializeStickyToolRecord,
+  type StickiesControlInput,
+} from "@/shared/tools/stickies";
 import { createShortIdMap, resolveId, type ShortIdMap } from "./helpers";
 
-export interface StickiesControlInput {
-  action: "list" | "create" | "update" | "delete" | "clear";
-  id?: string;
-  content?: string;
-  color?: StickyColor;
-  position?: { x: number; y: number };
-  size?: { width: number; height: number };
-}
+export type { StickiesControlInput } from "@/shared/tools/stickies";
 
 /**
  * Module-level storage for short ID mapping.
@@ -57,13 +55,9 @@ export const handleStickiesControl = (
         // Create short ID mapping for efficient AI communication
         stickyIdMap = createShortIdMap(notes.map((n) => n.id), "s");
         // Return data with short IDs to reduce token usage
-        const notesData = notes.map((n) => ({
-          id: stickyIdMap!.fullToShort.get(n.id),
-          color: n.color,
-          content: n.content,
-          position: n.position,
-          size: n.size,
-        }));
+        const notesData = notes.map((n) =>
+          serializeStickyToolRecord(n, stickyIdMap)
+        );
         context.addToolOutput({ 
           tool: "stickiesControl", 
           toolCallId, 
@@ -103,11 +97,11 @@ export const handleStickiesControl = (
           context.addToolOutput({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.notFound", { id }) });
           return;
         }
-        const updates: Record<string, unknown> = {};
-        if (content !== undefined) updates.content = content;
-        if (color !== undefined) updates.color = color;
-        if (position !== undefined) updates.position = position;
-        if (size !== undefined) updates.size = size;
+        // Input colors share the same union as the store; the shared patch
+        // builder is typed against the wire DTO (color: string).
+        const updates = buildStickyPatch(input) as Partial<
+          Omit<StickyNote, "id" | "createdAt">
+        >;
         if (Object.keys(updates).length === 0) {
           context.addToolOutput({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.noUpdates") });
           return;

--- a/src/apps/chats/tools/vfsHandlers.ts
+++ b/src/apps/chats/tools/vfsHandlers.ts
@@ -1,0 +1,1133 @@
+/**
+ * Virtual File System (VFS) Tool Handlers
+ *
+ * Client-side implementations of the `list`, `open`, `read`, `write`, and
+ * `edit` tools. Extracted from dispatchToolCall.ts so the dispatcher stays a
+ * thin router and each VFS concern is independently readable/testable.
+ *
+ * Path routing:
+ * - /Music            → iPod library (list) / playKnown (open)
+ * - /Applets Store    → shared applets API (list/read) / applet-viewer (open)
+ * - /Applications     → app registry (list) / launchApp (open)
+ * - /Applets          → IndexedDB applets (list/open/read/edit)
+ * - /Documents        → IndexedDB markdown docs (list/open/read/write/edit)
+ */
+
+import { useAppStore } from "@/stores/useAppStore";
+import { AppId } from "@/config/appIds";
+import { appRegistry } from "@/config/appRegistry";
+import { getTranslatedAppName } from "@/utils/i18n";
+import { getDefaultFileApp } from "@/utils/fileAssociations";
+import type { DocumentContent } from "@/apps/finder/hooks/useFileSystem";
+import { STORES, dbOperations } from "@/utils/indexedDB";
+import {
+  normalizeSearchText,
+  computeMatchScore,
+  deriveScoreThreshold,
+} from "@/apps/chats/utils/fuzzySearch";
+import { useTextEditStore } from "@/stores/useTextEditStore";
+import { useFilesStore } from "@/stores/useFilesStore";
+import {
+  getIpodTracksForLibrary,
+  type IpodLibrarySelection,
+  useIpodStore,
+} from "@/stores/useIpodStore";
+import { markdownToHtml } from "@/utils/markdown";
+import { generateJsonFromHtml } from "@/utils/tiptapHtml";
+import i18n from "@/lib/i18n";
+import { abortableFetch } from "@/utils/abortableFetch";
+import { getApiUrl } from "@/utils/platform";
+import { aiChatLog as log } from "../logging";
+import { emitAppletUpdated, emitDocumentUpdated } from "@/utils/appEventBus";
+import {
+  persistChatApplet,
+  persistChatDocument,
+  type SaveFileHandler,
+} from "../utils/chatFilePersistence";
+import { handleMediaControl } from "./mediaHandler";
+import type { ToolContext } from "./types";
+
+/**
+ * Context for VFS handlers: the shared tool context plus file persistence and
+ * open-result tracking used by the write/open flows.
+ */
+export interface VfsToolContext extends ToolContext {
+  saveFile: SaveFileHandler;
+  recordOpenedInstance: (instanceId: string) => void;
+}
+
+export interface VfsListInput {
+  path: string;
+  query?: string;
+  limit?: number;
+  librarySource?: IpodLibrarySelection;
+}
+
+export interface VfsPathInput {
+  path: string;
+}
+
+export interface VfsWriteInput {
+  path: string;
+  content: string;
+  mode?: "overwrite" | "append" | "prepend";
+}
+
+export interface VfsEditInput {
+  path: string;
+  old_string: string;
+  new_string: string;
+}
+
+async function storedContentToText(
+  content: DocumentContent["content"]
+): Promise<string> {
+  if (typeof content === "string") return content;
+  if (content instanceof Blob) return content.text();
+  return new TextDecoder().decode(content);
+}
+
+const recentlyCreatedTextEditInstances = new Map<
+  string,
+  { instanceId: string; path: string; timestamp: number }
+>();
+
+// Helper to add a newly created instance to tracking
+export const trackNewTextEditInstance = (instanceId: string, path: string) => {
+  recentlyCreatedTextEditInstances.set(instanceId, {
+    instanceId,
+    path,
+    timestamp: Date.now(),
+  });
+  // Clean up old entries (older than 5 minutes)
+  const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
+  for (const [id, data] of recentlyCreatedTextEditInstances.entries()) {
+    if (data.timestamp < fiveMinutesAgo) {
+      recentlyCreatedTextEditInstances.delete(id);
+    }
+  }
+};
+
+const getRecentTextEditInstanceForPath = (path: string): string | null => {
+  const appStore = useAppStore.getState();
+  let newestMatch: { instanceId: string; timestamp: number } | null = null;
+
+  for (const [id, tracked] of recentlyCreatedTextEditInstances.entries()) {
+    if (tracked.path !== path) {
+      continue;
+    }
+
+    const instance = appStore.instances[id];
+    if (!instance || !instance.isOpen || instance.appId !== "textedit") {
+      recentlyCreatedTextEditInstances.delete(id);
+      continue;
+    }
+
+    if (!newestMatch || tracked.timestamp > newestMatch.timestamp) {
+      newestMatch = { instanceId: id, timestamp: tracked.timestamp };
+    }
+  }
+
+  return newestMatch?.instanceId ?? null;
+};
+
+export async function handleVfsList(
+  input: VfsListInput,
+  toolName: string,
+  toolCallId: string,
+  context: VfsToolContext
+): Promise<void> {
+  const { addToolOutput } = context;
+  const { path, query, limit, librarySource } = input;
+
+  if (!path) {
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText: i18n.t("apps.chats.toolCalls.noPathProvided"),
+    });
+    return;
+  }
+
+  log.debug("Tool list", { path, query, limit });
+
+  try {
+    // Route based on path
+    if (path === "/Music") {
+      // List the selected iPod library. Karaoke asks for the YouTube
+      // slice even when the iPod UI is currently showing Apple Music.
+      const ipodStore = useIpodStore.getState();
+      const selectedLibrary = librarySource ?? "active";
+      const normalizedQuery = query ? normalizeSearchText(query.trim()) : "";
+      const queryTokens = normalizedQuery
+        ? normalizedQuery.split(/\s+/).filter(Boolean)
+        : [];
+      const hasQuery = normalizedQuery.length > 0;
+      const maxResults = limit ? Math.min(Math.max(limit, 1), 50) : 25;
+      const activeTracks = getIpodTracksForLibrary(ipodStore, selectedLibrary);
+      const scoredTracks = activeTracks.map((track) => {
+        const fields = [
+          track.id,
+          track.title,
+          track.artist ?? "",
+          track.album ?? "",
+        ].map(normalizeSearchText);
+        const score = hasQuery
+          ? fields.reduce(
+              (best, field) =>
+                Math.max(
+                  best,
+                  computeMatchScore(field, normalizedQuery, queryTokens)
+                ),
+              0
+            )
+          : 1;
+        return { track, score };
+      });
+      const scoreThreshold = hasQuery
+        ? deriveScoreThreshold(normalizedQuery.length)
+        : 0;
+      const matchingTracks = scoredTracks
+        .filter(({ score }) => score >= scoreThreshold)
+        .sort((a, b) => (hasQuery ? b.score - a.score : 0));
+      const library = matchingTracks.slice(0, maxResults).map(({ track }) => ({
+        path: `/Music/${track.id}`,
+        id: track.id,
+        title: track.title,
+        artist: track.artist,
+        source:
+          track.source ??
+          (selectedLibrary === "active"
+            ? ipodStore.librarySource
+            : selectedLibrary),
+      }));
+      const hiddenCount = Math.max(matchingTracks.length - library.length, 0);
+      const resolvedLibrary =
+        selectedLibrary === "active" ? ipodStore.librarySource : selectedLibrary;
+      const libraryName =
+        resolvedLibrary === "appleMusic" ? "Apple Music" : "YouTube";
+
+      const resultMessage =
+        library.length > 0
+          ? `${
+              library.length === 1
+                ? i18n.t("apps.chats.toolCalls.foundSongsInMusic", {
+                    count: library.length,
+                  })
+                : i18n.t("apps.chats.toolCalls.foundSongsInMusicPlural", {
+                    count: library.length,
+                  })
+            } (${libraryName})${
+              hiddenCount > 0
+                ? `; showing ${library.length} of ${matchingTracks.length}. Use query or limit to narrow results.`
+                : ""
+            }:\n${JSON.stringify(library, null, 2)}`
+          : hasQuery
+            ? `No songs matched "${query}" in ${libraryName}.`
+            : i18n.t("apps.chats.toolCalls.musicLibraryEmpty");
+
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        output: resultMessage,
+      });
+    } else if (path === "/Applets Store") {
+      // List shared applets from store
+      const normalizedKeyword = query ? normalizeSearchText(query.trim()) : "";
+      const keywordTokens = normalizedKeyword
+        ? normalizedKeyword.split(/\s+/).filter(Boolean)
+        : [];
+      const hasKeyword = normalizedKeyword.length > 0;
+      const maxResults = limit ? Math.min(Math.max(limit, 1), 100) : 50;
+
+      const response = await abortableFetch(
+        getApiUrl("/api/share-applet?list=true"),
+        {
+          timeout: 15000,
+          retry: { maxAttempts: 2, initialDelayMs: 500 },
+        }
+      );
+
+      const data = await response.json();
+      const allApplets: Array<{
+        id: string;
+        title?: string;
+        name?: string;
+        icon?: string;
+        createdAt?: number;
+        createdBy?: string;
+      }> = Array.isArray(data?.applets) ? data.applets : [];
+
+      const scoreThreshold = hasKeyword
+        ? deriveScoreThreshold(normalizedKeyword.length)
+        : 0;
+
+      const scoredApplets = allApplets.map((applet) => {
+        const normalizedFields = [
+          typeof applet.title === "string"
+            ? normalizeSearchText(applet.title)
+            : "",
+          typeof applet.name === "string"
+            ? normalizeSearchText(applet.name)
+            : "",
+          typeof applet.createdBy === "string"
+            ? normalizeSearchText(applet.createdBy)
+            : "",
+        ].filter((value) => value.length > 0);
+
+        const score = hasKeyword
+          ? normalizedFields.reduce((best, field) => {
+              const fieldScore = computeMatchScore(
+                field,
+                normalizedKeyword,
+                keywordTokens
+              );
+              return fieldScore > best ? fieldScore : best;
+            }, 0)
+          : 1;
+
+        return { applet, score };
+      });
+
+      const filteredApplets = hasKeyword
+        ? scoredApplets.filter(({ score }) => score >= scoreThreshold)
+        : scoredApplets;
+
+      filteredApplets.sort((a, b) => {
+        if (hasKeyword && b.score !== a.score) return b.score - a.score;
+        return (b.applet.createdAt ?? 0) - (a.applet.createdAt ?? 0);
+      });
+
+      const limitedApplets = filteredApplets
+        .slice(0, maxResults)
+        .map(({ applet }) => ({
+          path: `/Applets Store/${applet.id}`,
+          id: applet.id,
+          title: applet.title ?? applet.name ?? "Untitled",
+          name: applet.name,
+        }));
+
+      const resultMessage =
+        limitedApplets.length > 0
+          ? `${
+              limitedApplets.length === 1
+                ? i18n.t("apps.chats.toolCalls.foundSharedApplets", {
+                    count: limitedApplets.length,
+                  })
+                : i18n.t("apps.chats.toolCalls.foundSharedAppletsPlural", {
+                    count: limitedApplets.length,
+                  })
+            }:\n${JSON.stringify(limitedApplets, null, 2)}`
+          : hasKeyword
+            ? i18n.t("apps.chats.toolCalls.noSharedAppletsMatched", { query })
+            : i18n.t("apps.chats.toolCalls.noSharedAppletsAvailable");
+
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        output: resultMessage,
+      });
+    } else if (path === "/Applications") {
+      // List installed applications
+      const apps = Object.entries(appRegistry).reduce<
+        { path: string; name: string }[]
+      >((acc, [id, app]) => {
+        if (id !== "finder") {
+          acc.push({
+            path: `/Applications/${id}`,
+            name: app.name,
+          });
+        }
+        return acc;
+      }, []);
+
+      const appsMessage =
+        apps.length === 1
+          ? i18n.t("apps.chats.toolCalls.foundApplicationsList", {
+              count: apps.length,
+            })
+          : i18n.t("apps.chats.toolCalls.foundApplicationsListPlural", {
+              count: apps.length,
+            });
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        output: `${appsMessage}:\n${JSON.stringify(apps, null, 2)}`,
+      });
+    } else if (path === "/Applets" || path === "/Documents") {
+      // List files from file system
+      const filesStore = useFilesStore.getState();
+      const allItems = Object.values(filesStore.items);
+
+      const files = allItems.filter(
+        (item) =>
+          item.status === "active" &&
+          item.path.startsWith(`${path}/`) &&
+          !item.isDirectory &&
+          item.path !== `${path}/`
+      );
+
+      const fileList = files.map((file) => ({
+        path: file.path,
+        name: file.name,
+        type: file.type,
+      }));
+
+      const fileType = path === "/Applets" ? "applet" : "document";
+      const resultMessage =
+        fileList.length > 0
+          ? `${
+              fileList.length === 1
+                ? i18n.t("apps.chats.toolCalls.foundFileType", {
+                    count: fileList.length,
+                    fileType,
+                  })
+                : i18n.t("apps.chats.toolCalls.foundFileTypePlural", {
+                    count: fileList.length,
+                    fileType,
+                  })
+            }:\n${JSON.stringify(fileList, null, 2)}`
+          : i18n.t("apps.chats.toolCalls.noFileTypeFound", { fileType, path });
+
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        output: resultMessage,
+      });
+    } else {
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        state: "output-error",
+        errorText: i18n.t("apps.chats.toolCalls.invalidPathForList", { path }),
+      });
+    }
+  } catch (err) {
+    console.error("list error:", err);
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText:
+        err instanceof Error
+          ? err.message
+          : i18n.t("apps.chats.toolCalls.failedToListItems"),
+    });
+  }
+}
+
+export async function handleVfsOpen(
+  input: VfsPathInput,
+  toolName: string,
+  toolCallId: string,
+  context: VfsToolContext
+): Promise<void> {
+  const { addToolOutput, launchApp } = context;
+  const { path } = input;
+
+  if (!path) {
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText: i18n.t("apps.chats.toolCalls.noPathProvided"),
+    });
+    return;
+  }
+
+  log.debug("Tool open", { path });
+
+  try {
+    // Route based on path prefix
+    if (path.startsWith("/Music/")) {
+      const songId = path.replace("/Music/", "");
+      await handleMediaControl(
+        {
+          target: "music",
+          action: "playKnown",
+          id: songId,
+        },
+        toolCallId,
+        context,
+        toolName
+      );
+    } else if (path.startsWith("/Applets Store/")) {
+      // Open shared applet preview
+      const shareId = path.replace("/Applets Store/", "");
+
+      // Fetch applet metadata to get the name
+      let appletName = shareId;
+      try {
+        const response = await abortableFetch(
+          getApiUrl(`/api/share-applet?id=${encodeURIComponent(shareId)}`),
+          {
+            timeout: 15000,
+            retry: { maxAttempts: 1, initialDelayMs: 250 },
+          }
+        );
+        const data = await response.json();
+        appletName = data.title || data.name || shareId;
+      } catch {
+        // Fall back to shareId if fetch fails
+      }
+
+      launchApp("applet-viewer", {
+        initialData: { path: "", content: "", shareCode: shareId },
+      });
+
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        output: i18n.t("apps.chats.toolCalls.openedApplet", { appletName }),
+      });
+    } else if (path.startsWith("/Applications/")) {
+      // Launch application
+      const appId = path.replace("/Applications/", "") as AppId;
+      if (!appRegistry[appId]) {
+        throw new Error(`Application not found: ${appId}`);
+      }
+
+      launchApp(appId);
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        output: i18n.t("apps.chats.toolCalls.launchedApp", {
+          appName: getTranslatedAppName(appId),
+        }),
+      });
+    } else if (path.startsWith("/Applets/")) {
+      // Open applet in viewer
+      const filesStore = useFilesStore.getState();
+      const fileItem = filesStore.items[path];
+
+      if (!fileItem || fileItem.status !== "active") {
+        throw new Error(`Applet not found: ${path}`);
+      }
+
+      if (!fileItem.uuid) {
+        throw new Error(`Applet missing content: ${path}`);
+      }
+
+      const contentData = await dbOperations.get<DocumentContent>(
+        STORES.APPLETS,
+        fileItem.uuid
+      );
+
+      if (!contentData || !contentData.content) {
+        throw new Error(`Failed to read applet content: ${path}`);
+      }
+
+      const content = await storedContentToText(contentData.content);
+
+      launchApp("applet-viewer", {
+        initialData: { path, content },
+      });
+
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        output: i18n.t("apps.chats.toolCalls.openedFile", {
+          fileName: fileItem.name,
+        }),
+      });
+    } else if (path.startsWith("/Documents/")) {
+      // Open document in TextEdit
+      const filesStore = useFilesStore.getState();
+      const fileItem = filesStore.items[path];
+      const appStore = useAppStore.getState();
+      const textEditStore = useTextEditStore.getState();
+
+      if (!fileItem || fileItem.status !== "active") {
+        throw new Error(`Document not found: ${path}`);
+      }
+
+      if (getDefaultFileApp(fileItem) === "preview") {
+        launchApp("preview", {
+          initialData: { path },
+        });
+        addToolOutput({
+          tool: toolName,
+          toolCallId,
+          output: i18n.t("apps.chats.toolCalls.openedDocument", {
+            fileName: fileItem.name,
+          }),
+        });
+        return;
+      }
+
+      const existingInstanceId = textEditStore.getInstanceIdByPath(path);
+      if (existingInstanceId) {
+        if (appStore.instances[existingInstanceId]) {
+          appStore.bringInstanceToForeground(existingInstanceId);
+          context.recordOpenedInstance(existingInstanceId);
+          addToolOutput({
+            tool: toolName,
+            toolCallId,
+            output: i18n.t("apps.chats.toolCalls.openedDocument", {
+              fileName: fileItem.name,
+            }),
+          });
+          return;
+        }
+
+        // Stale reference in TextEdit store; clean it up and continue.
+        textEditStore.removeInstance(existingInstanceId);
+      }
+
+      // Fallback for write->open races: a freshly launched TextEdit window
+      // may not have registered its file path yet.
+      const recentInstanceId = getRecentTextEditInstanceForPath(path);
+      if (recentInstanceId) {
+        appStore.bringInstanceToForeground(recentInstanceId);
+        context.recordOpenedInstance(recentInstanceId);
+        addToolOutput({
+          tool: toolName,
+          toolCallId,
+          output: i18n.t("apps.chats.toolCalls.openedDocument", {
+            fileName: fileItem.name,
+          }),
+        });
+        return;
+      }
+
+      if (!fileItem.uuid) {
+        throw new Error(`Document missing content: ${path}`);
+      }
+
+      const contentData = await dbOperations.get<DocumentContent>(
+        STORES.DOCUMENTS,
+        fileItem.uuid
+      );
+
+      if (!contentData || !contentData.content) {
+        throw new Error(`Failed to read document content: ${path}`);
+      }
+
+      const content = await storedContentToText(contentData.content);
+
+      // Pass initialData directly to launchApp (consistent with Terminal/Finder approach).
+      // TextEdit handles markdown-to-HTML conversion internally.
+      launchApp("textedit", {
+        multiWindow: true,
+        initialData: { path, content },
+      });
+
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        output: i18n.t("apps.chats.toolCalls.openedDocument", {
+          fileName: fileItem.name,
+        }),
+      });
+    } else {
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        state: "output-error",
+        errorText: i18n.t("apps.chats.toolCalls.invalidPath", { path }),
+      });
+    }
+  } catch (err) {
+    console.error("open error:", err);
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText:
+        err instanceof Error
+          ? err.message
+          : i18n.t("apps.chats.toolCalls.failedToOpen"),
+    });
+  }
+}
+
+export async function handleVfsRead(
+  input: VfsPathInput,
+  toolName: string,
+  toolCallId: string,
+  context: VfsToolContext
+): Promise<void> {
+  const { addToolOutput } = context;
+  const { path } = input;
+
+  if (!path) {
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText: i18n.t("apps.chats.toolCalls.noPathProvided"),
+    });
+    return;
+  }
+
+  log.debug("Tool read", { path });
+
+  try {
+    if (path.startsWith("/Applets Store/")) {
+      // Fetch shared applet content
+      const shareId = path.replace("/Applets Store/", "");
+      const response = await abortableFetch(
+        getApiUrl(`/api/share-applet?id=${encodeURIComponent(shareId)}`),
+        {
+          timeout: 15000,
+          retry: { maxAttempts: 2, initialDelayMs: 500 },
+        }
+      );
+
+      const data = await response.json();
+      const filesStore = useFilesStore.getState();
+      const installedEntry = Object.values(filesStore.items).find(
+        (item) =>
+          item.status === "active" &&
+          typeof item.shareId === "string" &&
+          item.shareId.toLowerCase() === shareId.toLowerCase()
+      );
+
+      const payload = {
+        id: shareId,
+        title: data?.title ?? null,
+        name: data?.name ?? null,
+        icon: data?.icon ?? null,
+        createdBy: data?.createdBy ?? null,
+        installedPath: installedEntry?.path ?? null,
+        content: typeof data?.content === "string" ? data.content : "",
+      };
+
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        output: JSON.stringify(payload, null, 2),
+      });
+    } else if (path.startsWith("/Applets/") || path.startsWith("/Documents/")) {
+      // Read local file content
+      const isApplet = path.startsWith("/Applets/");
+      const filesStore = useFilesStore.getState();
+      const fileItem = filesStore.items[path];
+
+      if (!fileItem || fileItem.status !== "active") {
+        throw new Error(`File not found: ${path}`);
+      }
+
+      if (!fileItem.uuid) {
+        throw new Error(`File missing content: ${path}`);
+      }
+
+      const storeName = isApplet ? STORES.APPLETS : STORES.DOCUMENTS;
+      const contentData = await dbOperations.get<DocumentContent>(
+        storeName,
+        fileItem.uuid
+      );
+
+      if (!contentData || contentData.content == null) {
+        throw new Error(`Failed to read file content: ${path}`);
+      }
+
+      const content = await storedContentToText(contentData.content);
+
+      const fileLabel = isApplet
+        ? i18n.t("apps.chats.toolCalls.applet")
+        : i18n.t("apps.chats.toolCalls.document");
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        output:
+          i18n.t("apps.chats.toolCalls.fileContent", {
+            fileLabel,
+            fileName: fileItem.name,
+            charCount: content.length,
+          }) + `\n\n${content}`,
+      });
+    } else {
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        state: "output-error",
+        errorText: i18n.t("apps.chats.toolCalls.invalidPathForRead", { path }),
+      });
+    }
+  } catch (err) {
+    console.error("read error:", err);
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText:
+        err instanceof Error
+          ? err.message
+          : i18n.t("apps.chats.toolCalls.failedToReadFile"),
+    });
+  }
+}
+
+export async function handleVfsWrite(
+  input: VfsWriteInput,
+  toolName: string,
+  toolCallId: string,
+  context: VfsToolContext
+): Promise<void> {
+  const { addToolOutput, saveFile } = context;
+  const { path, content, mode = "overwrite" } = input;
+
+  if (!path) {
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText: i18n.t("apps.chats.toolCalls.noPathProvided"),
+    });
+    return;
+  }
+
+  // Validate path format for documents
+  if (!path.startsWith("/Documents/")) {
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText: i18n.t("apps.chats.toolCalls.invalidPathForWrite", { path }),
+    });
+    return;
+  }
+
+  // Validate filename has .md extension
+  const fileName = path.split("/").pop() || "";
+  if (!fileName.endsWith(".md")) {
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText: i18n.t("apps.chats.toolCalls.invalidFilename", { fileName }),
+    });
+    return;
+  }
+
+  if (!content && mode === "overwrite") {
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText: i18n.t("apps.chats.toolCalls.noContentProvided"),
+    });
+    return;
+  }
+
+  log.debug("Tool write", { path, mode, contentLength: content?.length });
+
+  try {
+    const appStore = useAppStore.getState();
+    const textEditStore = useTextEditStore.getState();
+
+    // Check if file exists for append/prepend modes
+    const existingItem = useFilesStore.getState().items[path];
+    const isNewFile = !existingItem || existingItem.status !== "active";
+
+    // Determine final content based on mode
+    let finalContent = content || "";
+    if (!isNewFile && mode !== "overwrite" && existingItem?.uuid) {
+      const existingData = await dbOperations.get<DocumentContent>(
+        STORES.DOCUMENTS,
+        existingItem.uuid
+      );
+      if (existingData?.content) {
+        const existingContent = await storedContentToText(
+          existingData.content
+        );
+        finalContent =
+          mode === "prepend"
+            ? content + existingContent
+            : existingContent + content;
+      }
+    }
+
+    await persistChatDocument({
+      saveFile,
+      path,
+      fileName,
+      content: finalContent,
+      icon: existingItem?.icon || "📄",
+    });
+
+    // Find existing TextEdit instance for this file
+    let targetInstanceId: string | null = null;
+    for (const [instanceId, instance] of Object.entries(
+      textEditStore.instances
+    )) {
+      if (instance.filePath === path) {
+        // Verify instance actually exists in AppStore
+        if (appStore.instances[instanceId]) {
+          targetInstanceId = instanceId;
+        } else {
+          // Stale instance reference - clean it up
+          textEditStore.removeInstance(instanceId);
+        }
+        break;
+      }
+    }
+
+    if (targetInstanceId) {
+      // Update existing TextEdit instance with content
+      const htmlFragment = markdownToHtml(finalContent);
+      const contentJson = await generateJsonFromHtml(htmlFragment);
+
+      textEditStore.updateInstance(targetInstanceId, {
+        filePath: path,
+        contentJson,
+        hasUnsavedChanges: false, // Already saved to disk
+      });
+
+      // Dispatch event to update the editor content
+      emitDocumentUpdated({
+        path,
+        content: JSON.stringify(contentJson),
+      });
+
+      appStore.bringInstanceToForeground(targetInstanceId);
+    } else {
+      // Create new TextEdit instance with initialData (same pattern as Finder)
+      const windowTitle = fileName.replace(/\.md$/, "") || "Untitled";
+      targetInstanceId = appStore.launchApp(
+        "textedit",
+        { path, content: finalContent },
+        windowTitle,
+        true
+      );
+      trackNewTextEditInstance(targetInstanceId, path);
+    }
+
+    context.recordOpenedInstance(targetInstanceId);
+    const outputKey = isNewFile ? "createdDocument" : "updatedDocument";
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      output: i18n.t(`apps.chats.toolCalls.${outputKey}`, { path }),
+    });
+  } catch (err) {
+    console.error("write error:", err);
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText:
+        err instanceof Error
+          ? err.message
+          : i18n.t("apps.chats.toolCalls.failedToWriteFile"),
+    });
+  }
+}
+
+export async function handleVfsEdit(
+  input: VfsEditInput,
+  toolName: string,
+  toolCallId: string,
+  context: VfsToolContext
+): Promise<void> {
+  const { addToolOutput, saveFile } = context;
+  const { path, old_string, new_string } = input;
+
+  if (
+    !path ||
+    typeof old_string !== "string" ||
+    typeof new_string !== "string"
+  ) {
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText: i18n.t("apps.chats.toolCalls.missingEditParameters"),
+    });
+    return;
+  }
+
+  log.debug("Tool edit", {
+    path,
+    oldStringLength: old_string.length,
+    newStringLength: new_string.length,
+  });
+
+  // Normalize line endings
+  const normalizedOldString = old_string.replace(/\r\n?/g, "\n");
+  const normalizedNewString = new_string.replace(/\r\n?/g, "\n");
+
+  try {
+    if (path.startsWith("/Documents/")) {
+      // Edit document - read directly from file system (independent of TextEdit instances)
+      const filesStore = useFilesStore.getState();
+      const fileItem = filesStore.items[path];
+
+      if (!fileItem || fileItem.status !== "active" || !fileItem.uuid) {
+        throw new Error(
+          `Document not found: ${path}. Use write tool to create new documents, or list({ path: "/Documents" }) to see available files.`
+        );
+      }
+
+      // Read existing content from IndexedDB
+      const contentData = await dbOperations.get<DocumentContent>(
+        STORES.DOCUMENTS,
+        fileItem.uuid
+      );
+      if (!contentData?.content) {
+        throw new Error(`Failed to read document content: ${path}`);
+      }
+
+      const existingContent = await storedContentToText(contentData.content);
+
+      // Normalize existing content
+      const normalizedExisting = existingContent.replace(/\r\n?/g, "\n");
+
+      // Check for uniqueness - count occurrences
+      const occurrences =
+        normalizedExisting.split(normalizedOldString).length - 1;
+
+      if (occurrences === 0) {
+        addToolOutput({
+          tool: toolName,
+          toolCallId,
+          state: "output-error",
+          errorText: i18n.t("apps.chats.toolCalls.oldStringNotFound"),
+        });
+        return;
+      }
+
+      if (occurrences > 1) {
+        addToolOutput({
+          tool: toolName,
+          toolCallId,
+          state: "output-error",
+          errorText: i18n.t("apps.chats.toolCalls.oldStringMultipleMatches", {
+            count: occurrences,
+          }),
+        });
+        return;
+      }
+
+      // Replace exactly one occurrence
+      const updatedContent = normalizedExisting.replace(
+        normalizedOldString,
+        normalizedNewString
+      );
+
+      await persistChatDocument({
+        saveFile,
+        path,
+        fileName: fileItem.name,
+        content: updatedContent,
+        icon: fileItem.icon || "📄",
+      });
+
+      // Also update any open TextEdit instance showing this file
+      const textEditState = useTextEditStore.getState();
+      for (const [instanceId, instance] of Object.entries(
+        textEditState.instances
+      )) {
+        if (instance.filePath === path) {
+          const updatedHtml = markdownToHtml(updatedContent);
+          const updatedJson = await generateJsonFromHtml(updatedHtml);
+
+          textEditState.updateInstance(instanceId, {
+            contentJson: updatedJson,
+            hasUnsavedChanges: false, // Already saved to disk
+          });
+          break;
+        }
+      }
+
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        output: i18n.t("apps.chats.toolCalls.editedDocument", { path }),
+      });
+    } else if (path.startsWith("/Applets/")) {
+      // Edit applet HTML
+      const filesStore = useFilesStore.getState();
+      const fileItem = filesStore.items[path];
+
+      if (!fileItem || fileItem.status !== "active" || !fileItem.uuid) {
+        throw new Error(
+          `Applet not found: ${path}. Use generateHtml tool to create new applets, or list({ path: "/Applets" }) to see available files.`
+        );
+      }
+
+      const contentData = await dbOperations.get<DocumentContent>(
+        STORES.APPLETS,
+        fileItem.uuid
+      );
+      if (!contentData?.content) {
+        throw new Error(`Failed to read applet content: ${path}`);
+      }
+
+      const existingContent = await storedContentToText(contentData.content);
+
+      // Normalize existing content
+      const normalizedExisting = existingContent.replace(/\r\n?/g, "\n");
+
+      // Check for uniqueness - count occurrences
+      const occurrences =
+        normalizedExisting.split(normalizedOldString).length - 1;
+
+      if (occurrences === 0) {
+        addToolOutput({
+          tool: toolName,
+          toolCallId,
+          state: "output-error",
+          errorText: i18n.t("apps.chats.toolCalls.oldStringNotFound"),
+        });
+        return;
+      }
+
+      if (occurrences > 1) {
+        addToolOutput({
+          tool: toolName,
+          toolCallId,
+          state: "output-error",
+          errorText: i18n.t("apps.chats.toolCalls.oldStringMultipleMatches", {
+            count: occurrences,
+          }),
+        });
+        return;
+      }
+
+      // Replace exactly one occurrence
+      const updatedContent = normalizedExisting.replace(
+        normalizedOldString,
+        normalizedNewString
+      );
+
+      await persistChatApplet({
+        saveFile,
+        fileItem,
+        content: updatedContent,
+      });
+
+      // Let any open applet viewers hot-reload this edited applet.
+      emitAppletUpdated({
+        path,
+        content: updatedContent,
+      });
+
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        output: i18n.t("apps.chats.toolCalls.editedApplet", { path }),
+      });
+    } else {
+      addToolOutput({
+        tool: toolName,
+        toolCallId,
+        state: "output-error",
+        errorText: i18n.t("apps.chats.toolCalls.invalidPathForEdit", { path }),
+      });
+    }
+  } catch (err) {
+    console.error("edit error:", err);
+    addToolOutput({
+      tool: toolName,
+      toolCallId,
+      state: "output-error",
+      errorText:
+        err instanceof Error
+          ? err.message
+          : i18n.t("apps.chats.toolCalls.failedToEditFile"),
+    });
+  }
+}

--- a/src/components/assistant/useAssistantChat.ts
+++ b/src/components/assistant/useAssistantChat.ts
@@ -235,28 +235,11 @@ export function useAssistantChat(): AssistantChatHandle {
   } = useChat<AIChatMessage>({ chat, experimental_throttle: 60 });
 
   const handlersRef = useRef({
-    onToolCall: async ({
-      toolCall,
-    }: {
+    // Placeholder; replaced with a fresh closure on every render below so the
+    // dispatch always sees the latest addToolOutput/launchApp identities.
+    onToolCall: async (_options: {
       toolCall: { toolName: string; toolCallId: string; input: unknown };
-    }) => {
-      const requestSequence = ++toolRequestSequenceRef.current;
-      const toolStartedAt = Date.now();
-      const result = await dispatchToolCall(
-        {
-          toolName: toolCall.toolName,
-          toolCallId: toolCall.toolCallId,
-          input: toolCall.input,
-        },
-        {
-          addToolOutput,
-          launchApp: (appId, options) => launchApp(appId as AppId, options),
-          saveFile,
-          onOpenAttempt: () => recordOpenAttempt(requestSequence),
-        }
-      );
-      recordOpenResult(result, requestSequence, toolStartedAt);
-    },
+    }): Promise<void> => {},
     onFinish: ({ messages: finished }: { messages: AIChatMessage[] }) => {
       const stamped = finished.map(
         (msg) =>

--- a/src/components/shared/tool-invocation-message/getToolInvocationCallMessage.ts
+++ b/src/components/shared/tool-invocation-message/getToolInvocationCallMessage.ts
@@ -141,6 +141,15 @@ export function getToolInvocationCallMessage(
             });
         break;
       }
+      case "memoryWrite":
+        displayCallMessage = t("apps.chats.toolCalls.memory.saving");
+        break;
+      case "memoryRead":
+        displayCallMessage = t("apps.chats.toolCalls.memory.recalling");
+        break;
+      case "memoryDelete":
+        displayCallMessage = t("apps.chats.toolCalls.memory.deleting");
+        break;
       case "cursorCloudAgent":
         displayCallMessage = t("apps.chats.toolCalls.cursorCloudAgent.starting");
         break;

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1193,6 +1193,7 @@
       "toolCalls": {
         "addedAndStartedPlaying": "Neues Lied hinzugefügt und Wiedergabe gestartet",
         "addingSong": "Lied wird hinzugefügt …",
+        "appNotRunning": "{{appName}} wird nicht ausgeführt",
         "applet": "Applet",
         "calendar": {
           "addedEvent": "Ereignis \"{{title}}\" hinzugefügt",
@@ -1413,6 +1414,20 @@
         "listingApplications": "Anwendungen werden aufgelistet …",
         "listingSharedApplets": "Geteilte Applets werden aufgelistet …",
         "loadingMusicLibrary": "Musikbibliothek wird geladen …",
+        "maps": {
+          "foundMany": "{{count}} Orte für „{{query}}“ gefunden.",
+          "foundOne": "1 Ort für „{{query}}“ gefunden.",
+          "noResults": "Keine Orte für „{{query}}“ gefunden.",
+          "openInAppleMaps": "In Apple Karten öffnen",
+          "openInMaps": "{{name}} in Karten öffnen",
+          "searching": "In Karten nach „{{query}}“ suchen …",
+          "searchingNoQuery": "In Karten suchen …"
+        },
+        "memory": {
+          "deleting": "Gedächtnis löschen …",
+          "recalling": "Erinnerungen abrufen …",
+          "saving": "Gedächtnis sichern …"
+        },
         "missingEditParameters": "Fehlende erforderliche Parameter: path, old_string und new_string",
         "multipleMatchesFound": "Mehrere Übereinstimmungen gefunden",
         "musicLibraryEmpty": "Musikbibliothek ist leer",
@@ -1449,6 +1464,8 @@
         "searchedWebFor": "Im Web nach {{query}} gesucht",
         "searchingSongs": "Suche „{{query}}“…",
         "searchingWeb": "Suche im Web…",
+        "settingsAccentChanged": "Akzentfarbe auf {{accent}} festgelegt",
+        "settingsAccentNotSupported": "Akzentfarben werden vom Erscheinungsbild „{{theme}}“ nicht unterstützt",
         "settingsCheckingForUpdates": "Nach Updates suchen …",
         "settingsLanguageChanged": "Sprache wurde auf {{language}} geändert",
         "settingsMasterVolumeSet": "Lautstärke auf {{volume}}% gesetzt",
@@ -1456,7 +1473,11 @@
         "settingsSpeechDisabled": "Sprachausgabe deaktiviert",
         "settingsSpeechEnabled": "Sprachausgabe aktiviert",
         "settingsThemeChanged": "Thema wurde auf {{theme}} geändert",
+        "settingsUiSoundsDisabled": "Bediengeräusche deaktiviert",
+        "settingsUiSoundsEnabled": "Bediengeräusche aktiviert",
         "settingsUpdated": "Einstellungen aktualisiert",
+        "settingsWallpaperChanged": "Hintergrundbild in {{name}} geändert",
+        "settingsWallpaperNotFound": "Kein Hintergrundbild gefunden, das „{{query}}“ entspricht",
         "skippedToNextTrack": "Zum nächsten Titel gesprungen",
         "skippedToPreviousTrack": "Zum vorherigen Titel gesprungen",
         "skippingToNext": "Zum nächsten springen…",
@@ -1509,6 +1530,7 @@
           "videoAlreadyInChannel": "{{title}} ist bereits in {{channel}}",
           "videoNotInChannel": "Video im Kanal nicht gefunden"
         },
+        "unhandledTool": "Nicht verarbeitetes Tool: {{toolName}}",
         "unknownError": "Unbekannter Fehler",
         "updatedDocument": "Dokument aktualisiert: {{path}}",
         "webFetch": {

--- a/src/lib/locales/en/shell.json
+++ b/src/lib/locales/en/shell.json
@@ -1025,7 +1025,29 @@
           "resumed": "Resumed",
           "statusRunning": "Running {{system}}",
           "statusNotRunning": "No system running"
-        }
+        },
+        "maps": {
+          "searching": "Searching maps for \"{{query}}\"…",
+          "searchingNoQuery": "Searching maps…",
+          "noResults": "No places found for \"{{query}}\".",
+          "foundOne": "Found 1 place for \"{{query}}\".",
+          "foundMany": "Found {{count}} places for \"{{query}}\".",
+          "openInMaps": "Open {{name}} in Maps",
+          "openInAppleMaps": "Open in Apple Maps"
+        },
+        "memory": {
+          "saving": "Saving memory…",
+          "recalling": "Recalling memories…",
+          "deleting": "Deleting memory…"
+        },
+        "settingsWallpaperChanged": "Wallpaper changed to {{name}}",
+        "settingsWallpaperNotFound": "No wallpaper matched \"{{query}}\"",
+        "settingsAccentChanged": "Accent color set to {{accent}}",
+        "settingsAccentNotSupported": "Accent colors are not supported by the {{theme}} theme",
+        "settingsUiSoundsEnabled": "UI sounds enabled",
+        "settingsUiSoundsDisabled": "UI sounds disabled",
+        "appNotRunning": "{{appName}} is not running",
+        "unhandledTool": "Unhandled tool: {{toolName}}"
       }
     },
     "textedit": {

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1294,7 +1294,29 @@
           "resumed": "Resumed",
           "statusRunning": "Running {{system}}",
           "statusNotRunning": "No system running"
-        }
+        },
+        "maps": {
+          "searching": "Searching maps for \"{{query}}\"…",
+          "searchingNoQuery": "Searching maps…",
+          "noResults": "No places found for \"{{query}}\".",
+          "foundOne": "Found 1 place for \"{{query}}\".",
+          "foundMany": "Found {{count}} places for \"{{query}}\".",
+          "openInMaps": "Open {{name}} in Maps",
+          "openInAppleMaps": "Open in Apple Maps"
+        },
+        "memory": {
+          "saving": "Saving memory…",
+          "recalling": "Recalling memories…",
+          "deleting": "Deleting memory…"
+        },
+        "settingsWallpaperChanged": "Wallpaper changed to {{name}}",
+        "settingsWallpaperNotFound": "No wallpaper matched \"{{query}}\"",
+        "settingsAccentChanged": "Accent color set to {{accent}}",
+        "settingsAccentNotSupported": "Accent colors are not supported by the {{theme}} theme",
+        "settingsUiSoundsEnabled": "UI sounds enabled",
+        "settingsUiSoundsDisabled": "UI sounds disabled",
+        "appNotRunning": "{{appName}} is not running",
+        "unhandledTool": "Unhandled tool: {{toolName}}"
       },
       "tokenStatus": {
         "authenticated": "Signed In",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1195,6 +1195,7 @@
       "toolCalls": {
         "addedAndStartedPlaying": "Se agregó y comenzó a reproducirse una nueva canción",
         "addingSong": "Añadiendo canción…",
+        "appNotRunning": "{{appName}} no se está ejecutando",
         "applet": "Applet",
         "calendar": {
           "addedEvent": "Evento \"{{title}}\" añadido",
@@ -1415,6 +1416,20 @@
         "listingApplications": "Listando aplicaciones…",
         "listingSharedApplets": "Listando applets compartidos…",
         "loadingMusicLibrary": "Cargando biblioteca de música…",
+        "maps": {
+          "foundMany": "Se han encontrado {{count}} lugares para \"{{query}}\".",
+          "foundOne": "Se ha encontrado 1 lugar para \"{{query}}\".",
+          "noResults": "No se han encontrado lugares para \"{{query}}\".",
+          "openInAppleMaps": "Abrir en Apple Maps",
+          "openInMaps": "Abrir {{name}} en Mapas",
+          "searching": "Buscando \"{{query}}\" en Mapas…",
+          "searchingNoQuery": "Buscando en Mapas…"
+        },
+        "memory": {
+          "deleting": "Eliminando memoria…",
+          "recalling": "Recordando memorias…",
+          "saving": "Guardando memoria…"
+        },
         "missingEditParameters": "Faltan parámetros obligatorios: path, old_string y new_string",
         "multipleMatchesFound": "Múltiples coincidencias encontradas",
         "musicLibraryEmpty": "La biblioteca de Música está vacía",
@@ -1451,6 +1466,8 @@
         "searchedWebFor": "Buscado en la web por {{query}}",
         "searchingSongs": "Buscando \"{{query}}\"…",
         "searchingWeb": "Buscando en la web…",
+        "settingsAccentChanged": "Color de realce establecido en {{accent}}",
+        "settingsAccentNotSupported": "El tema {{theme}} no admite colores de realce",
         "settingsCheckingForUpdates": "Comprobando actualizaciones…",
         "settingsLanguageChanged": "Idioma cambiado a {{language}}",
         "settingsMasterVolumeSet": "Volumen establecido en {{volume}}%",
@@ -1458,7 +1475,11 @@
         "settingsSpeechDisabled": "Texto a voz deshabilitado",
         "settingsSpeechEnabled": "Texto a voz habilitado",
         "settingsThemeChanged": "Tema cambiado a {{theme}}",
+        "settingsUiSoundsDisabled": "Sonidos de la interfaz desactivados",
+        "settingsUiSoundsEnabled": "Sonidos de la interfaz activados",
         "settingsUpdated": "Ajustes actualizados",
+        "settingsWallpaperChanged": "Fondo de pantalla cambiado a {{name}}",
+        "settingsWallpaperNotFound": "Ningún fondo de pantalla coincide con \"{{query}}\"",
         "skippedToNextTrack": "Saltó a la siguiente pista",
         "skippedToPreviousTrack": "Saltó a la pista anterior",
         "skippingToNext": "Saltando al siguiente…",
@@ -1511,6 +1532,7 @@
           "videoAlreadyInChannel": "{{title}} ya está en {{channel}}",
           "videoNotInChannel": "Video no encontrado en el canal"
         },
+        "unhandledTool": "Herramienta no gestionada: {{toolName}}",
         "unknownError": "Error desconocido",
         "updatedDocument": "Documento actualizado: {{path}}",
         "webFetch": {

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1195,6 +1195,7 @@
       "toolCalls": {
         "addedAndStartedPlaying": "Nouvelle chanson ajoutée et lecture démarrée",
         "addingSong": "Ajout de la chanson…",
+        "appNotRunning": "{{appName}} n’est pas ouverte",
         "applet": "Applet",
         "calendar": {
           "addedEvent": "Événement «{{title}}» ajouté",
@@ -1415,6 +1416,20 @@
         "listingApplications": "Liste des applications…",
         "listingSharedApplets": "Liste des applets partagées…",
         "loadingMusicLibrary": "Chargement de la bibliothèque musicale…",
+        "maps": {
+          "foundMany": "{{count}} lieux trouvés pour « {{query}} ».",
+          "foundOne": "1 lieu trouvé pour « {{query}} ».",
+          "noResults": "Aucun lieu trouvé pour « {{query}} ».",
+          "openInAppleMaps": "Ouvrir dans Apple Plans",
+          "openInMaps": "Ouvrir {{name}} dans Plans",
+          "searching": "Recherche de « {{query}} » dans Plans…",
+          "searchingNoQuery": "Recherche dans Plans…"
+        },
+        "memory": {
+          "deleting": "Suppression de la mémoire…",
+          "recalling": "Rappel des souvenirs…",
+          "saving": "Enregistrement de la mémoire…"
+        },
         "missingEditParameters": "Paramètres requis manquants : path, old_string et new_string",
         "multipleMatchesFound": "Plusieurs correspondances trouvées",
         "musicLibraryEmpty": "La bibliothèque Musique est vide",
@@ -1451,6 +1466,8 @@
         "searchedWebFor": "Recherché sur le web pour {{query}}",
         "searchingSongs": "Recherche de \"{{query}}\"…",
         "searchingWeb": "Recherche sur le web…",
+        "settingsAccentChanged": "Couleur d’accentuation définie sur {{accent}}",
+        "settingsAccentNotSupported": "Les couleurs d’accentuation ne sont pas prises en charge par le thème {{theme}}",
         "settingsCheckingForUpdates": "Recherche de mises à jour…",
         "settingsLanguageChanged": "Langue changée en {{language}}",
         "settingsMasterVolumeSet": "Volume réglé sur {{volume}}%",
@@ -1458,7 +1475,11 @@
         "settingsSpeechDisabled": "Synthèse vocale désactivée",
         "settingsSpeechEnabled": "Synthèse vocale activée",
         "settingsThemeChanged": "Thème changé en {{theme}}",
+        "settingsUiSoundsDisabled": "Sons de l’interface désactivés",
+        "settingsUiSoundsEnabled": "Sons de l’interface activés",
         "settingsUpdated": "Paramètres mis à jour",
+        "settingsWallpaperChanged": "Fond d’écran remplacé par {{name}}",
+        "settingsWallpaperNotFound": "Aucun fond d’écran ne correspond à « {{query}} »",
         "skippedToNextTrack": "Passage à la piste suivante",
         "skippedToPreviousTrack": "Passage à la piste précédente",
         "skippingToNext": "Passage au suivant…",
@@ -1511,6 +1532,7 @@
           "videoAlreadyInChannel": "{{title}} est déjà dans {{channel}}",
           "videoNotInChannel": "Vidéo introuvable dans la chaîne"
         },
+        "unhandledTool": "Outil non géré : {{toolName}}",
         "unknownError": "Erreur inconnue",
         "updatedDocument": "Document mis à jour : {{path}}",
         "webFetch": {

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1195,6 +1195,7 @@
       "toolCalls": {
         "addedAndStartedPlaying": "Aggiunta nuova canzone e avviata la riproduzione",
         "addingSong": "Aggiunta brano…",
+        "appNotRunning": "{{appName}} non è in esecuzione",
         "applet": "Applet",
         "calendar": {
           "addedEvent": "Aggiunto evento \"{{title}}\"",
@@ -1415,6 +1416,20 @@
         "listingApplications": "Elenco applicazioni…",
         "listingSharedApplets": "Elenco applet condivise…",
         "loadingMusicLibrary": "Carico libreria musicale…",
+        "maps": {
+          "foundMany": "Trovati {{count}} luoghi per \"{{query}}\".",
+          "foundOne": "Trovato 1 luogo per \"{{query}}\".",
+          "noResults": "Nessun luogo trovato per \"{{query}}\".",
+          "openInAppleMaps": "Apri in Mappe Apple",
+          "openInMaps": "Apri {{name}} in Mappe",
+          "searching": "Cerco su Mappe \"{{query}}\"…",
+          "searchingNoQuery": "Cerco su Mappe…"
+        },
+        "memory": {
+          "deleting": "Elimino memoria…",
+          "recalling": "Recupero ricordi…",
+          "saving": "Salvo memoria…"
+        },
         "missingEditParameters": "Parametri richiesti mancanti: path, old_string e new_string",
         "multipleMatchesFound": "Più corrispondenze trovate",
         "musicLibraryEmpty": "La libreria musicale è vuota",
@@ -1451,6 +1466,8 @@
         "searchedWebFor": "Cercato sul web per {{query}}",
         "searchingSongs": "Ricerca \"{{query}}\"…",
         "searchingWeb": "Ricerca sul web…",
+        "settingsAccentChanged": "Colore accento impostato su {{accent}}",
+        "settingsAccentNotSupported": "I colori accento non sono supportati dal tema {{theme}}",
         "settingsCheckingForUpdates": "Controllo aggiornamenti…",
         "settingsLanguageChanged": "Lingua cambiata in {{language}}",
         "settingsMasterVolumeSet": "Volume impostato a {{volume}}%",
@@ -1458,7 +1475,11 @@
         "settingsSpeechDisabled": "Sintesi vocale disabilitata",
         "settingsSpeechEnabled": "Sintesi vocale abilitata",
         "settingsThemeChanged": "Tema cambiato in {{theme}}",
+        "settingsUiSoundsDisabled": "Suoni interfaccia disattivati",
+        "settingsUiSoundsEnabled": "Suoni interfaccia attivati",
         "settingsUpdated": "Impostazioni aggiornate",
+        "settingsWallpaperChanged": "Sfondo modificato in {{name}}",
+        "settingsWallpaperNotFound": "Nessuno sfondo corrisponde a \"{{query}}\"",
         "skippedToNextTrack": "Saltato al brano successivo",
         "skippedToPreviousTrack": "Saltato al brano precedente",
         "skippingToNext": "Passaggio al successivo…",
@@ -1511,6 +1532,7 @@
           "videoAlreadyInChannel": "{{title}} è già in {{channel}}",
           "videoNotInChannel": "Video non trovato nel canale"
         },
+        "unhandledTool": "Strumento non gestito: {{toolName}}",
         "unknownError": "Errore sconosciuto",
         "updatedDocument": "Documento aggiornato: {{path}}",
         "webFetch": {

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1193,6 +1193,7 @@
       "toolCalls": {
         "addedAndStartedPlaying": "新しい曲を追加して再生を開始しました",
         "addingSong": "曲を追加中…",
+        "appNotRunning": "{{appName}}が実行されていません",
         "applet": "アプレット",
         "calendar": {
           "addedEvent": "「{{title}}」イベントを追加しました",
@@ -1413,6 +1414,20 @@
         "listingApplications": "アプリケーションを一覧表示中…",
         "listingSharedApplets": "共有アプレットを一覧表示中…",
         "loadingMusicLibrary": "音楽ライブラリを読み込み中…",
+        "maps": {
+          "foundMany": "\"{{query}}\"の場所が{{count}}件見つかりました。",
+          "foundOne": "\"{{query}}\"の場所が1件見つかりました。",
+          "noResults": "\"{{query}}\"の場所は見つかりませんでした。",
+          "openInAppleMaps": "Appleマップで開く",
+          "openInMaps": "{{name}}をマップで開く",
+          "searching": "マップで\"{{query}}\"を検索中…",
+          "searchingNoQuery": "マップを検索中…"
+        },
+        "memory": {
+          "deleting": "メモリを削除中…",
+          "recalling": "メモリを呼び出し中…",
+          "saving": "メモリを保存中…"
+        },
         "missingEditParameters": "必須パラメーターが不足しています: path, old_string, and new_string",
         "multipleMatchesFound": "複数の一致が見つかりました",
         "musicLibraryEmpty": "Musicライブラリは空です",
@@ -1449,6 +1464,8 @@
         "searchedWebFor": "「{{query}}」をウェブで検索しました",
         "searchingSongs": "\"{{query}}\"を検索中…",
         "searchingWeb": "ウェブを検索中…",
+        "settingsAccentChanged": "アクセントカラーを{{accent}}に設定しました",
+        "settingsAccentNotSupported": "アクセントカラーは{{theme}}テーマではサポートされていません",
         "settingsCheckingForUpdates": "アップデートを確認中…",
         "settingsLanguageChanged": "言語を{{language}}に変更しました",
         "settingsMasterVolumeSet": "音量を{{volume}}%に設定しました",
@@ -1456,7 +1473,11 @@
         "settingsSpeechDisabled": "音声読み上げを無効にしました",
         "settingsSpeechEnabled": "音声読み上げを有効にしました",
         "settingsThemeChanged": "テーマを{{theme}}に変更しました",
+        "settingsUiSoundsDisabled": "UIサウンドを無効にしました",
+        "settingsUiSoundsEnabled": "UIサウンドを有効にしました",
         "settingsUpdated": "設定が更新されました",
+        "settingsWallpaperChanged": "壁紙を{{name}}に変更しました",
+        "settingsWallpaperNotFound": "\"{{query}}\"に一致する壁紙が見つかりませんでした",
         "skippedToNextTrack": "次のトラックにスキップしました",
         "skippedToPreviousTrack": "前のトラックにスキップしました",
         "skippingToNext": "次へスキップ中…",
@@ -1509,6 +1530,7 @@
           "videoAlreadyInChannel": "{{title}}はすでに{{channel}}にあります",
           "videoNotInChannel": "チャンネル内に動画が見つかりません"
         },
+        "unhandledTool": "未処理のツール: {{toolName}}",
         "unknownError": "不明なエラー",
         "updatedDocument": "ドキュメントを更新しました: {{path}}",
         "webFetch": {

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1193,6 +1193,7 @@
       "toolCalls": {
         "addedAndStartedPlaying": "새 곡 추가 및 재생 시작됨",
         "addingSong": "곡 추가 중…",
+        "appNotRunning": "{{appName}}이(가) 실행 중이 아닙니다",
         "applet": "애플릿",
         "calendar": {
           "addedEvent": "\"{{title}}\" 이벤트가 추가되었습니다.",
@@ -1413,6 +1414,20 @@
         "listingApplications": "애플리케이션 목록 표시 중…",
         "listingSharedApplets": "공유 앱렛 목록 표시 중…",
         "loadingMusicLibrary": "음악 라이브러리 로드 중…",
+        "maps": {
+          "foundMany": "\"{{query}}\"에 대한 장소 {{count}}개를 찾았습니다.",
+          "foundOne": "\"{{query}}\"에 대한 장소 1개를 찾았습니다.",
+          "noResults": "\"{{query}}\"에 대한 장소를 찾을 수 없습니다.",
+          "openInAppleMaps": "Apple 지도에서 열기",
+          "openInMaps": "지도에서 {{name}} 열기",
+          "searching": "지도에서 \"{{query}}\" 검색 중…",
+          "searchingNoQuery": "지도 검색 중…"
+        },
+        "memory": {
+          "deleting": "기억 삭제 중…",
+          "recalling": "기억 불러오는 중…",
+          "saving": "기억 저장 중…"
+        },
         "missingEditParameters": "필수 매개변수 누락: path, old_string, new_string",
         "multipleMatchesFound": "여러 일치 항목 찾음",
         "musicLibraryEmpty": "음악 보관함이 비어 있습니다.",
@@ -1449,6 +1464,8 @@
         "searchedWebFor": "웹에서 '{{query}}'을(를) 검색했습니다",
         "searchingSongs": "\"{{query}}\" 검색 중…",
         "searchingWeb": "웹 검색 중…",
+        "settingsAccentChanged": "강조 색상이 {{accent}}(으)로 설정됨",
+        "settingsAccentNotSupported": "{{theme}} 테마에서는 강조 색상이 지원되지 않음",
         "settingsCheckingForUpdates": "업데이트 확인 중…",
         "settingsLanguageChanged": "언어가 {{language}}로 변경되었습니다",
         "settingsMasterVolumeSet": "볼륨이 {{volume}}%로 설정되었습니다",
@@ -1456,7 +1473,11 @@
         "settingsSpeechDisabled": "음성 합성 비활성화됨",
         "settingsSpeechEnabled": "음성 합성 활성화됨",
         "settingsThemeChanged": "테마가 {{theme}}로 변경되었습니다",
+        "settingsUiSoundsDisabled": "UI 사운드 비활성화됨",
+        "settingsUiSoundsEnabled": "UI 사운드 활성화됨",
         "settingsUpdated": "설정이 업데이트되었습니다",
+        "settingsWallpaperChanged": "배경화면이 {{name}}(으)로 변경됨",
+        "settingsWallpaperNotFound": "\"{{query}}\"와(과) 일치하는 배경화면 없음",
         "skippedToNextTrack": "다음 트랙으로 건너뜀",
         "skippedToPreviousTrack": "이전 트랙으로 건너뜀",
         "skippingToNext": "다음으로 건너뛰는 중…",
@@ -1509,6 +1530,7 @@
           "videoAlreadyInChannel": "{{title}}은(는) 이미 {{channel}}에 있습니다",
           "videoNotInChannel": "채널에서 동영상을 찾을 수 없습니다"
         },
+        "unhandledTool": "처리되지 않은 도구: {{toolName}}",
         "unknownError": "알 수 없는 오류",
         "updatedDocument": "문서 업데이트됨: {{path}}",
         "webFetch": {

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1195,6 +1195,7 @@
       "toolCalls": {
         "addedAndStartedPlaying": "Adicionada e começou a reproduzir nova música",
         "addingSong": "Adicionando música…",
+        "appNotRunning": "{{appName}} não está em execução",
         "applet": "Applet",
         "calendar": {
           "addedEvent": "Adicionado evento \"{{title}}\"",
@@ -1415,6 +1416,20 @@
         "listingApplications": "Listando aplicativos…",
         "listingSharedApplets": "Listando applets compartilhados…",
         "loadingMusicLibrary": "Carregando biblioteca de música…",
+        "maps": {
+          "foundMany": "Encontrei {{count}} lugares para \"{{query}}\".",
+          "foundOne": "Encontrei 1 lugar para \"{{query}}\".",
+          "noResults": "Nenhum lugar encontrado para \"{{query}}\".",
+          "openInAppleMaps": "Abrir no Apple Maps",
+          "openInMaps": "Abrir {{name}} no Mapas",
+          "searching": "Buscando \"{{query}}\" no Mapas…",
+          "searchingNoQuery": "Buscando no Mapas…"
+        },
+        "memory": {
+          "deleting": "Apagando memória…",
+          "recalling": "Recuperando memórias…",
+          "saving": "Salvando memória…"
+        },
         "missingEditParameters": "Parâmetros obrigatórios ausentes: path, old_string e new_string",
         "multipleMatchesFound": "Múltiplas correspondências encontradas",
         "musicLibraryEmpty": "A biblioteca de Música está vazia",
@@ -1451,6 +1466,8 @@
         "searchedWebFor": "Pesquisou na web por {{query}}",
         "searchingSongs": "Pesquisando \"{{query}}\"…",
         "searchingWeb": "Pesquisando na web…",
+        "settingsAccentChanged": "Cor de destaque definida como {{accent}}",
+        "settingsAccentNotSupported": "Cores de destaque não são compatíveis com o tema {{theme}}",
         "settingsCheckingForUpdates": "Buscando atualizações…",
         "settingsLanguageChanged": "Idioma alterado para {{language}}",
         "settingsMasterVolumeSet": "Volume definido para {{volume}}%",
@@ -1458,7 +1475,11 @@
         "settingsSpeechDisabled": "Texto para fala desativado",
         "settingsSpeechEnabled": "Texto para fala ativado",
         "settingsThemeChanged": "Tema alterado para {{theme}}",
+        "settingsUiSoundsDisabled": "Sons da interface desativados",
+        "settingsUiSoundsEnabled": "Sons da interface ativados",
         "settingsUpdated": "Configurações atualizadas",
+        "settingsWallpaperChanged": "Imagem de fundo alterada para {{name}}",
+        "settingsWallpaperNotFound": "Nenhuma imagem de fundo corresponde a \"{{query}}\"",
         "skippedToNextTrack": "Pulou para a próxima faixa",
         "skippedToPreviousTrack": "Pulou para a faixa anterior",
         "skippingToNext": "Pulando para o próximo…",
@@ -1511,6 +1532,7 @@
           "videoAlreadyInChannel": "{{title}} já está em {{channel}}",
           "videoNotInChannel": "Vídeo não encontrado no canal"
         },
+        "unhandledTool": "Ferramenta não tratada: {{toolName}}",
         "unknownError": "Erro desconhecido",
         "updatedDocument": "Documento atualizado: {{path}}",
         "webFetch": {

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1197,6 +1197,7 @@
       "toolCalls": {
         "addedAndStartedPlaying": "Добавлена новая песня и начато воспроизведение",
         "addingSong": "Добавление песни…",
+        "appNotRunning": "{{appName}} не запущено",
         "applet": "Апплет",
         "calendar": {
           "addedEvent": "Событие «{{title}}» добавлено",
@@ -1417,6 +1418,20 @@
         "listingApplications": "Перечисление приложений…",
         "listingSharedApplets": "Перечисление общих апплетов…",
         "loadingMusicLibrary": "Загрузка музыкальной библиотеки…",
+        "maps": {
+          "foundMany": "Найдено {{count}} мест по запросу «{{query}}».",
+          "foundOne": "Найдено 1 место по запросу «{{query}}».",
+          "noResults": "По запросу «{{query}}» ничего не найдено.",
+          "openInAppleMaps": "Открыть в Apple Maps",
+          "openInMaps": "Открыть «{{name}}» в Картах",
+          "searching": "Поиск «{{query}}» в Картах…",
+          "searchingNoQuery": "Поиск в Картах…"
+        },
+        "memory": {
+          "deleting": "Удаление из памяти…",
+          "recalling": "Поиск в памяти…",
+          "saving": "Сохранение в памяти…"
+        },
         "missingEditParameters": "Отсутствуют обязательные параметры: path, old_string и new_string",
         "multipleMatchesFound": "Найдено несколько совпадений",
         "musicLibraryEmpty": "Музыкальная библиотека пуста",
@@ -1453,6 +1468,8 @@
         "searchedWebFor": "Выполнен поиск в интернете по запросу {{query}}",
         "searchingSongs": "Поиск \"{{query}}\"…",
         "searchingWeb": "Поиск в интернете…",
+        "settingsAccentChanged": "Цвет акцента изменен на {{accent}}",
+        "settingsAccentNotSupported": "Цвета акцента не поддерживаются темой «{{theme}}»",
         "settingsCheckingForUpdates": "Проверка обновлений…",
         "settingsLanguageChanged": "Язык изменен на {{language}}",
         "settingsMasterVolumeSet": "Громкость установлена на {{volume}}%",
@@ -1460,7 +1477,11 @@
         "settingsSpeechDisabled": "Синтез речи отключен",
         "settingsSpeechEnabled": "Синтез речи включен",
         "settingsThemeChanged": "Тема изменена на {{theme}}",
+        "settingsUiSoundsDisabled": "Звуковые эффекты интерфейса выключены",
+        "settingsUiSoundsEnabled": "Звуковые эффекты интерфейса включены",
         "settingsUpdated": "Настройки обновлены",
+        "settingsWallpaperChanged": "Обои изменены на «{{name}}»",
+        "settingsWallpaperNotFound": "Обои по запросу «{{query}}» не найдены",
         "skippedToNextTrack": "Переключено на следующий трек",
         "skippedToPreviousTrack": "Переключено на предыдущий трек",
         "skippingToNext": "Переключение на следующий…",
@@ -1513,6 +1534,7 @@
           "videoAlreadyInChannel": "{{title}} уже есть в {{channel}}",
           "videoNotInChannel": "Видео не найдено в канале"
         },
+        "unhandledTool": "Необработанный инструмент: {{toolName}}",
         "unknownError": "Неизвестная ошибка",
         "updatedDocument": "Документ обновлен: {{path}}",
         "webFetch": {

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -1193,6 +1193,7 @@
       "toolCalls": {
         "addedAndStartedPlaying": "已添加新歌曲并开始播放",
         "addingSong": "正在添加歌曲…",
+        "appNotRunning": "{{appName}}未运行",
         "applet": "Applet",
         "calendar": {
           "addedEvent": "已添加事件「{{title}}」",
@@ -1413,6 +1414,20 @@
         "listingApplications": "列出应用程序…",
         "listingSharedApplets": "列出共享小程序…",
         "loadingMusicLibrary": "正在加载音乐库…",
+        "maps": {
+          "foundMany": "找到 {{count}} 个与“{{query}}”相关的位置。",
+          "foundOne": "找到 1 个与“{{query}}”相关的位置。",
+          "noResults": "未找到与“{{query}}”相关的位置。",
+          "openInAppleMaps": "在 Apple 地图中打开",
+          "openInMaps": "在“地图”中打开 {{name}}",
+          "searching": "正在地图中搜索“{{query}}”…",
+          "searchingNoQuery": "正在搜索地图…"
+        },
+        "memory": {
+          "deleting": "正在删除记忆…",
+          "recalling": "正在检索记忆…",
+          "saving": "正在保存记忆…"
+        },
         "missingEditParameters": "缺少必要参数：path、old_string 和 new_string",
         "multipleMatchesFound": "找到多个匹配项",
         "musicLibraryEmpty": "资料库是空的",
@@ -1449,6 +1464,8 @@
         "searchedWebFor": "已在网络上搜索 {{query}}",
         "searchingSongs": "正在搜索「{{query}}」…",
         "searchingWeb": "正在搜索网络…",
+        "settingsAccentChanged": "强调色已设为 {{accent}}",
+        "settingsAccentNotSupported": "{{theme}} 主题不支持强调色",
         "settingsCheckingForUpdates": "正在检查更新…",
         "settingsLanguageChanged": "语言已变更为{{language}}",
         "settingsMasterVolumeSet": "音量已设置为 {{volume}}%",
@@ -1456,7 +1473,11 @@
         "settingsSpeechDisabled": "语音朗读已关闭",
         "settingsSpeechEnabled": "已启用语音朗读",
         "settingsThemeChanged": "主题已变更为{{theme}}",
+        "settingsUiSoundsDisabled": "用户界面声音已禁用",
+        "settingsUiSoundsEnabled": "用户界面声音已启用",
         "settingsUpdated": "设置已更新",
+        "settingsWallpaperChanged": "墙纸已更改为 {{name}}",
+        "settingsWallpaperNotFound": "没有与“{{query}}”匹配的墙纸",
         "skippedToNextTrack": "跳到下一首",
         "skippedToPreviousTrack": "跳到上一首",
         "skippingToNext": "跳到下一首…",
@@ -1509,6 +1530,7 @@
           "videoAlreadyInChannel": "{{title}} 已在 {{channel}} 中",
           "videoNotInChannel": "频道中找不到视频"
         },
+        "unhandledTool": "未处理的工具：{{toolName}}",
         "unknownError": "未知错误",
         "updatedDocument": "文件已更新：{{path}}",
         "webFetch": {

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1193,6 +1193,7 @@
       "toolCalls": {
         "addedAndStartedPlaying": "已新增並開始播放新歌曲",
         "addingSong": "新增歌曲⋯",
+        "appNotRunning": "{{appName}} 未在執行",
         "applet": "小程式",
         "calendar": {
           "addedEvent": "已新增事件「{{title}}」",
@@ -1413,6 +1414,20 @@
         "listingApplications": "列出應用程式⋯",
         "listingSharedApplets": "列出共享小程式⋯",
         "loadingMusicLibrary": "載入資料庫⋯",
+        "maps": {
+          "foundMany": "找到 {{count}} 個「{{query}}」的地點。",
+          "foundOne": "找到 1 個「{{query}}」的地點。",
+          "noResults": "找不到「{{query}}」的地點。",
+          "openInAppleMaps": "在「Apple 地圖」中打開",
+          "openInMaps": "在「地圖」中打開 {{name}}",
+          "searching": "正在「地圖」中搜尋「{{query}}」⋯",
+          "searchingNoQuery": "正在搜尋「地圖」⋯"
+        },
+        "memory": {
+          "deleting": "正在刪除記憶⋯",
+          "recalling": "正在回想記憶⋯",
+          "saving": "正在儲存記憶⋯"
+        },
         "missingEditParameters": "缺少必要參數：path、old_string 和 new_string",
         "multipleMatchesFound": "找到多個符合項目",
         "musicLibraryEmpty": "資料庫是空的",
@@ -1449,6 +1464,8 @@
         "searchedWebFor": "已搜尋網路尋找 {{query}}",
         "searchingSongs": "正在搜尋「{{query}}」⋯",
         "searchingWeb": "正在搜尋網路⋯",
+        "settingsAccentChanged": "強調顏色已設定為 {{accent}}",
+        "settingsAccentNotSupported": "{{theme}} 主題不支援強調顏色",
         "settingsCheckingForUpdates": "正在檢查更新項目⋯",
         "settingsLanguageChanged": "語言已變更為{{language}}",
         "settingsMasterVolumeSet": "音量設定為 {{volume}}%",
@@ -1456,7 +1473,11 @@
         "settingsSpeechDisabled": "已停用語音朗讀",
         "settingsSpeechEnabled": "已啟用語音朗讀",
         "settingsThemeChanged": "主題已變更為{{theme}}",
+        "settingsUiSoundsDisabled": "使用者介面聲音已停用",
+        "settingsUiSoundsEnabled": "使用者介面聲音已啟用",
         "settingsUpdated": "設定已更新",
+        "settingsWallpaperChanged": "背景圖片已更改為 {{name}}",
+        "settingsWallpaperNotFound": "沒有符合「{{query}}」的背景圖片",
         "skippedToNextTrack": "跳到下一首",
         "skippedToPreviousTrack": "跳到上一首",
         "skippingToNext": "跳到下一首⋯",
@@ -1509,6 +1530,7 @@
           "videoAlreadyInChannel": "{{title}} 已在 {{channel}} 中",
           "videoNotInChannel": "頻道中找不到影片"
         },
+        "unhandledTool": "未處理的工具：{{toolName}}",
         "unknownError": "未知的錯誤",
         "updatedDocument": "文件已更新：{{path}}",
         "webFetch": {

--- a/tests/test-chat-tools-improvements.test.ts
+++ b/tests/test-chat-tools-improvements.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  settingsSchema,
+  documentsControlSchema,
+  calendarControlSchema,
+} from "../api/chat/tools/schemas";
+import { createChatTools } from "../api/chat/tools/index.js";
+import { repairRyoToolCall } from "../api/_utils/ryo-agent.js";
+import { checkToolRateLimit } from "../api/chat/tools/_tool-rate-limit.js";
+
+// ============================================================================
+// Expanded settings schema
+// ============================================================================
+
+describe("settingsSchema expanded fields", () => {
+  test("accepts wallpaper, accent, and uiSoundsEnabled", () => {
+    const result = settingsSchema.safeParse({
+      wallpaper: "aurora",
+      accent: "purple",
+      uiSoundsEnabled: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts special accent values 'default' and 'wallpaper'", () => {
+    expect(settingsSchema.safeParse({ accent: "default" }).success).toBe(true);
+    expect(settingsSchema.safeParse({ accent: "wallpaper" }).success).toBe(
+      true
+    );
+  });
+
+  test("rejects unknown accent ids", () => {
+    expect(settingsSchema.safeParse({ accent: "magenta" }).success).toBe(
+      false
+    );
+  });
+
+  test("rejects over-long wallpaper queries", () => {
+    expect(
+      settingsSchema.safeParse({ wallpaper: "x".repeat(121) }).success
+    ).toBe(false);
+  });
+
+  test("rejects non-boolean uiSoundsEnabled", () => {
+    expect(
+      settingsSchema.safeParse({ uiSoundsEnabled: "yes" }).success
+    ).toBe(false);
+  });
+});
+
+// ============================================================================
+// documentsControl schema hardening
+// ============================================================================
+
+describe("documentsControlSchema path hardening", () => {
+  test("accepts a plain file directly under /Documents", () => {
+    expect(
+      documentsControlSchema.safeParse({
+        action: "read",
+        path: "/Documents/notes.md",
+      }).success
+    ).toBe(true);
+  });
+
+  test("rejects subdirectories", () => {
+    expect(
+      documentsControlSchema.safeParse({
+        action: "read",
+        path: "/Documents/folder/notes.md",
+      }).success
+    ).toBe(false);
+  });
+
+  test("rejects path traversal", () => {
+    expect(
+      documentsControlSchema.safeParse({
+        action: "read",
+        path: "/Documents/..secret.md",
+      }).success
+    ).toBe(false);
+  });
+
+  test("rejects backslashes", () => {
+    expect(
+      documentsControlSchema.safeParse({
+        action: "read",
+        path: "/Documents/notes\\evil.md",
+      }).success
+    ).toBe(false);
+  });
+
+  test("rejects over-long content on write", () => {
+    expect(
+      documentsControlSchema.safeParse({
+        action: "write",
+        path: "/Documents/big.md",
+        content: "x".repeat(100_001),
+      }).success
+    ).toBe(false);
+  });
+});
+
+// ============================================================================
+// calendarControl location field
+// ============================================================================
+
+describe("calendarControlSchema location", () => {
+  test("accepts create with a location", () => {
+    expect(
+      calendarControlSchema.safeParse({
+        action: "create",
+        title: "Dinner",
+        date: "2026-07-10",
+        location: "Tokyo Tower",
+      }).success
+    ).toBe(true);
+  });
+
+  test("rejects over-long locations", () => {
+    expect(
+      calendarControlSchema.safeParse({
+        action: "create",
+        title: "Dinner",
+        date: "2026-07-10",
+        location: "x".repeat(201),
+      }).success
+    ).toBe(false);
+  });
+});
+
+// ============================================================================
+// Memory tools omitted for anonymous users
+// ============================================================================
+
+describe("createChatTools anonymous memory filtering", () => {
+  const baseContext = {
+    log: mock(() => {}),
+    logError: mock(() => {}),
+    env: {},
+    timeZone: "America/Los_Angeles",
+  };
+
+  test("'all' profile omits memory tools when username is missing", () => {
+    const tools = createChatTools(
+      { ...baseContext, username: null },
+      { profile: "all" }
+    ) as Record<string, unknown>;
+    expect(tools.memoryWrite).toBeUndefined();
+    expect(tools.memoryRead).toBeUndefined();
+    expect(tools.memoryDelete).toBeUndefined();
+    // Everything else stays available
+    expect(tools.launchApp).toBeDefined();
+    expect(tools.webFetch).toBeDefined();
+  });
+
+  test("'all' profile keeps memory tools for authenticated users", () => {
+    const tools = createChatTools(
+      { ...baseContext, username: "ryo" },
+      { profile: "all" }
+    ) as Record<string, unknown>;
+    expect(tools.memoryWrite).toBeDefined();
+    expect(tools.memoryRead).toBeDefined();
+    expect(tools.memoryDelete).toBeDefined();
+  });
+
+  test("'telegram' profile keeps memory tools (always authenticated)", () => {
+    const tools = createChatTools(
+      { ...baseContext, username: "ryo" },
+      { profile: "telegram" }
+    ) as Record<string, unknown>;
+    expect(tools.memoryWrite).toBeDefined();
+  });
+});
+
+// ============================================================================
+// Deterministic tool-call repair
+// ============================================================================
+
+type RepairArgs = Parameters<typeof repairRyoToolCall>[0];
+
+function makeRepairArgs(input: unknown, error?: Error): RepairArgs {
+  return {
+    toolCall: {
+      type: "tool-call",
+      toolCallId: "call-1",
+      toolName: "settings",
+      input,
+    },
+    error: error ?? new Error("validation failed"),
+  } as unknown as RepairArgs;
+}
+
+describe("repairRyoToolCall", () => {
+  test("strips markdown code fences around JSON input", async () => {
+    const repaired = await repairRyoToolCall(
+      makeRepairArgs('```json\n{"theme":"macosx"}\n```')
+    );
+    expect(repaired).not.toBeNull();
+    expect(repaired!.input).toBe('{"theme":"macosx"}');
+  });
+
+  test("unwraps double-encoded JSON strings", async () => {
+    const repaired = await repairRyoToolCall(
+      makeRepairArgs(JSON.stringify('{"theme":"macosx"}'))
+    );
+    expect(repaired).not.toBeNull();
+    expect(repaired!.input).toBe('{"theme":"macosx"}');
+  });
+
+  test("returns null when input is already clean (no repair possible)", async () => {
+    const repaired = await repairRyoToolCall(
+      makeRepairArgs('{"theme":"macosx"}')
+    );
+    expect(repaired).toBeNull();
+  });
+
+  test("returns null for unparseable input", async () => {
+    const repaired = await repairRyoToolCall(makeRepairArgs("not json at all"));
+    expect(repaired).toBeNull();
+  });
+
+  test("returns null for non-string input", async () => {
+    const repaired = await repairRyoToolCall(
+      makeRepairArgs({ theme: "macosx" })
+    );
+    expect(repaired).toBeNull();
+  });
+});
+
+// ============================================================================
+// Per-tool rate limiting
+// ============================================================================
+
+describe("checkToolRateLimit", () => {
+  test("anonymous users are always allowed (chat budget already caps them)", async () => {
+    const result = await checkToolRateLimit("webFetch", null, () => {});
+    expect(result.allowed).toBe(true);
+    const result2 = await checkToolRateLimit("searchSongs", undefined, () => {});
+    expect(result2.allowed).toBe(true);
+  });
+});

--- a/tests/test-chat-tools-improvements.test.ts
+++ b/tests/test-chat-tools-improvements.test.ts
@@ -7,6 +7,8 @@ import {
 import { createChatTools } from "../api/chat/tools/index.js";
 import { repairRyoToolCall } from "../api/_utils/ryo-agent.js";
 import { checkToolRateLimit } from "../api/chat/tools/_tool-rate-limit.js";
+import type { Redis } from "../api/_utils/redis.js";
+import { FakeRedis } from "./fake-redis";
 
 // ============================================================================
 // Expanded settings schema
@@ -233,9 +235,42 @@ describe("repairRyoToolCall", () => {
 
 describe("checkToolRateLimit", () => {
   test("anonymous users are always allowed (chat budget already caps them)", async () => {
-    const result = await checkToolRateLimit("webFetch", null, () => {});
+    const result = await checkToolRateLimit("webFetch", {
+      username: null,
+      logError: () => {},
+    });
     expect(result.allowed).toBe(true);
-    const result2 = await checkToolRateLimit("searchSongs", undefined, () => {});
+    const result2 = await checkToolRateLimit("searchSongs", {
+      logError: () => {},
+    });
     expect(result2.allowed).toBe(true);
+  });
+
+  test("uses the context redis client and enforces the hourly limit", async () => {
+    const redis = new FakeRedis() as unknown as Redis;
+    const context = { username: "alice", redis, logError: () => {} };
+
+    // searchSongs allows 30 calls per hour
+    for (let i = 0; i < 30; i++) {
+      const result = await checkToolRateLimit("searchSongs", context);
+      expect(result.allowed).toBe(true);
+    }
+    const blocked = await checkToolRateLimit("searchSongs", context);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.message).toContain("Rate limit reached for searchSongs");
+  });
+
+  test("fails open when the redis client errors", async () => {
+    const throwingRedis = {
+      incr: () => Promise.reject(new Error("redis down")),
+    } as unknown as Redis;
+    const logError = mock(() => {});
+    const result = await checkToolRateLimit("webFetch", {
+      username: "alice",
+      redis: throwingRedis,
+      logError,
+    });
+    expect(result.allowed).toBe(true);
+    expect(logError).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the improvements identified in the AI tool-call audit, plus the expanded settings tool.

### Expanded `settings` tool
- `wallpaper`: fuzzy-matched against the built-in tiles/photos/videos manifest (e.g. "aurora", "red tile")
- `accent`: accent color changes (Mac OS X / System 7 themes), including `default` and `wallpaper` sampling
- `uiSoundsEnabled`: toggle UI sound effects

### Reliability & consistency
- Client `calendarControl` / `stickiesControl` handlers now route through the shared `applyCalendarToolAction` / sticky patch helpers used by the server executors, fixing a dropped `location` field on calendar events and unifying short-ID mapping and serialization.
- Deterministic `experimental_repairToolCall` in the ryo agent loop: strips markdown fences and unwraps double-encoded JSON tool inputs without an extra LLM round-trip.
- `mediaHandler` soft failures ("no songs found", missing ID) now emit `output-error` states so the model gets a clear failure signal.

### Token & resource hygiene
- Memory tools (`memoryWrite`/`memoryRead`/`memoryDelete`) are omitted from the `all` profile for anonymous users — they have no persistent storage, so the calls were dead ends.
- Per-user hourly rate limits for `webFetch` (50/h), `searchSongs` (30/h), and `mapsSearchPlaces` (50/h), keyed in Redis via the tool context's client; fails open on Redis errors.
- `documentsControl` schema hardening: max lengths for path/content/edit strings, and path validation rejecting subdirectories, backslashes, and `..`.

### Structure & housekeeping
- VFS `list`/`open`/`read`/`write`/`edit` handlers extracted from `dispatchToolCall.ts` into `src/apps/chats/tools/vfsHandlers.ts`; the dispatcher is now a thin router.
- `contactsControl` mentioned in `TELEGRAM_CHAT_INSTRUCTIONS`.
- Missing `toolCalls` locale keys added (maps, memory, settings, app control) and machine-translated across all 11 locales; shell bundle regenerated.
- `add-ai-chat-tool` skill doc updated for the dispatcher architecture; removed a dead `onToolCall` reassignment in `useAssistantChat`.

## Testing

- ✅ `bun run test:unit` — 2277 pass / 0 fail (294 files)
- ✅ `bun test tests/test-chat-tools-improvements.test.ts` — 24 new tests covering the expanded settings schema, documentsControl path hardening, calendar location, anonymous memory filtering, `repairRyoToolCall`, and `checkToolRateLimit`
- ✅ `bun run test:api` — 332/335 pass; the 3 failures reproduce identically on `main` against a main-branch server (2× "Invalid auth token expects 401" in `test-ai.test.ts`, 1 flaky recovery reset test that passes in isolation), so they are pre-existing
- ✅ `bun run build`
- ✅ `bunx tsc --noEmit`, `bunx eslint` on changed files
- ✅ `bun run i18n:audit` and `bun run test:registration`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3055-fb88-7a5e-bcc9-87de683e7cda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3055-fb88-7a5e-bcc9-87de683e7cda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

