### PR TITLE
Add more assistant response-style presets

### DIFF
--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -174,7 +174,7 @@ export interface PrepareRyoConversationOptions {
    */
   assistantName?: string;
   /**
-   * Response-length preset from Assistant settings → Behavior (assistant
+   * Response-style preset from Assistant settings → Behavior (assistant
    * channel only). Unknown values fall back to the default style.
    */
   assistantResponseStyle?: string;

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1700,11 +1700,15 @@
           "instructionsHint": "Lege fest, wie sich der Assistent verhalten soll. Gilt für neue Antworten auf den Geräten dieses Accounts.",
           "instructionsPlaceholder": "z. B. Nenne mich Captain und erkläre Dinge mit Kochmetaphern.",
           "responseStyle": "Antwortstil",
-          "responseStyleDescription": "Länge der Antworten",
+          "responseStyleDescription": "Wie der Assistent antworten soll",
           "responseStyleOptions": {
             "chatty": "Gesprächig",
             "concise": "Prägnant",
-            "normal": "Normal"
+            "detailed": "Ausführlich",
+            "friendly": "Freundlich",
+            "normal": "Normal",
+            "playful": "Verspielt",
+            "professional": "Professionell"
           },
           "speech": "Sprachausgabe",
           "speechDescription": "Antworten laut vorlesen"

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -3486,11 +3486,15 @@
           "speech": "Speech",
           "speechDescription": "Speak replies aloud",
           "responseStyle": "Response Style",
-          "responseStyleDescription": "How long replies should be",
+          "responseStyleDescription": "How the assistant should reply",
           "responseStyleOptions": {
             "concise": "Concise",
             "normal": "Normal",
-            "chatty": "Chatty"
+            "chatty": "Chatty",
+            "detailed": "Detailed",
+            "friendly": "Friendly",
+            "professional": "Professional",
+            "playful": "Playful"
           },
           "instructions": "Instructions",
           "instructionsPlaceholder": "e.g. Call me Captain, and explain things with cooking metaphors.",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1702,11 +1702,15 @@
           "instructionsHint": "Indica al asistente cómo debe comportarse. Se aplica a las nuevas respuestas en los dispositivos de esta cuenta.",
           "instructionsPlaceholder": "p. ej., Llámame capitán y explica las cosas con metáforas de cocina.",
           "responseStyle": "Estilo de respuesta",
-          "responseStyleDescription": "Longitud de las respuestas",
+          "responseStyleDescription": "Cómo debe responder el asistente",
           "responseStyleOptions": {
             "chatty": "Locuaz",
             "concise": "Conciso",
-            "normal": "Normal"
+            "detailed": "Detallado",
+            "friendly": "Amistoso",
+            "normal": "Normal",
+            "playful": "Divertido",
+            "professional": "Profesional"
           },
           "speech": "Habla",
           "speechDescription": "Leer las respuestas en voz alta"

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1702,11 +1702,15 @@
           "instructionsHint": "Indiquez à l’assistant comment se comporter. S’applique aux nouvelles réponses sur les appareils de ce compte.",
           "instructionsPlaceholder": "p. ex. Appelez-moi Capitaine et expliquez les choses avec des métaphores culinaires.",
           "responseStyle": "Style de réponse",
-          "responseStyleDescription": "Longueur des réponses",
+          "responseStyleDescription": "Comment l’assistant doit répondre",
           "responseStyleOptions": {
             "chatty": "Bavard",
             "concise": "Concis",
-            "normal": "Normal"
+            "detailed": "Détaillé",
+            "friendly": "Amical",
+            "normal": "Normal",
+            "playful": "Ludique",
+            "professional": "Professionnel"
           },
           "speech": "Parole",
           "speechDescription": "Énoncer les réponses à haute voix"

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1702,11 +1702,15 @@
           "instructionsHint": "Indica all'assistente come comportarsi. Si applica alle nuove risposte sui dispositivi di questo account.",
           "instructionsPlaceholder": "ad es. Chiamami Capitano e spiega le cose usando metafore culinarie.",
           "responseStyle": "Stile di risposta",
-          "responseStyleDescription": "Lunghezza delle risposte",
+          "responseStyleDescription": "Come deve rispondere l'assistente",
           "responseStyleOptions": {
             "chatty": "Discorsivo",
             "concise": "Conciso",
-            "normal": "Normale"
+            "detailed": "Dettagliato",
+            "friendly": "Amichevole",
+            "normal": "Normale",
+            "playful": "Scherzoso",
+            "professional": "Professionale"
           },
           "speech": "Voce",
           "speechDescription": "Leggi le risposte a voce alta"

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1700,11 +1700,15 @@
           "instructionsHint": "アシスタントの振る舞いを指定します。このアカウントのデバイスでの新しい返信に適用されます。",
           "instructionsPlaceholder": "例：私のことは「キャプテン」と呼び、料理の比喩を使って説明してください。",
           "responseStyle": "応答スタイル",
-          "responseStyleDescription": "返信の長さを設定します",
+          "responseStyleDescription": "アシスタントの応答方法",
           "responseStyleOptions": {
             "chatty": "おしゃべり",
             "concise": "簡潔",
-            "normal": "標準"
+            "detailed": "詳細",
+            "friendly": "フレンドリー",
+            "normal": "標準",
+            "playful": "遊び心のある",
+            "professional": "プロフェッショナル"
           },
           "speech": "スピーチ",
           "speechDescription": "返信を読み上げます"

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1700,11 +1700,15 @@
           "instructionsHint": "어시스턴트가 어떻게 동작할지 설정합니다. 이 계정의 기기에서 생성되는 새로운 답변에 적용됩니다.",
           "instructionsPlaceholder": "예: 저를 선장님이라고 부르고, 요리에 비유해서 설명해 주세요.",
           "responseStyle": "답변 스타일",
-          "responseStyleDescription": "답변의 길이 설정",
+          "responseStyleDescription": "어시스턴트의 응답 방식",
           "responseStyleOptions": {
             "chatty": "수다스럽게",
             "concise": "간결하게",
-            "normal": "보통"
+            "detailed": "상세하게",
+            "friendly": "친근하게",
+            "normal": "보통",
+            "playful": "장난스럽게",
+            "professional": "전문적으로"
           },
           "speech": "말하기",
           "speechDescription": "답변을 소리 내어 읽기"

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1702,11 +1702,15 @@
           "instructionsHint": "Diga ao assistente como se comportar. Aplica-se a novas respostas nos dispositivos desta conta.",
           "instructionsPlaceholder": "ex.: Chame-me de Capitão e explique as coisas com metáforas culinárias.",
           "responseStyle": "Estilo de Resposta",
-          "responseStyleDescription": "O tamanho que as respostas devem ter",
+          "responseStyleDescription": "Como o assistente deve responder",
           "responseStyleOptions": {
             "chatty": "Conversador",
             "concise": "Conciso",
-            "normal": "Normal"
+            "detailed": "Detalhado",
+            "friendly": "Amigável",
+            "normal": "Normal",
+            "playful": "Divertido",
+            "professional": "Profissional"
           },
           "speech": "Fala",
           "speechDescription": "Falar respostas em voz alta"

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1707,11 +1707,15 @@
           "instructionsHint": "Укажите, как ассистент должен себя вести. Применяется к новым ответам на устройствах этой учетной записи.",
           "instructionsPlaceholder": "Например: «Называй меня Капитаном и используй кулинарные метафоры».",
           "responseStyle": "Стиль ответов",
-          "responseStyleDescription": "Длина ответов",
+          "responseStyleDescription": "Как ассистент должен отвечать",
           "responseStyleOptions": {
             "chatty": "Развернутые",
             "concise": "Краткие",
-            "normal": "Обычные"
+            "detailed": "Подробный",
+            "friendly": "Дружелюбный",
+            "normal": "Обычные",
+            "playful": "Игривый",
+            "professional": "Профессиональный"
           },
           "speech": "Проговаривание текста",
           "speechDescription": "Озвучивать ответы"

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -1700,11 +1700,15 @@
           "instructionsHint": "告诉助理如何表现。适用于此账户设备上的新回复。",
           "instructionsPlaceholder": "例如：称呼我为“船长”，并用烹饪比喻来解释事物。",
           "responseStyle": "回复风格",
-          "responseStyleDescription": "回复内容的长度",
+          "responseStyleDescription": "助理应如何回复",
           "responseStyleOptions": {
             "chatty": "话多",
             "concise": "简洁",
-            "normal": "标准"
+            "detailed": "详细",
+            "friendly": "亲切",
+            "normal": "标准",
+            "playful": "俏皮",
+            "professional": "专业"
           },
           "speech": "语音",
           "speechDescription": "朗读回复内容"

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1700,11 +1700,15 @@
           "instructionsHint": "告訴輔助程式如何運作。這會套用到此帳號裝置上的新回覆。",
           "instructionsPlaceholder": "例如：稱呼我為船長，並以烹飪比喻來解釋事情。",
           "responseStyle": "回覆風格",
-          "responseStyleDescription": "回覆內容的長度",
+          "responseStyleDescription": "助理應如何回覆",
           "responseStyleOptions": {
             "chatty": "詳盡",
             "concise": "精簡",
-            "normal": "標準"
+            "detailed": "詳細",
+            "friendly": "親切",
+            "normal": "標準",
+            "playful": "活潑",
+            "professional": "專業"
           },
           "speech": "語音",
           "speechDescription": "朗讀回覆內容"

--- a/src/shared/assistantCustomization.ts
+++ b/src/shared/assistantCustomization.ts
@@ -11,6 +11,10 @@ export const ASSISTANT_RESPONSE_STYLES = [
   "concise",
   "normal",
   "chatty",
+  "detailed",
+  "friendly",
+  "professional",
+  "playful",
 ] as const;
 
 export type AssistantResponseStyle = (typeof ASSISTANT_RESPONSE_STYLES)[number];
@@ -62,6 +66,14 @@ const RESPONSE_STYLE_PROMPTS: Record<AssistantResponseStyle, string> = {
   normal: "",
   chatty:
     "The user prefers chatty replies: feel free to use 3-4 sentences with a playful aside, while staying on topic.",
+  detailed:
+    "The user prefers detailed replies: give thorough, well-organized answers that cover the relevant context and caveats, not just the headline.",
+  friendly:
+    "The user prefers friendly replies: keep a warm, encouraging tone as if helping a friend, while staying accurate and on topic.",
+  professional:
+    "The user prefers professional replies: keep a polished, businesslike tone, avoid slang and filler, and get straight to the point.",
+  playful:
+    "The user prefers playful replies: sprinkle in light humor, puns, or whimsy where it fits, while still answering the question properly.",
 };
 
 export interface AssistantCustomization {
@@ -94,7 +106,7 @@ export function buildAssistantCustomizationAddon({
   const stylePrompt =
     RESPONSE_STYLE_PROMPTS[normalizeAssistantResponseStyle(responseStyle)];
   if (stylePrompt) {
-    sections.push(`## RESPONSE LENGTH\n${stylePrompt}`);
+    sections.push(`## RESPONSE STYLE\n${stylePrompt}`);
   }
 
   const sanitizedInstructions = sanitizeAssistantInstructions(instructions);

--- a/src/stores/useAssistantStore.ts
+++ b/src/stores/useAssistantStore.ts
@@ -43,7 +43,7 @@ interface AssistantStoreState {
   speechEnabled: boolean;
   /** Whether the assistant greets when the bubble is summoned/opened. */
   greetOnSummon: boolean;
-  /** Preferred reply length (injected into the assistant system prompt). */
+  /** Preferred reply style (injected into the assistant system prompt). */
   responseStyle: AssistantResponseStyle;
   /** User-written behavior instructions (injected into the system prompt). */
   customInstructions: string;

--- a/tests/test-assistant-customization.test.ts
+++ b/tests/test-assistant-customization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   ASSISTANT_INSTRUCTIONS_MAX_LENGTH,
+  ASSISTANT_RESPONSE_STYLES,
   buildAssistantCustomizationAddon,
   normalizeAssistantResponseStyle,
   sanitizeAssistantInstructions,
@@ -8,9 +9,9 @@ import {
 
 describe("normalizeAssistantResponseStyle", () => {
   test("accepts every valid style", () => {
-    expect(normalizeAssistantResponseStyle("concise")).toBe("concise");
-    expect(normalizeAssistantResponseStyle("normal")).toBe("normal");
-    expect(normalizeAssistantResponseStyle("chatty")).toBe("chatty");
+    for (const style of ASSISTANT_RESPONSE_STYLES) {
+      expect(normalizeAssistantResponseStyle(style)).toBe(style);
+    }
   });
 
   test("falls back to normal for unknown or non-string values", () => {
@@ -67,22 +68,22 @@ describe("buildAssistantCustomizationAddon", () => {
     expect(addon).not.toContain("N".repeat(41));
   });
 
-  test("normal style adds no response-length section", () => {
+  test("normal style adds no response-style section", () => {
     expect(
       buildAssistantCustomizationAddon({
         assistantName: "Rover",
         responseStyle: "normal",
       })
-    ).not.toContain("## RESPONSE LENGTH");
+    ).not.toContain("## RESPONSE STYLE");
   });
 
-  test("concise and chatty styles add a response-length section", () => {
-    expect(
-      buildAssistantCustomizationAddon({ responseStyle: "concise" })
-    ).toContain("## RESPONSE LENGTH");
-    expect(
-      buildAssistantCustomizationAddon({ responseStyle: "chatty" })
-    ).toContain("## RESPONSE LENGTH");
+  test("every non-normal style adds a response-style section", () => {
+    for (const style of ASSISTANT_RESPONSE_STYLES) {
+      if (style === "normal") continue;
+      expect(
+        buildAssistantCustomizationAddon({ responseStyle: style })
+      ).toContain("## RESPONSE STYLE");
+    }
   });
 
   test("unknown style falls back to the default (no section)", () => {
@@ -113,7 +114,7 @@ describe("buildAssistantCustomizationAddon", () => {
       instructions: "speak like a wizard",
     });
     const nameIndex = addon.indexOf("## YOUR NAME");
-    const styleIndex = addon.indexOf("## RESPONSE LENGTH");
+    const styleIndex = addon.indexOf("## RESPONSE STYLE");
     const instructionsIndex = addon.indexOf("## USER CUSTOM INSTRUCTIONS");
     expect(nameIndex).toBeGreaterThanOrEqual(0);
     expect(styleIndex).toBeGreaterThan(nameIndex);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands the desktop assistant's response-style presets (Control Panels → Assistant → Behavior) from 3 to 7:

- Existing: **Concise**, **Normal** (default), **Chatty**
- New: **Detailed**, **Friendly**, **Professional**, **Playful**

Changes:

- `src/shared/assistantCustomization.ts` — adds the four new styles to `ASSISTANT_RESPONSE_STYLES` with their system-prompt snippets; renames the injected prompt section from `## RESPONSE LENGTH` to `## RESPONSE STYLE` since the new presets shape tone, not just length.
- `src/lib/locales/*/translation.json` — adds option labels in all 11 locales (machine-translated via `bun run i18n:translate`) and updates the setting description from "How long replies should be" to "How the assistant should reply".
- `tests/test-assistant-customization.test.ts` — iterates all presets instead of a hardcoded list and covers the renamed prompt section.
- Comment-only touch-ups in `useAssistantStore.ts` and `api/_utils/ryo-conversation.ts` ("reply length" → "reply style").

The settings UI (`AssistantPaneContent.tsx`) and sync codecs are data-driven from `ASSISTANT_RESPONSE_STYLES`, so they pick up the new presets without code changes; unknown synced values still normalize to `normal`.

## Testing

- ✅ `bun test tests/test-assistant-customization.test.ts tests/test-sync-v2-codecs.test.ts` (61 pass)
- ✅ `bun run test:unit` (2345 pass, 0 fail)
- ✅ `bun run i18n:sync:dry-run` (0 missing keys) and `bun run i18n:audit` (passed for 10 locales)
- ✅ `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f31f8-56eb-756c-aa6f-aba153889e9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f31f8-56eb-756c-aa6f-aba153889e9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

