### PR TITLE
Fix clearing chats for legacy accounts

### DIFF
--- a/api/_utils/auth/_user-record.ts
+++ b/api/_utils/auth/_user-record.ts
@@ -28,8 +28,138 @@ export interface StoredUserRecord {
   emailUpdatedAt?: number;
 }
 
+export type StoredUserRecordWithCreatedAt = StoredUserRecord & {
+  createdAt: number;
+};
+
 /** Basic email shape check. Intentionally permissive (server is not an MX validator). */
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const ENSURE_STORED_USER_CREATED_AT_SCRIPT = `
+local raw = redis.call("GET", KEYS[1])
+if not raw then
+  return false
+end
+
+local decoded, account = pcall(cjson.decode, raw)
+if not decoded or type(account) ~= "table" then
+  return false
+end
+
+local createdAt = account["createdAt"]
+if type(createdAt) == "number" and createdAt > 0 and createdAt < math.huge then
+  return raw
+end
+if createdAt ~= nil then
+  return false
+end
+
+if redis.call("EXISTS", KEYS[2]) == 1 then
+  return false
+end
+
+local lastActive = account["lastActive"]
+if type(lastActive) ~= "number"
+  or lastActive ~= lastActive
+  or lastActive <= 0
+  or lastActive >= math.huge
+then
+  return false
+end
+
+local ttl = redis.call("PTTL", KEYS[1])
+account["createdAt"] = lastActive
+local encoded, updated = pcall(cjson.encode, account)
+if not encoded then
+  return false
+end
+redis.call("SET", KEYS[1], updated)
+if ttl >= 0 then
+  redis.call("PEXPIRE", KEYS[1], math.max(ttl, 1))
+end
+return updated
+`;
+
+const CREATE_STORED_USER_IF_NOT_EXISTS_SCRIPT = `
+if redis.call("EXISTS", KEYS[2]) == 1 or redis.call("EXISTS", KEYS[1]) == 1 then
+  return 0
+end
+
+redis.call("SET", KEYS[1], ARGV[1])
+return 1
+`;
+
+const UPDATE_STORED_USER_LAST_ACTIVE_SCRIPT = `
+if redis.call("EXISTS", KEYS[2]) == 1 then
+  return 0
+end
+
+local raw = redis.call("GET", KEYS[1])
+if not raw then
+  return 0
+end
+
+local decoded, account = pcall(cjson.decode, raw)
+if not decoded or type(account) ~= "table" then
+  return 0
+end
+
+local lastActive = tonumber(ARGV[1])
+if not lastActive
+  or lastActive ~= lastActive
+  or lastActive <= 0
+  or lastActive >= math.huge
+then
+  return 0
+end
+
+local currentLastActive = account["lastActive"]
+if type(currentLastActive) == "number"
+  and currentLastActive == currentLastActive
+  and currentLastActive > lastActive
+  and currentLastActive < math.huge
+then
+  lastActive = currentLastActive
+end
+
+account["lastActive"] = lastActive
+local encoded, updated = pcall(cjson.encode, account)
+if not encoded then
+  return 0
+end
+
+redis.call("SET", KEYS[1], updated)
+return 1
+`;
+
+const UPDATE_STORED_USER_TIME_ZONE_SCRIPT = `
+if redis.call("EXISTS", KEYS[2]) == 1 then
+  return false
+end
+
+local raw = redis.call("GET", KEYS[1])
+if not raw then
+  return false
+end
+
+local decoded, account = pcall(cjson.decode, raw)
+if not decoded or type(account) ~= "table" then
+  return false
+end
+if account["timeZone"] == ARGV[1] then
+  return raw
+end
+
+account["timeZone"] = ARGV[1]
+account["timeZoneUpdatedAt"] = tonumber(ARGV[2])
+local encoded, updated = pcall(cjson.encode, account)
+if not encoded then
+  return false
+end
+
+redis.call("SET", KEYS[1], updated)
+return updated
+`;
 
 export function normalizeEmail(email: string | null | undefined): string | null {
   if (!email || typeof email !== "string") return null;
@@ -96,6 +226,90 @@ export async function getStoredUserRecord(
   );
 }
 
+/**
+ * Return an account-generation timestamp for current and legacy profiles.
+ *
+ * Historical profiles may predate `createdAt`. Their existing `lastActive`
+ * value is the only stable timestamp available for an account-generation
+ * fence. The Lua script backfills it atomically and preserves the record's TTL.
+ * A deletion tombstone blocks backfills until registration establishes a new
+ * account generation.
+ */
+export async function ensureStoredUserCreatedAt(
+  redis: Redis,
+  username: string
+): Promise<StoredUserRecordWithCreatedAt | null> {
+  const normalizedUsername = username.toLowerCase();
+  const result = await redis.eval<unknown>(
+    ENSURE_STORED_USER_CREATED_AT_SCRIPT,
+    [
+      redisKeys.auth.userProfile(normalizedUsername),
+      redisKeys.chat.aiConversationTombstone(normalizedUsername),
+    ],
+    []
+  );
+  const record = parseStoredUser(result);
+  if (
+    !record ||
+    typeof record.createdAt !== "number" ||
+    !Number.isFinite(record.createdAt) ||
+    record.createdAt <= 0
+  ) {
+    return null;
+  }
+  return { ...record, createdAt: record.createdAt };
+}
+
+/**
+ * Update activity without replacing the rest of the profile.
+ *
+ * Room-message requests can overlap profile migrations, account deletion, and
+ * re-registration. An atomic field patch prevents a stale request from
+ * erasing `createdAt` or recreating a deleted profile.
+ */
+export async function updateStoredUserLastActive(
+  redis: Redis,
+  username: string,
+  lastActive: number
+): Promise<boolean> {
+  if (!Number.isFinite(lastActive) || lastActive <= 0) {
+    return false;
+  }
+
+  const normalizedUsername = username.toLowerCase();
+  const result = await redis.eval<number>(
+    UPDATE_STORED_USER_LAST_ACTIVE_SCRIPT,
+    [
+      redisKeys.auth.userProfile(normalizedUsername),
+      redisKeys.chat.aiConversationTombstone(normalizedUsername),
+    ],
+    [lastActive]
+  );
+  return result === 1;
+}
+
+/**
+ * Create a profile only when neither an account nor a deletion tombstone
+ * exists. This keeps stale room requests from recreating deleted accounts or
+ * overwriting a concurrent registration.
+ */
+export async function createStoredUserIfNotExists(
+  redis: Redis,
+  username: string,
+  record: StoredUserRecord
+): Promise<boolean> {
+  const normalizedUsername = username.toLowerCase();
+  const result = await redis.eval<number>(
+    CREATE_STORED_USER_IF_NOT_EXISTS_SCRIPT,
+    [
+      redisKeys.auth.userProfile(normalizedUsername),
+      redisKeys.chat.aiConversationTombstone(normalizedUsername),
+    ],
+    [JSON.stringify(record)]
+  );
+  return result === 1;
+}
+
 export async function setStoredUserRecord(
   redis: Redis,
   username: string,
@@ -129,24 +343,20 @@ export async function updateStoredUserTimeZone(
   if (!normalizedTimeZone) {
     return null;
   }
-
-  const key = redisKeys.auth.userProfile(username.toLowerCase());
-  const existingRecord = await getStoredUserRecord(redis, username);
-  if (!existingRecord) {
+  if (!Number.isFinite(now) || now <= 0) {
     return null;
   }
 
-  if (existingRecord.timeZone === normalizedTimeZone) {
-    return existingRecord;
-  }
-
-  const updatedRecord: StoredUserRecord = {
-    ...existingRecord,
-    timeZone: normalizedTimeZone,
-    timeZoneUpdatedAt: now,
-  };
-  await redis.set(key, JSON.stringify(updatedRecord));
-  return updatedRecord;
+  const normalizedUsername = username.toLowerCase();
+  const result = await redis.eval<unknown>(
+    UPDATE_STORED_USER_TIME_ZONE_SCRIPT,
+    [
+      redisKeys.auth.userProfile(normalizedUsername),
+      redisKeys.chat.aiConversationTombstone(normalizedUsername),
+    ],
+    [normalizedTimeZone, now]
+  );
+  return parseStoredUser(result);
 }
 
 /**

--- a/api/ai/conversations/[channel]/reset.ts
+++ b/api/ai/conversations/[channel]/reset.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { waitUntil } from "@vercel/functions";
 import { apiHandler } from "../../../_utils/api-handler.js";
-import { getStoredUserRecord } from "../../../_utils/auth/_user-record.js";
+import { ensureStoredUserCreatedAt } from "../../../_utils/auth/_user-record.js";
 import { isValidMemoryAccountCreatedAt } from "../../../_utils/_memory.js";
 import {
   AIConversationError,
@@ -36,7 +36,7 @@ export default apiHandler(
       res.status(404).json({ error: "conversation_channel_not_found" });
       return;
     }
-    const account = await getStoredUserRecord(redis, user!.username);
+    const account = await ensureStoredUserCreatedAt(redis, user!.username);
     if (!isValidMemoryAccountCreatedAt(account?.createdAt)) {
       logger.response(409, Date.now() - startTime);
       res.status(409).json({ error: "account_changed" });

--- a/api/rooms/[id]/messages.ts
+++ b/api/rooms/[id]/messages.ts
@@ -22,7 +22,15 @@ import {
 } from "../_helpers/_constants.js";
 import { makeKey } from "../../_utils/_rate-limit-key.js";
 import { ensureUserExists } from "../_helpers/_users.js";
-import { addMessage, generateId, getCurrentTimestamp, getLastMessage, getMessages, getRoom, setUser } from "../_helpers/_redis.js";
+import {
+  addMessage,
+  generateId,
+  getCurrentTimestamp,
+  getLastMessage,
+  getMessages,
+  getRoom,
+  updateUserLastActive,
+} from "../_helpers/_redis.js";
 import { setRoomPresence } from "../_helpers/_presence.js";
 import type { Message } from "../_helpers/_types.js";
 import { getRoomReadAccessError, getRoomWriteAccessError } from "../_helpers/_access.js";
@@ -227,10 +235,7 @@ export default apiHandler(
 
       await addMessage(roomId, message, redis);
 
-      // setUser's plain SET clears any legacy TTL: user records persist
-      // forever (an old expire call here used to attach one on each send).
-      const updatedUser = { ...userData, lastActive: getCurrentTimestamp() };
-      await setUser(username, updatedUser, redis);
+      await updateUserLastActive(username, getCurrentTimestamp(), redis);
       await setRoomPresence(roomId, username, redis);
 
       await broadcastNewMessage(roomId, message, roomData);

--- a/api/rooms/_helpers/_redis.ts
+++ b/api/rooms/_helpers/_redis.ts
@@ -13,8 +13,9 @@ import {
 } from "../../_utils/redis-helpers.js";
 import { redisKeys } from "../../../src/shared/redisKeys.js";
 import {
+  createStoredUserIfNotExists,
   getStoredUserRecord,
-  setStoredUserRecord,
+  updateStoredUserLastActive,
 } from "../../_utils/auth/_user-record.js";
 
 // Export for direct usage in endpoints and feature helpers.
@@ -174,14 +175,14 @@ export async function getUser(
 }
 
 /**
- * Set a user (user records persist forever)
+ * Patch a user's activity timestamp without replacing account metadata.
  */
-export async function setUser(
+export async function updateUserLastActive(
   username: string,
-  user: User,
+  lastActive: number,
   client: Redis = createRedisClient()
-): Promise<void> {
-  await setStoredUserRecord(client, username, user);
+): Promise<boolean> {
+  return updateStoredUserLastActive(client, username, lastActive);
 }
 
 /**
@@ -193,10 +194,7 @@ export async function createUserIfNotExists(
   user: User,
   client: Redis = createRedisClient()
 ): Promise<boolean> {
-  const existing = await getStoredUserRecord(client, username);
-  if (existing) return false;
-  await setStoredUserRecord(client, username, user);
-  return true;
+  return createStoredUserIfNotExists(client, username, user);
 }
 
 /**

--- a/tests/test-ai-conversation-api.test.ts
+++ b/tests/test-ai-conversation-api.test.ts
@@ -7,11 +7,22 @@ import {
   makeRateLimitBypassHeaders,
   uniqueTestUsername,
 } from "./test-utils";
+import { createRedis } from "../api/_utils/redis";
+import {
+  createStoredUserIfNotExists,
+  ensureStoredUserCreatedAt,
+  getStoredUserRecord,
+  setStoredUserRecord,
+  updateStoredUserLastActive,
+  updateStoredUserTimeZone,
+} from "../api/_utils/auth/_user-record";
+import { redisKeys } from "../src/shared/redisKeys";
 import type {
   AIConversationPage,
   AIConversationResetResult,
 } from "../src/shared/contracts/aiConversation";
 
+const redis = createRedis();
 const password = "testtest123";
 const CHAT_ID = "11111111-1111-4111-8111-111111111111";
 const PNG_1X1 = Buffer.from(
@@ -44,6 +55,209 @@ describe("AI conversation API", () => {
       `${BASE_URL}/api/ai/conversations/chat`
     );
     expect(response.status).toBe(401);
+  });
+
+  test("resets legacy accounts missing createdAt and preserves their profile", async () => {
+    const username = uniqueTestUsername("ailegacy");
+    const token = await ensureUserAuth(username, password);
+    if (!token) throw new Error("Failed to authenticate legacy-profile test user");
+
+    const initialResponse = await fetchWithAuth(
+      `${BASE_URL}/api/ai/conversations/chat`,
+      username,
+      token
+    );
+    expect(initialResponse.status).toBe(200);
+    const initial = (await initialResponse.json()) as AIConversationPage;
+
+    const account = await getStoredUserRecord(redis, username);
+    if (typeof account?.lastActive !== "number") {
+      throw new Error("Registered test user is missing lastActive");
+    }
+    const legacyAccount = {
+      ...account,
+      timeZone: "Europe/London",
+      timeZoneUpdatedAt: account.lastActive,
+    };
+    delete legacyAccount.createdAt;
+    await setStoredUserRecord(redis, username, legacyAccount);
+
+    const importResponse = await fetchWithAuth(
+      `${BASE_URL}/api/ai/conversations/chat/import`,
+      username,
+      token,
+      {
+        method: "POST",
+        headers: makeRateLimitBypassHeaders(),
+        body: JSON.stringify({
+          conversationId: initial.conversation.id,
+          expectedRevision: initial.conversation.revision,
+          operationId: crypto.randomUUID(),
+          messages: [apiMessage("legacy-user-message", "user", "clear me")],
+        }),
+      }
+    );
+    expect(importResponse.status).toBe(201);
+
+    const populatedResponse = await fetchWithAuth(
+      `${BASE_URL}/api/ai/conversations/chat`,
+      username,
+      token
+    );
+    expect(populatedResponse.status).toBe(200);
+    const populated = (await populatedResponse.json()) as AIConversationPage;
+    expect(populated.messages.map((message) => message.id)).toEqual([
+      "legacy-user-message",
+    ]);
+
+    const resetResponse = await fetchWithAuth(
+      `${BASE_URL}/api/ai/conversations/chat/reset`,
+      username,
+      token,
+      {
+        method: "POST",
+        headers: makeRateLimitBypassHeaders(),
+        body: JSON.stringify({
+          conversationId: initial.conversation.id,
+          operationId: crypto.randomUUID(),
+        }),
+      }
+    );
+    expect(resetResponse.status).toBe(200);
+    const reset = (await resetResponse.json()) as AIConversationResetResult;
+    expect(reset.reset).toBe(true);
+    expect(reset.conversation.id).not.toBe(initial.conversation.id);
+
+    const clearedResponse = await fetchWithAuth(
+      `${BASE_URL}/api/ai/conversations/chat`,
+      username,
+      token
+    );
+    expect(clearedResponse.status).toBe(200);
+    const cleared = (await clearedResponse.json()) as AIConversationPage;
+    expect(cleared.conversation.id).toBe(reset.conversation.id);
+    expect(cleared.messages).toEqual([]);
+
+    expect(await getStoredUserRecord(redis, username)).toEqual({
+      ...legacyAccount,
+      createdAt: account.lastActive,
+    });
+
+    const timeZoneUpdatedAt = account.lastActive + 1;
+    expect(
+      await updateStoredUserTimeZone(
+        redis,
+        username,
+        "Asia/Tokyo",
+        timeZoneUpdatedAt
+      )
+    ).toEqual({
+      ...legacyAccount,
+      createdAt: account.lastActive,
+      timeZone: "Asia/Tokyo",
+      timeZoneUpdatedAt,
+    });
+  });
+
+  test("does not backfill during deletion or replace a new account generation", async () => {
+    const username = uniqueTestUsername("aifence");
+    const token = await ensureUserAuth(username, password);
+    if (!token) throw new Error("Failed to authenticate account-fence test user");
+
+    const initialResponse = await fetchWithAuth(
+      `${BASE_URL}/api/ai/conversations/chat`,
+      username,
+      token
+    );
+    expect(initialResponse.status).toBe(200);
+    const initial = (await initialResponse.json()) as AIConversationPage;
+
+    const account = await getStoredUserRecord(redis, username);
+    if (typeof account?.lastActive !== "number") {
+      throw new Error("Registered test user is missing lastActive");
+    }
+    const legacyAccount = { ...account };
+    delete legacyAccount.createdAt;
+    await setStoredUserRecord(redis, username, legacyAccount);
+
+    const tombstoneKey = redisKeys.chat.aiConversationTombstone(username);
+    await redis.set(tombstoneKey, "1");
+    const blockedReset = await fetchWithAuth(
+      `${BASE_URL}/api/ai/conversations/chat/reset`,
+      username,
+      token,
+      {
+        method: "POST",
+        headers: makeRateLimitBypassHeaders(),
+        body: JSON.stringify({
+          conversationId: initial.conversation.id,
+          operationId: crypto.randomUUID(),
+        }),
+      }
+    );
+    expect(blockedReset.status).toBe(409);
+    expect(await blockedReset.json()).toEqual({ error: "account_changed" });
+    expect(await getStoredUserRecord(redis, username)).toEqual(legacyAccount);
+
+    await redis.del(redisKeys.auth.userProfile(username));
+    expect(
+      await createStoredUserIfNotExists(redis, username, legacyAccount)
+    ).toBe(false);
+    expect(await ensureStoredUserCreatedAt(redis, username)).toBeNull();
+    expect(await getStoredUserRecord(redis, username)).toBeNull();
+
+    const replacementCreatedAt = account.lastActive + 1;
+    const replacementAccount = {
+      username,
+      createdAt: replacementCreatedAt,
+      lastActive: replacementCreatedAt + 1,
+      timeZone: "UTC",
+    };
+    await setStoredUserRecord(redis, username, replacementAccount);
+    expect(
+      await updateStoredUserLastActive(
+        redis,
+        username,
+        replacementAccount.lastActive + 1
+      )
+    ).toBe(false);
+    expect(await ensureStoredUserCreatedAt(redis, username)).toEqual(
+      replacementAccount
+    );
+    expect(await getStoredUserRecord(redis, username)).toEqual(
+      replacementAccount
+    );
+
+    await redis.del(tombstoneKey);
+    expect(
+      await createStoredUserIfNotExists(redis, username, legacyAccount)
+    ).toBe(false);
+    expect(
+      await updateStoredUserLastActive(
+        redis,
+        username,
+        replacementAccount.lastActive - 1
+      )
+    ).toBe(true);
+    expect(await getStoredUserRecord(redis, username)).toEqual(
+      replacementAccount
+    );
+    const nextLastActive = replacementAccount.lastActive + 2;
+    expect(
+      await updateStoredUserLastActive(redis, username, nextLastActive)
+    ).toBe(true);
+    expect(await ensureStoredUserCreatedAt(redis, username)).toEqual(
+      {
+        ...replacementAccount,
+        lastActive: nextLastActive,
+      }
+    );
+    expect(await getStoredUserRecord(redis, username)).toEqual(
+      {
+        ...replacementAccount,
+        lastActive: nextLastActive,
+      }
+    );
   });
 
   test("round-trips long text, an owned image, and tool state", async () => {

--- a/tests/test-auth-user-record.test.ts
+++ b/tests/test-auth-user-record.test.ts
@@ -21,6 +21,31 @@ class FakeRedis {
     this.store.set(key, value);
     return "OK";
   }
+
+  async eval(
+    _script: string,
+    keys: string[],
+    args: Array<string | number>
+  ): Promise<unknown> {
+    if (this.store.has(keys[1])) return false;
+
+    const raw = this.store.get(keys[0]);
+    if (!raw) return false;
+    const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return false;
+    }
+    if (Reflect.get(parsed, "timeZone") === args[0]) return raw;
+
+    const updated = {
+      ...parsed,
+      timeZone: args[0],
+      timeZoneUpdatedAt: Number(args[1]),
+    };
+    const serialized = JSON.stringify(updated);
+    this.store.set(keys[0], serialized);
+    return serialized;
+  }
 }
 
 function makeRedis(): Redis {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- atomically backfill missing account-generation timestamps before resetting legacy AI conversations
- keep room activity, profile creation, and timezone updates from erasing or reviving account generations
- cover persisted-history clearing, profile preservation, tombstones, and re-registration fencing

## Testing
- `bun run test:unit` — 2,452 passed
- focused legacy reset API regressions against disposable local Redis — 2 passed
- `bun test tests/test-new-api.test.ts` against disposable local Redis — 30 passed
- configured Upstash REST Lua migration smoke test — passed; temporary keys removed
- `bun run typecheck` — passed
- targeted ESLint — passed
- `bun run test:registration` — passed
- `bun run build` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3acf-c1f5-7992-8a6e-b7885d345d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3acf-c1f5-7992-8a6e-b7885d345d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

