### PR TITLE
Fix junk-filled settings tool payloads: strict nullable wire schema + client guardrails

### DIFF
--- a/api/_utils/_aiPrompts.ts
+++ b/api/_utils/_aiPrompts.ts
@@ -434,7 +434,7 @@ Use the \`mediaControl\` tool for all media apps. Pick the app with \`target\`: 
 - **iOS RESTRICTION**: Same as iPod - do NOT auto-play on iOS devices.
 
 ## SYSTEM SETTINGS
-Use \`settings\` tool to change system preferences. **Include ONLY the fields the user asked to change** — omit all others (do not echo current values from system state).
+Use \`settings\` tool to change system preferences. **Include ONLY the fields the user asked to change** — omit all others (do not echo current values from system state, and never pad unrequested fields with placeholders like "string" or 0).
 - \`language\`: "en", "zh-TW", "zh-CN", "ja", "ko", "fr", "de", "es", "pt", "it", "ru"
 - \`theme\`: "system7" (Classic Mac), "macosx" (Mac OS X), "xp" (Windows XP), "win98" (Windows 98) — current theme is in system state as \`theme\`; omit when only changing wallpaper or other settings
 - \`wallpaper\`: exact name of one built-in wallpaper (e.g. "aurora", "clouds") — if it fails, the result lists close names to retry with; omit \`theme\`, \`accent\`, volume, and other fields when the user only asked for wallpaper

--- a/api/_utils/_aiPrompts.ts
+++ b/api/_utils/_aiPrompts.ts
@@ -434,7 +434,7 @@ Use the \`mediaControl\` tool for all media apps. Pick the app with \`target\`: 
 - **iOS RESTRICTION**: Same as iPod - do NOT auto-play on iOS devices.
 
 ## SYSTEM SETTINGS
-Use \`settings\` tool to change system preferences. **Include ONLY the fields the user asked to change** — omit all others (do not echo current values from system state, and never pad unrequested fields with placeholders like "string" or 0).
+Use \`settings\` tool to change system preferences. **Change ONLY the fields the user asked for** — set all other fields to null (do not echo current values from system state, and never pad unrequested fields with placeholders like "string" or 0).
 - \`language\`: "en", "zh-TW", "zh-CN", "ja", "ko", "fr", "de", "es", "pt", "it", "ru"
 - \`theme\`: "system7" (Classic Mac), "macosx" (Mac OS X), "xp" (Windows XP), "win98" (Windows 98) — current theme is in system state as \`theme\`; omit when only changing wallpaper or other settings
 - \`wallpaper\`: exact name of one built-in wallpaper (e.g. "aurora", "clouds") — if it fails, the result lists close names to retry with; omit \`theme\`, \`accent\`, volume, and other fields when the user only asked for wallpaper

--- a/api/chat/tools/index.ts
+++ b/api/chat/tools/index.ts
@@ -185,7 +185,7 @@ export const TOOL_DESCRIPTIONS = {
   
   settings:
     "Change system settings in ryOS. Use when the user asks to change language, theme, wallpaper, accent color, volume, enable/disable speech or UI sounds, or check for updates. " +
-    "IMPORTANT: Include ONLY the settings the user explicitly requested — omit every other field. Do not echo current values for language, theme, wallpaper, accent, volume, speech, or UI sounds. " +
+    "IMPORTANT: Include ONLY the settings the user explicitly requested — omit every other field. Do not echo current values for language, theme, wallpaper, accent, volume, speech, or UI sounds, and never fill unrequested fields with placeholder values like \"string\", 0, or false. " +
     "Wallpaper fields (use exactly one per call): 'wallpaper' sets one specific built-in wallpaper by exact name; 'wallpaperShuffle' rotates through a category (tiles, videos, or a photo category); 'wallpaperDynamic' sets a live wallpaper ('day-night' time-of-day gradient, 'weather' live weather, 'cover' now-playing album art, 'lyrics' now-playing lyrics). " +
     "Multiple settings can be changed in one call when the user asks for several (e.g. 'set XP theme and mute sounds').",
   

--- a/api/chat/tools/index.ts
+++ b/api/chat/tools/index.ts
@@ -185,7 +185,7 @@ export const TOOL_DESCRIPTIONS = {
   
   settings:
     "Change system settings in ryOS. Use when the user asks to change language, theme, wallpaper, accent color, volume, enable/disable speech or UI sounds, or check for updates. " +
-    "IMPORTANT: Include ONLY the settings the user explicitly requested — omit every other field. Do not echo current values for language, theme, wallpaper, accent, volume, speech, or UI sounds, and never fill unrequested fields with placeholder values like \"string\", 0, or false. " +
+    "IMPORTANT: Change ONLY the settings the user explicitly requested — set every other field to null. Do not echo current values for language, theme, wallpaper, accent, volume, speech, or UI sounds, and never fill unrequested fields with placeholder values like \"string\", 0, or false. " +
     "Wallpaper fields (use exactly one per call): 'wallpaper' sets one specific built-in wallpaper by exact name; 'wallpaperShuffle' rotates through a category (tiles, videos, or a photo category); 'wallpaperDynamic' sets a live wallpaper ('day-night' time-of-day gradient, 'weather' live weather, 'cover' now-playing album art, 'lyrics' now-playing lyrics). " +
     "Multiple settings can be changed in one call when the user asks for several (e.g. 'set XP theme and mute sounds').",
   
@@ -407,7 +407,11 @@ export function createChatTools(
     // ============================================================================
     settings: {
       description: TOOL_DESCRIPTIONS.settings,
-      inputSchema: schemas.settingsSchema,
+      // Strict-mode wire schema (required-but-nullable fields) so models
+      // emit null for unrequested settings instead of placeholder junk;
+      // nulls are stripped during validation. See settingsToolInputSchema.
+      inputSchema: schemas.settingsToolInputSchema,
+      strict: true,
       // No execute - handled client-side (requires Zustand store access)
     },
 

--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -439,7 +439,7 @@ const settingsObjectSchema = z.object({
   wallpaper: z
     .preprocess(normalizeOptionalString, z.string().max(120).optional())
     .describe(
-      "Set a specific built-in wallpaper by exact name (e.g. 'aurora', 'clouds', 'bondi'). Matched case-insensitively against built-in tile, photo, and video wallpaper names — no fuzzy matching. If no exact match exists, the tool result lists close names to retry with. Use 'wallpaperShuffle' or 'wallpaperDynamic' instead when the user wants a shuffled category or a dynamic wallpaper. ONLY include when the user explicitly asks to change wallpaper."
+      "Set a specific built-in wallpaper by exact name (e.g. 'aurora', 'clouds', 'bondi'). Matched case-insensitively against built-in tile, photo, and video wallpaper names — no fuzzy matching. If no exact match exists, the tool result lists close names to retry with. Use 'wallpaperShuffle' or 'wallpaperDynamic' instead when the user wants a shuffled category or a dynamic wallpaper. ONLY include when the user explicitly asks to change wallpaper. Do not combine with 'wallpaperShuffle' or 'wallpaperDynamic'."
     ),
   wallpaperShuffle: z
     .enum(WALLPAPER_SHUFFLE_CATEGORIES)
@@ -487,20 +487,14 @@ const settingsObjectSchema = z.object({
     ),
 });
 
+// The three wallpaper fields are documented as mutually exclusive, but
+// overfilled calls that bundle several of them are accepted here and resolved
+// client-side (`resolveWallpaperConflict`), where the current wallpaper is
+// known: echoes are dropped, and a genuine conflict fails only the wallpaper
+// change with a retry hint instead of rejecting the whole call.
 export const settingsSchema = z.preprocess(
   normalizeSettingsInput,
-  settingsObjectSchema.superRefine((data, ctx) => {
-    const wallpaperFields = (
-      ["wallpaper", "wallpaperShuffle", "wallpaperDynamic"] as const
-    ).filter((key) => data[key] !== undefined);
-    if (wallpaperFields.length > 1) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Provide only one of 'wallpaper', 'wallpaperShuffle', or 'wallpaperDynamic' (got ${wallpaperFields.join(", ")}).`,
-        path: [wallpaperFields[1]],
-      });
-    }
-  })
+  settingsObjectSchema
 );
 
 /**

--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from "zod";
+import { jsonSchema, zodSchema, type JSONSchema7 } from "ai";
 import { appIds } from "../../../src/config/appIds.js";
 import {
   THEME_IDS,
@@ -406,8 +407,12 @@ export const songLibraryControlSchema = z
  * Settings schema
  *
  * All fields are optional — callers should include ONLY settings the user
- * explicitly asked to change. Client-side `sanitizeSettingsInput` strips
- * parameters that match the live snapshot before store writes.
+ * explicitly asked to change. On the wire the tool uses a strict-mode schema
+ * (`settingsToolInputSchema`) where every field is required but nullable, so
+ * models set unrequested fields to `null` instead of inventing placeholder
+ * values; `null` is stripped here before validation. Client-side
+ * `sanitizeSettingsInput` then strips parameters that match the live
+ * snapshot before store writes.
  */
 const normalizeSettingsInput = (value: unknown): unknown => {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -415,6 +420,12 @@ const normalizeSettingsInput = (value: unknown): unknown => {
   }
 
   const data: Record<string, unknown> = { ...(value as Record<string, unknown>) };
+
+  for (const key of Object.keys(data)) {
+    if (data[key] === null) {
+      delete data[key];
+    }
+  }
 
   if (data.checkForUpdates === false) {
     delete data.checkForUpdates;
@@ -496,6 +507,63 @@ export const settingsSchema = z.preprocess(
   normalizeSettingsInput,
   settingsObjectSchema
 );
+
+/**
+ * Wire schema for the `settings` tool: strict-mode structured outputs.
+ *
+ * With plain all-optional schemas, models (observed with the default OpenAI
+ * model) sometimes treat every property as fillable and pad unrequested
+ * fields with placeholder junk (`wallpaper: "string"`, first enum values,
+ * `masterVolume: 0`, booleans). OpenAI strict mode constrains generation to
+ * the schema, but requires every property to be listed in `required` — the
+ * canonical strict pattern is required-but-nullable, where the model MUST
+ * emit `null` for anything it does not want to set.
+ *
+ * This helper derives that wire shape from the Zod object schema, and
+ * validation still runs through `settingsSchema`, whose preprocess strips
+ * `null` values, so parsed tool input stays a sparse object of only the
+ * requested settings.
+ */
+const buildStrictNullableJsonSchema = (
+  schema: z.ZodType
+): (() => JSONSchema7) => {
+  return () => {
+    const base = zodSchema(schema).jsonSchema as JSONSchema7;
+    const properties: Record<string, JSONSchema7> = {};
+    for (const [key, property] of Object.entries(base.properties ?? {})) {
+      if (typeof property === "boolean") continue;
+      // Anthropic strict tools reject numeric/string constraint keywords
+      // (minimum, maximum, maxLength). Zod validation still enforces them.
+      const { description, minimum, maximum, maxLength, ...shape } = property;
+      void minimum;
+      void maximum;
+      void maxLength;
+      const nullNote =
+        "Set to null unless the user explicitly requested this change.";
+      properties[key] = {
+        description: description ? `${description} ${nullNote}` : nullNote,
+        anyOf: [shape, { type: "null" }],
+      };
+    }
+    return {
+      type: "object",
+      properties,
+      required: Object.keys(properties),
+      additionalProperties: false,
+    };
+  };
+};
+
+export const settingsToolInputSchema = jsonSchema<
+  z.infer<typeof settingsObjectSchema>
+>(buildStrictNullableJsonSchema(settingsObjectSchema), {
+  validate: async (value) => {
+    const result = await settingsSchema.safeParseAsync(value);
+    return result.success
+      ? { success: true, value: result.data }
+      : { success: false, error: result.error };
+  },
+});
 
 /**
  * Stickies control schema

--- a/src/apps/chats/tools/sanitizeSettingsInput.ts
+++ b/src/apps/chats/tools/sanitizeSettingsInput.ts
@@ -110,9 +110,19 @@ export function readCurrentSettingsSnapshot(): CurrentSettingsSnapshot {
  * (system state + prompt guidance reduce bogus default-theme overfill).
  */
 export function sanitizeSettingsInput(
-  input: SettingsInput,
+  rawInput: SettingsInput,
   snapshot: CurrentSettingsSnapshot = readCurrentSettingsSnapshot()
 ): Partial<SettingsInput> {
+  // The wire schema is strict-mode (required-but-nullable): models emit null
+  // for unrequested fields. Nulls are stripped during server-side schema
+  // validation, but guard here too since tool input crosses a trust boundary.
+  const input: SettingsInput = { ...rawInput };
+  for (const key of SETTINGS_INPUT_KEYS) {
+    if ((input[key] as unknown) === null) {
+      delete input[key];
+    }
+  }
+
   const sanitized: Partial<SettingsInput> = {};
 
   if (input.language !== undefined && input.language !== snapshot.language) {

--- a/src/apps/chats/tools/sanitizeSettingsInput.ts
+++ b/src/apps/chats/tools/sanitizeSettingsInput.ts
@@ -56,6 +56,15 @@ export const SETTINGS_INPUT_KEYS = [
 
 export type SettingsInputKey = (typeof SETTINGS_INPUT_KEYS)[number];
 
+/** The mutually exclusive wallpaper parameters (exactly one may apply). */
+export const WALLPAPER_PARAM_KEYS = [
+  "wallpaper",
+  "wallpaperShuffle",
+  "wallpaperDynamic",
+] as const satisfies readonly SettingsInputKey[];
+
+export type WallpaperParamKey = (typeof WALLPAPER_PARAM_KEYS)[number];
+
 /** Live persisted settings used to detect no-op / overfilled parameters. */
 export interface CurrentSettingsSnapshot {
   language: LanguageCode;
@@ -167,4 +176,70 @@ export function sanitizeSettingsInput(
   }
 
   return sanitized;
+}
+
+/** Wallpaper parameter keys present on a (sanitized) settings input. */
+export function getWallpaperParamKeys(
+  params: Partial<SettingsInput>
+): WallpaperParamKey[] {
+  return WALLPAPER_PARAM_KEYS.filter((key) => params[key] !== undefined);
+}
+
+export interface WallpaperConflictResolution {
+  /** Input with at most one wallpaper parameter remaining. */
+  params: Partial<SettingsInput>;
+  /**
+   * When several non-echo wallpaper parameters were provided and intent could
+   * not be determined: the conflicting keys (all stripped from `params`).
+   */
+  conflict: WallpaperParamKey[] | null;
+}
+
+/**
+ * Resolve overfilled multi-wallpaper tool calls into at most one wallpaper
+ * parameter. The schema documents the three wallpaper fields as mutually
+ * exclusive, but models sometimes bundle all of them (typically the current
+ * wallpaper plus examples copied from field descriptions).
+ *
+ * Resolution is deterministic and never guesses:
+ * 1. Drop a `wallpaper` name query that resolves to the currently applied
+ *    wallpaper (an echo). Shuffle/dynamic echoes are already dropped by
+ *    `sanitizeSettingsInput`.
+ * 2. If more than one wallpaper parameter still remains, strip them all and
+ *    report the conflict so the caller can ask the model to retry with
+ *    exactly one — applying an arbitrary one could set the wrong wallpaper.
+ *
+ * `resolveWallpaperPath` maps a wallpaper name query to its manifest path
+ * (or null); it is optional so callers without the manifest degrade to
+ * conflict reporting alone.
+ */
+export function resolveWallpaperConflict(
+  params: Partial<SettingsInput>,
+  snapshot: CurrentSettingsSnapshot,
+  resolveWallpaperPath?: (query: string) => string | null
+): WallpaperConflictResolution {
+  let keys = getWallpaperParamKeys(params);
+  if (keys.length <= 1) {
+    return { params, conflict: null };
+  }
+
+  const resolved: Partial<SettingsInput> = { ...params };
+
+  if (
+    resolved.wallpaper !== undefined &&
+    resolveWallpaperPath &&
+    snapshot.currentWallpaper !== undefined &&
+    resolveWallpaperPath(resolved.wallpaper) === snapshot.currentWallpaper
+  ) {
+    delete resolved.wallpaper;
+    keys = getWallpaperParamKeys(resolved);
+    if (keys.length <= 1) {
+      return { params: resolved, conflict: null };
+    }
+  }
+
+  for (const key of keys) {
+    delete resolved[key];
+  }
+  return { params: resolved, conflict: keys };
 }

--- a/src/apps/chats/tools/sanitizeSettingsInput.ts
+++ b/src/apps/chats/tools/sanitizeSettingsInput.ts
@@ -206,8 +206,10 @@ export interface WallpaperConflictResolution {
  *    wallpaper (an echo). Shuffle/dynamic echoes are already dropped by
  *    `sanitizeSettingsInput`.
  * 2. If more than one wallpaper parameter still remains, strip them all and
- *    report the conflict so the caller can ask the model to retry with
- *    exactly one — applying an arbitrary one could set the wrong wallpaper.
+ *    report the conflict. Callers should treat a conflict as a junk-filled
+ *    bundle (observed in the wild: every field populated with placeholder
+ *    defaults like `wallpaper: "string"`, `masterVolume: 0`) and apply
+ *    nothing, asking the model to retry with only the requested settings.
  *
  * `resolveWallpaperPath` maps a wallpaper name query to its manifest path
  * (or null); it is optional so callers without the manifest degrade to

--- a/src/apps/chats/tools/settingsHandler.ts
+++ b/src/apps/chats/tools/settingsHandler.ts
@@ -4,7 +4,9 @@
  * Partial updates: the model should only send fields the user asked to change.
  * Raw tool input is sanitized in `sanitizeSettingsInput` before any store
  * mutation so echoed current values (language, theme, volume, etc.) are not
- * re-applied. See `sanitizeSettingsInput.ts` for the guardrail rules.
+ * re-applied, and overfilled multi-wallpaper calls are reduced to at most one
+ * wallpaper parameter via `resolveWallpaperConflict`. See
+ * `sanitizeSettingsInput.ts` for the guardrail rules.
  */
 
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
@@ -31,6 +33,8 @@ import { forceRefreshCache } from "@/utils/prefetch";
 import type { ToolContext } from "./types";
 import { chatToolsLog as log } from "../logging";
 import {
+  readCurrentSettingsSnapshot,
+  resolveWallpaperConflict,
   sanitizeSettingsInput,
   type SettingsInput,
 } from "./sanitizeSettingsInput";
@@ -101,21 +105,51 @@ export const handleSettings = async (
   toolCallId: string,
   context: ToolContext
 ): Promise<void> => {
+  const snapshot = readCurrentSettingsSnapshot();
+  const sanitized = sanitizeSettingsInput(input, snapshot);
+
+  // Overfilled calls sometimes bundle several wallpaper fields; resolve them
+  // to at most one (dropping echoes of the current wallpaper) instead of
+  // failing the whole call or applying an arbitrary wallpaper.
+  let resolveWallpaperPath: ((query: string) => string | null) | undefined;
+  if (sanitized.wallpaper !== undefined) {
+    try {
+      const manifest = await loadWallpaperManifest();
+      resolveWallpaperPath = (query) =>
+        resolveWallpaperFromManifest(manifest, query).match?.path ?? null;
+    } catch (error) {
+      log.debug("Wallpaper manifest load failed", { error });
+    }
+  }
   const {
-    language,
-    theme,
-    wallpaper,
-    wallpaperShuffle,
-    wallpaperDynamic,
-    accent,
-    masterVolume,
-    speechEnabled,
-    uiSoundsEnabled,
-    checkForUpdates,
-  } = sanitizeSettingsInput(input);
+    params: {
+      language,
+      theme,
+      wallpaper,
+      wallpaperShuffle,
+      wallpaperDynamic,
+      accent,
+      masterVolume,
+      speechEnabled,
+      uiSoundsEnabled,
+      checkForUpdates,
+    },
+    conflict: wallpaperConflict,
+  } = resolveWallpaperConflict(sanitized, snapshot, resolveWallpaperPath);
 
   const changes: string[] = [];
   const failures: string[] = [];
+
+  if (wallpaperConflict) {
+    failures.push(
+      i18n.t("apps.chats.toolCalls.settingsWallpaperConflict", {
+        fields: wallpaperConflict.join(", "),
+      })
+    );
+    log.debug("Conflicting wallpaper parameters dropped", {
+      fields: wallpaperConflict,
+    });
+  }
   const audioSettingsStore = useAudioSettingsStore.getState();
   const langStore = useLanguageStore.getState();
   const themeStore = useThemeStore.getState();
@@ -159,7 +193,7 @@ export const handleSettings = async (
   }
 
   // Shuffle wallpaper category (fixed descriptor — no matching involved)
-  if (wallpaperShuffle !== undefined && wallpaperDynamic === undefined) {
+  if (wallpaperShuffle !== undefined) {
     await useDisplaySettingsStore
       .getState()
       .setWallpaper(buildShuffleDescriptor(wallpaperShuffle));
@@ -172,11 +206,7 @@ export const handleSettings = async (
   }
 
   // Specific wallpaper by exact name (deterministic manifest resolution)
-  if (
-    wallpaper !== undefined &&
-    wallpaperShuffle === undefined &&
-    wallpaperDynamic === undefined
-  ) {
+  if (wallpaper !== undefined) {
     try {
       const resolution = resolveWallpaperFromManifest(
         await loadWallpaperManifest(),

--- a/src/apps/chats/tools/settingsHandler.ts
+++ b/src/apps/chats/tools/settingsHandler.ts
@@ -137,19 +137,27 @@ export const handleSettings = async (
     conflict: wallpaperConflict,
   } = resolveWallpaperConflict(sanitized, snapshot, resolveWallpaperPath);
 
-  const changes: string[] = [];
-  const failures: string[] = [];
-
+  // Several non-echo wallpaper fields means the call violated the
+  // one-wallpaper-field contract — a junk-filled bundle whose remaining
+  // fields (e.g. masterVolume: 0) cannot be trusted either. Apply nothing
+  // and ask the model to retry with only the requested settings.
   if (wallpaperConflict) {
-    failures.push(
-      i18n.t("apps.chats.toolCalls.settingsWallpaperConflict", {
-        fields: wallpaperConflict.join(", "),
-      })
-    );
-    log.debug("Conflicting wallpaper parameters dropped", {
+    log.debug("Conflicting wallpaper parameters; applying nothing", {
       fields: wallpaperConflict,
     });
+    context.addToolOutput({
+      tool: "settings",
+      toolCallId,
+      state: "output-error",
+      errorText: i18n.t("apps.chats.toolCalls.settingsWallpaperConflict", {
+        fields: wallpaperConflict.join(", "),
+      }),
+    });
+    return;
   }
+
+  const changes: string[] = [];
+  const failures: string[] = [];
   const audioSettingsStore = useAudioSettingsStore.getState();
   const langStore = useLanguageStore.getState();
   const themeStore = useThemeStore.getState();

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1477,6 +1477,7 @@
         "settingsUiSoundsEnabled": "Bediengeräusche aktiviert",
         "settingsUpdated": "Einstellungen aktualisiert",
         "settingsWallpaperChanged": "Hintergrundbild in {{name}} geändert",
+        "settingsWallpaperConflict": "Es wurden mehrere Hintergrundbild-Felder angegeben ({{fields}}); das Hintergrundbild wurde nicht geändert. Versuche es mit genau einem der Felder 'wallpaper', 'wallpaperShuffle' oder 'wallpaperDynamic' erneut.",
         "settingsWallpaperNotFound": "Kein Hintergrundbild gefunden, das „{{query}}“ entspricht",
         "settingsWallpaperShuffleChanged": "Hintergrundbild auf zufällige Auswahl ({{category}}) eingestellt",
         "settingsWallpaperSuggestions": "Kein Hintergrundbild namens „{{query}}“. Ähnliche Treffer: {{suggestions}}",

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1477,7 +1477,7 @@
         "settingsUiSoundsEnabled": "Bediengeräusche aktiviert",
         "settingsUpdated": "Einstellungen aktualisiert",
         "settingsWallpaperChanged": "Hintergrundbild in {{name}} geändert",
-        "settingsWallpaperConflict": "Es wurden mehrere Hintergrundbild-Felder angegeben ({{fields}}); das Hintergrundbild wurde nicht geändert. Versuche es mit genau einem der Felder 'wallpaper', 'wallpaperShuffle' oder 'wallpaperDynamic' erneut.",
+        "settingsWallpaperConflict": "Es wurden widersprüchliche Hintergrundbild-Felder angegeben ({{fields}}); es wurden keine Einstellungen geändert. Versuche es erneut nur mit den von der/dem Benutzer:in angeforderten Einstellungen und verwende dabei höchstens eines der Felder „wallpaper“, „wallpaperShuffle“ oder „wallpaperDynamic“.",
         "settingsWallpaperNotFound": "Kein Hintergrundbild gefunden, das „{{query}}“ entspricht",
         "settingsWallpaperShuffleChanged": "Hintergrundbild auf zufällige Auswahl ({{category}}) eingestellt",
         "settingsWallpaperSuggestions": "Kein Hintergrundbild namens „{{query}}“. Ähnliche Treffer: {{suggestions}}",

--- a/src/lib/locales/en/shell.json
+++ b/src/lib/locales/en/shell.json
@@ -1044,7 +1044,7 @@
         "settingsWallpaperShuffleChanged": "Wallpaper set to shuffle {{category}}",
         "settingsWallpaperNotFound": "No wallpaper matched \"{{query}}\"",
         "settingsWallpaperSuggestions": "No wallpaper named \"{{query}}\". Close matches: {{suggestions}}",
-        "settingsWallpaperConflict": "Several wallpaper fields were provided ({{fields}}); no wallpaper was changed. Retry with exactly one of 'wallpaper', 'wallpaperShuffle', or 'wallpaperDynamic'",
+        "settingsWallpaperConflict": "Conflicting wallpaper fields were provided ({{fields}}); no settings were changed. Retry with only the settings the user asked for, using at most one of 'wallpaper', 'wallpaperShuffle', or 'wallpaperDynamic'",
         "settingsAccentChanged": "Accent color set to {{accent}}",
         "settingsAccentNotSupported": "Accent colors are not supported by the {{theme}} theme",
         "settingsUiSoundsEnabled": "UI sounds enabled",

--- a/src/lib/locales/en/shell.json
+++ b/src/lib/locales/en/shell.json
@@ -1044,6 +1044,7 @@
         "settingsWallpaperShuffleChanged": "Wallpaper set to shuffle {{category}}",
         "settingsWallpaperNotFound": "No wallpaper matched \"{{query}}\"",
         "settingsWallpaperSuggestions": "No wallpaper named \"{{query}}\". Close matches: {{suggestions}}",
+        "settingsWallpaperConflict": "Several wallpaper fields were provided ({{fields}}); no wallpaper was changed. Retry with exactly one of 'wallpaper', 'wallpaperShuffle', or 'wallpaperDynamic'",
         "settingsAccentChanged": "Accent color set to {{accent}}",
         "settingsAccentNotSupported": "Accent colors are not supported by the {{theme}} theme",
         "settingsUiSoundsEnabled": "UI sounds enabled",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1313,6 +1313,7 @@
         "settingsWallpaperShuffleChanged": "Wallpaper set to shuffle {{category}}",
         "settingsWallpaperNotFound": "No wallpaper matched \"{{query}}\"",
         "settingsWallpaperSuggestions": "No wallpaper named \"{{query}}\". Close matches: {{suggestions}}",
+        "settingsWallpaperConflict": "Several wallpaper fields were provided ({{fields}}); no wallpaper was changed. Retry with exactly one of 'wallpaper', 'wallpaperShuffle', or 'wallpaperDynamic'",
         "settingsAccentChanged": "Accent color set to {{accent}}",
         "settingsAccentNotSupported": "Accent colors are not supported by the {{theme}} theme",
         "settingsUiSoundsEnabled": "UI sounds enabled",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1313,7 +1313,7 @@
         "settingsWallpaperShuffleChanged": "Wallpaper set to shuffle {{category}}",
         "settingsWallpaperNotFound": "No wallpaper matched \"{{query}}\"",
         "settingsWallpaperSuggestions": "No wallpaper named \"{{query}}\". Close matches: {{suggestions}}",
-        "settingsWallpaperConflict": "Several wallpaper fields were provided ({{fields}}); no wallpaper was changed. Retry with exactly one of 'wallpaper', 'wallpaperShuffle', or 'wallpaperDynamic'",
+        "settingsWallpaperConflict": "Conflicting wallpaper fields were provided ({{fields}}); no settings were changed. Retry with only the settings the user asked for, using at most one of 'wallpaper', 'wallpaperShuffle', or 'wallpaperDynamic'",
         "settingsAccentChanged": "Accent color set to {{accent}}",
         "settingsAccentNotSupported": "Accent colors are not supported by the {{theme}} theme",
         "settingsUiSoundsEnabled": "UI sounds enabled",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1479,7 +1479,7 @@
         "settingsUiSoundsEnabled": "Sonidos de la interfaz activados",
         "settingsUpdated": "Ajustes actualizados",
         "settingsWallpaperChanged": "Fondo de pantalla cambiado a {{name}}",
-        "settingsWallpaperConflict": "Se han proporcionado varios campos de fondo de pantalla ({{fields}}); no se ha cambiado ningún fondo de pantalla. Vuelve a intentarlo con exactamente uno de estos: 'wallpaper', 'wallpaperShuffle' o 'wallpaperDynamic'.",
+        "settingsWallpaperConflict": "Se han proporcionado campos de fondo de pantalla en conflicto ({{fields}}); no se ha cambiado ningún ajuste. Vuelve a intentarlo solo con los ajustes que el usuario ha solicitado, usando como máximo uno de 'wallpaper', 'wallpaperShuffle' o 'wallpaperDynamic'.",
         "settingsWallpaperNotFound": "Ningún fondo de pantalla coincide con \"{{query}}\"",
         "settingsWallpaperShuffleChanged": "Fondo de pantalla configurado para selección aleatoria de {{category}}",
         "settingsWallpaperSuggestions": "No hay ningún fondo de pantalla llamado \"{{query}}\". Coincidencias similares: {{suggestions}}",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1479,6 +1479,7 @@
         "settingsUiSoundsEnabled": "Sonidos de la interfaz activados",
         "settingsUpdated": "Ajustes actualizados",
         "settingsWallpaperChanged": "Fondo de pantalla cambiado a {{name}}",
+        "settingsWallpaperConflict": "Se han proporcionado varios campos de fondo de pantalla ({{fields}}); no se ha cambiado ningún fondo de pantalla. Vuelve a intentarlo con exactamente uno de estos: 'wallpaper', 'wallpaperShuffle' o 'wallpaperDynamic'.",
         "settingsWallpaperNotFound": "Ningún fondo de pantalla coincide con \"{{query}}\"",
         "settingsWallpaperShuffleChanged": "Fondo de pantalla configurado para selección aleatoria de {{category}}",
         "settingsWallpaperSuggestions": "No hay ningún fondo de pantalla llamado \"{{query}}\". Coincidencias similares: {{suggestions}}",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1479,6 +1479,7 @@
         "settingsUiSoundsEnabled": "Sons de l’interface activés",
         "settingsUpdated": "Paramètres mis à jour",
         "settingsWallpaperChanged": "Fond d’écran remplacé par {{name}}",
+        "settingsWallpaperConflict": "Plusieurs champs de fond d’écran ont été fournis ({{fields}}) ; aucun fond d’écran n’a été modifié. Réessayez avec exactement l’un des éléments suivants : 'wallpaper', 'wallpaperShuffle' ou 'wallpaperDynamic'",
         "settingsWallpaperNotFound": "Aucun fond d’écran ne correspond à « {{query}} »",
         "settingsWallpaperShuffleChanged": "Fond d’écran configuré pour le mélange {{category}}",
         "settingsWallpaperSuggestions": "Aucun fond d’écran nommé « {{query}} ». Résultats proches : {{suggestions}}",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1479,7 +1479,7 @@
         "settingsUiSoundsEnabled": "Sons de l’interface activés",
         "settingsUpdated": "Paramètres mis à jour",
         "settingsWallpaperChanged": "Fond d’écran remplacé par {{name}}",
-        "settingsWallpaperConflict": "Plusieurs champs de fond d’écran ont été fournis ({{fields}}) ; aucun fond d’écran n’a été modifié. Réessayez avec exactement l’un des éléments suivants : 'wallpaper', 'wallpaperShuffle' ou 'wallpaperDynamic'",
+        "settingsWallpaperConflict": "Des champs de fond d'écran contradictoires ont été fournis ({{fields}}) ; aucun réglage n'a été modifié. Réessayez avec uniquement les réglages demandés par l'utilisateur, en utilisant au plus l'un des éléments suivants : 'wallpaper', 'wallpaperShuffle' ou 'wallpaperDynamic'.",
         "settingsWallpaperNotFound": "Aucun fond d’écran ne correspond à « {{query}} »",
         "settingsWallpaperShuffleChanged": "Fond d’écran configuré pour le mélange {{category}}",
         "settingsWallpaperSuggestions": "Aucun fond d’écran nommé « {{query}} ». Résultats proches : {{suggestions}}",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1479,6 +1479,7 @@
         "settingsUiSoundsEnabled": "Suoni interfaccia attivati",
         "settingsUpdated": "Impostazioni aggiornate",
         "settingsWallpaperChanged": "Sfondo modificato in {{name}}",
+        "settingsWallpaperConflict": "Sono stati forniti diversi campi per lo sfondo ({{fields}}); non è stato modificato alcuno sfondo. Riprova con esattamente uno tra 'wallpaper', 'wallpaperShuffle' o 'wallpaperDynamic'.",
         "settingsWallpaperNotFound": "Nessuno sfondo corrisponde a \"{{query}}\"",
         "settingsWallpaperShuffleChanged": "Sfondo impostato sulla rotazione casuale {{category}}",
         "settingsWallpaperSuggestions": "Nessuno sfondo denominato \"{{query}}\". Corrispondenze simili: {{suggestions}}",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1479,7 +1479,7 @@
         "settingsUiSoundsEnabled": "Suoni interfaccia attivati",
         "settingsUpdated": "Impostazioni aggiornate",
         "settingsWallpaperChanged": "Sfondo modificato in {{name}}",
-        "settingsWallpaperConflict": "Sono stati forniti diversi campi per lo sfondo ({{fields}}); non è stato modificato alcuno sfondo. Riprova con esattamente uno tra 'wallpaper', 'wallpaperShuffle' o 'wallpaperDynamic'.",
+        "settingsWallpaperConflict": "Sono stati forniti campi dello sfondo in conflitto ({{fields}}); nessuna impostazione è stata modificata. Riprova solo con le impostazioni richieste dall'utente, utilizzando al massimo uno tra 'wallpaper', 'wallpaperShuffle' o 'wallpaperDynamic'.",
         "settingsWallpaperNotFound": "Nessuno sfondo corrisponde a \"{{query}}\"",
         "settingsWallpaperShuffleChanged": "Sfondo impostato sulla rotazione casuale {{category}}",
         "settingsWallpaperSuggestions": "Nessuno sfondo denominato \"{{query}}\". Corrispondenze simili: {{suggestions}}",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1477,6 +1477,7 @@
         "settingsUiSoundsEnabled": "UIサウンドを有効にしました",
         "settingsUpdated": "設定が更新されました",
         "settingsWallpaperChanged": "壁紙を{{name}}に変更しました",
+        "settingsWallpaperConflict": "複数の壁紙フィールドが指定されました（{{fields}}）。壁紙は変更されませんでした。'wallpaper'、'wallpaperShuffle'、または'wallpaperDynamic'のいずれか1つのみを指定して再試行してください。",
         "settingsWallpaperNotFound": "\"{{query}}\"に一致する壁紙が見つかりませんでした",
         "settingsWallpaperShuffleChanged": "壁紙が{{category}}のシャッフルに設定されました",
         "settingsWallpaperSuggestions": "「{{query}}」という名前の壁紙はありません。似ている候補: {{suggestions}}",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1477,7 +1477,7 @@
         "settingsUiSoundsEnabled": "UIサウンドを有効にしました",
         "settingsUpdated": "設定が更新されました",
         "settingsWallpaperChanged": "壁紙を{{name}}に変更しました",
-        "settingsWallpaperConflict": "複数の壁紙フィールドが指定されました（{{fields}}）。壁紙は変更されませんでした。'wallpaper'、'wallpaperShuffle'、または'wallpaperDynamic'のいずれか1つのみを指定して再試行してください。",
+        "settingsWallpaperConflict": "競合する壁紙フィールド（{{fields}}）が指定されました。設定は変更されませんでした。ユーザが要求した設定のみを使用し、「wallpaper」、「wallpaperShuffle」、または「wallpaperDynamic」のうち最大1つを指定してやり直してください。",
         "settingsWallpaperNotFound": "\"{{query}}\"に一致する壁紙が見つかりませんでした",
         "settingsWallpaperShuffleChanged": "壁紙が{{category}}のシャッフルに設定されました",
         "settingsWallpaperSuggestions": "「{{query}}」という名前の壁紙はありません。似ている候補: {{suggestions}}",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1477,6 +1477,7 @@
         "settingsUiSoundsEnabled": "UI 사운드 활성화됨",
         "settingsUpdated": "설정이 업데이트되었습니다",
         "settingsWallpaperChanged": "배경화면이 {{name}}(으)로 변경됨",
+        "settingsWallpaperConflict": "여러 개의 배경화면 필드가 제공되었습니다({{fields}}). 배경화면이 변경되지 않았습니다. 'wallpaper', 'wallpaperShuffle' 또는 'wallpaperDynamic' 중 정확히 하나만 사용하여 다시 시도하십시오.",
         "settingsWallpaperNotFound": "\"{{query}}\"와(과) 일치하는 배경화면 없음",
         "settingsWallpaperShuffleChanged": "배경화면이 {{category}} 셔플로 설정되었습니다.",
         "settingsWallpaperSuggestions": "\"{{query}}\"라는 이름의 배경화면이 없습니다. 유사한 항목: {{suggestions}}",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1477,7 +1477,7 @@
         "settingsUiSoundsEnabled": "UI 사운드 활성화됨",
         "settingsUpdated": "설정이 업데이트되었습니다",
         "settingsWallpaperChanged": "배경화면이 {{name}}(으)로 변경됨",
-        "settingsWallpaperConflict": "여러 개의 배경화면 필드가 제공되었습니다({{fields}}). 배경화면이 변경되지 않았습니다. 'wallpaper', 'wallpaperShuffle' 또는 'wallpaperDynamic' 중 정확히 하나만 사용하여 다시 시도하십시오.",
+        "settingsWallpaperConflict": "충돌하는 배경화면 필드({{fields}})가 제공되었습니다. 변경된 설정이 없습니다. 'wallpaper', 'wallpaperShuffle' 또는 'wallpaperDynamic' 중 최대 하나만 사용하여 사용자가 요청한 설정으로 다시 시도하십시오.",
         "settingsWallpaperNotFound": "\"{{query}}\"와(과) 일치하는 배경화면 없음",
         "settingsWallpaperShuffleChanged": "배경화면이 {{category}} 셔플로 설정되었습니다.",
         "settingsWallpaperSuggestions": "\"{{query}}\"라는 이름의 배경화면이 없습니다. 유사한 항목: {{suggestions}}",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1479,6 +1479,7 @@
         "settingsUiSoundsEnabled": "Sons da interface ativados",
         "settingsUpdated": "Configurações atualizadas",
         "settingsWallpaperChanged": "Imagem de fundo alterada para {{name}}",
+        "settingsWallpaperConflict": "Vários campos de imagem de fundo foram fornecidos ({{fields}}); nenhuma imagem de fundo foi alterada. Tente novamente com exatamente um de 'wallpaper', 'wallpaperShuffle' ou 'wallpaperDynamic'",
         "settingsWallpaperNotFound": "Nenhuma imagem de fundo corresponde a \"{{query}}\"",
         "settingsWallpaperShuffleChanged": "Imagem de fundo definida para fotos aleatórias de {{category}}",
         "settingsWallpaperSuggestions": "Nenhuma imagem de fundo chamada \"{{query}}\". Sugestões: {{suggestions}}",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1479,7 +1479,7 @@
         "settingsUiSoundsEnabled": "Sons da interface ativados",
         "settingsUpdated": "Configurações atualizadas",
         "settingsWallpaperChanged": "Imagem de fundo alterada para {{name}}",
-        "settingsWallpaperConflict": "Vários campos de imagem de fundo foram fornecidos ({{fields}}); nenhuma imagem de fundo foi alterada. Tente novamente com exatamente um de 'wallpaper', 'wallpaperShuffle' ou 'wallpaperDynamic'",
+        "settingsWallpaperConflict": "Foram fornecidos campos de imagem de fundo conflitantes ({{fields}}); nenhum ajuste foi alterado. Tente novamente apenas com os ajustes solicitados pelo usuário, usando no máximo um de 'wallpaper', 'wallpaperShuffle' ou 'wallpaperDynamic'.",
         "settingsWallpaperNotFound": "Nenhuma imagem de fundo corresponde a \"{{query}}\"",
         "settingsWallpaperShuffleChanged": "Imagem de fundo definida para fotos aleatórias de {{category}}",
         "settingsWallpaperSuggestions": "Nenhuma imagem de fundo chamada \"{{query}}\". Sugestões: {{suggestions}}",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1481,6 +1481,7 @@
         "settingsUiSoundsEnabled": "Звуковые эффекты интерфейса включены",
         "settingsUpdated": "Настройки обновлены",
         "settingsWallpaperChanged": "Обои изменены на «{{name}}»",
+        "settingsWallpaperConflict": "Указано несколько полей обоев ({{fields}}); обои не изменены. Повторите попытку, выбрав только одно из полей: «wallpaper», «wallpaperShuffle» или «wallpaperDynamic».",
         "settingsWallpaperNotFound": "Обои по запросу «{{query}}» не найдены",
         "settingsWallpaperShuffleChanged": "Для обоев установлено перемешивание: {{category}}",
         "settingsWallpaperSuggestions": "Обои с названием «{{query}}» не найдены. Похожие варианты: {{suggestions}}",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1481,7 +1481,7 @@
         "settingsUiSoundsEnabled": "Звуковые эффекты интерфейса включены",
         "settingsUpdated": "Настройки обновлены",
         "settingsWallpaperChanged": "Обои изменены на «{{name}}»",
-        "settingsWallpaperConflict": "Указано несколько полей обоев ({{fields}}); обои не изменены. Повторите попытку, выбрав только одно из полей: «wallpaper», «wallpaperShuffle» или «wallpaperDynamic».",
+        "settingsWallpaperConflict": "Указаны конфликтующие поля обоев ({{fields}}); настройки не изменены. Повторите попытку, используя только те настройки, которые запросил пользователь, и указав не более одного из параметров: «wallpaper», «wallpaperShuffle» или «wallpaperDynamic».",
         "settingsWallpaperNotFound": "Обои по запросу «{{query}}» не найдены",
         "settingsWallpaperShuffleChanged": "Для обоев установлено перемешивание: {{category}}",
         "settingsWallpaperSuggestions": "Обои с названием «{{query}}» не найдены. Похожие варианты: {{suggestions}}",

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -1477,6 +1477,7 @@
         "settingsUiSoundsEnabled": "用户界面声音已启用",
         "settingsUpdated": "设置已更新",
         "settingsWallpaperChanged": "墙纸已更改为 {{name}}",
+        "settingsWallpaperConflict": "提供了多个墙纸字段 ({{fields}})；未更改任何墙纸。请重试，并仅提供“wallpaper”、“wallpaperShuffle”或“wallpaperDynamic”中的一个",
         "settingsWallpaperNotFound": "没有与“{{query}}”匹配的墙纸",
         "settingsWallpaperShuffleChanged": "壁纸已设置为随机显示{{category}}",
         "settingsWallpaperSuggestions": "未找到名为“{{query}}”的壁纸。接近的匹配项：{{suggestions}}",

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -1477,7 +1477,7 @@
         "settingsUiSoundsEnabled": "用户界面声音已启用",
         "settingsUpdated": "设置已更新",
         "settingsWallpaperChanged": "墙纸已更改为 {{name}}",
-        "settingsWallpaperConflict": "提供了多个墙纸字段 ({{fields}})；未更改任何墙纸。请重试，并仅提供“wallpaper”、“wallpaperShuffle”或“wallpaperDynamic”中的一个",
+        "settingsWallpaperConflict": "提供了冲突的墙纸字段 ({{fields}})；未更改任何设置。请仅使用用户请求的设置重试，且最多只能使用 'wallpaper'、'wallpaperShuffle' 或 'wallpaperDynamic' 中的一个。",
         "settingsWallpaperNotFound": "没有与“{{query}}”匹配的墙纸",
         "settingsWallpaperShuffleChanged": "壁纸已设置为随机显示{{category}}",
         "settingsWallpaperSuggestions": "未找到名为“{{query}}”的壁纸。接近的匹配项：{{suggestions}}",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1477,7 +1477,7 @@
         "settingsUiSoundsEnabled": "使用者介面聲音已啟用",
         "settingsUpdated": "設定已更新",
         "settingsWallpaperChanged": "背景圖片已更改為 {{name}}",
-        "settingsWallpaperConflict": "提供了多個背景圖片欄位 ({{fields}})；未更改任何背景圖片。請僅使用「wallpaper」、「wallpaperShuffle」或「wallpaperDynamic」其中之一再試一次。",
+        "settingsWallpaperConflict": "提供了衝突的背景圖片欄位 ({{fields}})；未更改任何設定。請僅使用使用者要求的設定重試，且 'wallpaper'、'wallpaperShuffle' 或 'wallpaperDynamic' 中最多僅能使用一個。",
         "settingsWallpaperNotFound": "沒有符合「{{query}}」的背景圖片",
         "settingsWallpaperShuffleChanged": "背景圖片已設定為隨機顯示{{category}}",
         "settingsWallpaperSuggestions": "找不到名為「{{query}}」的背景圖片。最接近的項目：{{suggestions}}",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1477,6 +1477,7 @@
         "settingsUiSoundsEnabled": "使用者介面聲音已啟用",
         "settingsUpdated": "設定已更新",
         "settingsWallpaperChanged": "背景圖片已更改為 {{name}}",
+        "settingsWallpaperConflict": "提供了多個背景圖片欄位 ({{fields}})；未更改任何背景圖片。請僅使用「wallpaper」、「wallpaperShuffle」或「wallpaperDynamic」其中之一再試一次。",
         "settingsWallpaperNotFound": "沒有符合「{{query}}」的背景圖片",
         "settingsWallpaperShuffleChanged": "背景圖片已設定為隨機顯示{{category}}",
         "settingsWallpaperSuggestions": "找不到名為「{{query}}」的背景圖片。最接近的項目：{{suggestions}}",

--- a/tests/test-settings-partial-updates.test.ts
+++ b/tests/test-settings-partial-updates.test.ts
@@ -341,7 +341,9 @@ describe("resolveWallpaperConflict", () => {
 describe("handleSettings applies only sanitized fields", () => {
   const setLanguage = mock(() => {});
   const setTheme = mock(() => {});
+  const setAccent = mock(() => {});
   const setMasterVolume = mock(() => {});
+  const setSpeechEnabled = mock(() => {});
   const setUiSoundsEnabled = mock(() => {});
   const setWallpaper = mock(async () => {});
   const addToolOutput = mock(() => {});
@@ -349,7 +351,9 @@ describe("handleSettings applies only sanitized fields", () => {
   beforeEach(() => {
     setLanguage.mockClear();
     setTheme.mockClear();
+    setAccent.mockClear();
     setMasterVolume.mockClear();
+    setSpeechEnabled.mockClear();
     setUiSoundsEnabled.mockClear();
     setWallpaper.mockClear();
     addToolOutput.mockClear();
@@ -362,12 +366,14 @@ describe("handleSettings applies only sanitized fields", () => {
       current: "macosx",
       accentByTheme: { macosx: "wallpaper" },
       setTheme,
+      setAccent,
     } as Partial<ReturnType<typeof useThemeStore.getState>>);
     useAudioSettingsStore.setState({
       masterVolume: 1,
       speechEnabled: false,
       uiSoundsEnabled: true,
       setMasterVolume,
+      setSpeechEnabled,
       setUiSoundsEnabled,
     } as Partial<ReturnType<typeof useAudioSettingsStore.getState>>);
     useDisplaySettingsStore.setState({
@@ -429,22 +435,30 @@ describe("handleSettings applies only sanitized fields", () => {
     expect(setTheme).not.toHaveBeenCalled();
   });
 
-  test("overfilled bundle with three wallpaper fields changes nothing and reports the conflict", async () => {
-    // Regression: a real tool call bundled language, theme, all three
-    // wallpaper fields, accent, volume, speech, and sounds when the user only
-    // asked for the nature shuffle. It must not mutate any store; the
-    // conflicting wallpaper fields fail with a retry hint instead of the
-    // whole call being rejected by the schema.
+  test("junk-filled bundle with three wallpaper fields changes nothing and reports the conflict", async () => {
+    // Regression: asking for the nature shuffle produced a tool call with
+    // every field populated with junk defaults (observed live): language,
+    // theme "system7", wallpaper "string", nature shuffle, day-night dynamic,
+    // accent, masterVolume 0, speech/sounds, and an update check. The
+    // wallpaper-field conflict marks the whole bundle untrustworthy: nothing
+    // may be applied (no theme switch, no mute, no update check) and the
+    // model gets one retry-hint error instead of a schema rejection.
     const { handleSettings } = await import(
       "../src/apps/chats/tools/settingsHandler"
     );
 
     await handleSettings(
       {
-        ...OVERFILLED_CURRENT_VALUES,
-        wallpaper: "aurora",
+        language: "en",
+        theme: "system7",
+        wallpaper: "string",
         wallpaperShuffle: "nature",
         wallpaperDynamic: "day-night",
+        accent: "default",
+        masterVolume: 0,
+        speechEnabled: true,
+        uiSoundsEnabled: true,
+        checkForUpdates: true,
       },
       "tc_bundle",
       { addToolOutput, launchApp: () => {}, detectUserOS: () => "mac" }
@@ -454,7 +468,9 @@ describe("handleSettings applies only sanitized fields", () => {
     expect(setTheme).not.toHaveBeenCalled();
     expect(setLanguage).not.toHaveBeenCalled();
     expect(setMasterVolume).not.toHaveBeenCalled();
+    expect(setSpeechEnabled).not.toHaveBeenCalled();
     expect(setUiSoundsEnabled).not.toHaveBeenCalled();
+    expect(setAccent).not.toHaveBeenCalled();
     expect(addToolOutput).toHaveBeenCalledTimes(1);
     expect(addToolOutput.mock.calls[0][0]).toMatchObject({
       tool: "settings",

--- a/tests/test-settings-partial-updates.test.ts
+++ b/tests/test-settings-partial-updates.test.ts
@@ -48,7 +48,7 @@ Object.defineProperty(browserGlobals, "navigator", {
 });
 
 const { settingsSchema } = await import("../api/chat/tools/schemas");
-const { sanitizeSettingsInput } = await import(
+const { sanitizeSettingsInput, resolveWallpaperConflict } = await import(
   "../src/apps/chats/tools/sanitizeSettingsInput"
 );
 const { useLanguageStore } = await import("../src/stores/useLanguageStore");
@@ -259,6 +259,85 @@ describe("sanitizeSettingsInput", () => {
   });
 });
 
+describe("resolveWallpaperConflict", () => {
+  const AURORA_PATH = "/wallpapers/photos/nature/aurora.jpg";
+  const resolveName = (query: string) =>
+    query === "aurora" ? AURORA_PATH : null;
+
+  test("a single wallpaper param passes through untouched", () => {
+    expect(
+      resolveWallpaperConflict(
+        { wallpaperShuffle: "nature", masterVolume: 0 },
+        BASE_SNAPSHOT,
+        resolveName
+      )
+    ).toEqual({
+      params: { wallpaperShuffle: "nature", masterVolume: 0 },
+      conflict: null,
+    });
+  });
+
+  test("drops a wallpaper name echoing the current wallpaper, keeping the requested shuffle", () => {
+    expect(
+      resolveWallpaperConflict(
+        { wallpaper: "aurora", wallpaperShuffle: "nature" },
+        { ...BASE_SNAPSHOT, currentWallpaper: AURORA_PATH },
+        resolveName
+      )
+    ).toEqual({
+      params: { wallpaperShuffle: "nature" },
+      conflict: null,
+    });
+  });
+
+  test("reports remaining conflicts after dropping the echoed name", () => {
+    expect(
+      resolveWallpaperConflict(
+        {
+          wallpaper: "aurora",
+          wallpaperShuffle: "nature",
+          wallpaperDynamic: "day-night",
+        },
+        { ...BASE_SNAPSHOT, currentWallpaper: AURORA_PATH },
+        resolveName
+      )
+    ).toEqual({
+      params: {},
+      conflict: ["wallpaperShuffle", "wallpaperDynamic"],
+    });
+  });
+
+  test("strips all wallpaper params on an unresolvable conflict, keeping other settings", () => {
+    expect(
+      resolveWallpaperConflict(
+        {
+          wallpaper: "aurora",
+          wallpaperShuffle: "nature",
+          wallpaperDynamic: "day-night",
+          masterVolume: 0,
+        },
+        { ...BASE_SNAPSHOT, currentWallpaper: "/wallpapers/tiles/bondi.png" },
+        resolveName
+      )
+    ).toEqual({
+      params: { masterVolume: 0 },
+      conflict: ["wallpaper", "wallpaperShuffle", "wallpaperDynamic"],
+    });
+  });
+
+  test("without a name resolver, multi-wallpaper bundles report a conflict", () => {
+    expect(
+      resolveWallpaperConflict(
+        { wallpaper: "aurora", wallpaperShuffle: "nature" },
+        { ...BASE_SNAPSHOT, currentWallpaper: AURORA_PATH }
+      )
+    ).toEqual({
+      params: {},
+      conflict: ["wallpaper", "wallpaperShuffle"],
+    });
+  });
+});
+
 describe("handleSettings applies only sanitized fields", () => {
   const setLanguage = mock(() => {});
   const setTheme = mock(() => {});
@@ -348,6 +427,63 @@ describe("handleSettings applies only sanitized fields", () => {
 
     expect(setWallpaper).toHaveBeenCalledWith("dynamic://gradient/day-night");
     expect(setTheme).not.toHaveBeenCalled();
+  });
+
+  test("overfilled bundle with three wallpaper fields changes nothing and reports the conflict", async () => {
+    // Regression: a real tool call bundled language, theme, all three
+    // wallpaper fields, accent, volume, speech, and sounds when the user only
+    // asked for the nature shuffle. It must not mutate any store; the
+    // conflicting wallpaper fields fail with a retry hint instead of the
+    // whole call being rejected by the schema.
+    const { handleSettings } = await import(
+      "../src/apps/chats/tools/settingsHandler"
+    );
+
+    await handleSettings(
+      {
+        ...OVERFILLED_CURRENT_VALUES,
+        wallpaper: "aurora",
+        wallpaperShuffle: "nature",
+        wallpaperDynamic: "day-night",
+      },
+      "tc_bundle",
+      { addToolOutput, launchApp: () => {}, detectUserOS: () => "mac" }
+    );
+
+    expect(setWallpaper).not.toHaveBeenCalled();
+    expect(setTheme).not.toHaveBeenCalled();
+    expect(setLanguage).not.toHaveBeenCalled();
+    expect(setMasterVolume).not.toHaveBeenCalled();
+    expect(setUiSoundsEnabled).not.toHaveBeenCalled();
+    expect(addToolOutput).toHaveBeenCalledTimes(1);
+    expect(addToolOutput.mock.calls[0][0]).toMatchObject({
+      tool: "settings",
+      toolCallId: "tc_bundle",
+      state: "output-error",
+    });
+  });
+
+  test("shuffle plus an echoed dynamic wallpaper resolves to the shuffle", async () => {
+    const { handleSettings } = await import(
+      "../src/apps/chats/tools/settingsHandler"
+    );
+
+    useDisplaySettingsStore.setState({
+      currentWallpaper: "dynamic://gradient/day-night",
+      setWallpaper,
+    } as Partial<ReturnType<typeof useDisplaySettingsStore.getState>>);
+
+    await handleSettings(
+      { wallpaperShuffle: "nature", wallpaperDynamic: "day-night" },
+      "tc_echo_dynamic",
+      { addToolOutput, launchApp: () => {}, detectUserOS: () => "mac" }
+    );
+
+    expect(setWallpaper).toHaveBeenCalledTimes(1);
+    expect(setWallpaper).toHaveBeenCalledWith("shuffle://photos/nature");
+    expect(addToolOutput.mock.calls[0][0]).not.toMatchObject({
+      state: "output-error",
+    });
   });
 
   test("checkForUpdates-only call does not touch persisted settings", async () => {

--- a/tests/test-settings-partial-updates.test.ts
+++ b/tests/test-settings-partial-updates.test.ts
@@ -47,7 +47,9 @@ Object.defineProperty(browserGlobals, "navigator", {
   configurable: true,
 });
 
-const { settingsSchema } = await import("../api/chat/tools/schemas");
+const { settingsSchema, settingsToolInputSchema } = await import(
+  "../api/chat/tools/schemas"
+);
 const { sanitizeSettingsInput, resolveWallpaperConflict } = await import(
   "../src/apps/chats/tools/sanitizeSettingsInput"
 );
@@ -116,6 +118,72 @@ describe("settingsSchema partial updates", () => {
         uiSoundsEnabled: false,
       }).success
     ).toBe(true);
+  });
+
+  test("strips null fields during normalization (strict-mode wire format)", () => {
+    expect(
+      settingsSchema.safeParse({
+        language: null,
+        theme: null,
+        wallpaper: null,
+        wallpaperShuffle: "aqua",
+        wallpaperDynamic: null,
+        accent: null,
+        masterVolume: null,
+        speechEnabled: null,
+        uiSoundsEnabled: null,
+        checkForUpdates: null,
+      })
+    ).toEqual({
+      success: true,
+      data: { wallpaperShuffle: "aqua" },
+    });
+  });
+});
+
+describe("settingsToolInputSchema (strict-mode wire schema)", () => {
+  test("marks every field required and nullable so models emit null, not junk", () => {
+    const wire = settingsToolInputSchema.jsonSchema as {
+      properties: Record<string, { description?: string; anyOf?: unknown[] }>;
+      required: string[];
+      additionalProperties: boolean;
+    };
+    const keys = Object.keys(wire.properties);
+    expect(keys).toContain("wallpaperShuffle");
+    expect(wire.required.sort()).toEqual(keys.sort());
+    expect(wire.additionalProperties).toBe(false);
+    for (const key of keys) {
+      const property = wire.properties[key];
+      expect(property.anyOf).toHaveLength(2);
+      expect(property.anyOf![1]).toEqual({ type: "null" });
+      expect(property.description).toContain("Set to null");
+    }
+  });
+
+  test("validate strips nulls to a sparse settings object", async () => {
+    const result = await settingsToolInputSchema.validate!({
+      language: null,
+      theme: null,
+      wallpaper: null,
+      wallpaperShuffle: "aqua",
+      wallpaperDynamic: null,
+      accent: null,
+      masterVolume: null,
+      speechEnabled: null,
+      uiSoundsEnabled: null,
+      checkForUpdates: null,
+    });
+    expect(result).toEqual({
+      success: true,
+      value: { wallpaperShuffle: "aqua" },
+    });
+  });
+
+  test("validate still rejects invalid values", async () => {
+    const result = await settingsToolInputSchema.validate!({
+      wallpaperShuffle: "rainbows",
+    });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/tests/test-wallpaper-tool-settings.test.ts
+++ b/tests/test-wallpaper-tool-settings.test.ts
@@ -104,19 +104,22 @@ describe("settingsSchema wallpaper fields", () => {
     ).toBe(false);
   });
 
-  test("rejects combining multiple wallpaper fields in one call", () => {
+  test("accepts combined wallpaper fields (conflicts resolve client-side)", () => {
+    // Overfilled bundles must reach the client, where the current wallpaper
+    // is known: echoes are dropped by resolveWallpaperConflict and genuine
+    // conflicts fail only the wallpaper change with a retry hint.
     expect(
       settingsSchema.safeParse({
         wallpaper: "aurora",
         wallpaperShuffle: "nature",
       }).success
-    ).toBe(false);
+    ).toBe(true);
     expect(
       settingsSchema.safeParse({
         wallpaperShuffle: "tiles",
         wallpaperDynamic: "weather",
       }).success
-    ).toBe(false);
+    ).toBe(true);
   });
 
   test("wallpaper fields combine with unrelated settings", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Asking Ryo to shuffle a wallpaper category produced a `settings` tool call with **every** field populated with junk: `{"language":"en","theme":"system7","wallpaper":"string","wallpaperShuffle":"aqua","wallpaperDynamic":"day-night","accent":"default","masterVolume":0,"speechEnabled":false,"uiSoundsEnabled":false,...}` when the correct payload was `{"wallpaperShuffle":"aqua"}` (reproduced live against `/api/chat`; the placeholder pattern — literal `"string"`, first enum values, `0`, `false` — is the model treating every property as fillable).

Two layers of failure:
- **Generation**: the all-optional schema let the model pad unrequested fields with placeholders.
- **Handling**: the schema's `superRefine` rejected any call with more than one wallpaper field, so the whole call died before the client's partial-update sanitizer (#1807) could run; and even if it had passed, junk like `theme: "system7"` / `masterVolume: 0` differs from the live snapshot and would have been applied.

## Fix

**Root cause — strict wire schema (`settingsToolInputSchema`)**: the tool now ships a strict-mode JSON schema where every field is `required` but nullable (`anyOf: [shape, {type:"null"}]`, `strict: true`). Constrained decoding forces the model to emit `null` for unrequested settings instead of inventing values. `null`s (and `checkForUpdates: false`) are stripped in the schema preprocess, so parsed tool input is a sparse object of only the requested settings. Constraint keywords Anthropic strict tools reject (`minimum`/`maximum`/`maxLength`) are stripped from the wire shape; Zod still enforces them at validation. Tool description and assistant prompt updated for the null contract.

**Defense in depth — client guardrails** (kept from the earlier commits, for models/paths without strict support):
- `resolveWallpaperConflict` reduces sanitized input to at most one wallpaper parameter: a `wallpaper` name resolving to the currently applied wallpaper is dropped as an echo; if several non-echo wallpaper fields remain, the handler applies **nothing** and returns one localized `output-error` (`settingsWallpaperConflict`, translated to all 11 languages) telling the model to retry with only the requested settings.
- `settingsSchema` no longer hard-fails on combined wallpaper fields; `sanitizeSettingsInput` also drops `null`s at the client trust boundary.

## Live verification (real models, `bun run dev:api` tool loop)

"shuffle aqua wallpapers" now produces exactly `{"wallpaperShuffle":"aqua"}` on all three providers:
- gpt-5.5 (OpenAI strict structured outputs) ✅
- sonnet-4.6 (Anthropic strict tools) ✅
- gemini-3-flash (Google) ✅

"switch to xp theme and mute all sounds" → `{"theme":"xp","masterVolume":0,"uiSoundsEnabled":false}`; "set wallpaper to bondi" → `{"wallpaper":"bondi"}` — multi-setting intent and name lookup unaffected.

## Testing

- ✅ New unit tests: strict wire schema shape (all required, nullable, null-note descriptions), null-stripping validation, `resolveWallpaperConflict` echo/conflict cases, handler regression replaying the live junk bundle (no store mutations, single `output-error`).
- ✅ `bun run test:unit` — 2356 pass / 0 fail.
- ✅ `bun run typecheck`, `eslint` on changed files, `bun run i18n:audit`, `bun run i18n:generate-shell`.
- ✅ Live `/api/chat` payload checks across OpenAI/Anthropic/Google (see artifact).
- ⚠️ `bun run test:ai`: 38/40 — the two `Invalid auth token` failures are pre-existing environment pollution (shared anonymous per-IP chat budget returns 429 before auth is evaluated), unrelated to this change.

[settings_payload_before_after_strict_schema.log](https://cursor.com/artifacts/c/art-cdcf1eaa-cc04-4f8f-987f-1a6c1a9acd15)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f31fd-ef14-783a-9a1d-506e12baec78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f31fd-ef14-783a-9a1d-506e12baec78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

