### PR TITLE
Hold assistant bubble open while speech plays, re-arm dismiss timer after

### DIFF
--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -67,7 +67,10 @@ import {
   speakAssistantText,
   stopAssistantSpeech,
 } from "./assistantSpeech";
-import { useAssistantSpeech } from "./useAssistantSpeech";
+import {
+  useAssistantSpeech,
+  useAssistantSpeechPlaying,
+} from "./useAssistantSpeech";
 import {
   Streamdown,
   CHAT_STREAMDOWN_ANIMATED,
@@ -332,6 +335,7 @@ function AssistantOverlayInner() {
 
   // Speak finished replies aloud (browser TTS) when Speech is enabled.
   useAssistantSpeech({ latestAssistantText, isLoading });
+  const isSpeechPlaying = useAssistantSpeechPlaying();
 
   // The bubble stays hidden through the character's entrance sequence and
   // pops in once the entry/greeting animation finishes (or immediately when
@@ -401,8 +405,9 @@ function AssistantOverlayInner() {
     // Never close mid-reply: on mobile the input blurs as soon as the
     // keyboard dismisses, which would otherwise start the countdown while
     // the reply is still generating (or before the user can read it).
-    // Interacting with an embedded tool preview holds the bubble open too.
-    holdOpen: isLoading || isInteractingWithPreview,
+    // Interacting with an embedded tool preview holds the bubble open too,
+    // and so does speech (TTS) — the countdown re-arms once it finishes.
+    holdOpen: isLoading || isInteractingWithPreview || isSpeechPlaying,
   });
 
   // --- Position + dragging ---------------------------------------------------

--- a/src/components/assistant/assistantSpeech.ts
+++ b/src/components/assistant/assistantSpeech.ts
@@ -39,6 +39,34 @@ export function prepareAssistantSpeechTexts(text: string): string[] {
 let generation = 0;
 let voicesWarmed = false;
 /**
+ * True while an assistant reply is audibly speaking (from the first
+ * utterance's verified `start` until the chain ends or is cancelled). The
+ * bubble uses this to stay open until speech finishes.
+ */
+let speechPlaying = false;
+const speechPlayingListeners = new Set<() => void>();
+
+function setSpeechPlaying(next: boolean): void {
+  if (speechPlaying === next) return;
+  speechPlaying = next;
+  speechPlayingListeners.forEach((listener) => listener());
+}
+
+/** Whether an assistant reply is currently being spoken aloud. */
+export function isAssistantSpeechPlaying(): boolean {
+  return speechPlaying;
+}
+
+/** Subscribe to playing-state changes; returns an unsubscribe function. */
+export function subscribeAssistantSpeechPlaying(
+  listener: () => void
+): () => void {
+  speechPlayingListeners.add(listener);
+  return () => {
+    speechPlayingListeners.delete(listener);
+  };
+}
+/**
  * True once an utterance has actually started playing, which proves the
  * engine accepted a `speak()` (on iOS Safari that only happens after a call
  * made inside a user gesture). Until then every gesture retries the unlock:
@@ -135,6 +163,8 @@ export function speakAssistantText(
 
   const currentGeneration = ++generation;
   synth.cancel();
+  // The previous chain (if any) is dead; this reply reports its own start.
+  setSpeechPlaying(false);
 
   const texts = prepareAssistantSpeechTexts(text);
   if (texts.length === 0) {
@@ -158,7 +188,11 @@ export function speakAssistantText(
   );
 
   const speakAt = (index: number) => {
-    if (currentGeneration !== generation || index >= texts.length) return;
+    if (currentGeneration !== generation) return;
+    if (index >= texts.length) {
+      setSpeechPlaying(false);
+      return;
+    }
 
     const utterance = createSpeechUtterance(texts[index], {
       lang,
@@ -170,7 +204,10 @@ export function speakAssistantText(
       // An audible start proves the engine accepted the speak() (i.e.
       // synthesis is unlocked) and that this reply was not dropped.
       synthesisUnlocked = true;
-      if (currentGeneration === generation) droppedSpeech = null;
+      if (currentGeneration === generation) {
+        droppedSpeech = null;
+        setSpeechPlaying(true);
+      }
     };
 
     let advanced = false;
@@ -197,6 +234,7 @@ export function speakAssistantText(
 export function stopAssistantSpeech(): void {
   generation++;
   droppedSpeech = null;
+  setSpeechPlaying(false);
   getBrowserSpeechSynthesis()?.cancel();
 }
 
@@ -206,4 +244,5 @@ export function __resetAssistantSpeechStateForTests(): void {
   voicesWarmed = false;
   synthesisUnlocked = false;
   droppedSpeech = null;
+  setSpeechPlaying(false);
 }

--- a/src/components/assistant/useAssistantSpeech.ts
+++ b/src/components/assistant/useAssistantSpeech.ts
@@ -1,11 +1,25 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useSyncExternalStore } from "react";
 import { useTranslation } from "react-i18next";
 import { useAssistantStore } from "@/stores/useAssistantStore";
 import {
+  isAssistantSpeechPlaying,
   primeAssistantSpeech,
   speakAssistantText,
   stopAssistantSpeech,
+  subscribeAssistantSpeechPlaying,
 } from "./assistantSpeech";
+
+/**
+ * True while an assistant reply is being spoken aloud. The bubble holds off
+ * its auto-close countdown until speech finishes.
+ */
+export function useAssistantSpeechPlaying(): boolean {
+  return useSyncExternalStore(
+    subscribeAssistantSpeechPlaying,
+    isAssistantSpeechPlaying,
+    () => false
+  );
+}
 
 /** Gesture events iOS Safari accepts for unlocking speech synthesis. */
 const SPEECH_UNLOCK_EVENTS = ["pointerdown", "touchend", "keydown"] as const;

--- a/tests/test-assistant-speech.test.ts
+++ b/tests/test-assistant-speech.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  isAssistantSpeechPlaying,
   prepareAssistantSpeechTexts,
   primeAssistantSpeech,
   speakAssistantText,
   stopAssistantSpeech,
+  subscribeAssistantSpeechPlaying,
   __resetAssistantSpeechStateForTests,
 } from "../src/components/assistant/assistantSpeech";
 import {
@@ -328,6 +330,75 @@ describe("assistant speech playback", () => {
     // The priming gesture unlocks silently instead of resurrecting the
     // stopped reply.
     expect(spoken[1].volume).toBe(0);
+  });
+
+  test("playing state spans the utterance chain from start to final end", () => {
+    expect(isAssistantSpeechPlaying()).toBe(false);
+
+    speakAssistantText("First sentence. Second sentence.", { locale: "en" });
+    // speak() alone proves nothing (iOS drops blocked calls silently) —
+    // only a verified utterance start flips the playing state.
+    expect(isAssistantSpeechPlaying()).toBe(false);
+
+    spoken[0].onstart?.();
+    expect(isAssistantSpeechPlaying()).toBe(true);
+
+    // Still playing between chained utterances.
+    spoken[0].onend?.();
+    expect(isAssistantSpeechPlaying()).toBe(true);
+    spoken[1].onstart?.();
+    expect(isAssistantSpeechPlaying()).toBe(true);
+
+    spoken[1].onend?.();
+    expect(isAssistantSpeechPlaying()).toBe(false);
+  });
+
+  test("stopAssistantSpeech clears the playing state mid-chain", () => {
+    speakAssistantText("One. Two.", { locale: "en" });
+    spoken[0].onstart?.();
+    expect(isAssistantSpeechPlaying()).toBe(true);
+
+    stopAssistantSpeech();
+    expect(isAssistantSpeechPlaying()).toBe(false);
+
+    // The stale utterance's events must not resurrect the playing state.
+    spoken[0].onend?.();
+    expect(isAssistantSpeechPlaying()).toBe(false);
+  });
+
+  test("a new reply resets playing until its own utterance starts", () => {
+    speakAssistantText("Old reply.", { locale: "en" });
+    spoken[0].onstart?.();
+    expect(isAssistantSpeechPlaying()).toBe(true);
+
+    speakAssistantText("New reply.", { locale: "en" });
+    expect(isAssistantSpeechPlaying()).toBe(false);
+
+    // Stale start events from the cancelled chain are ignored.
+    spoken[0].onstart?.();
+    expect(isAssistantSpeechPlaying()).toBe(false);
+
+    spoken[1].onstart?.();
+    expect(isAssistantSpeechPlaying()).toBe(true);
+    spoken[1].onend?.();
+    expect(isAssistantSpeechPlaying()).toBe(false);
+  });
+
+  test("playing-state subscribers are notified on every transition", () => {
+    const seen: boolean[] = [];
+    const unsubscribe = subscribeAssistantSpeechPlaying(() => {
+      seen.push(isAssistantSpeechPlaying());
+    });
+
+    speakAssistantText("Hello there!", { locale: "en" });
+    spoken[0].onstart?.();
+    spoken[0].onend?.();
+    expect(seen).toEqual([true, false]);
+
+    unsubscribe();
+    speakAssistantText("Again!", { locale: "en" });
+    spoken[1].onstart?.();
+    expect(seen).toEqual([true, false]);
   });
 
   test("audible speech unlocks synthesis and drops the stale reply", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When Speech (browser TTS) is enabled, the assistant bubble could auto-dismiss while the reply was still being read aloud. The bubble now stays open for the whole utterance chain, and the dismiss countdown re-arms with a fresh full grace period once speech ends (reusing the existing `holdOpen` defer/restart mechanics in `useAssistantBubbleAutoClose`).

## Changes

- `assistantSpeech.ts`: track a module-level "speech playing" state — flipped on by a verified utterance `start` (so iOS Safari's silently-dropped `speak()` calls never hold the bubble), kept on across chained sentence utterances, and cleared when the chain finishes, is replaced by a new reply, or `stopAssistantSpeech()` runs. Exposes `isAssistantSpeechPlaying()` + `subscribeAssistantSpeechPlaying()`.
- `useAssistantSpeech.ts`: new `useAssistantSpeechPlaying()` hook (`useSyncExternalStore`) exposing that state to React.
- `AssistantOverlay.tsx`: fold the playing state into the bubble's `holdOpen`, alongside `isLoading` and tool-preview interaction.
- `tests/test-assistant-speech.test.ts`: new unit tests for the playing-state lifecycle (chain span, stop mid-chain, reply replacement, subscriber notifications).

## Testing

- ✅ `bun test tests/test-assistant-speech.test.ts tests/test-assistant-bubble-auto-close.test.tsx` (42 pass)
- ✅ `bun run test:unit` (2349 pass across 299 files)
- ✅ `bunx tsc -b --noEmit`
- ✅ `bunx eslint` on changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3214-ac0f-7e47-a69e-3d84279cf9f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3214-ac0f-7e47-a69e-3d84279cf9f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

