### PR TITLE
Make AI wallpaper tool predictable: exact names, shuffle categories, dynamic wallpapers

### DIFF
--- a/api/_utils/_aiPrompts.ts
+++ b/api/_utils/_aiPrompts.ts
@@ -437,7 +437,9 @@ Use the \`mediaControl\` tool for all media apps. Pick the app with \`target\`: 
 Use \`settings\` tool to change system preferences. **Include ONLY the fields the user asked to change** — omit all others (do not echo current values from system state).
 - \`language\`: "en", "zh-TW", "zh-CN", "ja", "ko", "fr", "de", "es", "pt", "it", "ru"
 - \`theme\`: "system7" (Classic Mac), "macosx" (Mac OS X), "xp" (Windows XP), "win98" (Windows 98) — current theme is in system state as \`theme\`; omit when only changing wallpaper or other settings
-- \`wallpaper\`: fuzzy name for a built-in wallpaper (e.g. "aurora", "clouds") — omit \`theme\`, \`accent\`, volume, and other fields when the user only asked for wallpaper
+- \`wallpaper\`: exact name of one built-in wallpaper (e.g. "aurora", "clouds") — if it fails, the result lists close names to retry with; omit \`theme\`, \`accent\`, volume, and other fields when the user only asked for wallpaper
+- \`wallpaperShuffle\`: shuffle a wallpaper category — "tiles", "videos", or a photo category ("aqua", "black_and_white", "convergency", "foliage", "graphics", "landscapes", "nature", "nostalgia", "objects", "plants", "structures"); use when the user wants rotating/shuffled wallpapers or a category
+- \`wallpaperDynamic\`: dynamic wallpaper — "day-night" (time-of-day gradient), "weather" (live weather), "cover" (now-playing album art), "lyrics" (now-playing lyrics); use exactly one of the three wallpaper fields per call
 - \`accent\`: accent color id ("default", "wallpaper", "purple", …) — Mac OS X / System 7 only
 - \`masterVolume\`: 0-1 (0 = mute, 1 = full volume)
 - \`speechEnabled\`: true/false (text-to-speech for AI responses)

--- a/api/chat/tools/index.ts
+++ b/api/chat/tools/index.ts
@@ -186,6 +186,7 @@ export const TOOL_DESCRIPTIONS = {
   settings:
     "Change system settings in ryOS. Use when the user asks to change language, theme, wallpaper, accent color, volume, enable/disable speech or UI sounds, or check for updates. " +
     "IMPORTANT: Include ONLY the settings the user explicitly requested — omit every other field. Do not echo current values for language, theme, wallpaper, accent, volume, speech, or UI sounds. " +
+    "Wallpaper fields (use exactly one per call): 'wallpaper' sets one specific built-in wallpaper by exact name; 'wallpaperShuffle' rotates through a category (tiles, videos, or a photo category); 'wallpaperDynamic' sets a live wallpaper ('day-night' time-of-day gradient, 'weather' live weather, 'cover' now-playing album art, 'lyrics' now-playing lyrics). " +
     "Multiple settings can be changed in one call when the user asks for several (e.g. 'set XP theme and mute sounds').",
   
   stickiesControl:

--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -24,6 +24,8 @@ import {
   TV_ACTIONS,
   MEDIA_TARGETS,
   MEDIA_CONTROL_ACTIONS,
+  DYNAMIC_WALLPAPER_IDS,
+  WALLPAPER_SHUFFLE_CATEGORIES,
   type TvAction,
 } from "./types.js";
 import {
@@ -437,7 +439,19 @@ const settingsObjectSchema = z.object({
   wallpaper: z
     .preprocess(normalizeOptionalString, z.string().max(120).optional())
     .describe(
-      "Change the desktop wallpaper by name. Fuzzy-matched against the built-in tiles, photos, and video wallpapers (e.g. 'aurora', 'clouds', 'red tile'). ONLY include when the user explicitly asks to change wallpaper."
+      "Set a specific built-in wallpaper by exact name (e.g. 'aurora', 'clouds', 'bondi'). Matched case-insensitively against built-in tile, photo, and video wallpaper names — no fuzzy matching. If no exact match exists, the tool result lists close names to retry with. Use 'wallpaperShuffle' or 'wallpaperDynamic' instead when the user wants a shuffled category or a dynamic wallpaper. ONLY include when the user explicitly asks to change wallpaper."
+    ),
+  wallpaperShuffle: z
+    .enum(WALLPAPER_SHUFFLE_CATEGORIES)
+    .optional()
+    .describe(
+      "Shuffle wallpapers from a category (rotates automatically every few minutes). 'tiles' shuffles tiled patterns, 'videos' shuffles video wallpapers, and the rest shuffle that photo category. ONLY include when the user asks to shuffle/rotate wallpapers or asks for a category rather than one specific wallpaper. Do not combine with 'wallpaper' or 'wallpaperDynamic'."
+    ),
+  wallpaperDynamic: z
+    .enum(DYNAMIC_WALLPAPER_IDS)
+    .optional()
+    .describe(
+      "Set a dynamic wallpaper: 'day-night' is a gradient that shifts with the time of day, 'weather' reflects the live local weather, 'cover' shows the now-playing album art, 'lyrics' shows the now-playing synced lyrics. ONLY include when the user asks for one of these dynamic wallpapers. Do not combine with 'wallpaper' or 'wallpaperShuffle'."
     ),
   accent: z
     .enum(ACCENT_IDS)
@@ -475,7 +489,18 @@ const settingsObjectSchema = z.object({
 
 export const settingsSchema = z.preprocess(
   normalizeSettingsInput,
-  settingsObjectSchema
+  settingsObjectSchema.superRefine((data, ctx) => {
+    const wallpaperFields = (
+      ["wallpaper", "wallpaperShuffle", "wallpaperDynamic"] as const
+    ).filter((key) => data[key] !== undefined);
+    if (wallpaperFields.length > 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Provide only one of 'wallpaper', 'wallpaperShuffle', or 'wallpaperDynamic' (got ${wallpaperFields.join(", ")}).`,
+        path: [wallpaperFields[1]],
+      });
+    }
+  })
 );
 
 /**

--- a/api/chat/tools/types.ts
+++ b/api/chat/tools/types.ts
@@ -31,6 +31,14 @@ export {
   type StickiesControlOutput,
   type StickyColor,
 } from "../../../src/shared/tools/stickies.js";
+export {
+  DYNAMIC_WALLPAPER_IDS,
+  WALLPAPER_PHOTO_CATEGORIES,
+  WALLPAPER_SHUFFLE_CATEGORIES,
+  type DynamicWallpaperToolId,
+  type WallpaperPhotoCategory,
+  type WallpaperShuffleCategory,
+} from "../../../src/shared/tools/wallpaper.js";
 
 // Central list of supported theme IDs for tool validation
 export const THEME_IDS = ["system7", "macosx", "xp", "win98"] as const;
@@ -282,6 +290,8 @@ export interface SettingsInput {
   language?: LanguageCode;
   theme?: ThemeId;
   wallpaper?: string;
+  wallpaperShuffle?: import("../../../src/shared/tools/wallpaper.js").WallpaperShuffleCategory;
+  wallpaperDynamic?: import("../../../src/shared/tools/wallpaper.js").DynamicWallpaperToolId;
   accent?: AccentId;
   masterVolume?: number;
   speechEnabled?: boolean;

--- a/src/apps/chats/tools/sanitizeSettingsInput.ts
+++ b/src/apps/chats/tools/sanitizeSettingsInput.ts
@@ -15,13 +15,24 @@
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useLanguageStore, type LanguageCode } from "@/stores/useLanguageStore";
 import { useThemeStore } from "@/stores/useThemeStore";
+import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
+import {
+  DYNAMIC_WALLPAPER_DESCRIPTORS,
+  buildShuffleDescriptor,
+} from "@/utils/dynamicWallpaper";
 import { DEFAULT_ACCENT, type AccentId } from "@/themes/accents";
 import type { OsThemeId } from "@/themes/types";
+import type {
+  DynamicWallpaperToolId,
+  WallpaperShuffleCategory,
+} from "@/shared/tools/wallpaper";
 
 export interface SettingsInput {
   language?: string;
   theme?: OsThemeId;
   wallpaper?: string;
+  wallpaperShuffle?: WallpaperShuffleCategory;
+  wallpaperDynamic?: DynamicWallpaperToolId;
   accent?: string;
   masterVolume?: number;
   speechEnabled?: boolean;
@@ -34,6 +45,8 @@ export const SETTINGS_INPUT_KEYS = [
   "language",
   "theme",
   "wallpaper",
+  "wallpaperShuffle",
+  "wallpaperDynamic",
   "accent",
   "masterVolume",
   "speechEnabled",
@@ -51,6 +64,12 @@ export interface CurrentSettingsSnapshot {
   masterVolume: number;
   speechEnabled: boolean;
   uiSoundsEnabled: boolean;
+  /**
+   * Persisted wallpaper selection (concrete path or `dynamic://`/`shuffle://`
+   * descriptor). Optional so callers/tests that only care about other
+   * settings can omit it; when absent, wallpaper params are always kept.
+   */
+  currentWallpaper?: string;
 }
 
 export function readCurrentSettingsSnapshot(): CurrentSettingsSnapshot {
@@ -66,6 +85,7 @@ export function readCurrentSettingsSnapshot(): CurrentSettingsSnapshot {
     masterVolume: audioStore.masterVolume,
     speechEnabled: audioStore.speechEnabled,
     uiSoundsEnabled: audioStore.uiSoundsEnabled,
+    currentWallpaper: useDisplaySettingsStore.getState().currentWallpaper,
   };
 }
 
@@ -73,9 +93,11 @@ export function readCurrentSettingsSnapshot(): CurrentSettingsSnapshot {
  * Drop settings parameters that match the current snapshot (typical model
  * overfill) and no-op sentinels like `checkForUpdates: false`.
  *
- * Wallpaper queries are always kept when present — the input is a fuzzy search
- * string, not the persisted descriptor, so it cannot be compared reliably to
- * `currentWallpaper`. Theme is kept whenever it differs from the live snapshot
+ * Wallpaper name queries are always kept when present — the input is a name,
+ * not the persisted descriptor, so it cannot be compared reliably to
+ * `currentWallpaper`. Shuffle/dynamic wallpaper params map to exact stored
+ * descriptors and are dropped when they match the current selection. Theme is
+ * kept whenever it differs from the live snapshot
  * (system state + prompt guidance reduce bogus default-theme overfill).
  */
 export function sanitizeSettingsInput(
@@ -96,6 +118,22 @@ export function sanitizeSettingsInput(
     const query = input.wallpaper.trim();
     if (query.length > 0) {
       sanitized.wallpaper = query;
+    }
+  }
+
+  // Shuffle/dynamic selections map to exact stored descriptors, so echoed
+  // current values *can* be detected and dropped (unlike name queries).
+  if (input.wallpaperShuffle !== undefined) {
+    const descriptor = buildShuffleDescriptor(input.wallpaperShuffle);
+    if (descriptor !== snapshot.currentWallpaper) {
+      sanitized.wallpaperShuffle = input.wallpaperShuffle;
+    }
+  }
+
+  if (input.wallpaperDynamic !== undefined) {
+    const descriptor = DYNAMIC_WALLPAPER_DESCRIPTORS[input.wallpaperDynamic];
+    if (descriptor !== undefined && descriptor !== snapshot.currentWallpaper) {
+      sanitized.wallpaperDynamic = input.wallpaperDynamic;
     }
   }
 

--- a/src/apps/chats/tools/settingsHandler.ts
+++ b/src/apps/chats/tools/settingsHandler.ts
@@ -18,10 +18,14 @@ import { themes } from "@/themes";
 import { getAccentChrome, isValidAccent, type AccentId } from "@/themes/accents";
 import { loadWallpaperManifest } from "@/utils/wallpapers";
 import {
-  normalizeSearchText,
-  computeMatchScore,
-  deriveScoreThreshold,
-} from "@/apps/chats/utils/fuzzySearch";
+  DYNAMIC_WALLPAPER_DESCRIPTORS,
+  buildShuffleDescriptor,
+} from "@/utils/dynamicWallpaper";
+import type {
+  DynamicWallpaperToolId,
+  WallpaperShuffleCategory,
+} from "@/shared/tools/wallpaper";
+import { resolveWallpaperFromManifest } from "./wallpaperResolution";
 import i18n from "@/lib/i18n";
 import { forceRefreshCache } from "@/utils/prefetch";
 import type { ToolContext } from "./types";
@@ -59,63 +63,34 @@ const getLanguageDisplayName = (langCode: string): string => {
   return langCode;
 };
 
-/** Human-readable label for a manifest-relative wallpaper path. */
-const wallpaperLabelFromPath = (relPath: string): string => {
-  const fileName = relPath.split("/").pop() || relPath;
-  return fileName.replace(/\.[^.]+$/, "").replace(/[-_]+/g, " ");
+/** Localized display name for a dynamic wallpaper id. */
+const getDynamicWallpaperDisplayName = (id: DynamicWallpaperToolId): string => {
+  const keyMap: Record<DynamicWallpaperToolId, string> = {
+    "day-night": "apps.control-panels.dynamicWallpapers.dayNight",
+    weather: "apps.control-panels.dynamicWallpapers.weather",
+    cover: "apps.control-panels.dynamicWallpapers.nowPlaying",
+    lyrics: "apps.control-panels.dynamicWallpapers.lyrics",
+  };
+  const translated = i18n.t(keyMap[id]);
+  return translated !== keyMap[id] ? translated : id;
 };
 
-/**
- * Fuzzy-match a requested wallpaper name against the built-in manifest
- * (tiles, photos across all categories, and video wallpapers). Returns the
- * absolute wallpaper path to feed `setWallpaper`, or null when nothing
- * matches well enough.
- */
-const resolveWallpaperPath = async (
-  query: string
-): Promise<{ path: string; label: string } | null> => {
-  const manifest = await loadWallpaperManifest();
-  const candidates: string[] = [
-    ...(manifest.tiles || []),
-    ...Object.values(manifest.photos || {}).flat(),
-    ...(manifest.videos || []),
-  ];
-
-  const normalizedQuery = normalizeSearchText(query.trim());
-  if (!normalizedQuery) return null;
-  const queryTokens = normalizedQuery.split(/\s+/).filter(Boolean);
-
-  let best: { relPath: string; score: number } | null = null;
-  for (const relPath of candidates) {
-    const label = wallpaperLabelFromPath(relPath);
-    // Match against both the bare name and the categorized path
-    // ("photos/nature/aurora") so category words like "nature" also hit.
-    const fields = [label, relPath.replace(/\.[^.]+$/, "").replace(/[/_-]+/g, " ")];
-    const score = fields.reduce(
-      (bestScore, field) =>
-        Math.max(
-          bestScore,
-          computeMatchScore(
-            normalizeSearchText(field),
-            normalizedQuery,
-            queryTokens
-          )
-        ),
-      0
-    );
-    if (!best || score > best.score) {
-      best = { relPath, score };
-    }
-  }
-
-  if (!best || best.score < deriveScoreThreshold(normalizedQuery.length)) {
-    return null;
-  }
-
-  return {
-    path: `/wallpapers/${best.relPath}`,
-    label: wallpaperLabelFromPath(best.relPath),
-  };
+/** Localized display name for a shuffle category (mirrors WallpaperPicker). */
+const getShuffleCategoryDisplayName = (
+  category: WallpaperShuffleCategory
+): string => {
+  const key =
+    category === "tiles"
+      ? "apps.control-panels.patterns"
+      : category === "videos"
+        ? "common.menu.videos"
+        : `apps.control-panels.wallpaperCategories.${category}`;
+  const translated = i18n.t(key);
+  if (translated !== key) return translated;
+  return category
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
 };
 
 /**
@@ -130,6 +105,8 @@ export const handleSettings = async (
     language,
     theme,
     wallpaper,
+    wallpaperShuffle,
+    wallpaperDynamic,
     accent,
     masterVolume,
     speechEnabled,
@@ -168,18 +145,60 @@ export const handleSettings = async (
     }
   }
 
-  // Wallpaper change (fuzzy-matched against built-in manifest)
-  if (wallpaper !== undefined) {
+  // Dynamic wallpaper (fixed descriptor — no matching involved)
+  if (wallpaperDynamic !== undefined) {
+    await useDisplaySettingsStore
+      .getState()
+      .setWallpaper(DYNAMIC_WALLPAPER_DESCRIPTORS[wallpaperDynamic]);
+    changes.push(
+      i18n.t("apps.chats.toolCalls.settingsWallpaperChanged", {
+        name: getDynamicWallpaperDisplayName(wallpaperDynamic),
+      })
+    );
+    log.debug("Dynamic wallpaper set", { wallpaperDynamic });
+  }
+
+  // Shuffle wallpaper category (fixed descriptor — no matching involved)
+  if (wallpaperShuffle !== undefined && wallpaperDynamic === undefined) {
+    await useDisplaySettingsStore
+      .getState()
+      .setWallpaper(buildShuffleDescriptor(wallpaperShuffle));
+    changes.push(
+      i18n.t("apps.chats.toolCalls.settingsWallpaperShuffleChanged", {
+        category: getShuffleCategoryDisplayName(wallpaperShuffle),
+      })
+    );
+    log.debug("Shuffle wallpaper set", { wallpaperShuffle });
+  }
+
+  // Specific wallpaper by exact name (deterministic manifest resolution)
+  if (
+    wallpaper !== undefined &&
+    wallpaperShuffle === undefined &&
+    wallpaperDynamic === undefined
+  ) {
     try {
-      const match = await resolveWallpaperPath(wallpaper);
-      if (match) {
-        await useDisplaySettingsStore.getState().setWallpaper(match.path);
+      const resolution = resolveWallpaperFromManifest(
+        await loadWallpaperManifest(),
+        wallpaper
+      );
+      if (resolution.match) {
+        await useDisplaySettingsStore
+          .getState()
+          .setWallpaper(resolution.match.path);
         changes.push(
           i18n.t("apps.chats.toolCalls.settingsWallpaperChanged", {
-            name: match.label,
+            name: resolution.match.label,
           })
         );
-        log.debug("Wallpaper changed", { wallpaper: match.path });
+        log.debug("Wallpaper changed", { wallpaper: resolution.match.path });
+      } else if (resolution.suggestions.length > 0) {
+        failures.push(
+          i18n.t("apps.chats.toolCalls.settingsWallpaperSuggestions", {
+            query: wallpaper,
+            suggestions: resolution.suggestions.join(", "),
+          })
+        );
       } else {
         failures.push(
           i18n.t("apps.chats.toolCalls.settingsWallpaperNotFound", {

--- a/src/apps/chats/tools/wallpaperResolution.ts
+++ b/src/apps/chats/tools/wallpaperResolution.ts
@@ -1,0 +1,195 @@
+/**
+ * Deterministic wallpaper name resolution for the AI `settings` tool.
+ *
+ * Replaces the previous fuzzy scoring (subsequence/Levenshtein), which was
+ * unpredictable: near-miss queries could land on unrelated wallpapers. The
+ * rules here are strict and ordered, so the same query always resolves the
+ * same way:
+ *
+ *   1. exact name match (case/diacritic-insensitive; `-`, `_`, `/` and runs
+ *      of whitespace are equivalent; the file extension is ignored)
+ *   2. exact "category name" or full path match (e.g. "nature aurora",
+ *      "photos/nature/aurora.jpg", "tiles/red_light.png")
+ *   3. unique prefix match on the name
+ *   4. unique substring match on the name or categorized path
+ *
+ * Anything else fails with suggestions the model can retry with, instead of
+ * silently applying a wrong wallpaper.
+ */
+
+import type { WallpaperManifest } from "@/utils/wallpapers";
+import { stripDiacritics } from "@/apps/chats/utils/fuzzySearch";
+
+export interface WallpaperMatch {
+  /** Absolute wallpaper path to feed `setWallpaper` (e.g. `/wallpapers/…`). */
+  path: string;
+  /** Human-readable name (file name without extension, separators as spaces). */
+  label: string;
+}
+
+export interface WallpaperResolution {
+  match: WallpaperMatch | null;
+  /** When no unique match exists: candidate names the caller can surface. */
+  suggestions: string[];
+  /** True when the query matched several wallpapers instead of none. */
+  ambiguous: boolean;
+}
+
+const MAX_SUGGESTIONS = 8;
+
+/** Strip the file extension from a manifest-relative path. */
+const withoutExtension = (relPath: string): string =>
+  relPath.replace(/\.[^./]+$/, "");
+
+/** Human-readable label for a manifest-relative wallpaper path. */
+export const wallpaperLabelFromPath = (relPath: string): string => {
+  const fileName = relPath.split("/").pop() || relPath;
+  return withoutExtension(fileName).replace(/[-_]+/g, " ");
+};
+
+/**
+ * Canonical comparison form: lowercase, diacritics stripped, extension
+ * removed, and `-`/`_`/`/`/whitespace runs collapsed to single spaces.
+ */
+export const normalizeWallpaperName = (value: string): string =>
+  stripDiacritics(withoutExtension(value))
+    .toLowerCase()
+    .replace(/[-_/\s]+/g, " ")
+    .trim();
+
+interface Candidate {
+  relPath: string;
+  label: string;
+  /** Lowercased manifest path with extension, e.g. "tiles/azul_dark.png". */
+  rawPath: string;
+  /** Normalized bare name, e.g. "azul dark". */
+  name: string;
+  /** Normalized categorized path, e.g. "photos nature aurora". */
+  path: string;
+  /** Normalized "category name" variant, e.g. "nature aurora". */
+  categoryName: string;
+}
+
+const buildCandidates = (manifest: WallpaperManifest): Candidate[] => {
+  const relPaths: string[] = [
+    ...(manifest.tiles || []),
+    ...Object.values(manifest.photos || {}).flat(),
+    ...(manifest.videos || []),
+  ];
+  return relPaths.map((relPath) => {
+    const label = wallpaperLabelFromPath(relPath);
+    const segments = withoutExtension(relPath).split("/");
+    // Drop the "photos" prefix so "nature aurora" matches photos/nature/aurora.
+    const categorySegments =
+      segments[0] === "photos" ? segments.slice(1) : segments;
+    return {
+      relPath,
+      label,
+      rawPath: relPath.toLowerCase(),
+      name: normalizeWallpaperName(label),
+      path: normalizeWallpaperName(relPath),
+      categoryName: normalizeWallpaperName(categorySegments.join(" ")),
+    };
+  });
+};
+
+const toMatch = (candidate: Candidate): WallpaperMatch => ({
+  path: `/wallpapers/${candidate.relPath}`,
+  label: candidate.label,
+});
+
+const uniqueLabels = (candidates: Candidate[]): string[] => {
+  const labels: string[] = [];
+  for (const candidate of candidates) {
+    if (!labels.includes(candidate.label)) labels.push(candidate.label);
+    if (labels.length >= MAX_SUGGESTIONS) break;
+  }
+  return labels;
+};
+
+/**
+ * Resolve a wallpaper name against the manifest using the strict, ordered
+ * rules documented above. Pure and synchronous for easy unit testing.
+ */
+export function resolveWallpaperFromManifest(
+  manifest: WallpaperManifest,
+  query: string
+): WallpaperResolution {
+  const normalizedQuery = normalizeWallpaperName(query);
+  if (!normalizedQuery) {
+    return { match: null, suggestions: [], ambiguous: false };
+  }
+
+  const candidates = buildCandidates(manifest);
+
+  // 0. Exact manifest path (with extension) — distinguishes assets that only
+  // differ by extension (e.g. tiles/default.jpg vs tiles/default.png).
+  const rawQuery = query.trim().toLowerCase().replace(/^\/?wallpapers\//, "");
+  const exactRaw = candidates.find((c) => c.rawPath === rawQuery);
+  if (exactRaw) {
+    return { match: toMatch(exactRaw), suggestions: [], ambiguous: false };
+  }
+
+  // 1. Exact name match (manifest order breaks rare cross-category ties).
+  const exactName = candidates.filter((c) => c.name === normalizedQuery);
+  if (exactName.length > 0) {
+    return { match: toMatch(exactName[0]), suggestions: [], ambiguous: false };
+  }
+
+  // 2. Exact categorized-path match ("nature aurora", "photos/nature/aurora").
+  const exactPath = candidates.filter(
+    (c) => c.path === normalizedQuery || c.categoryName === normalizedQuery
+  );
+  if (exactPath.length > 0) {
+    return { match: toMatch(exactPath[0]), suggestions: [], ambiguous: false };
+  }
+
+  // 3. Unique prefix match on the name.
+  const prefixMatches = candidates.filter((c) =>
+    c.name.startsWith(normalizedQuery)
+  );
+  if (prefixMatches.length === 1) {
+    return {
+      match: toMatch(prefixMatches[0]),
+      suggestions: [],
+      ambiguous: false,
+    };
+  }
+
+  // 4. Unique substring match on the name or categorized path.
+  const substringMatches =
+    prefixMatches.length > 0
+      ? prefixMatches
+      : candidates.filter(
+          (c) =>
+            c.name.includes(normalizedQuery) ||
+            c.categoryName.includes(normalizedQuery)
+        );
+  if (substringMatches.length === 1) {
+    return {
+      match: toMatch(substringMatches[0]),
+      suggestions: [],
+      ambiguous: false,
+    };
+  }
+  if (substringMatches.length > 1) {
+    return {
+      match: null,
+      suggestions: uniqueLabels(substringMatches),
+      ambiguous: true,
+    };
+  }
+
+  // No match at all: suggest wallpapers sharing any whole query token.
+  const tokens = normalizedQuery.split(" ").filter(Boolean);
+  const tokenMatches = candidates.filter((c) =>
+    tokens.some(
+      (token) => c.name.includes(token) || c.categoryName.includes(token)
+    )
+  );
+  return {
+    match: null,
+    suggestions: uniqueLabels(tokenMatches),
+    ambiguous: false,
+  };
+}

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1478,6 +1478,8 @@
         "settingsUpdated": "Einstellungen aktualisiert",
         "settingsWallpaperChanged": "Hintergrundbild in {{name}} geändert",
         "settingsWallpaperNotFound": "Kein Hintergrundbild gefunden, das „{{query}}“ entspricht",
+        "settingsWallpaperShuffleChanged": "Hintergrundbild auf zufällige Auswahl ({{category}}) eingestellt",
+        "settingsWallpaperSuggestions": "Kein Hintergrundbild namens „{{query}}“. Ähnliche Treffer: {{suggestions}}",
         "skippedToNextTrack": "Zum nächsten Titel gesprungen",
         "skippedToPreviousTrack": "Zum vorherigen Titel gesprungen",
         "skippingToNext": "Zum nächsten springen…",

--- a/src/lib/locales/en/shell.json
+++ b/src/lib/locales/en/shell.json
@@ -1041,7 +1041,9 @@
           "deleting": "Deleting memory…"
         },
         "settingsWallpaperChanged": "Wallpaper changed to {{name}}",
+        "settingsWallpaperShuffleChanged": "Wallpaper set to shuffle {{category}}",
         "settingsWallpaperNotFound": "No wallpaper matched \"{{query}}\"",
+        "settingsWallpaperSuggestions": "No wallpaper named \"{{query}}\". Close matches: {{suggestions}}",
         "settingsAccentChanged": "Accent color set to {{accent}}",
         "settingsAccentNotSupported": "Accent colors are not supported by the {{theme}} theme",
         "settingsUiSoundsEnabled": "UI sounds enabled",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1310,7 +1310,9 @@
           "deleting": "Deleting memory…"
         },
         "settingsWallpaperChanged": "Wallpaper changed to {{name}}",
+        "settingsWallpaperShuffleChanged": "Wallpaper set to shuffle {{category}}",
         "settingsWallpaperNotFound": "No wallpaper matched \"{{query}}\"",
+        "settingsWallpaperSuggestions": "No wallpaper named \"{{query}}\". Close matches: {{suggestions}}",
         "settingsAccentChanged": "Accent color set to {{accent}}",
         "settingsAccentNotSupported": "Accent colors are not supported by the {{theme}} theme",
         "settingsUiSoundsEnabled": "UI sounds enabled",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1480,6 +1480,8 @@
         "settingsUpdated": "Ajustes actualizados",
         "settingsWallpaperChanged": "Fondo de pantalla cambiado a {{name}}",
         "settingsWallpaperNotFound": "Ningún fondo de pantalla coincide con \"{{query}}\"",
+        "settingsWallpaperShuffleChanged": "Fondo de pantalla configurado para selección aleatoria de {{category}}",
+        "settingsWallpaperSuggestions": "No hay ningún fondo de pantalla llamado \"{{query}}\". Coincidencias similares: {{suggestions}}",
         "skippedToNextTrack": "Saltó a la siguiente pista",
         "skippedToPreviousTrack": "Saltó a la pista anterior",
         "skippingToNext": "Saltando al siguiente…",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1480,6 +1480,8 @@
         "settingsUpdated": "Paramètres mis à jour",
         "settingsWallpaperChanged": "Fond d’écran remplacé par {{name}}",
         "settingsWallpaperNotFound": "Aucun fond d’écran ne correspond à « {{query}} »",
+        "settingsWallpaperShuffleChanged": "Fond d’écran configuré pour le mélange {{category}}",
+        "settingsWallpaperSuggestions": "Aucun fond d’écran nommé « {{query}} ». Résultats proches : {{suggestions}}",
         "skippedToNextTrack": "Passage à la piste suivante",
         "skippedToPreviousTrack": "Passage à la piste précédente",
         "skippingToNext": "Passage au suivant…",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1480,6 +1480,8 @@
         "settingsUpdated": "Impostazioni aggiornate",
         "settingsWallpaperChanged": "Sfondo modificato in {{name}}",
         "settingsWallpaperNotFound": "Nessuno sfondo corrisponde a \"{{query}}\"",
+        "settingsWallpaperShuffleChanged": "Sfondo impostato sulla rotazione casuale {{category}}",
+        "settingsWallpaperSuggestions": "Nessuno sfondo denominato \"{{query}}\". Corrispondenze simili: {{suggestions}}",
         "skippedToNextTrack": "Saltato al brano successivo",
         "skippedToPreviousTrack": "Saltato al brano precedente",
         "skippingToNext": "Passaggio al successivo…",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1478,6 +1478,8 @@
         "settingsUpdated": "設定が更新されました",
         "settingsWallpaperChanged": "壁紙を{{name}}に変更しました",
         "settingsWallpaperNotFound": "\"{{query}}\"に一致する壁紙が見つかりませんでした",
+        "settingsWallpaperShuffleChanged": "壁紙が{{category}}のシャッフルに設定されました",
+        "settingsWallpaperSuggestions": "「{{query}}」という名前の壁紙はありません。似ている候補: {{suggestions}}",
         "skippedToNextTrack": "次のトラックにスキップしました",
         "skippedToPreviousTrack": "前のトラックにスキップしました",
         "skippingToNext": "次へスキップ中…",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1478,6 +1478,8 @@
         "settingsUpdated": "설정이 업데이트되었습니다",
         "settingsWallpaperChanged": "배경화면이 {{name}}(으)로 변경됨",
         "settingsWallpaperNotFound": "\"{{query}}\"와(과) 일치하는 배경화면 없음",
+        "settingsWallpaperShuffleChanged": "배경화면이 {{category}} 셔플로 설정되었습니다.",
+        "settingsWallpaperSuggestions": "\"{{query}}\"라는 이름의 배경화면이 없습니다. 유사한 항목: {{suggestions}}",
         "skippedToNextTrack": "다음 트랙으로 건너뜀",
         "skippedToPreviousTrack": "이전 트랙으로 건너뜀",
         "skippingToNext": "다음으로 건너뛰는 중…",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1480,6 +1480,8 @@
         "settingsUpdated": "Configurações atualizadas",
         "settingsWallpaperChanged": "Imagem de fundo alterada para {{name}}",
         "settingsWallpaperNotFound": "Nenhuma imagem de fundo corresponde a \"{{query}}\"",
+        "settingsWallpaperShuffleChanged": "Imagem de fundo definida para fotos aleatórias de {{category}}",
+        "settingsWallpaperSuggestions": "Nenhuma imagem de fundo chamada \"{{query}}\". Sugestões: {{suggestions}}",
         "skippedToNextTrack": "Pulou para a próxima faixa",
         "skippedToPreviousTrack": "Pulou para a faixa anterior",
         "skippingToNext": "Pulando para o próximo…",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1482,6 +1482,8 @@
         "settingsUpdated": "Настройки обновлены",
         "settingsWallpaperChanged": "Обои изменены на «{{name}}»",
         "settingsWallpaperNotFound": "Обои по запросу «{{query}}» не найдены",
+        "settingsWallpaperShuffleChanged": "Для обоев установлено перемешивание: {{category}}",
+        "settingsWallpaperSuggestions": "Обои с названием «{{query}}» не найдены. Похожие варианты: {{suggestions}}",
         "skippedToNextTrack": "Переключено на следующий трек",
         "skippedToPreviousTrack": "Переключено на предыдущий трек",
         "skippingToNext": "Переключение на следующий…",

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -1478,6 +1478,8 @@
         "settingsUpdated": "设置已更新",
         "settingsWallpaperChanged": "墙纸已更改为 {{name}}",
         "settingsWallpaperNotFound": "没有与“{{query}}”匹配的墙纸",
+        "settingsWallpaperShuffleChanged": "壁纸已设置为随机显示{{category}}",
+        "settingsWallpaperSuggestions": "未找到名为“{{query}}”的壁纸。接近的匹配项：{{suggestions}}",
         "skippedToNextTrack": "跳到下一首",
         "skippedToPreviousTrack": "跳到上一首",
         "skippingToNext": "跳到下一首…",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1478,6 +1478,8 @@
         "settingsUpdated": "設定已更新",
         "settingsWallpaperChanged": "背景圖片已更改為 {{name}}",
         "settingsWallpaperNotFound": "沒有符合「{{query}}」的背景圖片",
+        "settingsWallpaperShuffleChanged": "背景圖片已設定為隨機顯示{{category}}",
+        "settingsWallpaperSuggestions": "找不到名為「{{query}}」的背景圖片。最接近的項目：{{suggestions}}",
         "skippedToNextTrack": "跳到下一首",
         "skippedToPreviousTrack": "跳到上一首",
         "skippingToNext": "跳到下一首⋯",

--- a/src/shared/tools/wallpaper.ts
+++ b/src/shared/tools/wallpaper.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared wallpaper vocabulary for the AI `settings` tool.
+ *
+ * Dependency-free constants used by both the server-side Zod schema
+ * (`api/chat/tools/schemas.ts`) and the client-side settings handler, so the
+ * model sees exact enum values instead of relying on fuzzy string matching.
+ *
+ * `WALLPAPER_PHOTO_CATEGORIES` mirrors the photo category folders in
+ * `public/wallpapers/photos/` (and thus `public/wallpapers/manifest.json`).
+ * A unit test (`tests/test-wallpaper-tool-settings.test.ts`) verifies the two
+ * stay in sync when wallpapers are added or removed.
+ */
+
+/** Photo categories available in the built-in wallpaper manifest. */
+export const WALLPAPER_PHOTO_CATEGORIES = [
+  "aqua",
+  "black_and_white",
+  "convergency",
+  "foliage",
+  "graphics",
+  "landscapes",
+  "nature",
+  "nostalgia",
+  "objects",
+  "plants",
+  "structures",
+] as const;
+export type WallpaperPhotoCategory =
+  (typeof WALLPAPER_PHOTO_CATEGORIES)[number];
+
+/**
+ * Categories that can be shuffled: the tile patterns, the video wallpapers,
+ * or any photo category. Maps 1:1 onto `buildShuffleDescriptor` targets
+ * (`shuffle://tiles`, `shuffle://videos`, `shuffle://photos/<category>`).
+ */
+export const WALLPAPER_SHUFFLE_CATEGORIES = [
+  "tiles",
+  "videos",
+  ...WALLPAPER_PHOTO_CATEGORIES,
+] as const;
+export type WallpaperShuffleCategory =
+  (typeof WALLPAPER_SHUFFLE_CATEGORIES)[number];
+
+/**
+ * Dynamic wallpapers whose rendered pixels change over time. Each id maps to
+ * a `dynamic://…` descriptor (see `src/utils/dynamicWallpaper.ts`).
+ */
+export const DYNAMIC_WALLPAPER_IDS = [
+  "day-night",
+  "weather",
+  "cover",
+  "lyrics",
+] as const;
+export type DynamicWallpaperToolId = (typeof DYNAMIC_WALLPAPER_IDS)[number];

--- a/src/utils/dynamicWallpaper.ts
+++ b/src/utils/dynamicWallpaper.ts
@@ -25,6 +25,7 @@
 // (see `pickDeterministicCandidate` and `useShuffleWallpaper`).
 
 import type { WallpaperManifest } from "@/utils/wallpapers";
+import type { DynamicWallpaperToolId } from "@/shared/tools/wallpaper";
 import {
   getEffectiveTimezone,
   getZonedFractionalHour,
@@ -37,6 +38,20 @@ export const DAY_NIGHT_GRADIENT_WALLPAPER = "dynamic://gradient/day-night";
 export const WEATHER_WALLPAPER = "dynamic://weather";
 export const COVER_WALLPAPER = "dynamic://cover";
 export const LYRICS_WALLPAPER = "dynamic://lyrics";
+
+/**
+ * Maps the AI settings tool's dynamic wallpaper ids (see
+ * `src/shared/tools/wallpaper.ts`) onto their stored descriptors.
+ */
+export const DYNAMIC_WALLPAPER_DESCRIPTORS: Record<
+  DynamicWallpaperToolId,
+  string
+> = {
+  "day-night": DAY_NIGHT_GRADIENT_WALLPAPER,
+  weather: WEATHER_WALLPAPER,
+  cover: COVER_WALLPAPER,
+  lyrics: LYRICS_WALLPAPER,
+};
 
 /**
  * How often shuffle wallpapers swap to a new random pick. Rotation is

--- a/tests/test-settings-partial-updates.test.ts
+++ b/tests/test-settings-partial-updates.test.ts
@@ -221,6 +221,42 @@ describe("sanitizeSettingsInput", () => {
       sanitizeSettingsInput(OVERFILLED_CURRENT_VALUES, BASE_SNAPSHOT)
     ).toEqual({});
   });
+
+  test("keeps wallpaperShuffle when it differs from the current selection", () => {
+    expect(
+      sanitizeSettingsInput(
+        { wallpaperShuffle: "nature", ...OVERFILLED_CURRENT_VALUES },
+        { ...BASE_SNAPSHOT, currentWallpaper: "/wallpapers/tiles/bondi.png" }
+      )
+    ).toEqual({ wallpaperShuffle: "nature" });
+  });
+
+  test("drops wallpaperShuffle echoing the current shuffle descriptor", () => {
+    expect(
+      sanitizeSettingsInput(
+        { wallpaperShuffle: "nature" },
+        { ...BASE_SNAPSHOT, currentWallpaper: "shuffle://photos/nature" }
+      )
+    ).toEqual({});
+  });
+
+  test("keeps wallpaperDynamic when it differs from the current selection", () => {
+    expect(
+      sanitizeSettingsInput(
+        { wallpaperDynamic: "weather" },
+        { ...BASE_SNAPSHOT, currentWallpaper: "dynamic://cover" }
+      )
+    ).toEqual({ wallpaperDynamic: "weather" });
+  });
+
+  test("drops wallpaperDynamic echoing the current dynamic descriptor", () => {
+    expect(
+      sanitizeSettingsInput(
+        { wallpaperDynamic: "weather" },
+        { ...BASE_SNAPSHOT, currentWallpaper: "dynamic://weather" }
+      )
+    ).toEqual({});
+  });
 });
 
 describe("handleSettings applies only sanitized fields", () => {
@@ -256,6 +292,7 @@ describe("handleSettings applies only sanitized fields", () => {
       setUiSoundsEnabled,
     } as Partial<ReturnType<typeof useAudioSettingsStore.getState>>);
     useDisplaySettingsStore.setState({
+      currentWallpaper: "/wallpapers/tiles/bondi.png",
       setWallpaper,
     } as Partial<ReturnType<typeof useDisplaySettingsStore.getState>>);
   });
@@ -281,6 +318,36 @@ describe("handleSettings applies only sanitized fields", () => {
     expect(setLanguage).not.toHaveBeenCalled();
     expect(setMasterVolume).not.toHaveBeenCalled();
     expect(setWallpaper).not.toHaveBeenCalled();
+  });
+
+  test("wallpaperShuffle applies the shuffle descriptor directly", async () => {
+    const { handleSettings } = await import(
+      "../src/apps/chats/tools/settingsHandler"
+    );
+
+    await handleSettings(
+      { wallpaperShuffle: "nature" },
+      "tc_shuffle",
+      { addToolOutput, launchApp: () => {}, detectUserOS: () => "mac" }
+    );
+
+    expect(setWallpaper).toHaveBeenCalledWith("shuffle://photos/nature");
+    expect(setTheme).not.toHaveBeenCalled();
+  });
+
+  test("wallpaperDynamic applies the dynamic descriptor directly", async () => {
+    const { handleSettings } = await import(
+      "../src/apps/chats/tools/settingsHandler"
+    );
+
+    await handleSettings(
+      { wallpaperDynamic: "day-night" },
+      "tc_dynamic",
+      { addToolOutput, launchApp: () => {}, detectUserOS: () => "mac" }
+    );
+
+    expect(setWallpaper).toHaveBeenCalledWith("dynamic://gradient/day-night");
+    expect(setTheme).not.toHaveBeenCalled();
   });
 
   test("checkForUpdates-only call does not touch persisted settings", async () => {

--- a/tests/test-wallpaper-tool-settings.test.ts
+++ b/tests/test-wallpaper-tool-settings.test.ts
@@ -1,0 +1,226 @@
+/**
+ * AI settings tool — wallpaper vocabulary and deterministic name resolution.
+ *
+ * Covers the shared shuffle/dynamic enums (and that they stay in sync with the
+ * built-in wallpaper manifest), the settings schema's wallpaper fields, and
+ * the strict resolver that replaced fuzzy matching.
+ */
+import { describe, expect, test } from "bun:test";
+
+import manifest from "../public/wallpapers/manifest.json";
+import {
+  DYNAMIC_WALLPAPER_IDS,
+  WALLPAPER_PHOTO_CATEGORIES,
+  WALLPAPER_SHUFFLE_CATEGORIES,
+} from "../src/shared/tools/wallpaper";
+import {
+  COVER_WALLPAPER,
+  DAY_NIGHT_GRADIENT_WALLPAPER,
+  DYNAMIC_WALLPAPER_DESCRIPTORS,
+  LYRICS_WALLPAPER,
+  WEATHER_WALLPAPER,
+  buildShuffleDescriptor,
+  isDynamicWallpaper,
+  parseShuffleDescriptor,
+} from "../src/utils/dynamicWallpaper";
+import { settingsSchema } from "../api/chat/tools/schemas";
+import {
+  normalizeWallpaperName,
+  resolveWallpaperFromManifest,
+} from "../src/apps/chats/tools/wallpaperResolution";
+import type { WallpaperManifest } from "../src/utils/wallpapers";
+
+const MANIFEST = manifest as WallpaperManifest;
+
+// ============================================================================
+// Shared vocabulary stays in sync with the built-in manifest
+// ============================================================================
+
+describe("wallpaper tool vocabulary", () => {
+  test("photo categories match the built-in wallpaper manifest", () => {
+    expect([...WALLPAPER_PHOTO_CATEGORIES].sort()).toEqual(
+      Object.keys(MANIFEST.photos).sort()
+    );
+  });
+
+  test("every photo category has at least one wallpaper to shuffle", () => {
+    for (const category of WALLPAPER_PHOTO_CATEGORIES) {
+      expect(MANIFEST.photos[category].length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every shuffle category round-trips through the shuffle descriptor", () => {
+    for (const category of WALLPAPER_SHUFFLE_CATEGORIES) {
+      const target = parseShuffleDescriptor(buildShuffleDescriptor(category));
+      expect(target).not.toBeNull();
+      if (category === "tiles" || category === "videos") {
+        expect(target).toEqual({ kind: category });
+      } else {
+        expect(target).toEqual({ kind: "photos", category });
+      }
+    }
+  });
+
+  test("dynamic ids map to the canonical dynamic descriptors", () => {
+    expect(DYNAMIC_WALLPAPER_DESCRIPTORS).toEqual({
+      "day-night": DAY_NIGHT_GRADIENT_WALLPAPER,
+      weather: WEATHER_WALLPAPER,
+      cover: COVER_WALLPAPER,
+      lyrics: LYRICS_WALLPAPER,
+    });
+    for (const id of DYNAMIC_WALLPAPER_IDS) {
+      expect(isDynamicWallpaper(DYNAMIC_WALLPAPER_DESCRIPTORS[id])).toBe(true);
+    }
+  });
+});
+
+// ============================================================================
+// Settings schema wallpaper fields
+// ============================================================================
+
+describe("settingsSchema wallpaper fields", () => {
+  test("accepts each shuffle category", () => {
+    for (const category of WALLPAPER_SHUFFLE_CATEGORIES) {
+      expect(
+        settingsSchema.safeParse({ wallpaperShuffle: category }).success
+      ).toBe(true);
+    }
+  });
+
+  test("accepts each dynamic wallpaper id", () => {
+    for (const id of DYNAMIC_WALLPAPER_IDS) {
+      expect(settingsSchema.safeParse({ wallpaperDynamic: id }).success).toBe(
+        true
+      );
+    }
+  });
+
+  test("rejects unknown shuffle categories and dynamic ids", () => {
+    expect(
+      settingsSchema.safeParse({ wallpaperShuffle: "rainbows" }).success
+    ).toBe(false);
+    expect(
+      settingsSchema.safeParse({ wallpaperDynamic: "rainbow" }).success
+    ).toBe(false);
+  });
+
+  test("rejects combining multiple wallpaper fields in one call", () => {
+    expect(
+      settingsSchema.safeParse({
+        wallpaper: "aurora",
+        wallpaperShuffle: "nature",
+      }).success
+    ).toBe(false);
+    expect(
+      settingsSchema.safeParse({
+        wallpaperShuffle: "tiles",
+        wallpaperDynamic: "weather",
+      }).success
+    ).toBe(false);
+  });
+
+  test("wallpaper fields combine with unrelated settings", () => {
+    expect(
+      settingsSchema.safeParse({ theme: "xp", wallpaperDynamic: "weather" })
+        .success
+    ).toBe(true);
+    expect(
+      settingsSchema.safeParse({ masterVolume: 0, wallpaperShuffle: "aqua" })
+        .success
+    ).toBe(true);
+  });
+});
+
+// ============================================================================
+// Deterministic name resolution (no fuzzy matching)
+// ============================================================================
+
+describe("resolveWallpaperFromManifest", () => {
+  test("normalizeWallpaperName canonicalizes case, separators, and extensions", () => {
+    expect(normalizeWallpaperName("Azul_Dark.png")).toBe("azul dark");
+    expect(normalizeWallpaperName("photos/nature/aurora.jpg")).toBe(
+      "photos nature aurora"
+    );
+    expect(normalizeWallpaperName("  Day--Night  ")).toBe("day night");
+  });
+
+  test("exact name matches resolve to the manifest asset", () => {
+    const result = resolveWallpaperFromManifest(MANIFEST, "aurora");
+    expect(result.match).toEqual({
+      path: "/wallpapers/photos/nature/aurora.jpg",
+      label: "aurora",
+    });
+  });
+
+  test("matching is case- and separator-insensitive", () => {
+    const result = resolveWallpaperFromManifest(MANIFEST, "Azul Dark");
+    expect(result.match?.path).toBe("/wallpapers/tiles/azul_dark.png");
+  });
+
+  test("exact match wins even when longer names share the prefix", () => {
+    // tiles has bondi.png alongside bondi_dark, bondi_light, etc.
+    const result = resolveWallpaperFromManifest(MANIFEST, "bondi");
+    expect(result.match?.path).toBe("/wallpapers/tiles/bondi.png");
+  });
+
+  test("full manifest paths and category-qualified names resolve", () => {
+    expect(
+      resolveWallpaperFromManifest(MANIFEST, "photos/nature/aurora.jpg").match
+        ?.path
+    ).toBe("/wallpapers/photos/nature/aurora.jpg");
+    expect(
+      resolveWallpaperFromManifest(MANIFEST, "nature aurora").match?.path
+    ).toBe("/wallpapers/photos/nature/aurora.jpg");
+    expect(
+      resolveWallpaperFromManifest(MANIFEST, "tiles/azul_dark.png").match?.path
+    ).toBe("/wallpapers/tiles/azul_dark.png");
+  });
+
+  test("a unique prefix resolves deterministically", () => {
+    const result = resolveWallpaperFromManifest(MANIFEST, "clown");
+    expect(result.match?.path).toBe("/wallpapers/photos/nature/clown_fish.jpg");
+  });
+
+  test("a prefix shared by several wallpapers is ambiguous, not a guess", () => {
+    // "cancun" prefixes both the photo cancun_sunset and the video
+    // cancun_sunset_loop — the old fuzzy matcher would silently pick one.
+    const result = resolveWallpaperFromManifest(MANIFEST, "cancun");
+    expect(result.match).toBeNull();
+    expect(result.ambiguous).toBe(true);
+    expect(result.suggestions).toContain("cancun sunset");
+    expect(result.suggestions).toContain("cancun sunset loop");
+  });
+
+  test("ambiguous queries fail with suggestions instead of guessing", () => {
+    const result = resolveWallpaperFromManifest(MANIFEST, "azul");
+    expect(result.match).toBeNull();
+    expect(result.ambiguous).toBe(true);
+    expect(result.suggestions.length).toBeGreaterThan(1);
+    expect(result.suggestions).toContain("azul dark");
+  });
+
+  test("unknown names fail without a match", () => {
+    const result = resolveWallpaperFromManifest(MANIFEST, "flurble");
+    expect(result.match).toBeNull();
+    expect(result.ambiguous).toBe(false);
+    expect(result.suggestions).toEqual([]);
+  });
+
+  test("resolution is stable across repeated calls", () => {
+    const first = resolveWallpaperFromManifest(MANIFEST, "clouds");
+    const second = resolveWallpaperFromManifest(MANIFEST, "clouds");
+    expect(first).toEqual(second);
+  });
+
+  test("every manifest wallpaper resolves from its own exact name or path", () => {
+    const relPaths = [
+      ...MANIFEST.tiles,
+      ...Object.values(MANIFEST.photos).flat(),
+      ...MANIFEST.videos,
+    ];
+    for (const relPath of relPaths) {
+      const byPath = resolveWallpaperFromManifest(MANIFEST, relPath);
+      expect(byPath.match?.path).toBe(`/wallpapers/${relPath}`);
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `settings` tool's `wallpaper` field was a single fuzzy-matched string (subsequence/Levenshtein scoring), which made results unpredictable — near-miss queries could silently land on unrelated wallpapers — and there was no way to select shuffle categories or dynamic wallpapers (Day & Night, Weather, Now Playing cover, Lyrics) at all.

## Changes

### New structured wallpaper fields (use exactly one per call)

- `wallpaper` — one specific built-in wallpaper by **exact name** (case/separator/extension-insensitive), no fuzzy matching
- `wallpaperShuffle` — enum of shuffle categories: `tiles`, `videos`, or any photo category (`aqua`, `nature`, `nostalgia`, …) → maps to `shuffle://…` descriptors
- `wallpaperDynamic` — enum `day-night` / `weather` / `cover` / `lyrics` → maps to `dynamic://…` descriptors
- `superRefine` rejects combining two wallpaper fields in one call

### Deterministic name resolution (`src/apps/chats/tools/wallpaperResolution.ts`)

Strict, ordered rules replace the fuzzy scorer: exact manifest path → exact name → exact category-qualified name/path → unique prefix → unique substring. Ambiguous or unknown queries **fail with suggestions** (surfaced in the tool result so the model can retry with an exact name) instead of guessing.

### Supporting changes

- `src/shared/tools/wallpaper.ts` — shared enums used by both the server Zod schema and client handler; a unit test keeps the category list in sync with `public/wallpapers/manifest.json`
- `DYNAMIC_WALLPAPER_DESCRIPTORS` map in `src/utils/dynamicWallpaper.ts`
- `sanitizeSettingsInput` drops echoed shuffle/dynamic values that match the current `currentWallpaper` descriptor
- Updated tool description + system prompt (`_aiPrompts.ts`) with the exact vocabulary
- New localized tool-call messages (`settingsWallpaperShuffleChanged`, `settingsWallpaperSuggestions`) machine-translated across all 11 locales; regenerated `shell.json`

## Testing

- ✅ `bun test tests/test-wallpaper-tool-settings.test.ts` (new suite: manifest sync, schema enums/mutual exclusion, resolver rules incl. every manifest asset resolving from its own name/path)
- ✅ `bun run test:unit` (2331 pass / 0 fail)
- ✅ `bun run typecheck`, `bunx eslint <changed files>`, `bun run build`
- ✅ `bun run i18n:sync:dry-run`, `bun run i18n:audit`, `bun run test:registration`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f311b-f5e0-7a7c-9453-478018159831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f311b-f5e0-7a7c-9453-478018159831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

