### PR TITLE
Replace Chats mobile room sheet with dropdown menu switcher

### DIFF
--- a/src/apps/chats/components/ChatRoomDropdown.tsx
+++ b/src/apps/chats/components/ChatRoomDropdown.tsx
@@ -1,0 +1,178 @@
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { type ChatRoom } from "@/types/chat";
+import { getPrivateRoomDisplayName } from "@/utils/chat";
+import { useChatsStore } from "@/stores/useChatsStore";
+import {
+  isPrivateRoomOnline,
+  sortPrivateRoomsForSidebar,
+} from "../utils/privateRoomOrdering";
+
+interface ChatRoomDropdownProps {
+  rooms: ChatRoom[];
+  currentRoom: ChatRoom | null;
+  onRoomSelect: (room: ChatRoom | null) => void;
+  onAddRoom: () => void;
+  username?: string | null;
+  onlineUsers?: string[];
+  /** Trigger element (rendered via Radix `asChild`). */
+  children: React.ReactNode;
+}
+
+/**
+ * Room switcher for narrow (mobile) frames: anchors the shared dropdown menu
+ * to the chat header title instead of the desktop sidebar.
+ */
+export function ChatRoomDropdown({
+  rooms,
+  currentRoom,
+  onRoomSelect,
+  onAddRoom,
+  username,
+  onlineUsers = [],
+  children,
+}: ChatRoomDropdownProps) {
+  const { t } = useTranslation();
+  const roomMessages = useChatsStore((s) => s.roomMessages);
+  const unreadCounts = useChatsStore((s) => s.unreadCounts);
+
+  const { publicRooms, privateRooms } = useMemo(() => {
+    const nextPublicRooms: ChatRoom[] = [];
+    const nextPrivateRooms: ChatRoom[] = [];
+
+    for (const room of Array.isArray(rooms) ? rooms : []) {
+      if (room.type === "private") {
+        nextPrivateRooms.push(room);
+      } else {
+        nextPublicRooms.push(room);
+      }
+    }
+
+    return {
+      publicRooms: nextPublicRooms,
+      privateRooms: sortPrivateRoomsForSidebar(nextPrivateRooms, {
+        username,
+        onlineUsers,
+        roomMessages,
+      }),
+    };
+  }, [onlineUsers, roomMessages, rooms, username]);
+
+  const hasBoth = publicRooms.length > 0 && privateRooms.length > 0;
+
+  const renderRoomItem = (room: ChatRoom) => {
+    const isOnline = Boolean(
+      room.type === "private" &&
+        isPrivateRoomOnline(room, username, onlineUsers)
+    );
+    const unreadCount = unreadCounts[room.id] || 0;
+
+    return (
+      <DropdownMenuCheckboxItem
+        key={room.id}
+        checked={currentRoom?.id === room.id}
+        onCheckedChange={(checked) => {
+          if (checked) onRoomSelect(room);
+        }}
+        className="text-md h-6"
+      >
+        <span className="flex w-full min-w-0 items-center">
+          {isOnline && (
+            <span
+              className="mr-1.5 inline-block size-1.5 flex-shrink-0 rounded-full bg-green-500"
+              title="Online"
+            />
+          )}
+          <span className="truncate min-w-0">
+            {room.type === "private"
+              ? getPrivateRoomDisplayName(room, username ?? null)
+              : `#${room.name}`}
+          </span>
+          {room.type === "irc" && (
+            <span
+              className="ml-1 flex-shrink-0 text-[9px] font-bold uppercase tracking-wider opacity-40"
+              title={`IRC ${room.ircHost || "irc.pieter.com"}`}
+            >
+              irc
+            </span>
+          )}
+          {unreadCount > 0 && (
+            <span className="ml-auto flex-shrink-0 whitespace-nowrap pl-2 text-[10px] text-orange-600">
+              {`${unreadCount >= 20 ? "20+" : unreadCount} ${t(
+                "apps.chats.sidebar.new"
+              )}`}
+            </span>
+          )}
+        </span>
+      </DropdownMenuCheckboxItem>
+    );
+  };
+
+  const sectionLabelClassName = cn(
+    "flex h-5 items-center px-3 py-0 font-normal",
+    "!text-[10px] uppercase tracking-wide opacity-50"
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        sideOffset={2}
+        className="max-h-[min(60vh,320px)] min-w-[200px] max-w-[280px] overflow-y-auto px-0"
+      >
+        {/* Ryo (@ryo) Chat Selection */}
+        <DropdownMenuCheckboxItem
+          checked={currentRoom === null}
+          onCheckedChange={(checked) => {
+            if (checked) onRoomSelect(null);
+          }}
+          className="text-md h-6"
+        >
+          {t("apps.chats.status.ryo")}
+        </DropdownMenuCheckboxItem>
+
+        {hasBoth ? (
+          <>
+            <DropdownMenuLabel className={sectionLabelClassName}>
+              {t("apps.chats.sidebar.rooms")}
+            </DropdownMenuLabel>
+            {publicRooms.map(renderRoomItem)}
+            <DropdownMenuLabel className={sectionLabelClassName}>
+              {t("apps.chats.sidebar.private")}
+            </DropdownMenuLabel>
+            {privateRooms.map(renderRoomItem)}
+          </>
+        ) : (
+          <>
+            {(publicRooms.length > 0 ? publicRooms : privateRooms).map(
+              renderRoomItem
+            )}
+          </>
+        )}
+
+        {username && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={onAddRoom}
+              className="text-md h-6 px-3"
+            >
+              {t("apps.chats.menu.newChat")}
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -29,7 +29,6 @@ interface ChatRoomSidebarProps {
   onDeleteRoom?: (room: ChatRoom) => void;
   isVisible: boolean;
   isAdmin: boolean;
-  isOverlay?: boolean;
   username?: string | null;
   onlineUsers?: string[];
 }
@@ -149,7 +148,6 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
   onDeleteRoom,
   isVisible,
   isAdmin,
-  isOverlay = false,
   username,
   onlineUsers = [],
 }: ChatRoomSidebarProps) {
@@ -228,19 +226,11 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
           isAquaGlass,
         },
         {
-          layout: isOverlay ? "overlay" : "side",
-          className: isOverlay ? "min-h-0 overflow-hidden" : undefined,
+          layout: "side",
         }
       )}
     >
-      <div
-        className={cn(
-          "pt-3 flex flex-col",
-          isOverlay
-            ? "min-h-0 flex-1 overflow-hidden pb-3"
-            : "flex-1 overflow-hidden"
-        )}
-      >
+      <div className="pt-3 flex flex-col flex-1 overflow-hidden">
         <div className="os-app-sidebar-header flex justify-between items-center mb-2 flex-shrink-0 px-3">
           <div className="flex items-baseline gap-1.5">
             <h2 className="text-[14px] pl-1">{t("apps.chats.sidebar.chats")}</h2>
@@ -266,12 +256,7 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
           )}
         </div>
         <div
-          className={cn(
-            "os-app-sidebar-list space-y-1 overscroll-contain w-full",
-            isOverlay
-              ? "flex-1 overflow-y-auto min-h-0"
-              : "flex-1 overflow-y-auto min-h-0"
-          )}
+          className="os-app-sidebar-list space-y-1 overscroll-contain w-full flex-1 overflow-y-auto min-h-0"
           style={{ WebkitOverflowScrolling: "touch" }}
         >
           {/* Ryo (@ryo) Chat Selection */}

--- a/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
@@ -1,10 +1,10 @@
 import type { CSSProperties } from "react";
-import { AnimatePresence, motion } from "motion/react";
 import { CaretDown } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "react-i18next";
 import { getPrivateRoomDisplayName } from "@/utils/chat";
 import { ChatRoomSidebar } from "../ChatRoomSidebar";
+import { ChatRoomDropdown } from "../ChatRoomDropdown";
 import { ChatMessages } from "../ChatMessages";
 import { ChatInput } from "../ChatInput";
 import type { ChatsAppController } from "./useChatsAppController";
@@ -26,7 +26,6 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
     sidebarVisibleBool,
     isFrameNarrow,
     toggleSidebarVisibility,
-    handleMobileRoomSelect,
     rooms,
     currentRoom,
     handlePromptDeleteRoom,
@@ -102,77 +101,6 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
         isWindowsTheme ? "border-t border-[#919b9c]" : ""
       }`}
     >
-      <AnimatePresence>
-        {sidebarVisibleBool && isFrameNarrow && (
-          <motion.div
-            className="absolute inset-0 z-20"
-            style={{ perspective: "2000px" }}
-          >
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 0.4 }}
-              exit={{ opacity: 0 }}
-              transition={{
-                duration: 0.2,
-                ease: [0.4, 0, 0.2, 1],
-              }}
-              className="absolute inset-0 bg-black"
-              onClick={toggleSidebarVisibility}
-            />
-
-            <motion.div
-              initial={{
-                rotateX: -60,
-                y: "-30%",
-                scale: 0.9,
-                opacity: 0,
-                transformOrigin: "top center",
-              }}
-              animate={{
-                rotateX: 0,
-                y: "0%",
-                scale: 1,
-                opacity: 1,
-                transformOrigin: "top center",
-              }}
-              exit={{
-                rotateX: -60,
-                y: "-30%",
-                scale: 0.9,
-                opacity: 0,
-                transformOrigin: "top center",
-              }}
-              transition={{
-                type: "spring",
-                damping: 40,
-                stiffness: 300,
-                mass: 1,
-              }}
-              className="relative z-10 flex w-full flex-col overflow-hidden bg-neutral-100"
-              style={{
-                transformPerspective: "2000px",
-                backfaceVisibility: "hidden",
-                willChange: "transform",
-                maxHeight: "calc(100% - 44px)",
-              }}
-            >
-              <ChatRoomSidebar
-                rooms={rooms}
-                currentRoom={currentRoom ?? null}
-                onRoomSelect={handleMobileRoomSelect}
-                onAddRoom={promptAddRoom}
-                onDeleteRoom={handlePromptDeleteRoom}
-                isVisible={true}
-                isAdmin={isAdmin}
-                username={username}
-                isOverlay={true}
-                onlineUsers={globalOnlineUsers}
-              />
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
       <div
         className={`flex h-full ${isFrameNarrow ? "flex-col" : "flex-row"}`}
       >
@@ -227,23 +155,53 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
               }`}
               style={isAquaGlass ? aquaGlassIslandStyle : undefined}
             >
-              <Button
-                variant="ghost"
-                onClick={toggleSidebarVisibility}
-                className="flex items-center gap-0.5 px-2 py-1 h-7"
-              >
-                <h2 className="font-geneva-12 text-[12px] font-medium truncate">
-                  {currentRoom
-                    ? currentRoom.type === "private"
-                      ? getPrivateRoomDisplayName(currentRoom, username)
-                      : `#${currentRoom.name}`
-                    : "@ryo"}
-                </h2>
-                <CaretDown
-                  className="size-2.5 transform transition-transform duration-200 text-neutral-400"
-                  weight="bold"
-                />
-              </Button>
+              {isFrameNarrow ? (
+                // Narrow frames swap the sidebar for a dropdown room switcher
+                // anchored to the header title.
+                <ChatRoomDropdown
+                  rooms={rooms}
+                  currentRoom={currentRoom ?? null}
+                  onRoomSelect={handleMenuRoomSelect}
+                  onAddRoom={promptAddRoom}
+                  username={username}
+                  onlineUsers={globalOnlineUsers}
+                >
+                  <Button
+                    variant="ghost"
+                    className="group flex items-center gap-0.5 px-2 py-1 h-7"
+                  >
+                    <h2 className="font-geneva-12 text-[12px] font-medium truncate">
+                      {currentRoom
+                        ? currentRoom.type === "private"
+                          ? getPrivateRoomDisplayName(currentRoom, username)
+                          : `#${currentRoom.name}`
+                        : "@ryo"}
+                    </h2>
+                    <CaretDown
+                      className="size-2.5 transform transition-transform duration-200 text-neutral-400 group-data-[state=open]:rotate-180"
+                      weight="bold"
+                    />
+                  </Button>
+                </ChatRoomDropdown>
+              ) : (
+                <Button
+                  variant="ghost"
+                  onClick={toggleSidebarVisibility}
+                  className="flex items-center gap-0.5 px-2 py-1 h-7"
+                >
+                  <h2 className="font-geneva-12 text-[12px] font-medium truncate">
+                    {currentRoom
+                      ? currentRoom.type === "private"
+                        ? getPrivateRoomDisplayName(currentRoom, username)
+                        : `#${currentRoom.name}`
+                      : "@ryo"}
+                  </h2>
+                  <CaretDown
+                    className="size-2.5 transform transition-transform duration-200 text-neutral-400"
+                    weight="bold"
+                  />
+                </Button>
+              )}
 
               {currentRoom &&
                 currentRoom.type !== "private" &&

--- a/src/apps/chats/components/chats-app/useChatsAppController.tsx
+++ b/src/apps/chats/components/chats-app/useChatsAppController.tsx
@@ -256,16 +256,6 @@ export function useChatsAppController({
 
   const sidebarVisibleBool = isSidebarVisible ?? false;
 
-  const handleMobileRoomSelect = useCallback(
-    (room: ChatRoom | null) => {
-      handleRoomSelectWithScroll(room ? room.id : null);
-      if (sidebarVisibleBool) {
-        toggleSidebarVisibility();
-      }
-    },
-    [handleRoomSelectWithScroll, sidebarVisibleBool, toggleSidebarVisibility]
-  );
-
   const handleSubmit = useCallback(
     async (messageText: string, imageData: string | null) => {
       if (checkOfflineAndShowError(t("apps.chats.status.chatRequiresInternet"))) {
@@ -576,7 +566,6 @@ export function useChatsAppController({
     isFrameNarrow,
     sidebarVisibleBool,
     toggleSidebarVisibility,
-    handleMobileRoomSelect,
     handleMenuRoomSelect,
     handlePromptDeleteRoom,
     rooms,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On narrow Chats frames (mobile / small widths), tapping the header room title used to open a custom full-width animated sheet overlay. This replaces that sheet with the shared `DropdownMenu` component anchored to the title button.

- New `ChatRoomDropdown` component renders the room switcher using the shared dropdown primitives: `@ryo` entry, Rooms / Private sections (same ordering as the sidebar via `sortPrivateRoomsForSidebar`), online dots for private rooms, unread badges, and a New Chat action when signed in.
- `ChatsWindowContent` wraps the header title button in the dropdown when the frame is narrow; wide frames keep the sidebar toggle behavior. The custom motion sheet (and its backdrop) is removed.
- Removed the now-unused `handleMobileRoomSelect` from the controller and the dead `isOverlay` path from `ChatRoomSidebar`.

## Testing

- `bun run typecheck`
- `bunx eslint` on changed files (pre-existing warnings only)
- `bun run test:unit` (2469 pass)
- `bun run build`
- Manual verification at narrow width (screenshots in run artifacts)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3cea-5565-7df4-97a3-aab7addac99b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3cea-5565-7df4-97a3-aab7addac99b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

