### PR TITLE
Fix select viewport snapping back to selection while scrolling

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -73,46 +73,105 @@ const SelectTrigger = (
 };
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
-const SelectScrollUpButton = (
-  {
-    ref,
-    className,
-    ...props
-  }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton> & {
-    ref?: React.Ref<React.ElementRef<typeof SelectPrimitive.ScrollUpButton>>;
-  }
-) => (<SelectPrimitive.ScrollUpButton
-  ref={ref}
-  className={cn(
-    "flex cursor-default items-center justify-center py-1",
-    className
-  )}
-  {...props}
->
-  <CaretUp size={12} weight="bold" />
-</SelectPrimitive.ScrollUpButton>);
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+// Custom scroll buttons instead of Radix's SelectPrimitive.ScrollUp/DownButton.
+// The Radix buttons unmount/remount as the viewport crosses the top/bottom edge,
+// and every remount runs a layout effect that scrollIntoView()s the focused
+// (selected) item — snapping the list back to the selection while the user is
+// scrolling (worst on iOS touch, where focus never leaves the selected item).
+// See radix-ui/primitives#3686. These buttons read the viewport directly, never
+// force focus-based scrolling, and stay mounted while the list is scrollable so
+// the layout doesn't shift mid-scroll.
+const SelectScrollButton = ({
+  direction,
+  viewport,
+  className,
+}: {
+  direction: "up" | "down";
+  viewport: HTMLDivElement | null;
+  className?: string;
+}) => {
+  const [isScrollable, setIsScrollable] = React.useState(false);
+  const [canScroll, setCanScroll] = React.useState(false);
+  const autoScrollTimerRef = React.useRef<number | null>(null);
 
-const SelectScrollDownButton = (
-  {
-    ref,
-    className,
-    ...props
-  }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton> & {
-    ref?: React.Ref<React.ElementRef<typeof SelectPrimitive.ScrollDownButton>>;
-  }
-) => (<SelectPrimitive.ScrollDownButton
-  ref={ref}
-  className={cn(
-    "flex cursor-default items-center justify-center py-1",
-    className
-  )}
-  {...props}
->
-  <CaretDown size={12} weight="bold" />
-</SelectPrimitive.ScrollDownButton>);
-SelectScrollDownButton.displayName =
-  SelectPrimitive.ScrollDownButton.displayName;
+  React.useLayoutEffect(() => {
+    if (!viewport) return;
+    const update = () => {
+      const maxScroll = viewport.scrollHeight - viewport.clientHeight;
+      setIsScrollable(maxScroll > 1);
+      setCanScroll(
+        direction === "up"
+          ? viewport.scrollTop > 0
+          : Math.ceil(viewport.scrollTop) < maxScroll
+      );
+    };
+    update();
+    viewport.addEventListener("scroll", update);
+    const observer = new ResizeObserver(update);
+    observer.observe(viewport);
+    return () => {
+      viewport.removeEventListener("scroll", update);
+      observer.disconnect();
+    };
+  }, [viewport, direction]);
+
+  const stopAutoScroll = React.useCallback(() => {
+    if (autoScrollTimerRef.current !== null) {
+      window.clearInterval(autoScrollTimerRef.current);
+      autoScrollTimerRef.current = null;
+    }
+  }, []);
+
+  React.useEffect(() => stopAutoScroll, [stopAutoScroll]);
+
+  const startAutoScroll = React.useCallback(() => {
+    if (!viewport || autoScrollTimerRef.current !== null) return;
+    autoScrollTimerRef.current = window.setInterval(() => {
+      const step =
+        viewport.querySelector<HTMLElement>('[role="option"]')?.offsetHeight ??
+        24;
+      viewport.scrollTop += direction === "up" ? -step : step;
+    }, 50);
+  }, [viewport, direction]);
+
+  if (!isScrollable) return null;
+
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "flex shrink-0 cursor-default touch-none select-none items-center justify-center py-1 transition-opacity",
+        !canScroll && "opacity-30",
+        className
+      )}
+      onPointerDown={startAutoScroll}
+      onPointerMove={(event) => {
+        if (event.pointerType === "mouse") startAutoScroll();
+      }}
+      onPointerUp={stopAutoScroll}
+      onPointerLeave={stopAutoScroll}
+      onPointerCancel={stopAutoScroll}
+    >
+      {direction === "up" ? (
+        <CaretUp size={12} weight="bold" />
+      ) : (
+        <CaretDown size={12} weight="bold" />
+      )}
+    </div>
+  );
+};
+
+const SelectScrollUpButton = ({ className, viewport }: {
+  className?: string;
+  viewport: HTMLDivElement | null;
+}) => <SelectScrollButton direction="up" viewport={viewport} className={className} />;
+SelectScrollUpButton.displayName = "SelectScrollUpButton";
+
+const SelectScrollDownButton = ({ className, viewport }: {
+  className?: string;
+  viewport: HTMLDivElement | null;
+}) => <SelectScrollButton direction="down" viewport={viewport} className={className} />;
+SelectScrollDownButton.displayName = "SelectScrollDownButton";
 
 const SelectContent = (
   {
@@ -126,6 +185,7 @@ const SelectContent = (
   }
 ) => {
   const { isMacOSTheme, isAquaGlass } = useThemeFlags();
+  const [viewport, setViewport] = React.useState<HTMLDivElement | null>(null);
 
   return (
     <SelectPrimitive.Portal>
@@ -155,10 +215,11 @@ const SelectContent = (
         position={position}
         {...props}
       >
-        <SelectScrollUpButton />
+        <SelectScrollUpButton viewport={viewport} />
         <SelectPrimitive.Viewport
+          ref={setViewport}
           className={cn(
-            "p-1",
+            "p-1 overscroll-contain",
             position === "popper" &&
               "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
             isMacOSTheme && "p-0"
@@ -166,7 +227,7 @@ const SelectContent = (
         >
           {children}
         </SelectPrimitive.Viewport>
-        <SelectScrollDownButton />
+        <SelectScrollDownButton viewport={viewport} />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Scrollable selects (e.g. the year picker in Internet Explorer) kept snapping back to the selected item while scrolling, worst on iOS mobile where the list was effectively unscrollable.

## Cause

Radix's `SelectPrimitive.ScrollUpButton`/`ScrollDownButton` unmount whenever the viewport touches the top/bottom edge and remount when it leaves it. Every remount runs a layout effect that calls `scrollIntoView()` on the focused item — which in an open select is the selected item. So as soon as the user scrolled away from the selection and crossed an edge threshold, the viewport was yanked back to the middle of the list. On touch devices focus never leaves the selected item, so every scroll gesture snapped back. This is upstream bug radix-ui/primitives#3686 (fix still unreleased).

## Fix

Replaced the Radix scroll buttons in `src/components/ui/select.tsx` with custom caret buttons that:

- read the viewport element directly (scroll + resize listeners) and never trigger focus-based scrolling — no snap-back;
- stay mounted while the list is scrollable (dimming to 30% opacity at the edge instead of unmounting), so the layout doesn't shift mid-scroll;
- keep the hover/hold auto-scroll behavior for mouse users (scrolls one item height every 50 ms, matching Radix).

Also added `overscroll-contain` on the viewport to stop iOS scroll chaining/bounce from leaking to the page.

## Verification

Playwright script against `bun run dev`, driving the IE year select (open → scroll viewport to top → scroll down slightly, plus a CDP touch-drag emulating an iOS finger scroll):

- **Pre-fix (main):** setting `scrollTop` to 40 after reaching the top snapped back to 674 (the selected item's offset) — bug reproduced.
- **Post-fix:** scroll position preserved (40 stays 40; touch drag from top lands at 135 and stays); hover auto-scroll works (674 → 962); up caret dims at top; selecting an item still updates the trigger.

![Year select stays where the user touch-scrolled instead of snapping back](https://cursor.com/artifacts/c/art-34b7ea1f-61dd-46c5-9dc6-2fe800d10f82)

Full before/after log: `select_scroll_repro_and_fix.log` (attached artifact).

- ✅ `bun run typecheck`
- ✅ `bunx eslint src/components/ui/select.tsx`
- ✅ `bun run test:unit` (2260 pass, 0 fail)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f30f8-d801-74a7-b077-e3e0a063bf0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f30f8-d801-74a7-b077-e3e0a063bf0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

