### PR TITLE
Add OsTextarea with search-style recessed chrome for assistant behavior

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AssistantPaneContent.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Switch } from "@/components/ui/switch";
-import { Textarea } from "@/components/ui/textarea";
+import { OsTextarea } from "@/components/ui/os-textarea";
 import {
   Select,
   SelectContent,
@@ -330,12 +330,12 @@ export function AssistantPaneContent({ t, tabStyles }: AssistantPaneContentProps
                     {customInstructions.length}/{ASSISTANT_INSTRUCTIONS_MAX_LENGTH}
                   </span>
                 </div>
-                <Textarea
+                <OsTextarea
                   value={customInstructions}
                   onChange={(e) => setCustomInstructions(e.target.value)}
                   maxLength={ASSISTANT_INSTRUCTIONS_MAX_LENGTH}
                   rows={4}
-                  className="min-h-20 max-h-40 font-geneva-12 text-[12px] md:text-[12px]"
+                  textareaClassName="min-h-20 max-h-40 text-[12px] resize-none"
                   placeholder={t(
                     "apps.control-panels.assistant.behavior.instructionsPlaceholder"
                   )}

--- a/src/components/dialogs/FutureSettingsDialog.tsx
+++ b/src/components/dialogs/FutureSettingsDialog.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/dialog";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
+import { OsTextarea } from "@/components/ui/os-textarea";
 import {
   Select,
   SelectContent,
@@ -133,7 +133,7 @@ const FutureSettingsDialog = ({
             </SelectContent>
           </Select>
         </div>
-        <Textarea
+        <OsTextarea
           value={
             timelineSettings[selectedYear] ||
             getDefaultTimelineText(selectedYear)
@@ -146,18 +146,12 @@ const FutureSettingsDialog = ({
             setTimelineSettings(newSettings);
           }}
           placeholder={getDefaultTimelineText(selectedYear)}
-          className={cn(
-            "min-h-[200px]",
+          textareaClassName={cn(
+            "min-h-[200px] resize-none",
             isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"
           )}
-          style={{
-            fontFamily: isWindowsTheme
-              ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
-              : undefined,
-            fontSize: isWindowsTheme ? "11px" : undefined,
-          }}
         />
         <div className="flex justify-end gap-1">
           <Button

--- a/src/components/dialogs/TelegramLinkDialog.tsx
+++ b/src/components/dialogs/TelegramLinkDialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { OsTextarea } from "@/components/ui/os-textarea";
 import { cn } from "@/lib/utils";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import type {
@@ -185,7 +186,7 @@ export function TelegramLinkDialog({
               {t("apps.control-panels.telegram.heartbeatInstructionsDescription")}
             </p>
           </div>
-          <textarea
+          <OsTextarea
             id="telegram-heartbeat-instructions"
             value={heartbeatInstructionsDraft}
             onChange={(event) =>
@@ -196,8 +197,8 @@ export function TelegramLinkDialog({
             )}
             maxLength={1200}
             rows={5}
-            className={cn(
-              "w-full resize-none rounded-os border-[length:var(--os-metrics-border-width)] border-os-input-border bg-os-input-bg p-2 text-os-text-primary shadow-inner outline-none focus:border-os-input-focusBorder",
+            textareaClassName={cn(
+              "resize-none text-os-text-primary",
               isWindowsTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                 : "font-geneva-12 text-[11px]"

--- a/src/components/ui/os-field-styles.ts
+++ b/src/components/ui/os-field-styles.ts
@@ -9,6 +9,10 @@ export interface OsFieldPadding {
   withTrailingAction?: boolean;
 }
 
+/** Classic Mac/Windows themes use square field corners. */
+const osFieldClassicSquareCorners =
+  "os-theme-system7:rounded-none os-windows:rounded-none";
+
 /** Shared recessed field chrome used by SearchInput, OsTextarea, etc. */
 export function osFieldInputClasses(
   isMacOSTheme: boolean,
@@ -16,7 +20,10 @@ export function osFieldInputClasses(
   { withLeadingIcon = false, withTrailingAction = false }: OsFieldPadding = {},
   className?: string,
 ) {
-  const rounding = shape === "pill" ? "rounded-full" : "rounded-os";
+  const rounding =
+    shape === "pill"
+      ? "rounded-full"
+      : cn("rounded-os", osFieldClassicSquareCorners);
   const pl = withLeadingIcon ? "pl-7" : "pl-3";
   const pr = withTrailingAction ? "pr-7" : "pr-3";
 
@@ -36,9 +43,11 @@ export function osFieldTextareaClasses(
 ) {
   return cn(
     "w-full outline-none min-w-0 resize-y",
+    "rounded-os",
+    osFieldClassicSquareCorners,
     isMacOSTheme
-      ? "rounded-os border border-black/40 bg-white px-3 py-2 text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.3),inset_0_0_1px_rgba(0,0,0,0.15),0_1px_0_rgba(255,255,255,0.45)] font-geneva-12"
-      : "rounded-os border border-black/20 bg-white px-3 py-2 text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.12)]",
+      ? "border border-black/40 bg-white px-3 py-2 text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.3),inset_0_0_1px_rgba(0,0,0,0.15),0_1px_0_rgba(255,255,255,0.45)] font-geneva-12"
+      : "border border-black/20 bg-white px-3 py-2 text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.12)]",
     className,
   );
 }

--- a/src/components/ui/os-field-styles.ts
+++ b/src/components/ui/os-field-styles.ts
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+
+export type OsFieldShape = "pill" | "rounded";
+
+export interface OsFieldPadding {
+  /** Room for a left glyph (e.g. search icon). */
+  withLeadingIcon?: boolean;
+  /** Room for a right action (e.g. clear button). */
+  withTrailingAction?: boolean;
+}
+
+/** Shared recessed field chrome used by SearchInput, OsTextarea, etc. */
+export function osFieldInputClasses(
+  isMacOSTheme: boolean,
+  shape: OsFieldShape = "rounded",
+  { withLeadingIcon = false, withTrailingAction = false }: OsFieldPadding = {},
+  className?: string,
+) {
+  const rounding = shape === "pill" ? "rounded-full" : "rounded-os";
+  const pl = withLeadingIcon ? "pl-7" : "pl-3";
+  const pr = withTrailingAction ? "pr-7" : "pr-3";
+
+  return cn(
+    "w-full outline-none min-w-0",
+    isMacOSTheme
+      ? `${rounding} border border-black/40 bg-white ${pl} ${pr} py-[3px] text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.3),inset_0_0_1px_rgba(0,0,0,0.15),0_1px_0_rgba(255,255,255,0.45)] font-geneva-12`
+      : `${rounding} border border-black/20 bg-white ${pl} ${pr} py-1 text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.12)]`,
+    className,
+  );
+}
+
+/** Multi-line variant: same chrome as osFieldInputClasses but with textarea padding. */
+export function osFieldTextareaClasses(
+  isMacOSTheme: boolean,
+  className?: string,
+) {
+  return cn(
+    "w-full outline-none min-w-0 resize-y",
+    isMacOSTheme
+      ? "rounded-os border border-black/40 bg-white px-3 py-2 text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.3),inset_0_0_1px_rgba(0,0,0,0.15),0_1px_0_rgba(255,255,255,0.45)] font-geneva-12"
+      : "rounded-os border border-black/20 bg-white px-3 py-2 text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.12)]",
+    className,
+  );
+}

--- a/src/components/ui/os-textarea.tsx
+++ b/src/components/ui/os-textarea.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { cn } from "@/lib/utils";
+import { osFieldTextareaClasses } from "@/components/ui/os-field-styles";
+
+export interface OsTextareaProps
+  extends Omit<React.ComponentProps<"textarea">, "className"> {
+  className?: string;
+  /** Extra classes for the inner textarea element. */
+  textareaClassName?: string;
+  textareaRef?: React.Ref<HTMLTextAreaElement>;
+}
+
+/**
+ * OS-themed multi-line field: same recessed chrome as SearchInput but with
+ * `rounded-os` corners instead of a full pill.
+ */
+export function OsTextarea({
+  className,
+  textareaClassName,
+  textareaRef,
+  disabled,
+  ...props
+}: OsTextareaProps) {
+  const { isMacOSTheme } = useThemeFlags();
+
+  return (
+    <textarea
+      ref={textareaRef}
+      disabled={disabled}
+      data-os-field-input="true"
+      className={cn(
+        osFieldTextareaClasses(isMacOSTheme, textareaClassName),
+        disabled && "cursor-not-allowed opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -2,30 +2,7 @@ import * as React from "react";
 import { MagnifyingGlass, XCircle } from "@phosphor-icons/react";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { cn } from "@/lib/utils";
-
-interface OsPillInputPadding {
-  /** Room for a left search glyph (`pl-7`). */
-  withSearchIcon?: boolean;
-  /** Room for a right clear button (`pr-7`). */
-  withClearButton?: boolean;
-}
-
-function osPillInputClasses(
-  isMacOSTheme: boolean,
-  { withSearchIcon = false, withClearButton = false }: OsPillInputPadding = {},
-  inputClassName?: string,
-) {
-  const pl = withSearchIcon ? "pl-7" : "pl-3";
-  const pr = withClearButton ? "pr-7" : "pr-3";
-
-  return cn(
-    "w-full outline-none min-w-0",
-    isMacOSTheme
-      ? `rounded-full border border-black/40 bg-white ${pl} ${pr} py-[3px] text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.3),inset_0_0_1px_rgba(0,0,0,0.15),0_1px_0_rgba(255,255,255,0.45)] font-geneva-12`
-      : `rounded-full border border-black/20 bg-white ${pl} ${pr} py-1 text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.12)]`,
-    inputClassName,
-  );
-}
+import { osFieldInputClasses } from "@/components/ui/os-field-styles";
 
 interface SearchInputProps {
   value: string;
@@ -113,11 +90,12 @@ export function SearchInput({
               }
             : undefined
         }
-        className={osPillInputClasses(
+        className={osFieldInputClasses(
           isMacOSTheme,
+          "pill",
           {
-            withSearchIcon: showSearchIcon,
-            withClearButton: canClear,
+            withLeadingIcon: showSearchIcon,
+            withTrailingAction: canClear,
           },
           inputClassName,
         )}

--- a/src/styles/themes/aqua-glass.css
+++ b/src/styles/themes/aqua-glass.css
@@ -936,7 +936,7 @@
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
     [data-os-color-scheme="dark"]
   )
-  input[data-os-search-input="true"] {
+  :is(input[data-os-search-input="true"], textarea[data-os-field-input="true"]) {
   background-color: rgba(255, 255, 255, 0.26) !important;
   -webkit-backdrop-filter: blur(12px) saturate(180%);
   backdrop-filter: blur(12px) saturate(180%);
@@ -946,7 +946,7 @@
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
-  input[data-os-search-input="true"] {
+  :is(input[data-os-search-input="true"], textarea[data-os-field-input="true"]) {
   background-color: rgba(255, 255, 255, 0.06) !important;
   -webkit-backdrop-filter: blur(12px) saturate(180%);
   backdrop-filter: blur(12px) saturate(180%);

--- a/src/styles/themes/dark-aqua.css
+++ b/src/styles/themes/dark-aqua.css
@@ -912,7 +912,7 @@
    white-glow inset. Override per-attribute so the field reads as a recessed
    dark pill with a light glyph. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
-  input[data-os-search-input="true"] {
+  :is(input[data-os-search-input="true"], textarea[data-os-field-input="true"]) {
   background-color: var(--os-color-input-bg) !important;
   color: var(--os-color-text-primary) !important;
   border-color: rgba(255, 255, 255, 0.18) !important;
@@ -923,7 +923,7 @@
 }
 
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
-  input[data-os-search-input="true"]::placeholder {
+  :is(input[data-os-search-input="true"], textarea[data-os-field-input="true"])::placeholder {
   color: var(--os-color-text-disabled);
 }
 
@@ -1500,7 +1500,7 @@
     .bg-white\/30,
     .bg-white\/20,
     .bg-white\/10
-  ):not([data-os-search-input="true"]):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not(.dashboard-overlay *) {
+  ):not([data-os-search-input="true"]):not([data-os-field-input="true"]):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not(.dashboard-overlay *) {
   background-color: var(--os-color-input-bg) !important;
   color: var(--os-color-text-primary) !important;
   /* Subtle inset recess — matches the canonical Finder SearchInput dark

--- a/tests/test-os-textarea.test.tsx
+++ b/tests/test-os-textarea.test.tsx
@@ -12,9 +12,11 @@ describe("os-field-styles", () => {
     expect(osFieldInputClasses(true, "pill")).not.toContain("rounded-os");
   });
 
-  test("textarea field uses rounded-os corners", () => {
+  test("textarea field uses rounded-os on macOS and square corners on classic themes", () => {
     expect(osFieldTextareaClasses(true)).toContain("rounded-os");
     expect(osFieldTextareaClasses(true)).not.toContain("rounded-full");
+    expect(osFieldTextareaClasses(true)).toContain("os-theme-system7:rounded-none");
+    expect(osFieldTextareaClasses(true)).toContain("os-windows:rounded-none");
   });
 
   test("search field reserves space for leading and trailing chrome", () => {

--- a/tests/test-os-textarea.test.tsx
+++ b/tests/test-os-textarea.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { OsTextarea } from "@/components/ui/os-textarea";
+import {
+  osFieldInputClasses,
+  osFieldTextareaClasses,
+} from "@/components/ui/os-field-styles";
+
+describe("os-field-styles", () => {
+  test("pill search field uses rounded-full", () => {
+    expect(osFieldInputClasses(true, "pill")).toContain("rounded-full");
+    expect(osFieldInputClasses(true, "pill")).not.toContain("rounded-os");
+  });
+
+  test("textarea field uses rounded-os corners", () => {
+    expect(osFieldTextareaClasses(true)).toContain("rounded-os");
+    expect(osFieldTextareaClasses(true)).not.toContain("rounded-full");
+  });
+
+  test("search field reserves space for leading and trailing chrome", () => {
+    const classes = osFieldInputClasses(true, "pill", {
+      withLeadingIcon: true,
+      withTrailingAction: true,
+    });
+    expect(classes).toContain("pl-7");
+    expect(classes).toContain("pr-7");
+  });
+});
+
+describe("OsTextarea", () => {
+  test("marks field for shared OS theme overrides", () => {
+    const html = renderToStaticMarkup(
+      <OsTextarea value="hello" onChange={() => {}} aria-label="Notes" />
+    );
+    expect(html).toContain('data-os-field-input="true"');
+    expect(html).toContain("rounded-os");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces a reusable `OsTextarea` component styled like the existing `SearchInput` recessed field chrome, but with `rounded-os` corners instead of a full pill. Uses it for pref-style text fields across Control Panels and dialogs.

## Changes

- Extract shared styling into `os-field-styles.ts` (used by both `SearchInput` and `OsTextarea`)
- Add `OsTextarea` with `data-os-field-input` marker for theme overrides
- Square corners on System 7 / Windows via `os-theme-system7:rounded-none os-windows:rounded-none`
- Extend dark Aqua and Aqua Glass CSS to style the new textarea marker alongside search inputs
- **Assistant** behavior instructions field
- **TelegramLinkDialog** heartbeat instructions field
- **FutureSettingsDialog** Internet Explorer future timeline editor

## Verification

![Assistant behavior OsTextarea](https://cursor.com/artifacts/c/art-c09d10a9-eb26-40ef-9174-0e31a847f55e)

- `bun test tests/test-os-textarea.test.tsx`
- Manual: Control Panels → Assistant → Behavior instructions field shows recessed search-like styling with rounded corners

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f32b1-0edf-7c39-b970-0537afefade3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f32b1-0edf-7c39-b970-0537afefade3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

