### PR TITLE
Show sign-in button when assistant bubble is rate limited

### DIFF
--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -84,6 +84,7 @@ import { ArrowUp } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { createClientLogger } from "@/utils/logger";
 import { AssistantBubbleToolParts } from "./AssistantBubbleToolParts";
+import { LoginDialog } from "@/components/dialogs/LoginDialog";
 
 /**
  * Animation state machine trace. Silent in production unless the user enables
@@ -300,7 +301,26 @@ function AssistantOverlayInner() {
   const character = getAssistantCharacter(characterId);
   const { computeInsets } = useWindowInsets();
   const launchApp = useLaunchApp();
-  const { promptSetUsername } = useAuth();
+  const {
+    promptSetUsername,
+    usernameDialogInitialTab,
+    isUsernameDialogOpen,
+    setIsUsernameDialogOpen,
+    newUsername,
+    setNewUsername,
+    newPassword,
+    setNewPassword,
+    isSettingUsername,
+    usernameError,
+    submitUsernameDialog,
+    verifyUsernameInput,
+    setVerifyUsernameInput,
+    verifyPasswordInput,
+    setVerifyPasswordInput,
+    isVerifyingToken,
+    verifyError,
+    handleVerifyTokenSubmit,
+  } = useAuth();
   const reduceMotion = useReducedMotion();
   const lastUserDragAtRef = useRef(0);
   const pendingRelocationCancelRef = useRef<(() => void) | null>(null);
@@ -1819,6 +1839,28 @@ function AssistantOverlayInner() {
         position={contextMenuPos}
         onClose={() => setContextMenuPos(null)}
         items={contextMenuItems}
+      />
+
+      <LoginDialog
+        initialTab={usernameDialogInitialTab}
+        isOpen={isUsernameDialogOpen}
+        onOpenChange={setIsUsernameDialogOpen}
+        usernameInput={verifyUsernameInput}
+        onUsernameInputChange={setVerifyUsernameInput}
+        passwordInput={verifyPasswordInput}
+        onPasswordInputChange={setVerifyPasswordInput}
+        onLoginSubmit={async () => {
+          await handleVerifyTokenSubmit(verifyPasswordInput, true);
+        }}
+        isLoginLoading={isVerifyingToken}
+        loginError={verifyError}
+        newUsername={newUsername}
+        onNewUsernameChange={setNewUsername}
+        newPassword={newPassword}
+        onNewPasswordChange={setNewPassword}
+        onSignUpSubmit={submitUsernameDialog}
+        isSignUpLoading={isSettingUsername}
+        signUpError={usernameError}
       />
     </motion.div>
   );

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/stores/useAssistantStore";
 import { useWindowInsets } from "@/hooks/useWindowInsets";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
+import { useAuth } from "@/hooks/useAuth";
 import { RightClickMenu, type MenuItem } from "@/components/ui/right-click-menu";
 import {
   ASSISTANT_CHARACTERS,
@@ -299,6 +300,7 @@ function AssistantOverlayInner() {
   const character = getAssistantCharacter(characterId);
   const { computeInsets } = useWindowInsets();
   const launchApp = useLaunchApp();
+  const { promptSetUsername } = useAuth();
   const reduceMotion = useReducedMotion();
   const lastUserDragAtRef = useRef(0);
   const pendingRelocationCancelRef = useRef<(() => void) | null>(null);
@@ -313,6 +315,8 @@ function AssistantOverlayInner() {
     isAwaitingReply,
     isLoading,
     errorText,
+    showLoginForRateLimit,
+    isInputBlockedByRateLimit,
     sendUserMessage,
     greetIfStale,
     startNewConversation,
@@ -1734,32 +1738,44 @@ function AssistantOverlayInner() {
                   onInteractionChange={setIsInteractingWithPreview}
                 />
               )}
-              <form
-                onSubmit={handleSubmit}
-                className="-mx-3 mt-1.5 flex items-center gap-1 border-t border-black/15 px-3 pt-1 pb-0.5"
-              >
-                <input
-                  ref={inputRef}
-                  type="text"
-                  value={input}
-                  onChange={(event) => setInput(event.target.value)}
-                  onCompositionStart={handleInputCompositionStart}
-                  onCompositionEnd={handleInputCompositionEnd}
-                  placeholder={t("common.assistant.inputPlaceholder")}
-                  aria-label={t("common.assistant.inputPlaceholder")}
-                  className="min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-[12px] leading-tight font-geneva-12 placeholder:text-black/45 focus:outline-none focus:ring-0"
-                />
-                <button
-                  type="submit"
-                  disabled={!input.trim() || isLoading}
-                  aria-label={t("common.assistant.send")}
-                  className="group flex size-7 shrink-0 items-center justify-center rounded-full disabled:opacity-35"
+              {showLoginForRateLimit ? (
+                <div className="-mx-3 mt-1.5 border-t border-black/15 px-3 pt-1 pb-0.5">
+                  <button
+                    type="button"
+                    onClick={promptSetUsername}
+                    className="w-full rounded bg-orange-600 px-2 py-1 text-[12px] leading-tight font-geneva-12 text-white hover:bg-orange-700 active:bg-orange-800"
+                  >
+                    {t("apps.chats.status.loginToChat")}
+                  </button>
+                </div>
+              ) : !isInputBlockedByRateLimit ? (
+                <form
+                  onSubmit={handleSubmit}
+                  className="-mx-3 mt-1.5 flex items-center gap-1 border-t border-black/15 px-3 pt-1 pb-0.5"
                 >
-                  <span className="flex size-5 items-center justify-center rounded-full bg-black/10 text-black/70 group-hover:bg-black/15 group-active:bg-black/20">
-                    <ArrowUp className="size-3" weight="bold" aria-hidden />
-                  </span>
-                </button>
-              </form>
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    value={input}
+                    onChange={(event) => setInput(event.target.value)}
+                    onCompositionStart={handleInputCompositionStart}
+                    onCompositionEnd={handleInputCompositionEnd}
+                    placeholder={t("common.assistant.inputPlaceholder")}
+                    aria-label={t("common.assistant.inputPlaceholder")}
+                    className="min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-[12px] leading-tight font-geneva-12 placeholder:text-black/45 focus:outline-none focus:ring-0"
+                  />
+                  <button
+                    type="submit"
+                    disabled={!input.trim() || isLoading}
+                    aria-label={t("common.assistant.send")}
+                    className="group flex size-7 shrink-0 items-center justify-center rounded-full disabled:opacity-35"
+                  >
+                    <span className="flex size-5 items-center justify-center rounded-full bg-black/10 text-black/70 group-hover:bg-black/15 group-active:bg-black/20">
+                      <ArrowUp className="size-3" weight="bold" aria-hidden />
+                    </span>
+                  </button>
+                </form>
+              ) : null}
               {/* Bubble tail pointing at the character */}
               <div
                 style={{

--- a/src/components/assistant/AssistantOverlay.tsx
+++ b/src/components/assistant/AssistantOverlay.tsx
@@ -406,6 +406,10 @@ function AssistantOverlayInner() {
     setBubbleOpen(false);
     useAssistantStore.getState().markBubbleDismissed();
   }, []);
+  const handleRateLimitSignIn = useCallback(() => {
+    closeBubble();
+    promptSetUsername();
+  }, [closeBubble, promptSetUsername]);
   /** First-load bubble pop, deferred until the entrance sequence ends. */
   const openInitialBubble = useCallback(() => {
     if (!initialBubblePendingRef.current) return;
@@ -1762,7 +1766,7 @@ function AssistantOverlayInner() {
                 <div className="-mx-3 mt-1.5 border-t border-black/15 px-3 pt-1 pb-0.5">
                   <button
                     type="button"
-                    onClick={promptSetUsername}
+                    onClick={handleRateLimitSignIn}
                     className="w-full rounded bg-orange-600 px-2 py-1 text-[12px] leading-tight font-geneva-12 text-white hover:bg-orange-700 active:bg-orange-800"
                   >
                     {t("apps.chats.status.loginToChat")}

--- a/src/components/assistant/useAssistantChat.ts
+++ b/src/components/assistant/useAssistantChat.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Chat, useChat } from "@ai-sdk/react";
 import {
   DefaultChatTransport,
@@ -74,6 +74,48 @@ const TOOL_STATUS_KEYS: Record<string, string> = {
   songLibraryControl: "apps.chats.toolCalls.loadingMusicLibrary",
 };
 
+export function parseAssistantRateLimitState(
+  error: Error | undefined,
+  isAuthenticated: boolean
+): { blocked: boolean; showLogin: boolean } | null {
+  if (!error) return null;
+  const message = error.message || "";
+  if (
+    message.includes("AI_TypeValidationError") ||
+    message.includes("Type validation failed")
+  ) {
+    return null;
+  }
+
+  const jsonMatch = message.match(/\{.*\}/);
+  if (jsonMatch) {
+    try {
+      const errorData = JSON.parse(jsonMatch[0]) as {
+        error?: string;
+        isAuthenticated?: boolean;
+      };
+      if (errorData.error === "rate_limit_exceeded") {
+        const authed = !!errorData.isAuthenticated;
+        return {
+          blocked: true,
+          showLogin: !authed && !isAuthenticated,
+        };
+      }
+    } catch {
+      // Fall through to generic 429 detection.
+    }
+  }
+
+  if (message.includes("429") || message.includes("rate_limit_exceeded")) {
+    return {
+      blocked: true,
+      showLogin: !isAuthenticated,
+    };
+  }
+
+  return null;
+}
+
 function getToolStatusLabel(toolName: string, input: unknown): string {
   const appId =
     input && typeof input === "object"
@@ -148,6 +190,10 @@ export interface AssistantChatHandle {
   isAwaitingReply: boolean;
   isLoading: boolean;
   errorText: string | null;
+  /** True when the chat input should be replaced with a sign-in prompt. */
+  showLoginForRateLimit: boolean;
+  /** True when rate limiting blocks further messages (signed-in or not). */
+  isInputBlockedByRateLimit: boolean;
   sendUserMessage: (text: string) => void;
   /**
    * Call when the bubble opens (summon or tap). Starts a fresh conversation
@@ -372,6 +418,11 @@ export function useAssistantChat(): AssistantChatHandle {
     return labels;
   }, [messages, isLoading]);
 
+  const rateLimitState = useMemo(
+    () => parseAssistantRateLimitState(error, isAuthenticated),
+    [error, isAuthenticated]
+  );
+
   const errorText = useMemo(() => {
     if (!error) return null;
     const message = error.message || "";
@@ -381,11 +432,20 @@ export function useAssistantChat(): AssistantChatHandle {
     ) {
       return null;
     }
-    if (message.includes("429") || message.includes("rate_limit_exceeded")) {
+    if (rateLimitState?.blocked) {
       return i18n.t("common.assistant.rateLimited");
     }
     return i18n.t("common.assistant.genericError");
-  }, [error]);
+  }, [error, rateLimitState]);
+
+  const showLoginForRateLimit = rateLimitState?.showLogin ?? false;
+  const isInputBlockedByRateLimit = rateLimitState?.blocked ?? false;
+
+  useEffect(() => {
+    if (isAuthenticated && rateLimitState?.showLogin) {
+      clearError();
+    }
+  }, [isAuthenticated, rateLimitState?.showLogin, clearError]);
 
   const sendUserMessage = useCallback(
     (text: string) => {
@@ -487,6 +547,8 @@ export function useAssistantChat(): AssistantChatHandle {
     isAwaitingReply,
     isLoading,
     errorText,
+    showLoginForRateLimit,
+    isInputBlockedByRateLimit,
     sendUserMessage,
     greetIfStale,
     startNewConversation,

--- a/tests/test-assistant-rate-limit-login.test.ts
+++ b/tests/test-assistant-rate-limit-login.test.ts
@@ -56,4 +56,10 @@ describe("assistant bubble rate-limit login wiring", () => {
     expect(overlaySource).toContain("isUsernameDialogOpen");
     expect(overlaySource).toContain("submitUsernameDialog");
   });
+
+  test("closes the bubble before opening the auth dialog", () => {
+    expect(overlaySource).toContain("handleRateLimitSignIn");
+    expect(overlaySource).toContain("closeBubble()");
+    expect(overlaySource).toContain("promptSetUsername()");
+  });
 });

--- a/tests/test-assistant-rate-limit-login.test.ts
+++ b/tests/test-assistant-rate-limit-login.test.ts
@@ -50,4 +50,10 @@ describe("assistant bubble rate-limit login wiring", () => {
     expect(overlaySource).toContain("isInputBlockedByRateLimit");
     expect(overlaySource).toContain('t("apps.chats.status.loginToChat")');
   });
+
+  test("mounts LoginDialog so the sign-in button opens the auth dialog", () => {
+    expect(overlaySource).toContain("LoginDialog");
+    expect(overlaySource).toContain("isUsernameDialogOpen");
+    expect(overlaySource).toContain("submitUsernameDialog");
+  });
 });

--- a/tests/test-assistant-rate-limit-login.test.ts
+++ b/tests/test-assistant-rate-limit-login.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseAssistantRateLimitState } from "../src/components/assistant/useAssistantChat";
+
+describe("parseAssistantRateLimitState", () => {
+  test("anonymous 429 JSON prompts login", () => {
+    const error = new Error(
+      'Failed: {"error":"rate_limit_exceeded","isAuthenticated":false,"count":3,"limit":3}'
+    );
+    expect(parseAssistantRateLimitState(error, false)).toEqual({
+      blocked: true,
+      showLogin: true,
+    });
+  });
+
+  test("authenticated 429 JSON blocks input without login prompt", () => {
+    const error = new Error(
+      'Failed: {"error":"rate_limit_exceeded","isAuthenticated":true,"count":15,"limit":15}'
+    );
+    expect(parseAssistantRateLimitState(error, true)).toEqual({
+      blocked: true,
+      showLogin: false,
+    });
+  });
+
+  test("generic 429 without JSON falls back to local auth state", () => {
+    expect(
+      parseAssistantRateLimitState(new Error("HTTP 429 Too Many Requests"), false)
+    ).toEqual({ blocked: true, showLogin: true });
+    expect(
+      parseAssistantRateLimitState(new Error("HTTP 429 Too Many Requests"), true)
+    ).toEqual({ blocked: true, showLogin: false });
+  });
+
+  test("ignores unrelated errors", () => {
+    expect(parseAssistantRateLimitState(new Error("network down"), false)).toBeNull();
+  });
+});
+
+describe("assistant bubble rate-limit login wiring", () => {
+  const overlaySource = readFileSync(
+    join(import.meta.dir, "../src/components/assistant/AssistantOverlay.tsx"),
+    "utf8"
+  );
+
+  test("replaces the input with a sign-in button when rate limited for anonymous users", () => {
+    expect(overlaySource).toContain("showLoginForRateLimit");
+    expect(overlaySource).toContain("promptSetUsername");
+    expect(overlaySource).toContain("isInputBlockedByRateLimit");
+    expect(overlaySource).toContain('t("apps.chats.status.loginToChat")');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When anonymous users hit the `/api/chat` rate limit in the desktop assistant bubble, the text input is replaced with a **Sign in to Chats** button — matching the Chats app behavior when `needsUsername` is set after a 429.

- Parses 429 responses in `useAssistantChat` to detect anonymous vs authenticated rate limits
- Shows a login button instead of the input for anonymous users
- Hides the input entirely for authenticated users who hit their limit (error message remains in the bubble body)
- Clears the rate-limit error when the user signs in
- Mounts `LoginDialog` in `AssistantOverlay` so the sign-in button opens the create/sign-in dialog
- **Closes the assistant bubble** when the sign-in button is tapped, before opening the dialog

## Testing

- ✅ `bun test tests/test-assistant-rate-limit-login.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f32bd-0065-7748-bb35-939a97ec1932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f32bd-0065-7748-bb35-939a97ec1932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

