### PR TITLE
Fix selected debug filter pill losing accent bg in dark mode

### DIFF
--- a/src/components/debug/DebugLogOverlay.tsx
+++ b/src/components/debug/DebugLogOverlay.tsx
@@ -94,10 +94,15 @@ const NETWORK_FILTER_VALUES = [
 type NetworkFilter = (typeof NETWORK_FILTER_VALUES)[number];
 type DebugPanelTab = "logs" | "live" | "network" | "idb";
 
+// The neutral (off) backgrounds are scoped to data-[state=off] — a bare
+// `os-mac-aqua-dark:bg-white/5` selector has higher specificity than
+// `data-[state=on]:bg-os-selection-bg` and would swallow the accent fill of
+// the selected pill in dark mode.
 const quickFilterPillClassName = cn(
   "flex h-5 items-center gap-1 rounded-full border px-1.5 font-os-ui text-[10px] leading-none",
-  "border-[color:var(--os-color-separator)] bg-black/5 text-os-text-secondary hover:bg-black/10",
-  "os-mac-aqua-dark:bg-white/5 os-mac-aqua-dark:hover:bg-white/10",
+  "border-[color:var(--os-color-separator)] text-os-text-secondary",
+  "data-[state=off]:bg-black/5 data-[state=off]:hover:bg-black/10",
+  "os-mac-aqua-dark:data-[state=off]:bg-white/5 os-mac-aqua-dark:data-[state=off]:hover:bg-white/10",
   "data-[state=on]:border-transparent data-[state=on]:bg-os-selection-bg data-[state=on]:text-os-selection-text",
   "data-[state=on]:[text-shadow:var(--os-color-selection-text-shadow)]"
 );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the debug panel, the selected log/network filter pill (e.g. "All Logs") did not show the accent selection background in macOS Aqua dark mode — it rendered with the neutral `bg-white/5` fill instead (see attached screenshot in the issue).

## Root cause

The pill's neutral dark-mode background `os-mac-aqua-dark:bg-white/5` compiles to a selector scoped under `:root[data-os-mac-chrome="aqua"][data-os-color-scheme="dark"]` (specificity 0-4-0), which beats the selected-state rule `data-[state=on]:bg-os-selection-bg` (0-2-0). In dark mode the neutral fill always won, swallowing the accent background of the selected pill. Light mode was unaffected (`bg-black/5` is 0-1-0).

## Fix

Scope the neutral (off) backgrounds to `data-[state=off]` in `quickFilterPillClassName` so they never compete with the `data-[state=on]` accent fill:

- `data-[state=off]:bg-black/5` / `data-[state=off]:hover:bg-black/10`
- `os-mac-aqua-dark:data-[state=off]:bg-white/5` / `...hover:bg-white/10`

The selected pill now always paints `--os-color-selection-bg` / `--os-color-selection-text` (accent-aware), in light and dark mode, for the logger dropdown trigger pill and the Errors/Warnings quick-filter pills across the Logs and Network tabs.

## Verification (dark Aqua Glass, wallpaper accent)

![All Logs pill selected with accent background](https://cursor.com/artifacts/c/art-7734c1b1-4634-4f92-b3a4-d3a3dc4421ae)

![Errors pill selected with accent background, All Logs back to neutral](https://cursor.com/artifacts/c/art-f2db3edd-f7f5-4386-b6d3-31dd2ffaab84)

- Selected "All Logs" pill paints the accent background with selection text.
- Clicking "Errors" moves the accent fill to the Errors pill; "All Logs" reverts to the faint neutral pill.
- Bottom tab bar (Logs / Live / Network / IndexedDB) selection styling unchanged and consistent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3c70-a47e-7db4-98a7-644539ec89c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3c70-a47e-7db4-98a7-644539ec89c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

