### PR TITLE
Stream AI conversation updates to other signed-in devices in realtime

### DIFF
--- a/api/ai/conversations/[channel]/import.ts
+++ b/api/ai/conversations/[channel]/import.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
+import { waitUntil } from "@vercel/functions";
 import { apiHandler } from "../../../_utils/api-handler.js";
 import {
   AIConversationError,
   getAIConversationSummary,
   importAIConversationMessages,
 } from "../_helpers/store.js";
+import { broadcastAIConversationUpdate } from "../_helpers/realtime.js";
 import {
   AI_CONVERSATION_OPERATION_ID_MAX_LENGTH,
   isAIConversationChannel,
@@ -52,6 +54,16 @@ export default apiHandler(
         messages: body!.messages,
         historyTruncated: body!.historyTruncated,
       });
+      waitUntil(
+        broadcastAIConversationUpdate({
+          username: user!.username,
+          channel,
+          conversationId: document.id,
+          revision: document.revision,
+          reason: "import",
+          operationId: body!.operationId,
+        })
+      );
       logger.response(201, Date.now() - startTime);
       res.status(201).json({
         owner: user!.username,

--- a/api/ai/conversations/[channel]/reset.ts
+++ b/api/ai/conversations/[channel]/reset.ts
@@ -8,6 +8,7 @@ import {
   resetAIConversation,
 } from "../_helpers/store.js";
 import { extractPendingAIConversationResetMemory } from "../_helpers/reset-memory.js";
+import { broadcastAIConversationUpdate } from "../_helpers/realtime.js";
 import {
   AI_CONVERSATION_OPERATION_ID_MAX_LENGTH,
   isAIConversationChannel,
@@ -57,6 +58,18 @@ export default apiHandler(
         logger.error("Cleared conversation memory extraction failed", error);
       });
       waitUntil(memoryProcessing);
+      if (result.reset) {
+        waitUntil(
+          broadcastAIConversationUpdate({
+            username: user!.username,
+            channel,
+            conversationId: result.document.id,
+            revision: result.document.revision,
+            reason: "reset",
+            operationId: body!.operationId,
+          })
+        );
+      }
       logger.response(200, Date.now() - startTime);
       res.status(200).json({
         owner: user!.username,

--- a/api/ai/conversations/_helpers/realtime.ts
+++ b/api/ai/conversations/_helpers/realtime.ts
@@ -1,0 +1,48 @@
+import { triggerRealtimeEvent } from "../../../_utils/realtime.js";
+import { getAIConversationRealtimeChannelName } from "../../../../src/shared/constants/realtime.js";
+import {
+  AI_CONVERSATION_UPDATED_REALTIME_EVENT,
+  type AIConversationChannel,
+  type AIConversationUpdateReason,
+  type AIConversationUpdatedRealtimeEvent,
+} from "../../../../src/shared/contracts/aiConversation.js";
+
+export interface BroadcastAIConversationUpdateInput {
+  username: string;
+  channel: AIConversationChannel;
+  conversationId: string;
+  revision: number;
+  reason: AIConversationUpdateReason;
+  operationId: string;
+}
+
+/**
+ * Notify the owner's other signed-in devices that the canonical server
+ * conversation changed. Fire-and-forget: a delivery failure must never fail
+ * the write it announces (the focus/visibility refresh remains the fallback).
+ */
+export async function broadcastAIConversationUpdate({
+  username,
+  channel,
+  conversationId,
+  revision,
+  reason,
+  operationId,
+}: BroadcastAIConversationUpdateInput): Promise<void> {
+  const event: AIConversationUpdatedRealtimeEvent = {
+    channel,
+    conversationId,
+    revision,
+    reason,
+    operationId,
+  };
+  try {
+    await triggerRealtimeEvent(
+      getAIConversationRealtimeChannelName(username),
+      AI_CONVERSATION_UPDATED_REALTIME_EVENT,
+      event
+    );
+  } catch (error) {
+    console.warn("[ai-conversation] Failed to broadcast update:", error);
+  }
+}

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -59,6 +59,7 @@ import {
   type BeginAIConversationTurnInput,
 } from "./ai/conversations/_helpers/store.js";
 import { extractPendingAIConversationResetMemory } from "./ai/conversations/_helpers/reset-memory.js";
+import { broadcastAIConversationUpdate } from "./ai/conversations/_helpers/realtime.js";
 import { resolveAIAttachmentsForModel } from "./ai/attachments/_helpers/store.js";
 type SystemState = RyoConversationSystemState;
 
@@ -453,6 +454,19 @@ export default apiHandler<{
           channel: conversationChannel,
           id: conversationOperationId,
         };
+        // Regeneration doesn't change stored content until it completes.
+        if (normalizedTrigger !== "regenerate-message") {
+          waitUntil(
+            broadcastAIConversationUpdate({
+              username,
+              channel: conversationChannel,
+              conversationId: beginResult.document.id,
+              revision: beginResult.document.revision,
+              reason: "turn-begin",
+              operationId: conversationOperationId,
+            })
+          );
+        }
       } catch (error) {
         if (error instanceof AIConversationError) {
           logger.response(error.status, Date.now() - startTime);
@@ -702,12 +716,13 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
         let appended: Awaited<
           ReturnType<typeof appendAIConversationAssistantMessage>
         >;
+        const greetingOperationId = crypto.randomUUID();
         try {
           appended = await appendAIConversationAssistantMessage({
             redis,
             username,
             channel: "chat",
-            operationId: crypto.randomUUID(),
+            operationId: greetingOperationId,
             message: greetingMessage,
             expectedConversationId: greetingConversation.id,
             expectedRevision: greetingConversation.revision,
@@ -726,6 +741,16 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
           respondGreetingSkipped("persist_failed");
           return;
         }
+        waitUntil(
+          broadcastAIConversationUpdate({
+            username,
+            channel: "chat",
+            conversationId: appended.document.id,
+            revision: appended.document.revision,
+            reason: "greeting",
+            operationId: greetingOperationId,
+          })
+        );
 
         res.status(200).json({
           greeting,
@@ -835,8 +860,9 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
             return;
           }
 
+          let completedDocument;
           if (normalizedTrigger === "regenerate-message") {
-            await commitAIConversationRegeneration({
+            completedDocument = await commitAIConversationRegeneration({
               redis,
               username,
               channel: conversationChannel,
@@ -850,7 +876,7 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
                 : {}),
             });
           } else {
-            await completeAIConversationTurn({
+            completedDocument = await completeAIConversationTurn({
               redis,
               username,
               channel: conversationChannel,
@@ -862,6 +888,16 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
             });
           }
           activeConversationTurn = null;
+          waitUntil(
+            broadcastAIConversationUpdate({
+              username,
+              channel: conversationChannel,
+              conversationId: completedDocument.id,
+              revision: completedDocument.revision,
+              reason: "turn-complete",
+              operationId: conversationOperationId,
+            })
+          );
         } catch (error) {
           logError("Failed to persist completed conversation response", error);
           await releaseAIConversationTurn({

--- a/docs/8.1-chat-api.md
+++ b/docs/8.1-chat-api.md
@@ -39,6 +39,18 @@ It also schedules memory extraction from the cleared server snapshot exactly
 once for that reset operation. Conversation records are removed by account
 deletion.
 
+### Realtime cross-device updates
+
+Every canonical conversation write is announced on the owner's authorized
+`private-ai-{username}` realtime channel as an `ai-conversation-updated` event
+carrying `{ channel, conversationId, revision, reason, operationId }` with
+`reason` one of `turn-begin`, `turn-complete`, `greeting`, `import`, or
+`reset`. Other signed-in devices listening on the channel re-hydrate the
+conversation immediately (the user's message appears at `turn-begin`, the
+assistant reply at `turn-complete`); the originating device recognizes its own
+`operationId` and skips the echo. Delivery is best-effort — the
+focus/visibility refresh remains the catch-up path.
+
 ## Request
 
 ### Headers

--- a/src/api/aiConversations.ts
+++ b/src/api/aiConversations.ts
@@ -73,6 +73,26 @@ const activeOwners = new Map<AIConversationChannel, string>();
 let cacheEpoch = 0;
 const utf8Encoder = new TextEncoder();
 
+// Operation ids minted by this device. Realtime `ai-conversation-updated`
+// events echo the originating operation id, so tracking ours lets the sender
+// skip re-hydrating for changes it already has (insertion order = age).
+const MAX_TRACKED_LOCAL_OPERATIONS = 64;
+const localOperationIds = new Set<string>();
+
+function trackLocalAIConversationOperation(operationId: string): void {
+  localOperationIds.delete(operationId);
+  localOperationIds.add(operationId);
+  while (localOperationIds.size > MAX_TRACKED_LOCAL_OPERATIONS) {
+    const oldest = localOperationIds.values().next().value;
+    if (oldest === undefined) break;
+    localOperationIds.delete(oldest);
+  }
+}
+
+export function isLocalAIConversationOperation(operationId: string): boolean {
+  return localOperationIds.has(operationId);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -692,10 +712,12 @@ async function importLocalConversation(
   conversation: AIConversation,
   messages: readonly AIChatMessage[]
 ): Promise<void> {
+  const importOperationId = crypto.randomUUID();
+  trackLocalAIConversationOperation(importOperationId);
   const request = buildAIConversationImportRequest({
     conversationId: conversation.id,
     expectedRevision: conversation.revision,
-    operationId: crypto.randomUUID(),
+    operationId: importOperationId,
     messages: await externalizeLocalImages(messages),
   });
   if (!request.messages.some((message) => message.role === "user")) return;
@@ -820,10 +842,12 @@ export async function getAIConversationRequestContext({
   if (session.stale) {
     throw new Error("Conversation changed while preparing the request");
   }
+  const operationId = crypto.randomUUID();
+  trackLocalAIConversationOperation(operationId);
   return {
     id: session.conversation.id,
     revision: session.conversation.revision,
-    operationId: crypto.randomUUID(),
+    operationId,
   };
 }
 
@@ -850,6 +874,8 @@ export async function resetAIConversationSession({
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const requestEpoch = cacheEpoch;
     const requestGeneration = incrementGeneration(key);
+    const resetOperationId = crypto.randomUUID();
+    trackLocalAIConversationOperation(resetOperationId);
     const response = await abortableFetch(
       getApiUrl(`/api/ai/conversations/${channel}/reset`),
       {
@@ -857,7 +883,7 @@ export async function resetAIConversationSession({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           conversationId: session.conversation.id,
-          operationId: crypto.randomUUID(),
+          operationId: resetOperationId,
         }),
         timeout: 15_000,
         throwOnHttpError: false,
@@ -907,6 +933,14 @@ export async function resetAIConversationSession({
   }
 
   throw new Error("Conversation reset failed after refreshing");
+}
+
+export function getAIConversationSessionSnapshot(
+  channel: AIConversationChannel
+): { owner: string; conversation: AIConversation } | null {
+  const session = sessions.get(channel);
+  if (!session) return null;
+  return { owner: session.owner, conversation: session.conversation };
 }
 
 export function clearAIConversationSessionCache(): void {

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -38,6 +38,7 @@ import {
   resetAIConversationSession,
   uploadAIConversationImage,
 } from "@/api/aiConversations";
+import { useAIConversationRealtime } from "@/hooks/useAIConversationRealtime";
 
 
 // Helper to check if chats app is currently in the foreground
@@ -669,6 +670,23 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       document.removeEventListener("visibilitychange", refresh);
     };
   }, [username, isAuthenticated, hydrateServerConversation]);
+
+  // Live cross-device updates: when another signed-in device changes the
+  // canonical conversation (turn committed, greeting, import, clear), pull
+  // the fresh server state immediately instead of waiting for a focus event.
+  useAIConversationRealtime({
+    channel: "chat",
+    username: chatIdentity,
+    onRemoteUpdate: () => {
+      if (getSharedAiChat().status !== "ready") return;
+      void hydrateServerConversation(true).catch((hydrationError) => {
+        log.error(
+          "Failed to apply realtime conversation update",
+          hydrationError
+        );
+      });
+    },
+  });
 
   const isLoading = status === "streaming" || status === "submitted";
   const retryLastUserMessage = useCallback((): Promise<void> => {

--- a/src/components/assistant/useAssistantChat.ts
+++ b/src/components/assistant/useAssistantChat.ts
@@ -40,6 +40,7 @@ import {
   loadAIConversation,
   resetAIConversationSession,
 } from "@/api/aiConversations";
+import { useAIConversationRealtime } from "@/hooks/useAIConversationRealtime";
 
 const log = createClientLogger("Assistant");
 
@@ -414,6 +415,21 @@ export function useAssistantChat(): AssistantChatHandle {
       document.removeEventListener("visibilitychange", refresh);
     };
   }, [username, isAuthenticated, chat, hydrateServerConversation]);
+
+  // Live cross-device updates for the assistant thread: re-hydrate as soon
+  // as another signed-in device changes the canonical conversation.
+  useAIConversationRealtime({
+    channel: "assistant",
+    username: assistantIdentity,
+    onRemoteUpdate: () => {
+      if (chat.status !== "ready") return;
+      void hydrateServerConversation(true).catch((hydrationError) => {
+        log.warn("Failed to apply realtime conversation update", {
+          error: hydrationError,
+        });
+      });
+    },
+  });
 
   const handlersRef = useRef({
     // Placeholder; replaced with a fresh closure on every render below so the

--- a/src/hooks/useAIConversationRealtime.ts
+++ b/src/hooks/useAIConversationRealtime.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from "react";
+import {
+  subscribePusherChannel,
+  unsubscribePusherChannel,
+} from "@/lib/pusherClient";
+import { getAIConversationRealtimeChannelName } from "@/shared/constants/realtime";
+import {
+  AI_CONVERSATION_UPDATED_REALTIME_EVENT,
+  parseAIConversationUpdatedRealtimeEvent,
+  type AIConversationChannel,
+  type AIConversationUpdatedRealtimeEvent,
+} from "@/shared/contracts/aiConversation";
+import {
+  getAIConversationSessionSnapshot,
+  invalidateAIConversationSession,
+  isLocalAIConversationOperation,
+} from "@/api/aiConversations";
+
+interface UseAIConversationRealtimeOptions {
+  /** Which server-owned thread to watch (`chat` or `assistant`). */
+  channel: AIConversationChannel;
+  /** Lowercased authenticated username, or null when signed out. */
+  username: string | null;
+  /**
+   * Called after the session cache has been invalidated for a genuine remote
+   * update (another device changed the conversation). Typically triggers a
+   * forced server re-hydration.
+   */
+  onRemoteUpdate: (event: AIConversationUpdatedRealtimeEvent) => void;
+}
+
+/**
+ * Live cross-device updates for the server-owned AI conversation. Subscribes
+ * to the user's `private-ai-…` realtime channel and reacts to
+ * `ai-conversation-updated` events emitted whenever another device commits a
+ * turn, receives a proactive greeting, imports history, or clears the thread.
+ *
+ * Events produced by this device (matched via locally minted operation ids)
+ * and events at or below the cached revision are ignored.
+ */
+export function useAIConversationRealtime({
+  channel,
+  username,
+  onRemoteUpdate,
+}: UseAIConversationRealtimeOptions): void {
+  const onRemoteUpdateRef = useRef(onRemoteUpdate);
+  onRemoteUpdateRef.current = onRemoteUpdate;
+
+  useEffect(() => {
+    if (!username) return;
+    const channelName = getAIConversationRealtimeChannelName(username);
+    const realtimeChannel = subscribePusherChannel(channelName);
+
+    const handleUpdate = (payload?: unknown) => {
+      const event = parseAIConversationUpdatedRealtimeEvent(payload);
+      if (!event || event.channel !== channel) return;
+      // This device made the change; it already holds the resulting state.
+      if (isLocalAIConversationOperation(event.operationId)) return;
+
+      const session = getAIConversationSessionSnapshot(channel);
+      if (
+        session &&
+        session.owner === username &&
+        session.conversation.id === event.conversationId &&
+        event.revision <= session.conversation.revision
+      ) {
+        return;
+      }
+
+      invalidateAIConversationSession(channel, username);
+      onRemoteUpdateRef.current(event);
+    };
+
+    realtimeChannel.bind(AI_CONVERSATION_UPDATED_REALTIME_EVENT, handleUpdate);
+    return () => {
+      realtimeChannel.unbind(
+        AI_CONVERSATION_UPDATED_REALTIME_EVENT,
+        handleUpdate
+      );
+      unsubscribePusherChannel(channelName);
+    };
+  }, [channel, username]);
+}

--- a/src/shared/constants/realtime.ts
+++ b/src/shared/constants/realtime.ts
@@ -9,6 +9,10 @@ export const PRIVATE_CHAT_ROOM_CHANNEL_PREFIX = "private-room-";
 // Per-user cross-device sync channel. Carries the user's documents/state, so it
 // MUST be an authorized channel.
 export const SYNC_CHANNEL_PREFIX = "private-sync-";
+// Per-user AI conversation channel. Carries `ai-conversation-updated` events
+// for the user's server-owned Ryo/assistant threads, so it MUST be an
+// authorized channel.
+export const AI_CONVERSATION_CHANNEL_PREFIX = "private-ai-";
 export const LISTEN_SESSION_CHANNEL_PREFIX = "listen-";
 export const GLOBAL_PRESENCE_CHANNEL = "presence-global";
 
@@ -57,6 +61,12 @@ export function getSyncChannelName(username: string): string {
   return `${SYNC_CHANNEL_PREFIX}${sanitizeUsernameForRealtimeChannel(username)}`;
 }
 
+export function getAIConversationRealtimeChannelName(
+  username: string
+): string {
+  return `${AI_CONVERSATION_CHANNEL_PREFIX}${sanitizeUsernameForRealtimeChannel(username)}`;
+}
+
 export function getListenSessionChannelName(sessionId: string): string {
   return `${LISTEN_SESSION_CHANNEL_PREFIX}${sessionId}`;
 }
@@ -100,6 +110,13 @@ export function classifyRealtimeChannel(
 
   if (name.startsWith(SYNC_CHANNEL_PREFIX)) {
     return { kind: "user", target: name.slice(SYNC_CHANNEL_PREFIX.length) };
+  }
+
+  if (name.startsWith(AI_CONVERSATION_CHANNEL_PREFIX)) {
+    return {
+      kind: "user",
+      target: name.slice(AI_CONVERSATION_CHANNEL_PREFIX.length),
+    };
   }
 
   if (name.startsWith(PRIVATE_CHAT_ROOM_CHANNEL_PREFIX)) {

--- a/src/shared/contracts/aiConversation.ts
+++ b/src/shared/contracts/aiConversation.ts
@@ -76,3 +76,74 @@ export interface AIConversationResetResult {
   conversation: AIConversation;
   reset: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Realtime cross-device updates
+// ---------------------------------------------------------------------------
+
+/**
+ * Event emitted on the owner's `private-ai-…` realtime channel whenever the
+ * canonical server conversation changes, so other signed-in devices can
+ * re-hydrate live instead of waiting for the next focus refresh.
+ */
+export const AI_CONVERSATION_UPDATED_REALTIME_EVENT =
+  "ai-conversation-updated";
+
+export const AI_CONVERSATION_UPDATE_REASONS = [
+  "turn-begin",
+  "turn-complete",
+  "greeting",
+  "import",
+  "reset",
+] as const;
+
+export type AIConversationUpdateReason =
+  (typeof AI_CONVERSATION_UPDATE_REASONS)[number];
+
+export interface AIConversationUpdatedRealtimeEvent {
+  channel: AIConversationChannel;
+  conversationId: string;
+  revision: number;
+  reason: AIConversationUpdateReason;
+  /**
+   * The operation that produced this update. Turn events carry the
+   * client-minted operation id, letting the originating device recognize and
+   * skip its own echo.
+   */
+  operationId: string;
+}
+
+export function parseAIConversationUpdatedRealtimeEvent(
+  value: unknown
+): AIConversationUpdatedRealtimeEvent | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const channel = Reflect.get(value, "channel");
+  const conversationId = Reflect.get(value, "conversationId");
+  const revision = Reflect.get(value, "revision");
+  const reason = Reflect.get(value, "reason");
+  const operationId = Reflect.get(value, "operationId");
+  if (
+    !isAIConversationChannel(channel) ||
+    typeof conversationId !== "string" ||
+    conversationId.length === 0 ||
+    typeof revision !== "number" ||
+    !Number.isSafeInteger(revision) ||
+    revision < 0 ||
+    !AI_CONVERSATION_UPDATE_REASONS.includes(
+      reason as AIConversationUpdateReason
+    ) ||
+    typeof operationId !== "string" ||
+    operationId.length === 0
+  ) {
+    return null;
+  }
+  return {
+    channel,
+    conversationId,
+    revision,
+    reason: reason as AIConversationUpdateReason,
+    operationId,
+  };
+}

--- a/tests/test-ai-conversation-realtime.test.ts
+++ b/tests/test-ai-conversation-realtime.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit + wiring tests for realtime cross-device AI conversation updates.
+ *
+ * Covers:
+ * - the `ai-conversation-updated` event contract parser
+ * - guardrail wiring checks that server write sites broadcast the event and
+ *   client hooks subscribe to it (same style as test-chat-broadcast-wiring)
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  AI_CONVERSATION_UPDATED_REALTIME_EVENT,
+  parseAIConversationUpdatedRealtimeEvent,
+} from "../src/shared/contracts/aiConversation";
+
+const readSource = (relativePath: string): string =>
+  readFileSync(resolve(process.cwd(), relativePath), "utf-8");
+
+const assertHasCall = (source: string, fnName: string): void => {
+  const callPattern = new RegExp(`\\b${fnName}\\s*\\(`);
+  expect(source).toMatch(callPattern);
+};
+
+const countCalls = (source: string, fnName: string): number => {
+  const callPattern = new RegExp(`\\b${fnName}\\s*\\(`, "g");
+  return source.match(callPattern)?.length || 0;
+};
+
+describe("ai-conversation-updated event contract", () => {
+  const validEvent = {
+    channel: "chat",
+    conversationId: "11111111-1111-4111-8111-111111111111",
+    revision: 3,
+    reason: "turn-complete",
+    operationId: "op-1",
+  };
+
+  test("event name is stable", () => {
+    expect(AI_CONVERSATION_UPDATED_REALTIME_EVENT).toBe(
+      "ai-conversation-updated"
+    );
+  });
+
+  test("parses a valid event", () => {
+    expect(parseAIConversationUpdatedRealtimeEvent(validEvent)).toEqual(
+      validEvent
+    );
+  });
+
+  test("accepts every documented reason", () => {
+    for (const reason of [
+      "turn-begin",
+      "turn-complete",
+      "greeting",
+      "import",
+      "reset",
+    ]) {
+      expect(
+        parseAIConversationUpdatedRealtimeEvent({ ...validEvent, reason })
+      ).not.toBeNull();
+    }
+  });
+
+  test("rejects malformed payloads", () => {
+    expect(parseAIConversationUpdatedRealtimeEvent(null)).toBeNull();
+    expect(parseAIConversationUpdatedRealtimeEvent("event")).toBeNull();
+    expect(parseAIConversationUpdatedRealtimeEvent([])).toBeNull();
+    expect(
+      parseAIConversationUpdatedRealtimeEvent({
+        ...validEvent,
+        channel: "rooms",
+      })
+    ).toBeNull();
+    expect(
+      parseAIConversationUpdatedRealtimeEvent({
+        ...validEvent,
+        conversationId: "",
+      })
+    ).toBeNull();
+    expect(
+      parseAIConversationUpdatedRealtimeEvent({ ...validEvent, revision: -1 })
+    ).toBeNull();
+    expect(
+      parseAIConversationUpdatedRealtimeEvent({
+        ...validEvent,
+        revision: 1.5,
+      })
+    ).toBeNull();
+    expect(
+      parseAIConversationUpdatedRealtimeEvent({
+        ...validEvent,
+        reason: "unknown",
+      })
+    ).toBeNull();
+    expect(
+      parseAIConversationUpdatedRealtimeEvent({
+        ...validEvent,
+        operationId: "",
+      })
+    ).toBeNull();
+  });
+});
+
+describe("AI conversation realtime broadcast wiring", () => {
+  test("chat route broadcasts turn begin/complete and greeting updates", () => {
+    const source = readSource("api/chat.ts");
+    assertHasCall(source, "broadcastAIConversationUpdate");
+    // turn-begin, turn-complete, greeting
+    expect(
+      countCalls(source, "broadcastAIConversationUpdate")
+    ).toBeGreaterThanOrEqual(3);
+    expect(source).toContain('reason: "turn-begin"');
+    expect(source).toContain('reason: "turn-complete"');
+    expect(source).toContain('reason: "greeting"');
+  });
+
+  test("reset route broadcasts a reset update", () => {
+    const source = readSource("api/ai/conversations/[channel]/reset.ts");
+    assertHasCall(source, "broadcastAIConversationUpdate");
+    expect(source).toContain('reason: "reset"');
+  });
+
+  test("import route broadcasts an import update", () => {
+    const source = readSource("api/ai/conversations/[channel]/import.ts");
+    assertHasCall(source, "broadcastAIConversationUpdate");
+    expect(source).toContain('reason: "import"');
+  });
+
+  test("broadcast helper targets the per-user private-ai channel", () => {
+    const source = readSource("api/ai/conversations/_helpers/realtime.ts");
+    assertHasCall(source, "getAIConversationRealtimeChannelName");
+    assertHasCall(source, "triggerRealtimeEvent");
+    expect(source).toContain("AI_CONVERSATION_UPDATED_REALTIME_EVENT");
+  });
+});
+
+describe("AI conversation realtime client wiring", () => {
+  test("shared realtime hook subscribes and filters echoes", () => {
+    const source = readSource("src/hooks/useAIConversationRealtime.ts");
+    assertHasCall(source, "subscribePusherChannel");
+    assertHasCall(source, "unsubscribePusherChannel");
+    assertHasCall(source, "parseAIConversationUpdatedRealtimeEvent");
+    assertHasCall(source, "isLocalAIConversationOperation");
+    assertHasCall(source, "invalidateAIConversationSession");
+    expect(source).toContain("AI_CONVERSATION_UPDATED_REALTIME_EVENT");
+  });
+
+  test("Chats AI hook reacts to remote conversation updates", () => {
+    const source = readSource("src/apps/chats/hooks/useAiChat.ts");
+    assertHasCall(source, "useAIConversationRealtime");
+    expect(source).toContain('channel: "chat"');
+  });
+
+  test("desktop assistant hook reacts to remote conversation updates", () => {
+    const source = readSource("src/components/assistant/useAssistantChat.ts");
+    assertHasCall(source, "useAIConversationRealtime");
+    expect(source).toContain('channel: "assistant"');
+  });
+
+  test("client session tracks locally minted operation ids", () => {
+    const source = readSource("src/api/aiConversations.ts");
+    assertHasCall(source, "trackLocalAIConversationOperation");
+    // Sends, resets, and legacy imports each mint (and track) an operation id.
+    expect(
+      countCalls(source, "trackLocalAIConversationOperation")
+    ).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/tests/test-realtime-channels.test.ts
+++ b/tests/test-realtime-channels.test.ts
@@ -3,6 +3,7 @@ import {
   CHATS_PUBLIC_CHANNEL,
   GLOBAL_PRESENCE_CHANNEL,
   classifyRealtimeChannel,
+  getAIConversationRealtimeChannelName,
   getChatRoomChannelName,
   getChatsGlobalChannelName,
   getChatsUserChannelName,
@@ -43,6 +44,13 @@ describe("realtime channel constants", () => {
     expect(GLOBAL_PRESENCE_CHANNEL).toBe("presence-global");
   });
 
+  test("builds per-user AI conversation channels", () => {
+    expect(getAIConversationRealtimeChannelName("Ryo")).toBe("private-ai-ryo");
+    expect(getAIConversationRealtimeChannelName("User/Name")).toBe(
+      "private-ai-user_name"
+    );
+  });
+
   test("classifies channels for authorization", () => {
     expect(classifyRealtimeChannel(CHATS_PUBLIC_CHANNEL)).toEqual({
       kind: "public",
@@ -55,6 +63,10 @@ describe("realtime channel constants", () => {
       target: "ryo",
     });
     expect(classifyRealtimeChannel("private-sync-ryo")).toEqual({
+      kind: "user",
+      target: "ryo",
+    });
+    expect(classifyRealtimeChannel("private-ai-ryo")).toEqual({
       kind: "user",
       target: "ryo",
     });
@@ -74,6 +86,7 @@ describe("realtime channel constants", () => {
     expect(realtimeChannelRequiresAuth("room-123")).toBe(false);
     expect(realtimeChannelRequiresAuth(CHATS_PUBLIC_CHANNEL)).toBe(false);
     expect(realtimeChannelRequiresAuth("private-chats-ryo")).toBe(true);
+    expect(realtimeChannelRequiresAuth("private-ai-ryo")).toBe(true);
     expect(realtimeChannelRequiresAuth("private-room-abc")).toBe(true);
     expect(realtimeChannelRequiresAuth("presence-global")).toBe(true);
   });

--- a/tests/test-realtime-ws-local.test.ts
+++ b/tests/test-realtime-ws-local.test.ts
@@ -188,6 +188,74 @@ maybeDescribe("local WebSocket realtime authorization", () => {
     expect(result.authorized).toBe(false);
   });
 
+  test("private-ai channel: owner authorized, outsider denied", async () => {
+    if (!memberCookie || !outsiderCookie) return;
+    const ownTicket = await getTicket(memberCookie);
+    const allowed = await subscribeOnce(ownTicket, `private-ai-${memberUser}`);
+    expect(allowed.authorized).toBe(true);
+
+    const foreignTicket = await getTicket(outsiderCookie);
+    const denied = await subscribeOnce(
+      foreignTicket,
+      `private-ai-${memberUser}`
+    );
+    expect(denied.authorized).toBe(false);
+  });
+
+  test("conversation import broadcasts ai-conversation-updated to the owner", async () => {
+    if (!memberCookie) return;
+
+    // Read (and lazily create) the canonical conversation to get its id.
+    const conversationRes = await fetch(
+      `${origin}/api/ai/conversations/chat?limit=1`,
+      { headers: { Origin: origin, Cookie: memberCookie } }
+    );
+    expect(conversationRes.status).toBe(200);
+    const page = (await conversationRes.json()) as {
+      conversation: { id: string; revision: number };
+    };
+
+    const freshTicket = await getTicket(memberCookie);
+    const result = await subscribeOnce(freshTicket, `private-ai-${memberUser}`, {
+      waitMs: 2500,
+      triggerAfterSubscribe: async () => {
+        await fetch(`${origin}/api/ai/conversations/chat/import`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Origin: origin,
+            Cookie: memberCookie as string,
+          },
+          body: JSON.stringify({
+            conversationId: page.conversation.id,
+            expectedRevision: page.conversation.revision,
+            operationId: crypto.randomUUID(),
+            messages: [
+              {
+                id: "u-realtime",
+                role: "user",
+                parts: [{ type: "text", text: "hello from another device" }],
+                metadata: { createdAt: new Date().toISOString() },
+              },
+            ],
+          }),
+        });
+      },
+    });
+    expect(result.authorized).toBe(true);
+    expect(result.message).toBeDefined();
+    const delivered = result.message as {
+      event?: string;
+      data?: { channel?: string; reason?: string; revision?: number };
+    };
+    expect(delivered.event).toBe("ai-conversation-updated");
+    expect(delivered.data?.channel).toBe("chat");
+    expect(delivered.data?.reason).toBe("import");
+    expect(delivered.data?.revision).toBeGreaterThan(
+      page.conversation.revision
+    );
+  });
+
   test("private room: member authorized + receives messages, outsider denied", async () => {
     if (!privateRoomId || !memberCookie) return;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follows up the server-owned chat persistence work (#1817, #1821): the canonical Ryo/assistant conversation now streams to every signed-in device live, instead of only syncing on the next focus/visibility refresh.

- New per-user authorized realtime channel `private-ai-{username}` (`classifyRealtimeChannel` → `user`, so both Pusher auth and the local WebSocket ticket flow authorize only the owner).
- New `ai-conversation-updated` event contract (`{ channel, conversationId, revision, reason, operationId }`) in `src/shared/contracts/aiConversation.ts`, broadcast by `broadcastAIConversationUpdate` (`api/ai/conversations/_helpers/realtime.ts`) from every canonical write site:
  - `api/chat.ts`: `turn-begin` (user message persisted — other devices show it immediately), `turn-complete` (assistant reply committed, incl. regeneration), `greeting` (proactive greeting appended)
  - `reset` route: `reset`; `import` route: `import`
- New client hook `useAIConversationRealtime` subscribes to the channel and forces a server re-hydration on genuine remote updates; wired into both `useAiChat` (`chat`) and `useAssistantChat` (`assistant`).
- Echo suppression: the client session layer tracks locally minted operation ids (`isLocalAIConversationOperation`), and events at or below the cached session revision are ignored, so the originating device never re-fetches state it already holds.
- Broadcasts are fire-and-forget (`waitUntil` + swallow errors); the existing focus/visibility refresh remains the catch-up path. Token-level streaming of the in-flight reply to other devices is intentionally out of scope — remote devices see the user turn at `turn-begin` and the full reply at `turn-complete`.
- Docs: `docs/8.1-chat-api.md` gains a "Realtime cross-device updates" section.

## Verification

Two-device end-to-end run against the standalone server in local WebSocket mode — device B subscribed to `private-ai-{user}`, device A ran a full authenticated `/api/chat` streamed turn; B received `turn-begin` (rev 1) and `turn-complete` (rev 2) and hydrated both messages at the broadcast revision:

[two_device_realtime_chat_verification.log](https://cursor.com/artifacts/c/art-9d8b2c41-3246-4726-894c-e17d58246f28)

## Testing

- ✅ `bun run typecheck`
- ✅ `eslint` on all touched files
- ✅ `bun test tests/test-ai-conversation-realtime.test.ts tests/test-realtime-channels.test.ts tests/test-ai-conversation-client.test.ts` (35 pass; includes new contract-parser + broadcast/subscription wiring guardrails)
- ✅ `bun run test:registration`
- ✅ `REALTIME_LOCAL_URL=… bun test tests/test-realtime-ws-local.test.ts` (8 pass; new tests: `private-ai` owner authorized / outsider denied, and import delivers `ai-conversation-updated` end-to-end)
- ✅ `bun run test:unit` (2476 pass; 1 known cross-file-pollution flake in `test-audio-system` that passes in isolation and also fails on clean `main`)
- ✅ `bun run test:api` (342/345; the 3 failures — iframe-check raw-proxy POST and two "Invalid auth token" cases — reproduce identically on clean `main` and are environment/rate-limit related, not regressions)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3c67-5c1e-7c18-8b5d-d9e70e5bf465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3c67-5c1e-7c18-8b5d-d9e70e5bf465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

