### PR TITLE
Rearchitect proactive greeting as a server-owned conversation message

### DIFF
--- a/api/ai/conversations/[channel]/import.ts
+++ b/api/ai/conversations/[channel]/import.ts
@@ -15,7 +15,9 @@ export const maxDuration = 10;
 
 const importConversationSchema = z.object({
   conversationId: z.string().uuid(),
-  expectedRevision: z.literal(0),
+  // Revision 0 for a truly empty conversation; higher when the only server
+  // content is a proactive greeting the import is allowed to replace.
+  expectedRevision: z.number().int().nonnegative(),
   operationId: z
     .string()
     .min(1)

--- a/api/ai/conversations/_helpers/store.ts
+++ b/api/ai/conversations/_helpers/store.ts
@@ -8,6 +8,8 @@ import {
   type AIConversationPart,
   type AIConversationPage,
   AI_CONVERSATION_OPERATION_ID_MAX_LENGTH,
+  AI_PROACTIVE_GREETING_STALE_AFTER_MS,
+  isAIProactiveGreetingMessageId,
 } from "../../../../src/shared/contracts/aiConversation.js";
 import {
   getAIAttachmentUrl,
@@ -140,6 +142,14 @@ interface WriteAIConversationMessagesInput {
   expectedRevision?: number;
   requireEmpty?: boolean;
   requireAssistantContinuation?: boolean;
+  /** Reject the write while another conversation turn is still pending. */
+  requireNoPendingTurn?: boolean;
+  /**
+   * Keep `legacyImportAllowed` untouched. Used for proactive greetings so a
+   * server-generated greeting on an otherwise-empty conversation does not
+   * permanently block a legacy device from importing its local history.
+   */
+  preserveLegacyImport?: boolean;
   historyTruncated?: boolean;
   turn?: {
     id: string;
@@ -172,6 +182,11 @@ export interface CompleteAIConversationTurnInput extends ConversationWriteContex
 export interface ImportAIConversationMessagesInput extends ConversationWriteContext {
   messages: readonly unknown[];
   historyTruncated?: boolean;
+}
+
+export interface AppendAIConversationAssistantMessageInput
+  extends ConversationWriteContext {
+  message: unknown;
 }
 
 export interface ResetAIConversationInput {
@@ -1003,7 +1018,21 @@ async function writeAIConversationMessages(
                 "Conversation revision changed",
               );
             }
-            if (input.requireEmpty && document.messages.length > 0) {
+            // A legacy import may replace a conversation whose only content is
+            // server-generated proactive greetings: the greeting is disposable
+            // while the device-local history it would otherwise block is not.
+            const existingAreOnlyProactiveGreetings =
+              document.messages.length > 0 &&
+              document.messages.every(
+                (message) =>
+                  message.role === "assistant" &&
+                  isAIProactiveGreetingMessageId(message.id),
+              );
+            if (
+              input.requireEmpty &&
+              document.messages.length > 0 &&
+              !existingAreOnlyProactiveGreetings
+            ) {
               throw new AIConversationError(
                 "conversation_not_empty",
                 409,
@@ -1021,11 +1050,28 @@ async function writeAIConversationMessages(
               assertValidAssistantContinuation(document, input.messages[0]);
             }
 
+            const pendingIsStale =
+              document.pendingTurnStartedAt !== null &&
+              Date.now() - document.pendingTurnStartedAt > PENDING_TURN_TTL_MS;
+            if (
+              input.requireNoPendingTurn &&
+              document.pendingTurnId &&
+              !pendingIsStale
+            ) {
+              throw new AIConversationError(
+                "conversation_busy",
+                409,
+                "Another conversation turn is still running",
+              );
+            }
+
+            let droppedProactiveGreetings = false;
+            if (input.requireEmpty && existingAreOnlyProactiveGreetings) {
+              document.messages = [];
+              droppedProactiveGreetings = true;
+            }
+
             if (input.turn) {
-              const pendingIsStale =
-                document.pendingTurnStartedAt !== null &&
-                Date.now() - document.pendingTurnStartedAt >
-                  PENDING_TURN_TTL_MS;
               if (input.turn.action === "begin") {
                 if (
                   document.pendingTurnId &&
@@ -1063,8 +1109,14 @@ async function writeAIConversationMessages(
               document.pendingTurnStartedAt = null;
             }
             appendOperation(document, input.operationId);
-            document.legacyImportAllowed = false;
-            if (messagesChanged || truncationChanged) {
+            if (!input.preserveLegacyImport) {
+              document.legacyImportAllowed = false;
+            }
+            if (
+              messagesChanged ||
+              truncationChanged ||
+              droppedProactiveGreetings
+            ) {
               document.revision += 1;
               document.updatedAt = new Date().toISOString();
             }
@@ -1164,6 +1216,34 @@ export async function importAIConversationMessages(
       requireEmpty: true,
     })
   ).document;
+}
+
+/**
+ * Append a standalone assistant message (e.g. a proactive greeting) outside a
+ * regular user turn. The write is optimistic: it fails cleanly when a turn is
+ * pending or when the conversation moved past the caller's snapshot, and it
+ * keeps `legacyImportAllowed` intact so a greeting never blocks a legacy
+ * device from importing its local history later.
+ */
+export async function appendAIConversationAssistantMessage(
+  input: AppendAIConversationAssistantMessageInput,
+): Promise<{ document: StoredConversation; operationApplied: boolean }> {
+  assertMessageRole(input.message, "assistant");
+  return writeAIConversationMessages({
+    redis: input.redis,
+    username: input.username,
+    channel: input.channel,
+    operationId: input.operationId,
+    messages: [input.message],
+    requireNoPendingTurn: true,
+    preserveLegacyImport: true,
+    ...(input.expectedConversationId
+      ? { expectedConversationId: input.expectedConversationId }
+      : {}),
+    ...(input.expectedRevision === undefined
+      ? {}
+      : { expectedRevision: input.expectedRevision }),
+  });
 }
 
 export async function releaseAIConversationTurn({
@@ -1543,6 +1623,53 @@ export function getAIConversationSummary(
   document: StoredConversation,
 ): AIConversation {
   return summarizeConversation(document);
+}
+
+export type AIProactiveGreetingEligibility =
+  | { eligible: true; mode: "fresh" | "stale" }
+  | {
+      eligible: false;
+      reason: "turn_in_progress" | "already_greeted" | "conversation_active";
+    };
+
+export interface AIProactiveGreetingConversationState {
+  messages: ReadonlyArray<Pick<AIConversationMessage, "id" | "createdAt">>;
+  pendingTurnId: string | null;
+  pendingTurnStartedAt: number | null;
+}
+
+/**
+ * Server-side decision for proactive greetings, evaluated against the
+ * canonical conversation: greet when the thread is brand new ("fresh") or has
+ * been idle for a while ("stale"), and never greet twice in a row, mid-turn,
+ * or while the user is actively chatting.
+ */
+export function getAIProactiveGreetingEligibility(
+  document: AIProactiveGreetingConversationState,
+  now = Date.now(),
+): AIProactiveGreetingEligibility {
+  const pendingIsStale =
+    document.pendingTurnStartedAt !== null &&
+    now - document.pendingTurnStartedAt > PENDING_TURN_TTL_MS;
+  if (document.pendingTurnId && !pendingIsStale) {
+    return { eligible: false, reason: "turn_in_progress" };
+  }
+  if (document.messages.length === 0) {
+    return { eligible: true, mode: "fresh" };
+  }
+
+  const last = document.messages[document.messages.length - 1];
+  if (isAIProactiveGreetingMessageId(last.id)) {
+    return { eligible: false, reason: "already_greeted" };
+  }
+  const lastTimestamp = new Date(last.createdAt).getTime();
+  if (
+    !Number.isFinite(lastTimestamp) ||
+    now - lastTimestamp < AI_PROACTIVE_GREETING_STALE_AFTER_MS
+  ) {
+    return { eligible: false, reason: "conversation_active" };
+  }
+  return { eligible: true, mode: "stale" };
 }
 
 export function getAIConversationModelMessages(

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -277,7 +277,10 @@ export default apiHandler<{
     let clientConversationMessages: UIMessage[] = [];
     let clientActionMessage: UIMessage | undefined;
     try {
-      if (isAuthenticated && !isProactiveGreeting) {
+      if (isAuthenticated && isProactiveGreeting) {
+        // Proactive greetings ignore client messages entirely: the server
+        // decides against the canonical conversation.
+      } else if (isAuthenticated) {
         if (normalizedTrigger !== "regenerate-message") {
           const actionCandidate = message ?? rawMessages?.at(-1);
           if (!actionCandidate) {

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -39,16 +39,21 @@ import { buildUserLocalTimeContext } from "./_utils/user-time-context.js";
 import { isAssistantGreetingRequest } from "../src/shared/assistantGreeting.js";
 import {
   AI_CONVERSATION_OPERATION_ID_MAX_LENGTH,
+  AI_PROACTIVE_GREETING_MESSAGE_ID_PREFIX,
   type AIConversationRequestContext,
 } from "../src/shared/contracts/aiConversation.js";
 import {
   AIConversationError,
+  appendAIConversationAssistantMessage,
   beginAIConversationTurnWithStatus,
   commitAIConversationRegeneration,
   completeAIConversationTurn,
   getAIConversationModelMessages,
   getAIConversationRegenerationModelMessages,
+  getAIConversationSummary,
   getAIConversationTurnCompletionOperationId,
+  getAIProactiveGreetingEligibility,
+  getOrCreateAIConversation,
   prepareAIConversationRegeneration,
   releaseAIConversationTurn,
   type BeginAIConversationTurnInput,
@@ -560,11 +565,43 @@ export default apiHandler<{
     });
 
     // -------------------------------------------------------------
-    // Proactive greeting mode – streamed text response
-    // Only for authenticated users with memories available
+    // Proactive greeting mode – JSON response
+    // Only for authenticated users with memories available. The greeting is
+    // server-owned: eligibility is decided against the canonical conversation
+    // and the generated greeting is persisted as a real conversation message,
+    // so it survives client hydration and syncs across devices.
     // -------------------------------------------------------------
     if (isProactiveGreeting && username && isAuthenticated) {
       log("Proactive greeting requested");
+      res.setHeader("Access-Control-Allow-Origin", validOrigin);
+      const respondGreetingSkipped = (reason: string) => {
+        log(`Proactive greeting skipped: ${reason}`);
+        res.status(200).json({ greeting: null, reason });
+      };
+
+      let greetingConversation: Awaited<
+        ReturnType<typeof getOrCreateAIConversation>
+      >;
+      try {
+        greetingConversation = await getOrCreateAIConversation({
+          redis,
+          username,
+          channel: "chat",
+        });
+      } catch (error) {
+        if (error instanceof AIConversationError) {
+          respondGreetingSkipped(error.code);
+          return;
+        }
+        throw error;
+      }
+      const greetingEligibility = getAIProactiveGreetingEligibility(
+        greetingConversation
+      );
+      if (!greetingEligibility.eligible) {
+        respondGreetingSkipped(greetingEligibility.reason);
+        return;
+      }
 
       // Background: process past daily notes into long-term memory (fire-and-forget)
       // Only triggered on proactive greetings (once per session) to avoid
@@ -604,8 +641,7 @@ export default apiHandler<{
 
       // If no memories, return null (client will keep the generic greeting)
       if (!greetingMemoryContext) {
-        log("No memories available for proactive greeting");
-        res.status(200).json({ greeting: null, reason: "no memories available" });
+        respondGreetingSkipped("no memories available");
         return;
       }
 
@@ -645,10 +681,54 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
         });
 
         const greeting = text.trim();
+        if (!greeting) {
+          respondGreetingSkipped("generation failed");
+          return;
+        }
         log(`Generated proactive greeting (${greeting.length} chars, finishReason=${finishReason}): "${greeting}"`);
 
-        res.setHeader("Access-Control-Allow-Origin", validOrigin);
-        res.status(200).json({ greeting });
+        // Persist the greeting to the canonical conversation. The optimistic
+        // guards (snapshot revision + no pending turn) make sure a user
+        // message that raced the generation wins and the greeting is dropped.
+        const greetingMessage = {
+          id: `${AI_PROACTIVE_GREETING_MESSAGE_ID_PREFIX}${crypto.randomUUID()}`,
+          role: "assistant" as const,
+          parts: [{ type: "text" as const, text: greeting }],
+          metadata: { createdAt: new Date().toISOString() },
+        };
+        let appended: Awaited<
+          ReturnType<typeof appendAIConversationAssistantMessage>
+        >;
+        try {
+          appended = await appendAIConversationAssistantMessage({
+            redis,
+            username,
+            channel: "chat",
+            operationId: crypto.randomUUID(),
+            message: greetingMessage,
+            expectedConversationId: greetingConversation.id,
+            expectedRevision: greetingConversation.revision,
+          });
+        } catch (persistError) {
+          if (persistError instanceof AIConversationError) {
+            respondGreetingSkipped(persistError.code);
+            return;
+          }
+          throw persistError;
+        }
+        const storedGreeting = appended.document.messages.find(
+          (message) => message.id === greetingMessage.id
+        );
+        if (!storedGreeting) {
+          respondGreetingSkipped("persist_failed");
+          return;
+        }
+
+        res.status(200).json({
+          greeting,
+          message: storedGreeting,
+          conversation: getAIConversationSummary(appended.document),
+        });
         return;
       } catch (greetingErr) {
         logError("Failed to generate proactive greeting", greetingErr);

--- a/docs/8.1-chat-api.md
+++ b/docs/8.1-chat-api.md
@@ -189,10 +189,26 @@ interface TrackInfo {
 
 The endpoint returns a **Server-Sent Events (SSE)** stream using the Vercel AI SDK's UI message stream format.
 
-If `proactiveGreeting` is `true`, the endpoint returns JSON instead of SSE:
+If `proactiveGreeting` is `true` (authenticated only), the endpoint returns JSON instead of SSE. The greeting is **server-owned**: eligibility is decided against the canonical conversation (empty thread, or last message idle for 5+ minutes and not already a greeting, and no turn in flight), and the generated greeting is persisted as a real conversation message (`proactive-<uuid>` id) so it survives hydration and syncs across devices.
 
 ```json
-{ "greeting": "..." }
+{
+  "greeting": "hey, how's the cursor roadmap coming along?",
+  "message": {
+    "id": "proactive-6f0f…",
+    "seq": 12,
+    "role": "assistant",
+    "parts": [{ "type": "text", "text": "hey, how's the cursor roadmap coming along?" }],
+    "createdAt": "2026-07-07T05:00:00.000Z"
+  },
+  "conversation": { "id": "…", "revision": 4, "…": "…" }
+}
+```
+
+When the greeting is skipped (not eligible, no memories, generation failure, or a conflicting write won the race), the response is:
+
+```json
+{ "greeting": null, "reason": "conversation_active" }
 ```
 
 ### Stream Format

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test:song": "bun test tests/test-song.test.ts",
     "test:sync-v2:unit": "bun test tests/test-sync-v2-core.test.ts tests/test-songs-tombstone-sync.test.ts tests/test-sync-maintenance.test.ts tests/test-sync-v2-codecs.test.ts tests/test-sync-v2-state-storage.test.ts tests/test-cloud-sync-deletion-marker-pruning.test.ts",
     "test:sync-v2": "bun run test:sync-v2:unit && bun test tests/test-sync-v2-api.test.ts",
-    "test:ai": "bun test tests/test-ai.test.ts",
+    "test:ai": "bun test tests/test-ai.test.ts tests/test-proactive-greeting-api.test.ts",
     "test:media": "bun test tests/test-media.test.ts",
     "test:auth-extra": "bun test tests/test-auth-extra.test.ts",
     "test:auth-ban-lockout": "bun test tests/test-auth-ban-lockout.test.ts",

--- a/scripts/test-groups.ts
+++ b/scripts/test-groups.ts
@@ -16,6 +16,7 @@ export const API_TEST_FILES = [
   "tests/test-media.test.ts",
   "tests/test-new-api.test.ts",
   "tests/test-parse-title.test.ts",
+  "tests/test-proactive-greeting-api.test.ts",
   "tests/test-pusher-auth.test.ts",
   "tests/test-rooms-extra.test.ts",
   "tests/test-share-applet.test.ts",

--- a/src/api/aiConversations.ts
+++ b/src/api/aiConversations.ts
@@ -3,6 +3,7 @@ import { abortableFetch } from "@/utils/abortableFetch";
 import { getApiUrl } from "@/utils/platform";
 import {
   isAIConversationChannel,
+  isAIProactiveGreetingMessageId,
   type AIConversation,
   type AIConversationChannel,
   type AIConversationMessage,
@@ -43,7 +44,7 @@ type ProjectedAIConversationMessage = {
 
 export interface AIConversationImportRequestBody {
   conversationId: string;
-  expectedRevision: 0;
+  expectedRevision: number;
   operationId: string;
   messages: ProjectedAIConversationMessage[];
   historyTruncated: boolean;
@@ -492,11 +493,13 @@ function groupLegacyImportTurns(
 
 export function buildAIConversationImportRequest({
   conversationId,
+  expectedRevision = 0,
   operationId,
   messages,
   requestByteLimit = AI_CONVERSATION_IMPORT_REQUEST_MAX_BYTES,
 }: {
   conversationId: string;
+  expectedRevision?: number;
   operationId: string;
   messages: readonly AIChatMessage[];
   requestByteLimit?: number;
@@ -530,7 +533,7 @@ export function buildAIConversationImportRequest({
       turn.payloadTruncated;
     const candidate: AIConversationImportRequestBody = {
       conversationId,
-      expectedRevision: 0,
+      expectedRevision,
       operationId,
       messages: candidateMessages,
       historyTruncated: candidatePayloadTruncated,
@@ -554,7 +557,7 @@ export function buildAIConversationImportRequest({
     selected.length !== projected.length;
   const request: AIConversationImportRequestBody = {
     conversationId,
-    expectedRevision: 0,
+    expectedRevision,
     operationId,
     messages: selected,
     historyTruncated,
@@ -691,6 +694,7 @@ async function importLocalConversation(
 ): Promise<void> {
   const request = buildAIConversationImportRequest({
     conversationId: conversation.id,
+    expectedRevision: conversation.revision,
     operationId: crypto.randomUUID(),
     messages: await externalizeLocalImages(messages),
   });
@@ -750,11 +754,17 @@ export async function loadAIConversation(
         ? { ...current, stale: true }
         : { ...loaded, stale: true };
     }
+    // Legacy import is allowed while the server has no real content: an empty
+    // conversation, or one whose only messages are server-generated proactive
+    // greetings (the server drops those in favor of the imported history).
     if (
       input.importLocalIfEmpty !== false &&
       loaded.conversation.canImportLegacy &&
-      loaded.conversation.revision === 0 &&
-      loaded.messages.length === 0
+      loaded.messages.every(
+        (message) =>
+          message.role === "assistant" &&
+          isAIProactiveGreetingMessageId(message.id)
+      )
     ) {
       await importLocalConversation(
         input.channel,

--- a/src/apps/chats/hooks/useProactiveGreeting.ts
+++ b/src/apps/chats/hooks/useProactiveGreeting.ts
@@ -1,15 +1,17 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useChatsStore } from "@/stores/useChatsStore";
-import type { AIChatMessage } from "@/types/chat";
 import { getApiUrl } from "@/utils/platform";
 import { abortableFetch } from "@/utils/abortableFetch";
-import { applyFreshProactiveGreeting } from "../utils/proactiveGreetingApply";
-
-/**
- * Minimum idle time (ms) since the last chat message before a proactive
- * greeting is triggered when re-opening / loading the chats app from state.
- */
-const STALE_CHAT_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+import {
+  invalidateAIConversationSession,
+  loadAIConversation,
+} from "@/api/aiConversations";
+import {
+  applyServerProactiveGreeting,
+  isConversationGreetable,
+  parseServerProactiveGreeting,
+} from "../utils/proactiveGreetingApply";
+import type { AIChatMessage } from "@/types/chat";
 
 export interface UseProactiveGreetingOptions {
   /** Latest AI SDK messages (may be ahead of the persisted store mid-stream). */
@@ -19,37 +21,15 @@ export interface UseProactiveGreetingOptions {
 }
 
 /**
- * Get the timestamp (epoch ms) of the most recent message in the AI chat.
- * Falls back to 0 if no valid timestamp is found.
- */
-function getLastMessageTimestamp(messages: AIChatMessage[]): number {
-  if (messages.length === 0) return 0;
-
-  const last = messages[messages.length - 1];
-  const createdAt = last.metadata?.createdAt;
-  if (!createdAt) return 0;
-
-  if (createdAt instanceof Date) return createdAt.getTime();
-  if (typeof createdAt === "number") return createdAt;
-  if (typeof createdAt === "string") {
-    const ts = new Date(createdAt).getTime();
-    return Number.isFinite(ts) ? ts : 0;
-  }
-  return 0;
-}
-
-/**
  * Hook that manages proactive AI greetings for logged-in users with memories.
  *
- * Triggers in two scenarios:
- * 1. **Fresh chat** – only the default greeting message is present.
- *    The proactive greeting *replaces* the generic greeting.
- * 2. **Stale chat** – the app is opened / loaded from persisted state and
- *    the last message is older than 5 minutes. The proactive greeting is
- *    *appended* to the existing conversation.
- *
- * The greeting is fetched as a complete JSON response from the server and
- * displayed in the chat as a single batch update.
+ * The Ryo conversation is server-owned, so the greeting is too: the client
+ * only decides *when to ask* (fresh chat, or a thread idle for 5+ minutes on
+ * app open); the server re-validates against the canonical conversation,
+ * generates the greeting, and **persists it as a real conversation message**.
+ * The returned message is patched into the live chat immediately and survives
+ * server hydration / cross-device sync because it is part of the canonical
+ * history.
  */
 export function useProactiveGreeting({
   getLiveMessages,
@@ -64,8 +44,7 @@ export function useProactiveGreeting({
     const eligible = !!state.username && !!state.isAuthenticated;
     return fresh && eligible;
   });
-  const hasTriggeredFreshRef = useRef(false);
-  const hasTriggeredStaleRef = useRef(false);
+  const hasAttemptedRef = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
   const fetchInFlightRef = useRef(false);
   const liveMessageAccessorsRef = useRef({
@@ -79,135 +58,112 @@ export function useProactiveGreeting({
   const aiMessages = useChatsStore((s) => s.aiMessages);
   const setAiMessages = useChatsStore((s) => s.setAiMessages);
 
-  const isFreshChat =
-    aiMessages.length === 1 &&
-    aiMessages[0].id === "1" &&
-    aiMessages[0].role === "assistant";
-
   const isEligible = !!username && !!isAuthenticated;
-
-  const isStaleChat = (() => {
-    if (isFreshChat) return false;
-    if (aiMessages.length < 2) return false;
-    const lastMsg = aiMessages[aiMessages.length - 1];
-    if (lastMsg.id?.startsWith("proactive-")) return false;
-
-    const lastTs = getLastMessageTimestamp(aiMessages);
-    if (lastTs === 0) return false;
-
-    return Date.now() - lastTs > STALE_CHAT_THRESHOLD_MS;
-  })();
+  const isGreetable = isConversationGreetable(aiMessages);
 
   /**
-   * Fetch a proactive greeting from the server and display it immediately.
+   * Ask the server for a proactive greeting and merge the persisted message
+   * into the live conversation.
    */
-  const fetchGreeting = useCallback(
-    async (mode: "fresh" | "stale" = "fresh") => {
-      if (!username || !isAuthenticated) return;
+  const fetchGreeting = useCallback(async () => {
+    if (!username || !isAuthenticated) return;
 
-      // Prevent duplicate concurrent requests
-      if (fetchInFlightRef.current) return;
-      fetchInFlightRef.current = true;
+    // Prevent duplicate concurrent requests
+    if (fetchInFlightRef.current) return;
+    fetchInFlightRef.current = true;
 
-      // Abort any previous in-flight request
-      abortRef.current?.abort();
-      const controller = new AbortController();
-      abortRef.current = controller;
+    // Abort any previous in-flight request
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
 
-      setIsLoadingGreeting(true);
+    setIsLoadingGreeting(true);
 
-      try {
-        const response = await abortableFetch(getApiUrl("/api/chat"), {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            messages: [],
-            proactiveGreeting: true,
-          }),
-          timeout: 20000,
-          signal: controller.signal,
-        });
+    const owner = username.toLowerCase();
+    try {
+      // Wait for the canonical conversation first. This shares the pending
+      // hydration (and one-time legacy import) from useAiChat, so greeting
+      // decisions never race the initial server sync.
+      const session = await loadAIConversation({
+        channel: "chat",
+        username: owner,
+        localMessages: useChatsStore.getState().aiMessages,
+      });
+      if (controller.signal.aborted || session.stale) return;
+      if (!isConversationGreetable(session.messages)) return;
 
-        if (controller.signal.aborted) return;
+      const response = await abortableFetch(getApiUrl("/api/chat"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [],
+          proactiveGreeting: true,
+        }),
+        timeout: 20000,
+        signal: controller.signal,
+      });
 
-        const data = await response.json();
+      if (controller.signal.aborted) return;
 
-        if (data.greeting && typeof data.greeting === "string") {
-          const proactiveMessage: AIChatMessage = {
-            id:
-              mode === "fresh"
-                ? "proactive-1"
-                : `proactive-${Date.now()}`,
-            role: "assistant",
-            parts: [{ type: "text", text: data.greeting }],
-            metadata: { createdAt: new Date() },
-          };
+      const greetingMessage = parseServerProactiveGreeting(
+        await response.json()
+      );
+      if (!greetingMessage) return;
 
-          const storeMessages = useChatsStore.getState().aiMessages;
-          const { getLiveMessages: getLive, patchLiveMessages: patchLive } =
-            liveMessageAccessorsRef.current;
-          const liveMessages = getLive?.() ?? storeMessages;
-
-          if (mode === "fresh") {
-            const updatedMessages = applyFreshProactiveGreeting(
-              liveMessages,
-              proactiveMessage
-            );
-            if (updatedMessages) {
-              patchLive?.(updatedMessages);
-              setAiMessages(updatedMessages);
-            }
-          } else {
-            const lastMsg = storeMessages[storeMessages.length - 1];
-            const lastTs = getLastMessageTimestamp(storeMessages);
-            const stillStale =
-              lastTs > 0 &&
-              Date.now() - lastTs > STALE_CHAT_THRESHOLD_MS;
-
-            if (stillStale && !lastMsg.id?.startsWith("proactive-")) {
-              const updatedMessages = [...liveMessages, proactiveMessage];
-              patchLive?.(updatedMessages);
-              setAiMessages(updatedMessages);
-            }
-          }
-        }
-      } catch (err) {
-        if (!(err instanceof DOMException && err.name === "AbortError")) {
-          console.warn("[ProactiveGreeting] Failed to fetch greeting:", err);
-        }
-      } finally {
-        if (!controller.signal.aborted) {
-          setIsLoadingGreeting(false);
-        }
-        fetchInFlightRef.current = false;
+      const current = useChatsStore.getState();
+      if (
+        current.username?.toLowerCase() !== owner ||
+        !current.isAuthenticated
+      ) {
+        return;
       }
-    },
-    [username, isAuthenticated, setAiMessages]
-  );
 
-  // Trigger proactive greeting for fresh chats
+      // The greeting is now part of the canonical conversation. Drop the
+      // cached session so in-flight hydrations can't clobber the greeting and
+      // the next request context picks up the new revision.
+      invalidateAIConversationSession("chat", owner);
+
+      const { getLiveMessages: getLive, patchLiveMessages: patchLive } =
+        liveMessageAccessorsRef.current;
+      const liveMessages = getLive?.() ?? current.aiMessages;
+      const updatedMessages = applyServerProactiveGreeting(
+        liveMessages,
+        greetingMessage
+      );
+      if (updatedMessages) {
+        patchLive?.(updatedMessages);
+        setAiMessages(updatedMessages);
+      }
+    } catch (err) {
+      if (!(err instanceof DOMException && err.name === "AbortError")) {
+        console.warn("[ProactiveGreeting] Failed to fetch greeting:", err);
+      }
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsLoadingGreeting(false);
+      }
+      fetchInFlightRef.current = false;
+    }
+  }, [username, isAuthenticated, setAiMessages]);
+
+  // A new identity gets a fresh greeting attempt (e.g. logout → login).
   useEffect(() => {
-    if (isFreshChat && isEligible && !hasTriggeredFreshRef.current) {
-      hasTriggeredFreshRef.current = true;
-      fetchGreeting("fresh");
-    }
+    hasAttemptedRef.current = false;
+  }, [username, isAuthenticated]);
 
-    if (!isFreshChat) {
-      hasTriggeredFreshRef.current = false;
-    }
-  }, [isFreshChat, isEligible, fetchGreeting]);
-
-  // Trigger proactive greeting for stale chats on mount / app open
+  // Trigger a greeting attempt when the chat is fresh (default greeting only)
+  // or stale (idle 5+ minutes) on mount / app open. The server is the final
+  // authority, so this only gates when a request is worth making.
   useEffect(() => {
-    if (isStaleChat && isEligible && !hasTriggeredStaleRef.current) {
-      hasTriggeredStaleRef.current = true;
-      fetchGreeting("stale");
+    if (isGreetable && isEligible && !hasAttemptedRef.current) {
+      hasAttemptedRef.current = true;
+      void fetchGreeting();
     }
 
-    if (!isStaleChat) {
-      hasTriggeredStaleRef.current = false;
+    if (!isGreetable) {
+      hasAttemptedRef.current = false;
     }
-  }, [isStaleChat, isEligible, fetchGreeting]);
+  }, [isGreetable, isEligible, fetchGreeting]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -221,19 +177,17 @@ export function useProactiveGreeting({
    * Used after clearChats to re-trigger the greeting.
    */
   const triggerGreeting = useCallback(() => {
-    hasTriggeredStaleRef.current = false;
     setTimeout(() => {
       const state = useChatsStore.getState();
-      const stillFresh =
-        state.aiMessages.length === 1 &&
-        (state.aiMessages[0].id === "1" ||
-          state.aiMessages[0].id === "proactive-1") &&
-        state.aiMessages[0].role === "assistant";
       const stillEligible = !!state.username && !!state.isAuthenticated;
 
-      if (stillFresh && stillEligible && !fetchInFlightRef.current) {
-        hasTriggeredFreshRef.current = true;
-        fetchGreeting("fresh");
+      if (
+        stillEligible &&
+        isConversationGreetable(state.aiMessages) &&
+        !fetchInFlightRef.current
+      ) {
+        hasAttemptedRef.current = true;
+        void fetchGreeting();
       }
     }, 300);
   }, [fetchGreeting]);

--- a/src/apps/chats/utils/proactiveGreetingApply.ts
+++ b/src/apps/chats/utils/proactiveGreetingApply.ts
@@ -1,4 +1,8 @@
 import type { AIChatMessage } from "@/types/chat";
+import {
+  AI_PROACTIVE_GREETING_STALE_AFTER_MS,
+  isAIProactiveGreetingMessageId,
+} from "@/shared/contracts/aiConversation";
 
 export const isDefaultGreetingMessage = (message: AIChatMessage): boolean =>
   message.id === "1" && message.role === "assistant";
@@ -40,7 +44,127 @@ export function applyFreshProactiveGreeting(
 }
 
 const isProactiveGreetingMessage = (message: AIChatMessage): boolean =>
-  message.id === "proactive-1" || !!message.id?.startsWith("proactive-");
+  isAIProactiveGreetingMessageId(message.id);
+
+/**
+ * Get the timestamp (epoch ms) of a message's createdAt metadata.
+ * Falls back to 0 if no valid timestamp is found.
+ */
+export function getMessageCreatedAtTime(message: AIChatMessage): number {
+  const createdAt = message.metadata?.createdAt;
+  if (!createdAt) return 0;
+
+  if (createdAt instanceof Date) return createdAt.getTime();
+  if (typeof createdAt === "number") return createdAt;
+  if (typeof createdAt === "string") {
+    const ts = new Date(createdAt).getTime();
+    return Number.isFinite(ts) ? ts : 0;
+  }
+  return 0;
+}
+
+/**
+ * Client-side pre-check mirroring the server's proactive-greeting
+ * eligibility: greet a brand-new thread (only the local default greeting) or
+ * a thread whose last message has gone stale. The server re-validates against
+ * the canonical conversation, so this only avoids pointless requests.
+ */
+export function isConversationGreetable(
+  messages: AIChatMessage[],
+  now = Date.now()
+): boolean {
+  if (messages.length === 0) return true;
+  if (isClearedToDefaultGreeting(messages)) return true;
+
+  const last = messages[messages.length - 1];
+  if (isProactiveGreetingMessage(last)) return false;
+
+  const lastTimestamp = getMessageCreatedAtTime(last);
+  return (
+    lastTimestamp > 0 &&
+    now - lastTimestamp > AI_PROACTIVE_GREETING_STALE_AFTER_MS
+  );
+}
+
+/**
+ * Parse the `/api/chat` proactive-greeting JSON response into the persisted
+ * greeting message, or null when the server skipped the greeting.
+ */
+export function parseServerProactiveGreeting(
+  value: unknown
+): AIChatMessage | null {
+  if (typeof value !== "object" || value === null) return null;
+  const greeting = Reflect.get(value, "greeting");
+  const message = Reflect.get(value, "message");
+  if (typeof greeting !== "string" || !greeting.trim()) return null;
+  if (typeof message !== "object" || message === null) return null;
+
+  const id = Reflect.get(message, "id");
+  const role = Reflect.get(message, "role");
+  const rawParts = Reflect.get(message, "parts");
+  const rawCreatedAt = Reflect.get(message, "createdAt");
+  if (
+    !isAIProactiveGreetingMessageId(id) ||
+    typeof id !== "string" ||
+    role !== "assistant" ||
+    !Array.isArray(rawParts)
+  ) {
+    return null;
+  }
+
+  const parts = rawParts.filter(
+    (part): part is AIChatMessage["parts"][number] =>
+      typeof part === "object" &&
+      part !== null &&
+      typeof Reflect.get(part, "type") === "string"
+  );
+  if (parts.length === 0) return null;
+
+  const createdAt =
+    typeof rawCreatedAt === "string" ? new Date(rawCreatedAt) : new Date();
+  return {
+    id,
+    role: "assistant",
+    parts,
+    metadata: {
+      createdAt: Number.isFinite(createdAt.getTime()) ? createdAt : new Date(),
+    },
+  };
+}
+
+/**
+ * Merge a server-persisted proactive greeting into the live message list:
+ * replace the default greeting when present (fresh chat), otherwise append to
+ * the stale thread. Returns null when nothing should change — e.g. the
+ * greeting already landed via hydration, or local activity (a newer message /
+ * an unsent user turn) raced the greeting and hydration should reconcile.
+ */
+export function applyServerProactiveGreeting(
+  currentMessages: AIChatMessage[],
+  greetingMessage: AIChatMessage
+): AIChatMessage[] | null {
+  if (currentMessages.some((message) => message.id === greetingMessage.id)) {
+    return null;
+  }
+  if (shouldApplyFreshProactiveGreeting(currentMessages)) {
+    return applyFreshProactiveGreeting(currentMessages, greetingMessage);
+  }
+
+  const last = currentMessages[currentMessages.length - 1];
+  if (!last) return [greetingMessage];
+  if (last.role === "user") return null;
+
+  const lastTimestamp = getMessageCreatedAtTime(last);
+  const greetingTimestamp = getMessageCreatedAtTime(greetingMessage);
+  if (
+    lastTimestamp > 0 &&
+    greetingTimestamp > 0 &&
+    lastTimestamp > greetingTimestamp
+  ) {
+    return null;
+  }
+  return [...currentMessages, greetingMessage];
+}
 
 export type AiMessageSyncDecision =
   | { action: "patch-greeting"; messages: AIChatMessage[] }

--- a/src/shared/contracts/aiConversation.ts
+++ b/src/shared/contracts/aiConversation.ts
@@ -3,6 +3,26 @@ import type { UIMessage } from "ai";
 export const AI_CONVERSATION_CHANNELS = ["chat", "assistant"] as const;
 export const AI_CONVERSATION_OPERATION_ID_MAX_LENGTH = 128;
 
+/**
+ * Server-persisted proactive greeting messages are identified by this id
+ * prefix. The prefix predates server-owned history (older clients minted
+ * local-only `proactive-*` ids), so both sides share one definition.
+ */
+export const AI_PROACTIVE_GREETING_MESSAGE_ID_PREFIX = "proactive-";
+
+/**
+ * Minimum idle time since the last conversation message before a proactive
+ * greeting may be appended to an existing thread.
+ */
+export const AI_PROACTIVE_GREETING_STALE_AFTER_MS = 5 * 60 * 1000;
+
+export function isAIProactiveGreetingMessageId(id: unknown): boolean {
+  return (
+    typeof id === "string" &&
+    id.startsWith(AI_PROACTIVE_GREETING_MESSAGE_ID_PREFIX)
+  );
+}
+
 export type AIConversationChannel =
   (typeof AI_CONVERSATION_CHANNELS)[number];
 

--- a/tests/test-ai-conversation-store.test.ts
+++ b/tests/test-ai-conversation-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   AIConversationError,
+  appendAIConversationAssistantMessage,
   beginAIConversationTurn,
   beginAIConversationTurnWithStatus,
   commitAIConversationRegeneration,
@@ -8,6 +9,7 @@ import {
   completeAIConversationTurn,
   deleteAIConversationKeys,
   getAIConversationPage,
+  getAIProactiveGreetingEligibility,
   getPendingAIConversationResetMemory,
   getAIConversationTurnCompletionOperationId,
   importAIConversationMessages,
@@ -1147,5 +1149,173 @@ describe("AI conversation store", () => {
       },
     });
     expect(recreated.messages.map((entry) => entry.id)).toEqual(["u2"]);
+  });
+
+  test("persists proactive greetings outside a turn and keeps legacy import open", async () => {
+    const redis = new MemoryConversationRedis();
+    const initial = await getAIConversationPage({
+      redis,
+      username: "alice",
+      channel: "chat",
+      limit: 10,
+    });
+    expect(
+      getAIProactiveGreetingEligibility({
+        messages: [],
+        pendingTurnId: null,
+        pendingTurnStartedAt: null,
+      }),
+    ).toEqual({ eligible: true, mode: "fresh" });
+
+    const appended = await appendAIConversationAssistantMessage({
+      redis,
+      username: "alice",
+      channel: "chat",
+      operationId: "greet-op-1",
+      expectedConversationId: initial.conversation.id,
+      expectedRevision: 0,
+      message: message("proactive-greeting-1", "assistant", "hey, welcome back"),
+    });
+    expect(appended.operationApplied).toBe(true);
+    expect(appended.document.revision).toBe(1);
+    expect(appended.document.pendingTurnId).toBeNull();
+    expect(
+      appended.document.messages.map((entry) => [entry.id, entry.seq]),
+    ).toEqual([["proactive-greeting-1", 1]]);
+    // The greeting alone must not lock out a legacy device's history import.
+    expect(appended.document.legacyImportAllowed).toBe(true);
+
+    expect(getAIProactiveGreetingEligibility(appended.document)).toEqual({
+      eligible: false,
+      reason: "already_greeted",
+    });
+
+    const imported = await importAIConversationMessages({
+      redis,
+      username: "alice",
+      channel: "chat",
+      operationId: "legacy-import",
+      expectedConversationId: initial.conversation.id,
+      expectedRevision: appended.document.revision,
+      messages: [
+        message("legacy-user", "user", "old question"),
+        message("legacy-assistant", "assistant", "old answer"),
+      ],
+    });
+    expect(imported.messages.map((entry) => entry.id)).toEqual([
+      "legacy-user",
+      "legacy-assistant",
+    ]);
+    expect(imported.legacyImportAllowed).toBe(false);
+    expect(imported.revision).toBe(2);
+  });
+
+  test("drops proactive greetings that lose the race against a turn", async () => {
+    const redis = new MemoryConversationRedis();
+    const initial = await getAIConversationPage({
+      redis,
+      username: "alice",
+      channel: "chat",
+      limit: 10,
+    });
+
+    const started = await beginAIConversationTurn({
+      redis,
+      username: "alice",
+      channel: "chat",
+      expectedConversationId: initial.conversation.id,
+      expectedRevision: 0,
+      operationId: "turn-op",
+      turnId: "turn-1",
+      action: {
+        kind: "user-message",
+        message: message("u1", "user", "hello"),
+      },
+    });
+    expect(getAIProactiveGreetingEligibility(started)).toEqual({
+      eligible: false,
+      reason: "turn_in_progress",
+    });
+
+    // Snapshot taken before the user's turn began → revision conflict.
+    await expect(
+      appendAIConversationAssistantMessage({
+        redis,
+        username: "alice",
+        channel: "chat",
+        operationId: "greet-stale",
+        expectedConversationId: initial.conversation.id,
+        expectedRevision: 0,
+        message: message("proactive-stale", "assistant", "late greeting"),
+      }),
+    ).rejects.toMatchObject({ code: "revision_conflict", status: 409 });
+
+    // Even with a fresh snapshot, a pending turn blocks the append.
+    await expect(
+      appendAIConversationAssistantMessage({
+        redis,
+        username: "alice",
+        channel: "chat",
+        operationId: "greet-mid-turn",
+        expectedConversationId: initial.conversation.id,
+        expectedRevision: started.revision,
+        message: message("proactive-mid-turn", "assistant", "mid-turn greeting"),
+      }),
+    ).rejects.toMatchObject({ code: "conversation_busy", status: 409 });
+  });
+
+  test("decides proactive greeting eligibility for stale and active threads", () => {
+    const now = Date.parse("2026-07-07T12:00:00.000Z");
+    const staleThread = {
+      messages: [
+        { id: "u1", createdAt: "2026-07-07T11:00:00.000Z" },
+        { id: "a1", createdAt: "2026-07-07T11:01:00.000Z" },
+      ],
+      pendingTurnId: null,
+      pendingTurnStartedAt: null,
+    };
+    expect(getAIProactiveGreetingEligibility(staleThread, now)).toEqual({
+      eligible: true,
+      mode: "stale",
+    });
+
+    const activeThread = {
+      ...staleThread,
+      messages: [{ id: "a1", createdAt: "2026-07-07T11:58:00.000Z" }],
+    };
+    expect(getAIProactiveGreetingEligibility(activeThread, now)).toEqual({
+      eligible: false,
+      reason: "conversation_active",
+    });
+
+    const invalidTimestampThread = {
+      ...staleThread,
+      messages: [{ id: "a1", createdAt: "not a date" }],
+    };
+    expect(
+      getAIProactiveGreetingEligibility(invalidTimestampThread, now),
+    ).toEqual({ eligible: false, reason: "conversation_active" });
+
+    const greetedThread = {
+      ...staleThread,
+      messages: [
+        ...staleThread.messages,
+        { id: "proactive-old", createdAt: "2026-07-07T11:02:00.000Z" },
+      ],
+    };
+    expect(getAIProactiveGreetingEligibility(greetedThread, now)).toEqual({
+      eligible: false,
+      reason: "already_greeted",
+    });
+
+    // A stale pending turn no longer blocks greetings.
+    const abandonedTurnThread = {
+      messages: [],
+      pendingTurnId: "abandoned",
+      pendingTurnStartedAt: now - 10 * 60 * 1000,
+    };
+    expect(getAIProactiveGreetingEligibility(abandonedTurnThread, now)).toEqual(
+      { eligible: true, mode: "fresh" },
+    );
   });
 });

--- a/tests/test-proactive-greeting-api.test.ts
+++ b/tests/test-proactive-greeting-api.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import { createRedis } from "../api/_utils/redis";
+import { saveMemoryIndex, MEMORY_SCHEMA_VERSION } from "../api/_utils/_memory";
+import {
+  BASE_URL,
+  ensureUserAuth,
+  fetchWithAuth,
+  makeRateLimitBypassHeaders,
+  uniqueTestUsername,
+} from "./test-utils";
+import type { AIConversationPage } from "../src/shared/contracts/aiConversation";
+
+/**
+ * API integration tests for the server-owned proactive greeting.
+ * Requires the standalone API server (`bun run dev:api`).
+ */
+
+const password = "testtest123";
+
+interface ProactiveGreetingResponse {
+  greeting: string | null;
+  reason?: string;
+  message?: {
+    id: string;
+    seq: number;
+    role: string;
+    parts: Array<{ type: string; text?: string }>;
+    createdAt: string;
+  };
+  conversation?: { id: string; revision: number; canImportLegacy: boolean };
+}
+
+async function requestProactiveGreeting(
+  username: string,
+  token: string
+): Promise<ProactiveGreetingResponse> {
+  const response = await fetchWithAuth(`${BASE_URL}/api/chat`, username, token, {
+    method: "POST",
+    headers: makeRateLimitBypassHeaders(),
+    body: JSON.stringify({ messages: [], proactiveGreeting: true }),
+  });
+  expect(response.status).toBe(200);
+  return (await response.json()) as ProactiveGreetingResponse;
+}
+
+async function fetchConversation(
+  username: string,
+  token: string
+): Promise<AIConversationPage> {
+  const response = await fetchWithAuth(
+    `${BASE_URL}/api/ai/conversations/chat`,
+    username,
+    token
+  );
+  expect(response.status).toBe(200);
+  return (await response.json()) as AIConversationPage;
+}
+
+function apiMessage(
+  id: string,
+  role: "user" | "assistant",
+  text: string,
+  createdAt: string
+) {
+  return {
+    id,
+    role,
+    parts: [{ type: "text", text }],
+    metadata: { createdAt },
+  };
+}
+
+async function seedMemory(username: string): Promise<void> {
+  const redis = createRedis();
+  await saveMemoryIndex(redis, username, {
+    memories: [
+      {
+        key: "hobbies",
+        summary: "loves playing chess and building mechanical keyboards",
+        updatedAt: Date.now(),
+      },
+    ],
+    version: MEMORY_SCHEMA_VERSION,
+  });
+}
+
+async function importConversation(
+  username: string,
+  token: string,
+  messages: ReturnType<typeof apiMessage>[],
+  expectedRevision = 0
+): Promise<Response> {
+  const page = await fetchConversation(username, token);
+  return fetchWithAuth(
+    `${BASE_URL}/api/ai/conversations/chat/import`,
+    username,
+    token,
+    {
+      method: "POST",
+      headers: makeRateLimitBypassHeaders(),
+      body: JSON.stringify({
+        conversationId: page.conversation.id,
+        expectedRevision,
+        operationId: crypto.randomUUID(),
+        messages,
+      }),
+    }
+  );
+}
+
+describe("Proactive greeting API", () => {
+  test("skips the greeting when the user has no memories", async () => {
+    const username = uniqueTestUsername("greetnomem");
+    const token = await ensureUserAuth(username, password);
+    if (!token) throw new Error("Failed to authenticate test user");
+
+    const result = await requestProactiveGreeting(username, token);
+    expect(result.greeting).toBeNull();
+    expect(result.reason).toBe("no memories available");
+  });
+
+  test("skips the greeting while the conversation is active", async () => {
+    const username = uniqueTestUsername("greetactive");
+    const token = await ensureUserAuth(username, password);
+    if (!token) throw new Error("Failed to authenticate test user");
+
+    const now = new Date().toISOString();
+    const imported = await importConversation(username, token, [
+      apiMessage("u-active", "user", "hey ryo", now),
+      apiMessage("a-active", "assistant", "hey!", now),
+    ]);
+    expect(imported.status).toBe(201);
+
+    // Eligibility is checked before memories, so this is deterministic even
+    // though the user has no memories seeded.
+    const result = await requestProactiveGreeting(username, token);
+    expect(result.greeting).toBeNull();
+    expect(result.reason).toBe("conversation_active");
+  });
+
+  test(
+    "greets a fresh conversation, persists the message, and never greets twice",
+    async () => {
+      const username = uniqueTestUsername("greetfresh");
+      const token = await ensureUserAuth(username, password);
+      if (!token) throw new Error("Failed to authenticate test user");
+      await seedMemory(username);
+
+      const result = await requestProactiveGreeting(username, token);
+      expect(result.greeting).toBeTruthy();
+      expect(result.message?.id.startsWith("proactive-")).toBe(true);
+      expect(result.message?.role).toBe("assistant");
+      expect(result.conversation?.revision).toBe(1);
+
+      // The greeting is part of the canonical conversation.
+      const page = await fetchConversation(username, token);
+      expect(page.messages.length).toBe(1);
+      expect(page.messages[0].id).toBe(result.message!.id);
+      expect(page.messages[0].parts).toEqual([
+        { type: "text", text: result.greeting! },
+      ]);
+      // A greeting alone must not block a legacy device from importing.
+      expect(page.conversation.canImportLegacy).toBe(true);
+
+      // Asking again is a no-op: the last message is already a greeting.
+      const second = await requestProactiveGreeting(username, token);
+      expect(second.greeting).toBeNull();
+      expect(second.reason).toBe("already_greeted");
+
+      // A legacy import replaces the greeting-only conversation.
+      const historic = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const imported = await importConversation(
+        username,
+        token,
+        [
+          apiMessage("u-legacy", "user", "remember my chess opening?", historic),
+          apiMessage("a-legacy", "assistant", "the king's gambit!", historic),
+        ],
+        page.conversation.revision
+      );
+      expect(imported.status).toBe(201);
+
+      const afterImport = await fetchConversation(username, token);
+      expect(afterImport.messages.map((message) => message.id)).toEqual([
+        "u-legacy",
+        "a-legacy",
+      ]);
+      expect(afterImport.conversation.canImportLegacy).toBe(false);
+    },
+    30_000
+  );
+
+  test(
+    "appends the greeting to a stale conversation",
+    async () => {
+      const username = uniqueTestUsername("greetstale");
+      const token = await ensureUserAuth(username, password);
+      if (!token) throw new Error("Failed to authenticate test user");
+      await seedMemory(username);
+
+      const staleTime = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+      const imported = await importConversation(username, token, [
+        apiMessage("u-stale", "user", "gotta run, talk later", staleTime),
+        apiMessage("a-stale", "assistant", "see you!", staleTime),
+      ]);
+      expect(imported.status).toBe(201);
+
+      const result = await requestProactiveGreeting(username, token);
+      expect(result.greeting).toBeTruthy();
+      expect(result.message?.id.startsWith("proactive-")).toBe(true);
+
+      const page = await fetchConversation(username, token);
+      expect(page.messages.map((message) => message.id)).toEqual([
+        "u-stale",
+        "a-stale",
+        result.message!.id,
+      ]);
+    },
+    30_000
+  );
+});

--- a/tests/test-proactive-greeting-apply.test.ts
+++ b/tests/test-proactive-greeting-apply.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, test } from "bun:test";
 import type { AIChatMessage } from "../src/types/chat";
 import {
   applyFreshProactiveGreeting,
+  applyServerProactiveGreeting,
   isClearedToDefaultGreeting,
+  isConversationGreetable,
   isDefaultGreetingMessage,
+  parseServerProactiveGreeting,
   resolveAiMessageSync,
   shouldApplyFreshProactiveGreeting,
 } from "../src/apps/chats/utils/proactiveGreetingApply";
@@ -88,6 +91,134 @@ describe("cleared chat detection", () => {
     expect(
       isClearedToDefaultGreeting([defaultGreeting, userMessage, assistantStream])
     ).toBe(false);
+  });
+});
+
+describe("isConversationGreetable", () => {
+  const NOW = Date.parse("2026-07-07T12:00:00.000Z");
+  const timedMessage = (
+    base: AIChatMessage,
+    createdAt: string
+  ): AIChatMessage => ({
+    ...base,
+    metadata: { createdAt: new Date(createdAt) },
+  });
+
+  test("greets empty and freshly cleared chats", () => {
+    expect(isConversationGreetable([], NOW)).toBe(true);
+    expect(isConversationGreetable([defaultGreeting], NOW)).toBe(true);
+  });
+
+  test("greets a stale thread but not an active one", () => {
+    const stale = [
+      timedMessage(userMessage, "2026-07-07T11:00:00.000Z"),
+      timedMessage(assistantStream, "2026-07-07T11:01:00.000Z"),
+    ];
+    expect(isConversationGreetable(stale, NOW)).toBe(true);
+
+    const active = [timedMessage(assistantStream, "2026-07-07T11:58:00.000Z")];
+    expect(isConversationGreetable(active, NOW)).toBe(false);
+  });
+
+  test("never greets twice in a row and skips unknown timestamps", () => {
+    const greeted = [
+      timedMessage(userMessage, "2026-07-07T11:00:00.000Z"),
+      timedMessage(proactiveGreeting, "2026-07-07T11:01:00.000Z"),
+    ];
+    expect(isConversationGreetable(greeted, NOW)).toBe(false);
+    expect(isConversationGreetable([userMessage, assistantStream], NOW)).toBe(
+      false
+    );
+  });
+});
+
+describe("parseServerProactiveGreeting", () => {
+  test("parses a persisted greeting message", () => {
+    const parsed = parseServerProactiveGreeting({
+      greeting: "welcome back alice!",
+      message: {
+        id: "proactive-6f0f0000-0000-4000-8000-000000000000",
+        seq: 3,
+        role: "assistant",
+        parts: [{ type: "text", text: "welcome back alice!" }],
+        createdAt: "2026-07-07T12:00:00.000Z",
+      },
+    });
+
+    expect(parsed).toEqual({
+      id: "proactive-6f0f0000-0000-4000-8000-000000000000",
+      role: "assistant",
+      parts: [{ type: "text", text: "welcome back alice!" }],
+      metadata: { createdAt: new Date("2026-07-07T12:00:00.000Z") },
+    });
+  });
+
+  test("returns null for skipped greetings and malformed payloads", () => {
+    expect(
+      parseServerProactiveGreeting({ greeting: null, reason: "no memories" })
+    ).toBeNull();
+    expect(parseServerProactiveGreeting({ greeting: "hi" })).toBeNull();
+    expect(
+      parseServerProactiveGreeting({
+        greeting: "hi",
+        message: { id: "not-proactive", role: "assistant", parts: [] },
+      })
+    ).toBeNull();
+    expect(
+      parseServerProactiveGreeting({
+        greeting: "hi",
+        message: { id: "proactive-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      })
+    ).toBeNull();
+  });
+});
+
+describe("applyServerProactiveGreeting", () => {
+  const timed = (base: AIChatMessage, createdAt: string): AIChatMessage => ({
+    ...base,
+    metadata: { createdAt: new Date(createdAt) },
+  });
+  const serverGreeting = timed(
+    proactiveGreeting,
+    "2026-07-07T12:00:00.000Z"
+  );
+
+  test("replaces the default greeting in a fresh chat", () => {
+    expect(applyServerProactiveGreeting([defaultGreeting], serverGreeting)).toEqual([
+      serverGreeting,
+    ]);
+  });
+
+  test("appends to a stale thread", () => {
+    const thread = [
+      timed(userMessage, "2026-07-07T11:00:00.000Z"),
+      timed(assistantStream, "2026-07-07T11:01:00.000Z"),
+    ];
+    expect(applyServerProactiveGreeting(thread, serverGreeting)).toEqual([
+      ...thread,
+      serverGreeting,
+    ]);
+  });
+
+  test("skips when the greeting already landed via hydration", () => {
+    expect(
+      applyServerProactiveGreeting([serverGreeting], serverGreeting)
+    ).toBeNull();
+  });
+
+  test("skips when local activity raced the greeting", () => {
+    expect(
+      applyServerProactiveGreeting(
+        [timed(userMessage, "2026-07-07T12:00:01.000Z")],
+        serverGreeting
+      )
+    ).toBeNull();
+    expect(
+      applyServerProactiveGreeting(
+        [timed(assistantStream, "2026-07-07T12:00:02.000Z")],
+        serverGreeting
+      )
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Proactive greetings stopped working after Ryo's conversation history became server-owned (#1817). The greeting was still generated and applied **locally only**: the server never persisted it, so the very next hydration (`useSyncedAiMessages` reconciling against the canonical server conversation) clobbered the greeting out of the message list — usually before the user even saw it, and always on reload or on another device.

## Rearchitecture

The greeting is now owned by the server, like the rest of the conversation:

- **Server decides eligibility** — `/api/chat` with `proactiveGreeting: true` loads the canonical conversation and greets only when the thread is brand new (`fresh`) or idle for 5+ minutes (`stale`), never twice in a row, and never while a turn is in flight (`getAIProactiveGreetingEligibility` in `api/ai/conversations/_helpers/store.ts`). Skips respond with `{ greeting: null, reason }`.
- **Server persists the greeting** — the generated greeting is appended to the canonical conversation as a real assistant message with a `proactive-<uuid>` id via a new `appendAIConversationAssistantMessage` write. The write is optimistic (snapshot revision + `requireNoPendingTurn`), so a user message that races the generation wins and the greeting is dropped cleanly.
- **Greetings never block legacy import** — the append preserves `legacyImportAllowed`, and both the import endpoint and `writeAIConversationMessages` now allow a legacy import to replace a conversation whose only content is proactive greetings (client sends the real `expectedRevision` instead of hard-coded `0`).
- **Client is a thin orchestrator** — `useProactiveGreeting` awaits `loadAIConversation` (sharing the pending hydration/one-time legacy import with `useAiChat`) before asking, re-checks greetability, then patches the server-persisted message into the live chat and invalidates the session cache so hydration picks up the new revision. Identity changes (logout → login) reset the attempt gate.

Shared constants (`AI_PROACTIVE_GREETING_MESSAGE_ID_PREFIX`, `AI_PROACTIVE_GREETING_STALE_AFTER_MS`, `isAIProactiveGreetingMessageId`) live in `src/shared/contracts/aiConversation.ts` so client and server agree on ids and thresholds.

## Testing

- New API integration suite `tests/test-proactive-greeting-api.test.ts` (registered in `scripts/test-groups.ts` + `test:ai`): no-memories skip, active-conversation skip, fresh greet → persisted message → `already_greeted` → legacy import replaces greeting, stale greet appended after existing history.
- Store unit tests: append + revision bump + `legacyImportAllowed` preserved, race losses (`conversation_busy` / `revision_conflict`), eligibility matrix (fresh/stale/active/already-greeted/abandoned turn).
- Client unit tests: `isConversationGreetable`, `parseServerProactiveGreeting`, `applyServerProactiveGreeting` (replace default greeting, append to stale thread, skip on hydration/local-activity races).

- ✅ `bun run typecheck`
- ✅ `bun run test:unit` (2464 pass / 0 fail)
- ✅ `bun run test:api` (342 pass; the 3 failures — 2× "Invalid auth token", 1× iframe raw-proxy POST — reproduce identically on `main` in this environment and are unrelated)
- ✅ `bun run test:registration`, `bunx eslint <changed files>`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3b0d-154b-7a70-aa10-92f72bd7b137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3b0d-154b-7a70-aa10-92f72bd7b137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

