### PR TITLE
Add runJs chat tool: QuickJS WASM sandbox for server-side scripting

### DIFF
--- a/api/_utils/_aiPrompts.ts
+++ b/api/_utils/_aiPrompts.ts
@@ -472,6 +472,16 @@ Use \`mapsSearchPlaces\` whenever the user asks to find a place, look up an addr
 - Default \`limit\` is 5; bump up to 10 only when the user clearly wants a long list. Apple's daily quota is shared with MapKit JS.
 - The client renders a rich place card with the POI icon, title, and address — tapping it opens the place plotted in the ryOS Maps app. Don't paste raw lat/lng into your chat reply; let the card do the work and just refer to results by name + city.
 
+## SCRIPTING & CALCULATIONS
+Use \`runJs\` (sandboxed JavaScript) instead of computing in your head whenever a question involves actual computation:
+- Math beyond trivial sums: percentages, exponents, compound interest, unit/date conversions, big numbers (use BigInt like \`2n ** 100n\` for exact results)
+- Loops and iteration: counting, generating sequences, simulations
+- Data processing: sorting, filtering, deduping, statistics (mean/median), parsing JSON, text processing (word counts, regex extraction)
+- **Combine with other tools**: after \`webFetch\` or other tools return data, paste the relevant text/JSON into the script as a literal and compute over it (e.g. fetch a page → count words / extract and sum numbers in a follow-up \`runJs\` call)
+- Write self-contained scripts: no state persists between runs; \`console.log\` intermediate steps and make the last expression the final answer
+- The sandbox has no network/timers/DOM — do all fetching with \`webFetch\` first, then compute
+- Don't use \`runJs\` for building UI (that's \`generateHtml\`) or for things you can answer directly without computation
+
 </tool_usage_instructions>
 `;
 

--- a/api/chat/tools/_tool-rate-limit.ts
+++ b/api/chat/tools/_tool-rate-limit.ts
@@ -18,7 +18,8 @@ import { checkCounterLimit } from "../../_utils/_rate-limit.js";
 export type RateLimitedToolName =
   | "webFetch"
   | "searchSongs"
-  | "mapsSearchPlaces";
+  | "mapsSearchPlaces"
+  | "runJs";
 
 const TOOL_RATE_LIMITS: Record<
   RateLimitedToolName,
@@ -27,6 +28,8 @@ const TOOL_RATE_LIMITS: Record<
   webFetch: { limit: 50, windowSeconds: 60 * 60 },
   searchSongs: { limit: 30, windowSeconds: 60 * 60 },
   mapsSearchPlaces: { limit: 50, windowSeconds: 60 * 60 },
+  // Each run is CPU-bounded (15s max) but still burns server compute.
+  runJs: { limit: 60, windowSeconds: 60 * 60 },
 };
 
 export interface ToolRateLimitResult {

--- a/api/chat/tools/executors.ts
+++ b/api/chat/tools/executors.ts
@@ -30,7 +30,10 @@ import type {
   SongLibraryLyricsSource,
   WebFetchInput,
   WebFetchOutput,
+  RunJsInput,
+  RunJsOutput,
 } from "./types.js";
+import { runJsInSandbox, JS_SANDBOX_MAX_TIMEOUT_MS } from "./js-sandbox.js";
 import {
   readFilesMetadataToolState,
   writeFilesMetadataToolState,
@@ -364,6 +367,60 @@ export async function executeWebFetch(
       message: isTimeout
         ? "Request timed out — the page took too long to respond."
         : `Failed to fetch: ${error instanceof Error ? error.message : "Unknown error"}`,
+    };
+  }
+}
+
+// ============================================================================
+// Run JS (QuickJS sandbox) Tool Executor
+// ============================================================================
+
+export async function executeRunJs(
+  input: RunJsInput,
+  context: ServerToolContext & { username?: string | null; redis?: Redis }
+): Promise<RunJsOutput> {
+  const { code, timeoutSeconds } = input;
+
+  context.log(
+    `[runJs] Executing script (${code.length} chars${timeoutSeconds ? `, timeout ${timeoutSeconds}s` : ""})`
+  );
+
+  const rateLimit = await checkToolRateLimit("runJs", context);
+  if (!rateLimit.allowed) {
+    return {
+      success: false,
+      logs: "",
+      durationMs: 0,
+      truncated: false,
+      error: rateLimit.message!,
+      message: rateLimit.message!,
+    };
+  }
+
+  try {
+    const run = await runJsInSandbox(code, {
+      timeoutMs: timeoutSeconds
+        ? Math.min(timeoutSeconds * 1000, JS_SANDBOX_MAX_TIMEOUT_MS)
+        : undefined,
+    });
+
+    const message = run.success
+      ? `Script ran in ${run.durationMs}ms${run.truncated ? " (output truncated)" : ""}`
+      : `Script failed: ${run.error}`;
+    context.log(`[runJs] ${message}`);
+
+    return { ...run, message };
+  } catch (error) {
+    // Unexpected sandbox failure (e.g. WASM init) — not a script error.
+    context.logError("[runJs] Sandbox failure", error);
+    const message = `Sandbox failed to run: ${error instanceof Error ? error.message : "Unknown error"}`;
+    return {
+      success: false,
+      logs: "",
+      durationMs: 0,
+      truncated: false,
+      error: message,
+      message,
     };
   }
 }

--- a/api/chat/tools/index.ts
+++ b/api/chat/tools/index.ts
@@ -38,6 +38,7 @@ import type {
   MemoryReadInput,
   MemoryDeleteInput,
   WebFetchInput,
+  RunJsInput,
   MapsSearchPlacesInput,
 } from "./types.js";
 import * as schemas from "./schemas.js";
@@ -57,6 +58,7 @@ import {
   executeMemoryDelete,
   executeDocumentsControl,
   executeWebFetch,
+  executeRunJs,
   type MemoryToolContext,
 } from "./executors.js";
 import {
@@ -78,6 +80,7 @@ export {
   executeMemoryDelete,
   executeDocumentsControl,
   executeWebFetch,
+  executeRunJs,
   type MemoryToolContext,
 } from "./executors.js";
 export {
@@ -103,6 +106,7 @@ const _TELEGRAM_TOOL_NAMES = [
   "contactsControl",
   "songLibraryControl",
   "mapsSearchPlaces",
+  "runJs",
 ] as const;
 
 export type ChatToolProfile = "all" | "memory" | "telegram";
@@ -257,6 +261,17 @@ export const TOOL_DESCRIPTIONS = {
     "For JS-heavy single-page apps, content may be limited. " +
     "Optionally pass a CSS selector to extract a specific section.",
 
+  runJs:
+    "Run pure JavaScript (ES2023) in a secure server-side sandbox and get back console output plus the completion value. " +
+    "ALWAYS use this instead of computing in your head for: arithmetic beyond trivial sums, percentages, compound interest, " +
+    "date/unit conversions, counting, loops, sorting/filtering lists, statistics, string/text processing, parsing JSON, and any multi-step calculation. " +
+    "COMBINE WITH OTHER TOOLS: paste data from webFetch/searchSongs/other tool results into the script as string or object literals, then compute over it " +
+    "(e.g. fetch a page, then count words or extract numbers here). " +
+    "RULES: write self-contained scripts (each run starts fresh — no state persists between calls); console.log intermediate values and make the final expression the answer; " +
+    "use BigInt (e.g. 2n ** 100n) for exact large-integer math; " +
+    "the sandbox has NO fetch/network, NO timers (setTimeout), NO DOM, and NO Node/Bun APIs — inline all needed data as literals. " +
+    "Synchronous async/await works, but promises that rely on timers or I/O never settle.",
+
   // Unified Memory Tools
   memoryWrite:
     "Write to user memory. Supports two types via the 'type' parameter:\n" +
@@ -388,6 +403,17 @@ export function createChatTools(
       inputSchema: schemas.webFetchSchema,
       execute: async (input: WebFetchInput) => {
         return executeWebFetch(input, context);
+      },
+    },
+
+    // ============================================================================
+    // Run JS Tool (Server-side execution — QuickJS WASM sandbox)
+    // ============================================================================
+    runJs: {
+      description: TOOL_DESCRIPTIONS.runJs,
+      inputSchema: schemas.runJsSchema,
+      execute: async (input: RunJsInput) => {
+        return executeRunJs(input, context);
       },
     },
 
@@ -525,6 +551,7 @@ export function createChatTools(
   if (profile === "telegram") {
     return {
       webFetch: allTools.webFetch,
+      runJs: allTools.runJs,
       memoryWrite: allTools.memoryWrite,
       memoryRead: allTools.memoryRead,
       memoryDelete: allTools.memoryDelete,

--- a/api/chat/tools/js-sandbox.ts
+++ b/api/chat/tools/js-sandbox.ts
@@ -1,0 +1,205 @@
+/**
+ * QuickJS (WASM) sandbox for the runJs chat tool.
+ *
+ * Runs model-written JavaScript inside a QuickJS interpreter compiled to
+ * WebAssembly. The VM has zero host access — no filesystem, no network, no
+ * timers, no process/env — the only injected binding is a `console` shim that
+ * captures log output. CPU-bound runaways are stopped by an interrupt-handler
+ * deadline and allocations are capped with a memory limit, so no worker
+ * thread or child process is needed.
+ */
+
+import { getQuickJS, shouldInterruptAfterDeadline } from "quickjs-emscripten";
+import type { QuickJSContext } from "quickjs-emscripten";
+
+export const JS_SANDBOX_DEFAULT_TIMEOUT_MS = 5_000;
+export const JS_SANDBOX_MAX_TIMEOUT_MS = 15_000;
+export const JS_SANDBOX_MAX_CODE_LENGTH = 20_000;
+export const JS_SANDBOX_MAX_OUTPUT_CHARS = 16_000;
+const MEMORY_LIMIT_BYTES = 64 * 1024 * 1024;
+const MAX_STACK_SIZE_BYTES = 1024 * 1024;
+
+export interface JsSandboxRunResult {
+  success: boolean;
+  /** Captured console output, newline-joined. */
+  logs: string;
+  /** Stringified completion value of the script (absent when undefined). */
+  result?: string;
+  error?: string;
+  durationMs: number;
+  /** True when logs or the result were cut to fit the output cap. */
+  truncated: boolean;
+}
+
+/** Render a dumped VM value for logs / the completion value. */
+export function stringifySandboxValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "bigint") return `${value}n`;
+  if (value === undefined) return "undefined";
+  if (typeof value === "function") return "[function]";
+  try {
+    const json = JSON.stringify(value, (_key, val: unknown) =>
+      typeof val === "bigint" ? `${val}n` : val
+    );
+    // JSON.stringify(undefined-like values, e.g. bare Symbol) returns undefined
+    return json ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/** Accumulates output lines under a total character budget. */
+export function createOutputBuffer(maxChars: number = JS_SANDBOX_MAX_OUTPUT_CHARS) {
+  const lines: string[] = [];
+  let used = 0;
+  let truncated = false;
+  return {
+    push(line: string) {
+      if (truncated) return;
+      const remaining = maxChars - used;
+      if (remaining <= 0) {
+        truncated = true;
+        return;
+      }
+      if (line.length > remaining) {
+        lines.push(line.slice(0, remaining) + "…");
+        used = maxChars;
+        truncated = true;
+        return;
+      }
+      lines.push(line);
+      used += line.length + 1; // +1 for the joining newline
+    },
+    get text() {
+      return lines.join("\n");
+    },
+    get truncated() {
+      return truncated;
+    },
+  };
+}
+
+function installConsole(
+  ctx: QuickJSContext,
+  pushLog: (line: string) => void
+): void {
+  const consoleHandle = ctx.newObject();
+  const levels = ["log", "info", "debug", "warn", "error"] as const;
+  for (const level of levels) {
+    const fnHandle = ctx.newFunction(level, (...args) => {
+      const text = args
+        .map((handle) => stringifySandboxValue(ctx.dump(handle)))
+        .join(" ");
+      pushLog(level === "warn" || level === "error" ? `[${level}] ${text}` : text);
+    });
+    ctx.setProp(consoleHandle, level, fnHandle);
+    fnHandle.dispose();
+  }
+  ctx.setProp(ctx.global, "console", consoleHandle);
+  consoleHandle.dispose();
+}
+
+function formatSandboxError(dumped: unknown, timeoutMs: number): string {
+  if (dumped && typeof dumped === "object") {
+    const err = dumped as { name?: string; message?: string };
+    const name = typeof err.name === "string" ? err.name : "Error";
+    const message = typeof err.message === "string" ? err.message : "";
+    if (name === "InternalError" && message === "interrupted") {
+      return `Execution timed out after ${timeoutMs}ms`;
+    }
+    if (message.includes("out of memory")) {
+      return `Script exceeded the sandbox memory limit (${MEMORY_LIMIT_BYTES / (1024 * 1024)}MB)`;
+    }
+    return message ? `${name}: ${message}` : name;
+  }
+  return stringifySandboxValue(dumped);
+}
+
+export interface RunJsSandboxOptions {
+  timeoutMs?: number;
+  maxOutputChars?: number;
+}
+
+/**
+ * Execute JavaScript in a fresh, disposable QuickJS context.
+ *
+ * Each run is stateless: a new runtime + context is created and disposed per
+ * call, so nothing leaks between users or requests. The WASM module itself is
+ * memoized by quickjs-emscripten, so warm calls only pay context creation.
+ */
+export async function runJsInSandbox(
+  code: string,
+  options: RunJsSandboxOptions = {}
+): Promise<JsSandboxRunResult> {
+  const timeoutMs = Math.min(
+    Math.max(options.timeoutMs ?? JS_SANDBOX_DEFAULT_TIMEOUT_MS, 1),
+    JS_SANDBOX_MAX_TIMEOUT_MS
+  );
+  const output = createOutputBuffer(options.maxOutputChars);
+  const startedAt = Date.now();
+
+  const finish = (
+    partial: Pick<JsSandboxRunResult, "success" | "result" | "error">
+  ): JsSandboxRunResult => ({
+    ...partial,
+    logs: output.text,
+    durationMs: Date.now() - startedAt,
+    truncated: output.truncated,
+  });
+
+  const QuickJS = await getQuickJS();
+  const runtime = QuickJS.newRuntime();
+  runtime.setMemoryLimit(MEMORY_LIMIT_BYTES);
+  runtime.setMaxStackSize(MAX_STACK_SIZE_BYTES);
+  runtime.setInterruptHandler(shouldInterruptAfterDeadline(startedAt + timeoutMs));
+  const ctx = runtime.newContext();
+
+  try {
+    installConsole(ctx, output.push);
+
+    const evalResult = ctx.evalCode(code, "script.js");
+    if (evalResult.error) {
+      const dumped = ctx.dump(evalResult.error);
+      evalResult.error.dispose();
+      return finish({ success: false, error: formatSandboxError(dumped, timeoutMs) });
+    }
+
+    const handle = evalResult.value;
+    // Drain microtasks so async code / promise chains settle. The sandbox has
+    // no timers or I/O, so anything still pending afterwards can never settle.
+    const jobs = runtime.executePendingJobs();
+    if (jobs.error) jobs.error.dispose();
+
+    const state = ctx.getPromiseState(handle);
+    if (state.type === "pending") {
+      handle.dispose();
+      return finish({
+        success: false,
+        error:
+          "Script returned a promise that never settles — the sandbox has no timers or network. Compute synchronously instead.",
+      });
+    }
+    if (state.type === "rejected") {
+      const dumped = ctx.dump(state.error);
+      state.error.dispose();
+      handle.dispose();
+      return finish({ success: false, error: formatSandboxError(dumped, timeoutMs) });
+    }
+
+    const dumpedValue = ctx.dump(state.value);
+    if (!state.notAPromise) state.value.dispose();
+    handle.dispose();
+
+    const result =
+      dumpedValue === undefined
+        ? undefined
+        : stringifySandboxValue(dumpedValue).slice(
+            0,
+            options.maxOutputChars ?? JS_SANDBOX_MAX_OUTPUT_CHARS
+          );
+    return finish({ success: true, result });
+  } finally {
+    ctx.dispose();
+    runtime.dispose();
+  }
+}

--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -1151,6 +1151,29 @@ export const webFetchSchema = z.object({
 });
 
 // ============================================================================
+// Run JS (QuickJS sandbox) Tool Schema
+// ============================================================================
+
+export const runJsSchema = z.object({
+  code: z
+    .string()
+    .min(1)
+    .max(20_000)
+    .describe(
+      "Pure JavaScript (ES2023) to execute. The completion value of the last expression is returned, " +
+      "and console.log/info/warn/error output is captured. Use BigInt (e.g. 2n ** 100n) for exact large-integer math. " +
+      "No fetch, timers, DOM, or Node/Bun APIs exist — inline any needed data as literals."
+    ),
+  timeoutSeconds: z
+    .number()
+    .int()
+    .min(1)
+    .max(15)
+    .optional()
+    .describe("Optional execution time limit in seconds (default 5, max 15)."),
+});
+
+// ============================================================================
 // Unified Media Control Schema (MediaCore)
 // ============================================================================
 

--- a/api/chat/tools/types.ts
+++ b/api/chat/tools/types.ts
@@ -606,5 +606,26 @@ export interface WebFetchOutput {
 }
 
 // ============================================================================
+// Run JS (QuickJS sandbox) Tool Types
+// ============================================================================
+
+export interface RunJsInput {
+  code: string;
+  timeoutSeconds?: number;
+}
+
+export interface RunJsOutput {
+  success: boolean;
+  /** Captured console output, newline-joined. */
+  logs: string;
+  /** Stringified completion value of the script (absent when undefined). */
+  result?: string;
+  error?: string;
+  durationMs: number;
+  truncated: boolean;
+  message: string;
+}
+
+// ============================================================================
 // App State Types (for server-side calendar/stickies executors)
 // ============================================================================

--- a/bun.lock
+++ b/bun.lock
@@ -73,6 +73,7 @@
         "pusher": "^5.3.4",
         "pusher-js": "^8.5.0",
         "qrcode.react": "^4.2.0",
+        "quickjs-emscripten": "^0.32.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-i18next": "^16.6.6",
@@ -632,6 +633,16 @@
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
+    "@jitl/quickjs-ffi-types": ["@jitl/quickjs-ffi-types@0.32.0", "", {}, "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg=="],
+
+    "@jitl/quickjs-wasmfile-debug-asyncify": ["@jitl/quickjs-wasmfile-debug-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw=="],
+
+    "@jitl/quickjs-wasmfile-debug-sync": ["@jitl/quickjs-wasmfile-debug-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q=="],
+
+    "@jitl/quickjs-wasmfile-release-asyncify": ["@jitl/quickjs-wasmfile-release-asyncify@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q=="],
+
+    "@jitl/quickjs-wasmfile-release-sync": ["@jitl/quickjs-wasmfile-release-sync@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.8", "", { "dependencies": { "@jridgewell/set-array": "^1.2.1", "@jridgewell/sourcemap-codec": "^1.4.10", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA=="],
 
@@ -1759,7 +1770,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron": ["electron@github:castlabs/electron-releases#d239796", { "dependencies": { "@electron/get": "^5.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "castlabs-electron-releases-d239796", "sha512-/U1DPgsORxGeWs5njX2PpftF9xIQhU3T/axHX6a6yexgUWJt23y/U/OWWX/Ctd/dRXQOZw4PQfNzUodmVkNyZA=="],
+    "electron": ["electron@github:castlabs/electron-releases#d239796", { "dependencies": { "@electron/get": "^5.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "castlabs-electron-releases-d239796"],
 
     "electron-builder": ["electron-builder@25.1.8", "", { "dependencies": { "app-builder-lib": "25.1.8", "builder-util": "25.1.7", "builder-util-runtime": "9.2.10", "chalk": "^4.1.2", "dmg-builder": "25.1.8", "fs-extra": "^10.1.0", "is-ci": "^3.0.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "cli.js", "install-app-deps": "install-app-deps.js" } }, "sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig=="],
 
@@ -2760,6 +2771,10 @@
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
+
+    "quickjs-emscripten": ["quickjs-emscripten@0.32.0", "", { "dependencies": { "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-debug-sync": "0.32.0", "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0", "@jitl/quickjs-wasmfile-release-sync": "0.32.0", "quickjs-emscripten-core": "0.32.0" } }, "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA=="],
+
+    "quickjs-emscripten-core": ["quickjs-emscripten-core@0.32.0", "", { "dependencies": { "@jitl/quickjs-ffi-types": "0.32.0" } }, "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg=="],
 
     "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
 

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "pusher": "^5.3.4",
     "pusher-js": "^8.5.0",
     "qrcode.react": "^4.2.0",
+    "quickjs-emscripten": "^0.32.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-i18next": "^16.6.6",

--- a/src/components/shared/JsRunCard.tsx
+++ b/src/components/shared/JsRunCard.tsx
@@ -139,47 +139,63 @@ export function JsRunCard({ code, run, className }: JsRunCardProps) {
             type="button"
             onClick={() => setCodeVisible((visible) => !visible)}
             className={cn(
-              "flex h-6 shrink-0 items-center gap-1 rounded px-1.5",
+              "flex size-6 shrink-0 items-center justify-center rounded",
               "focus:outline-none focus-visible:ring-1",
               osSubtleIconButtonClassName(),
               codeVisible && "bg-black/10 os-mac-aqua-dark:bg-white/15"
             )}
             aria-pressed={codeVisible}
-          >
-            <Code size={13} weight="bold" aria-hidden />
-            <span>
-              {codeVisible
+            aria-label={
+              codeVisible
                 ? t("apps.chats.toolCalls.runJs.hideCode", {
                     defaultValue: "Hide Code",
                   })
                 : t("apps.chats.toolCalls.runJs.showCode", {
                     defaultValue: "Show Code",
-                  })}
-            </span>
+                  })
+            }
+            title={
+              codeVisible
+                ? t("apps.chats.toolCalls.runJs.hideCode", {
+                    defaultValue: "Hide Code",
+                  })
+                : t("apps.chats.toolCalls.runJs.showCode", {
+                    defaultValue: "Show Code",
+                  })
+            }
+          >
+            <Code size={13} weight="bold" aria-hidden />
           </button>
           <button
             type="button"
             onClick={handleSave}
             disabled={savedPath !== null}
             className={cn(
-              "flex h-6 shrink-0 items-center gap-1 rounded px-1.5",
+              "flex size-6 shrink-0 items-center justify-center rounded",
               "focus:outline-none focus-visible:ring-1",
               osSubtleIconButtonClassName(),
               savedPath !== null && "opacity-60"
             )}
+            aria-label={
+              savedPath !== null
+                ? t("apps.chats.toolCalls.runJs.saved", {
+                    defaultValue: "Saved",
+                  })
+                : t("apps.chats.toolCalls.runJs.save", { defaultValue: "Save" })
+            }
+            title={
+              savedPath !== null
+                ? t("apps.chats.toolCalls.runJs.saved", {
+                    defaultValue: "Saved",
+                  })
+                : t("apps.chats.toolCalls.runJs.save", { defaultValue: "Save" })
+            }
           >
             {savedPath !== null ? (
               <Check size={13} weight="bold" aria-hidden />
             ) : (
               <FloppyDisk size={13} weight="bold" aria-hidden />
             )}
-            <span>
-              {savedPath !== null
-                ? t("apps.chats.toolCalls.runJs.saved", {
-                    defaultValue: "Saved",
-                  })
-                : t("apps.chats.toolCalls.runJs.save", { defaultValue: "Save" })}
-            </span>
           </button>
         </div>
       </div>

--- a/src/components/shared/JsRunCard.tsx
+++ b/src/components/shared/JsRunCard.tsx
@@ -94,10 +94,12 @@ export function JsRunCard({ code, run, className }: JsRunCardProps) {
         className
       )}
     >
-      {/* Header: status + duration, code/save actions */}
+      {/* Header: status + duration, code/save actions. flex-wrap + the
+          status label's minimum basis push the buttons onto a second row in
+          narrow chat bubbles instead of crushing the status text. */}
       <div
         className={cn(
-          "flex items-center gap-1.5 px-2.5 py-1.5 text-[11px]",
+          "flex flex-wrap items-center gap-x-1.5 gap-y-1 px-2.5 py-1.5 text-[11px]",
           "border-b border-black/10 os-mac-aqua-dark:border-[color:var(--os-color-separator)]"
         )}
       >
@@ -117,7 +119,7 @@ export function JsRunCard({ code, run, className }: JsRunCardProps) {
             aria-hidden
           />
         )}
-        <span className="min-w-0 flex-1 truncate text-os-text-secondary">
+        <span className="min-w-24 flex-1 truncate text-os-text-secondary">
           {run.success
             ? t("apps.chats.toolCalls.runJs.ran", {
                 defaultValue: "Script ran in {{duration}}",
@@ -132,52 +134,54 @@ export function JsRunCard({ code, run, className }: JsRunCardProps) {
               })}`
             : ""}
         </span>
-        <button
-          type="button"
-          onClick={() => setCodeVisible((visible) => !visible)}
-          className={cn(
-            "flex h-6 shrink-0 items-center gap-1 rounded px-1.5",
-            "focus:outline-none focus-visible:ring-1",
-            osSubtleIconButtonClassName(),
-            codeVisible && "bg-black/10 os-mac-aqua-dark:bg-white/15"
-          )}
-          aria-pressed={codeVisible}
-        >
-          <Code size={13} weight="bold" aria-hidden />
-          <span>
-            {codeVisible
-              ? t("apps.chats.toolCalls.runJs.hideCode", {
-                  defaultValue: "Hide Code",
-                })
-              : t("apps.chats.toolCalls.runJs.showCode", {
-                  defaultValue: "Show Code",
-                })}
-          </span>
-        </button>
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={savedPath !== null}
-          className={cn(
-            "flex h-6 shrink-0 items-center gap-1 rounded px-1.5",
-            "focus:outline-none focus-visible:ring-1",
-            osSubtleIconButtonClassName(),
-            savedPath !== null && "opacity-60"
-          )}
-        >
-          {savedPath !== null ? (
-            <Check size={13} weight="bold" aria-hidden />
-          ) : (
-            <FloppyDisk size={13} weight="bold" aria-hidden />
-          )}
-          <span>
-            {savedPath !== null
-              ? t("apps.chats.toolCalls.runJs.saved", {
-                  defaultValue: "Saved",
-                })
-              : t("apps.chats.toolCalls.runJs.save", { defaultValue: "Save" })}
-          </span>
-        </button>
+        <div className="ml-auto flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setCodeVisible((visible) => !visible)}
+            className={cn(
+              "flex h-6 shrink-0 items-center gap-1 rounded px-1.5",
+              "focus:outline-none focus-visible:ring-1",
+              osSubtleIconButtonClassName(),
+              codeVisible && "bg-black/10 os-mac-aqua-dark:bg-white/15"
+            )}
+            aria-pressed={codeVisible}
+          >
+            <Code size={13} weight="bold" aria-hidden />
+            <span>
+              {codeVisible
+                ? t("apps.chats.toolCalls.runJs.hideCode", {
+                    defaultValue: "Hide Code",
+                  })
+                : t("apps.chats.toolCalls.runJs.showCode", {
+                    defaultValue: "Show Code",
+                  })}
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={savedPath !== null}
+            className={cn(
+              "flex h-6 shrink-0 items-center gap-1 rounded px-1.5",
+              "focus:outline-none focus-visible:ring-1",
+              osSubtleIconButtonClassName(),
+              savedPath !== null && "opacity-60"
+            )}
+          >
+            {savedPath !== null ? (
+              <Check size={13} weight="bold" aria-hidden />
+            ) : (
+              <FloppyDisk size={13} weight="bold" aria-hidden />
+            )}
+            <span>
+              {savedPath !== null
+                ? t("apps.chats.toolCalls.runJs.saved", {
+                    defaultValue: "Saved",
+                  })
+                : t("apps.chats.toolCalls.runJs.save", { defaultValue: "Save" })}
+            </span>
+          </button>
+        </div>
       </div>
 
       {/* Collapsible source */}

--- a/src/components/shared/JsRunCard.tsx
+++ b/src/components/shared/JsRunCard.tsx
@@ -1,0 +1,223 @@
+import { Check, Code, FloppyDisk, Warning } from "@phosphor-icons/react";
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useFileSystem } from "@/apps/finder/hooks/useFileSystem";
+import { useAppStore } from "@/stores/useAppStore";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { cn } from "@/lib/utils";
+import { toolInlineCardShellClassName } from "@/components/shared/toolInlineCardShell";
+import { osSubtleIconButtonClassName } from "@/components/shared/osThemePrimitives";
+
+/**
+ * Result payload of the `runJs` server tool. Mirrors `RunJsOutput` from
+ * `api/chat/tools/types.ts` (re-declared so the chat UI doesn't import
+ * server-only code).
+ */
+export interface JsRunCardData {
+  success: boolean;
+  logs: string;
+  result?: string;
+  error?: string;
+  durationMs: number;
+  truncated: boolean;
+}
+
+export interface JsRunCardProps {
+  /** The script source from the tool call input (hidden until revealed). */
+  code: string;
+  run: JsRunCardData;
+  /** Extra classes merged onto the card shell (e.g. compact-host overrides). */
+  className?: string;
+}
+
+function formatJsRunDuration(durationMs: number): string {
+  return durationMs < 1000
+    ? `${durationMs}ms`
+    : `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+function makeScriptFileName(now = new Date()): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `script-${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(
+    now.getDate()
+  )}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}.js`;
+}
+
+/**
+ * Inline chat card rendered when the assistant calls `runJs`. Shows the
+ * script output (console logs + completion value) up front; the code itself
+ * stays collapsed behind a "show code" toggle and can be saved to
+ * /Documents as a .js file on demand.
+ */
+export function JsRunCard({ code, run, className }: JsRunCardProps) {
+  const { t } = useTranslation();
+  const { isMacOSTheme, isWindowsTheme, isSystem7Theme, isWin98 } =
+    useThemeFlags();
+  const { saveFile } = useFileSystem("/Documents", { skipLoad: true });
+  const [codeVisible, setCodeVisible] = useState(false);
+  const [savedPath, setSavedPath] = useState<string | null>(null);
+
+  const handleSave = useCallback(async () => {
+    if (savedPath) return;
+    const fileName = makeScriptFileName();
+    const path = `/Documents/${fileName}`;
+    await saveFile({
+      name: fileName,
+      path,
+      content: code,
+      type: "text",
+      icon: "📜",
+    });
+    setSavedPath(path);
+    // Open the saved script so the user sees where it went (same behavior
+    // as the AI `write` tool).
+    useAppStore
+      .getState()
+      .launchApp("textedit", { path, content: code }, fileName, true);
+  }, [code, saveFile, savedPath]);
+
+  const hasLogs = run.logs.trim().length > 0;
+  const hasResult =
+    typeof run.result === "string" && run.result.trim().length > 0;
+  const hasError = typeof run.error === "string" && run.error.length > 0;
+
+  return (
+    <div
+      className={cn(
+        toolInlineCardShellClassName({
+          isMacOSTheme,
+          isSystem7Theme,
+          isWindowsTheme,
+          isWin98,
+        }),
+        "overflow-hidden",
+        className
+      )}
+    >
+      {/* Header: status + duration, code/save actions */}
+      <div
+        className={cn(
+          "flex items-center gap-1.5 px-2.5 py-1.5 text-[11px]",
+          "border-b border-black/10 os-mac-aqua-dark:border-[color:var(--os-color-separator)]"
+        )}
+      >
+        {run.success ? (
+          <Check
+            className="size-3 shrink-0"
+            style={{
+              color: "var(--os-accent-color, var(--os-color-selection-bg))",
+            }}
+            weight="bold"
+            aria-hidden
+          />
+        ) : (
+          <Warning
+            className="size-3 shrink-0 text-red-600 dark:text-red-400"
+            weight="bold"
+            aria-hidden
+          />
+        )}
+        <span className="min-w-0 flex-1 truncate text-os-text-secondary">
+          {run.success
+            ? t("apps.chats.toolCalls.runJs.ran", {
+                defaultValue: "Script ran in {{duration}}",
+                duration: formatJsRunDuration(run.durationMs),
+              })
+            : t("apps.chats.toolCalls.runJs.failed", {
+                defaultValue: "Script failed",
+              })}
+          {run.truncated
+            ? ` ${t("apps.chats.toolCalls.runJs.truncated", {
+                defaultValue: "(output truncated)",
+              })}`
+            : ""}
+        </span>
+        <button
+          type="button"
+          onClick={() => setCodeVisible((visible) => !visible)}
+          className={cn(
+            "flex h-6 shrink-0 items-center gap-1 rounded px-1.5",
+            "focus:outline-none focus-visible:ring-1",
+            osSubtleIconButtonClassName(),
+            codeVisible && "bg-black/10 os-mac-aqua-dark:bg-white/15"
+          )}
+          aria-pressed={codeVisible}
+        >
+          <Code size={13} weight="bold" aria-hidden />
+          <span>
+            {codeVisible
+              ? t("apps.chats.toolCalls.runJs.hideCode", {
+                  defaultValue: "Hide Code",
+                })
+              : t("apps.chats.toolCalls.runJs.showCode", {
+                  defaultValue: "Show Code",
+                })}
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={savedPath !== null}
+          className={cn(
+            "flex h-6 shrink-0 items-center gap-1 rounded px-1.5",
+            "focus:outline-none focus-visible:ring-1",
+            osSubtleIconButtonClassName(),
+            savedPath !== null && "opacity-60"
+          )}
+        >
+          {savedPath !== null ? (
+            <Check size={13} weight="bold" aria-hidden />
+          ) : (
+            <FloppyDisk size={13} weight="bold" aria-hidden />
+          )}
+          <span>
+            {savedPath !== null
+              ? t("apps.chats.toolCalls.runJs.saved", {
+                  defaultValue: "Saved",
+                })
+              : t("apps.chats.toolCalls.runJs.save", { defaultValue: "Save" })}
+          </span>
+        </button>
+      </div>
+
+      {/* Collapsible source */}
+      {codeVisible && (
+        <pre
+          className={cn(
+            "max-h-48 overflow-auto px-2.5 py-2 font-os-mono text-[11px] leading-snug",
+            "whitespace-pre-wrap break-words",
+            "border-b border-black/10 os-mac-aqua-dark:border-[color:var(--os-color-separator)]",
+            "bg-black/[0.04] os-mac-aqua-dark:bg-white/[0.06]",
+            "text-os-text-primary"
+          )}
+        >
+          {code}
+        </pre>
+      )}
+
+      {/* Output: logs, completion value, error */}
+      <pre
+        className={cn(
+          "max-h-48 overflow-auto px-2.5 py-2 font-os-mono text-[11px] leading-snug",
+          "whitespace-pre-wrap break-words"
+        )}
+      >
+        {hasLogs && <span className="text-os-text-primary">{run.logs}</span>}
+        {hasLogs && (hasResult || hasError) && "\n"}
+        {hasResult && (
+          <span className="text-os-text-secondary">{`→ ${run.result}`}</span>
+        )}
+        {hasError && (
+          <span className="text-red-600 dark:text-red-400">{run.error}</span>
+        )}
+        {!hasLogs && !hasResult && !hasError && (
+          <span className="italic text-os-text-secondary">
+            {t("apps.chats.toolCalls.runJs.noOutput", {
+              defaultValue: "(no output)",
+            })}
+          </span>
+        )}
+      </pre>
+    </div>
+  );
+}

--- a/src/components/shared/tool-invocation-message/getToolInvocationCallMessage.ts
+++ b/src/components/shared/tool-invocation-message/getToolInvocationCallMessage.ts
@@ -129,6 +129,11 @@ export function getToolInvocationCallMessage(
         displayCallMessage = t("apps.chats.toolCalls.webFetch.fetching", { hostname: hostname || url });
         break;
       }
+      case "runJs":
+        displayCallMessage = t("apps.chats.toolCalls.runJs.running", {
+          defaultValue: "Running script…",
+        });
+        break;
       case "mapsSearchPlaces": {
         const query = typeof input?.query === "string" ? input.query : "";
         displayCallMessage = query

--- a/src/components/shared/tool-invocation-message/getToolInvocationResultMessage.ts
+++ b/src/components/shared/tool-invocation-message/getToolInvocationResultMessage.ts
@@ -365,6 +365,22 @@ export function getToolInvocationResultMessage(
       } else if (out?.message) {
         displayResultMessage = out.message;
       }
+    } else if (toolName === "runJs") {
+      const out = output as { success?: boolean; durationMs?: number; error?: string } | undefined;
+      if (out?.success) {
+        const durationMs = typeof out.durationMs === "number" ? out.durationMs : 0;
+        const duration =
+          durationMs < 1000 ? `${durationMs}ms` : `${(durationMs / 1000).toFixed(1)}s`;
+        displayResultMessage = t("apps.chats.toolCalls.runJs.ran", {
+          defaultValue: "Script ran in {{duration}}",
+          duration,
+        });
+      } else if (out?.error) {
+        displayResultMessage = t("apps.chats.toolCalls.runJs.failedWithError", {
+          defaultValue: "Script failed: {{error}}",
+          error: out.error,
+        });
+      }
     } else if (toolName === "infiniteMacControl") {
       const action = input?.action;
       const x = input?.x;

--- a/src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx
+++ b/src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx
@@ -11,6 +11,7 @@ import {
   MapsSearchPlacesCard,
   type MapsSearchPlaceCardData,
 } from "@/components/shared/MapsSearchPlacesCard";
+import { JsRunCard, type JsRunCardData } from "@/components/shared/JsRunCard";
 import { ActivityIndicator } from "@/components/ui/activity-indicator";
 import { ToolInvocationStatusRow } from "./ToolInvocationStatusRow";
 import type { ToolInvocationMessageProps, ToolInvocationPart } from "./types";
@@ -237,6 +238,32 @@ export function tryRenderToolInvocationSpecialContent(
               })}
             </span>
           </ToolInvocationStatusRow>
+        </div>
+      );
+    }
+  }
+
+  // Special handling for runJs — terminal-style output card with the code
+  // collapsed behind a "show code" toggle + save-to-Documents action.
+  if (state === "output-available" && toolName === "runJs") {
+    const out = output as Partial<JsRunCardData> | undefined;
+    if (out && typeof out === "object" && typeof out.success === "boolean") {
+      const codeText = typeof input?.code === "string" ? input.code : "";
+      return (
+        <div key={partKey} className="mb-0 px-1 py-0.5 text-[12px]">
+          <JsRunCard
+            code={codeText}
+            run={{
+              success: out.success,
+              logs: typeof out.logs === "string" ? out.logs : "",
+              result: typeof out.result === "string" ? out.result : undefined,
+              error: typeof out.error === "string" ? out.error : undefined,
+              durationMs:
+                typeof out.durationMs === "number" ? out.durationMs : 0,
+              truncated: out.truncated === true,
+            }}
+            className={compactCardClassName}
+          />
         </div>
       );
     }

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1459,6 +1459,18 @@
         "preparingHtmlPreview": "Vorbereiten …",
         "read": "{{fileName}} gelesen",
         "readingFile": "Datei wird gelesen …",
+        "runJs": {
+          "failed": "Skript fehlgeschlagen",
+          "failedWithError": "Skript fehlgeschlagen: {{error}}",
+          "hideCode": "Code ausblenden",
+          "noOutput": "(keine Ausgabe)",
+          "ran": "Skript in {{duration}} ausgeführt",
+          "running": "Skript wird ausgeführt …",
+          "save": "Sichern",
+          "saved": "Gesichert",
+          "showCode": "Code einblenden",
+          "truncated": "(Ausgabe gekürzt)"
+        },
         "running": "{{toolName}} wird ausgeführt …",
         "searchedWeb": "Im Web gesucht",
         "searchedWebFor": "Im Web nach {{query}} gesucht",

--- a/src/lib/locales/en/shell.json
+++ b/src/lib/locales/en/shell.json
@@ -825,6 +825,18 @@
           "fetched": "Read {{siteName}}",
           "fetchedPage": "Read \"{{title}}\""
         },
+        "runJs": {
+          "running": "Running script…",
+          "ran": "Script ran in {{duration}}",
+          "failed": "Script failed",
+          "failedWithError": "Script failed: {{error}}",
+          "truncated": "(output truncated)",
+          "showCode": "Show Code",
+          "hideCode": "Hide Code",
+          "save": "Save",
+          "saved": "Saved",
+          "noOutput": "(no output)"
+        },
         "cursorCloudAgent": {
           "starting": "Starting Cursor Cloud agent…",
           "panelTitle": "Cursor Cloud agent",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1094,6 +1094,18 @@
           "fetched": "Read {{siteName}}",
           "fetchedPage": "Read \"{{title}}\""
         },
+        "runJs": {
+          "running": "Running script…",
+          "ran": "Script ran in {{duration}}",
+          "failed": "Script failed",
+          "failedWithError": "Script failed: {{error}}",
+          "truncated": "(output truncated)",
+          "showCode": "Show Code",
+          "hideCode": "Hide Code",
+          "save": "Save",
+          "saved": "Saved",
+          "noOutput": "(no output)"
+        },
         "cursorCloudAgent": {
           "starting": "Starting Cursor Cloud agent…",
           "panelTitle": "Cursor Cloud agent",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1461,6 +1461,18 @@
         "preparingHtmlPreview": "Preparando vista previa HTML…",
         "read": "Se leyó {{fileName}}",
         "readingFile": "Leyendo archivo…",
+        "runJs": {
+          "failed": "Error en el script",
+          "failedWithError": "Error en el script: {{error}}",
+          "hideCode": "Ocultar código",
+          "noOutput": "(sin salida)",
+          "ran": "Script ejecutado en {{duration}}",
+          "running": "Ejecutando script…",
+          "save": "Guardar",
+          "saved": "Guardado",
+          "showCode": "Mostrar código",
+          "truncated": "(salida truncada)"
+        },
         "running": "Ejecutando {{toolName}}…",
         "searchedWeb": "Buscado en la web",
         "searchedWebFor": "Buscado en la web por {{query}}",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1461,6 +1461,18 @@
         "preparingHtmlPreview": "Préparation de l’aperçu HTML…",
         "read": "{{fileName}} lu",
         "readingFile": "Lecture du fichier…",
+        "runJs": {
+          "failed": "Échec du script",
+          "failedWithError": "Échec du script : {{error}}",
+          "hideCode": "Masquer le code",
+          "noOutput": "(aucune sortie)",
+          "ran": "Script exécuté en {{duration}}",
+          "running": "Exécution du script…",
+          "save": "Enregistrer",
+          "saved": "Enregistré",
+          "showCode": "Afficher le code",
+          "truncated": "(sortie tronquée)"
+        },
         "running": "Exécution de {{toolName}}…",
         "searchedWeb": "Recherché sur le web",
         "searchedWebFor": "Recherché sur le web pour {{query}}",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1461,6 +1461,18 @@
         "preparingHtmlPreview": "Preparo anteprima HTML…",
         "read": "Letto {{fileName}}",
         "readingFile": "Lettura file…",
+        "runJs": {
+          "failed": "Script non riuscito",
+          "failedWithError": "Script non riuscito: {{error}}",
+          "hideCode": "Nascondi codice",
+          "noOutput": "(nessun output)",
+          "ran": "Script eseguito in {{duration}}",
+          "running": "Esecuzione script…",
+          "save": "Salva",
+          "saved": "Salvato",
+          "showCode": "Mostra codice",
+          "truncated": "(output troncato)"
+        },
         "running": "Esecuzione {{toolName}}…",
         "searchedWeb": "Cercato sul web",
         "searchedWebFor": "Cercato sul web per {{query}}",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1459,6 +1459,18 @@
         "preparingHtmlPreview": "HTML プレビューを準備中…",
         "read": "{{fileName}}を読み取りました",
         "readingFile": "ファイルを読み取り中…",
+        "runJs": {
+          "failed": "スクリプトが失敗しました",
+          "failedWithError": "スクリプトが失敗しました: {{error}}",
+          "hideCode": "コードを非表示",
+          "noOutput": "(出力なし)",
+          "ran": "スクリプトを{{duration}}で実行しました",
+          "running": "スクリプトを実行中…",
+          "save": "保存",
+          "saved": "保存済み",
+          "showCode": "コードを表示",
+          "truncated": "(出力を省略)"
+        },
         "running": "{{toolName}}を実行中…",
         "searchedWeb": "ウェブを検索しました",
         "searchedWebFor": "「{{query}}」をウェブで検索しました",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1459,6 +1459,18 @@
         "preparingHtmlPreview": "HTML 미리보기 준비 중…",
         "read": "{{fileName}} 읽음",
         "readingFile": "파일 읽는 중…",
+        "runJs": {
+          "failed": "스크립트 실패",
+          "failedWithError": "스크립트 실패: {{error}}",
+          "hideCode": "코드 가리기",
+          "noOutput": "(출력 없음)",
+          "ran": "{{duration}} 동안 스크립트 실행됨",
+          "running": "스크립트 실행 중…",
+          "save": "저장",
+          "saved": "저장됨",
+          "showCode": "코드 보기",
+          "truncated": "(출력 생략됨)"
+        },
         "running": "{{toolName}} 실행 중…",
         "searchedWeb": "웹을 검색했습니다",
         "searchedWebFor": "웹에서 '{{query}}'을(를) 검색했습니다",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1461,6 +1461,18 @@
         "preparingHtmlPreview": "Preparando pré-visualização HTML…",
         "read": "Lido {{fileName}}",
         "readingFile": "Lendo arquivo…",
+        "runJs": {
+          "failed": "Falha no script",
+          "failedWithError": "Falha no script: {{error}}",
+          "hideCode": "Ocultar Código",
+          "noOutput": "(sem saída)",
+          "ran": "Script executado em {{duration}}",
+          "running": "Executando script…",
+          "save": "Salvar",
+          "saved": "Salvo",
+          "showCode": "Mostrar Código",
+          "truncated": "(saída truncada)"
+        },
         "running": "Executando {{toolName}}…",
         "searchedWeb": "Pesquisou na web",
         "searchedWebFor": "Pesquisou na web por {{query}}",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1463,6 +1463,18 @@
         "preparingHtmlPreview": "Подготовка предварительного просмотра HTML…",
         "read": "Прочитать {{fileName}}",
         "readingFile": "Чтение файла…",
+        "runJs": {
+          "failed": "Сбой скрипта",
+          "failedWithError": "Сбой скрипта: {{error}}",
+          "hideCode": "Скрыть код",
+          "noOutput": "(нет вывода)",
+          "ran": "Скрипт выполнен за {{duration}}",
+          "running": "Выполнение скрипта…",
+          "save": "Сохранить",
+          "saved": "Сохранено",
+          "showCode": "Показать код",
+          "truncated": "(вывод сокращен)"
+        },
         "running": "Выполнение {{toolName}}…",
         "searchedWeb": "Выполнен поиск в интернете",
         "searchedWebFor": "Выполнен поиск в интернете по запросу {{query}}",

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -1459,6 +1459,18 @@
         "preparingHtmlPreview": "准备 HTML 预览…",
         "read": "已读取 {{fileName}}",
         "readingFile": "正在读取文件…",
+        "runJs": {
+          "failed": "脚本失败",
+          "failedWithError": "脚本失败：{{error}}",
+          "hideCode": "隐藏代码",
+          "noOutput": "(无输出)",
+          "ran": "脚本运行用时 {{duration}}",
+          "running": "正在运行脚本…",
+          "save": "保存",
+          "saved": "已保存",
+          "showCode": "显示代码",
+          "truncated": "(输出已截断)"
+        },
         "running": "执行 {{toolName}}…",
         "searchedWeb": "已搜索网络",
         "searchedWebFor": "已在网络上搜索 {{query}}",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1459,6 +1459,18 @@
         "preparingHtmlPreview": "準備 HTML 預覽⋯",
         "read": "已讀取 {{fileName}}",
         "readingFile": "讀取檔案⋯",
+        "runJs": {
+          "failed": "腳本失敗",
+          "failedWithError": "腳本失敗：{{error}}",
+          "hideCode": "隱藏程式碼",
+          "noOutput": "(無輸出)",
+          "ran": "腳本執行耗時 {{duration}}",
+          "running": "正在執行腳本…",
+          "save": "儲存",
+          "saved": "已儲存",
+          "showCode": "顯示程式碼",
+          "truncated": "(輸出已截斷)"
+        },
         "running": "執行 {{toolName}}⋯",
         "searchedWeb": "已搜尋網路",
         "searchedWebFor": "已搜尋網路尋找 {{query}}",

--- a/src/shared/tools/serverExecuted.ts
+++ b/src/shared/tools/serverExecuted.ts
@@ -8,6 +8,7 @@ export const TOOL_EXECUTION_METADATA = [
   { name: "cursorCloudAgent", execution: "server" },
   { name: "listCursorCloudAgentRuns", execution: "server" },
   { name: "mapsSearchPlaces", execution: "server" },
+  { name: "runJs", execution: "server" },
 ] as const;
 
 export const SERVER_EXECUTED_TOOL_NAMES = TOOL_EXECUTION_METADATA

--- a/tests/test-run-js.test.ts
+++ b/tests/test-run-js.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for the runJs chat tool: Zod input schema plus the QuickJS
+ * sandbox itself (no server required — the sandbox is a pure in-process
+ * WASM interpreter).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { runJsSchema } from "../api/chat/tools/schemas";
+import {
+  createOutputBuffer,
+  runJsInSandbox,
+  stringifySandboxValue,
+} from "../api/chat/tools/js-sandbox";
+
+describe("runJsSchema", () => {
+  test("accepts plain code", () => {
+    expect(runJsSchema.safeParse({ code: "1 + 1" }).success).toBe(true);
+  });
+
+  test("accepts code with a timeout", () => {
+    expect(
+      runJsSchema.safeParse({ code: "1 + 1", timeoutSeconds: 10 }).success
+    ).toBe(true);
+  });
+
+  test("rejects missing code", () => {
+    expect(runJsSchema.safeParse({}).success).toBe(false);
+  });
+
+  test("rejects empty code", () => {
+    expect(runJsSchema.safeParse({ code: "" }).success).toBe(false);
+  });
+
+  test("rejects oversized code", () => {
+    expect(
+      runJsSchema.safeParse({ code: "x".repeat(20_001) }).success
+    ).toBe(false);
+  });
+
+  test("rejects out-of-range timeouts", () => {
+    expect(
+      runJsSchema.safeParse({ code: "1", timeoutSeconds: 0 }).success
+    ).toBe(false);
+    expect(
+      runJsSchema.safeParse({ code: "1", timeoutSeconds: 16 }).success
+    ).toBe(false);
+    expect(
+      runJsSchema.safeParse({ code: "1", timeoutSeconds: 2.5 }).success
+    ).toBe(false);
+  });
+});
+
+describe("stringifySandboxValue", () => {
+  test("passes strings through", () => {
+    expect(stringifySandboxValue("hello")).toBe("hello");
+  });
+
+  test("renders BigInt with n suffix", () => {
+    expect(stringifySandboxValue(42n)).toBe("42n");
+  });
+
+  test("JSON-stringifies objects (BigInt-safe)", () => {
+    expect(stringifySandboxValue({ a: 1, b: 2n })).toBe('{"a":1,"b":"2n"}');
+  });
+
+  test("renders undefined", () => {
+    expect(stringifySandboxValue(undefined)).toBe("undefined");
+  });
+});
+
+describe("createOutputBuffer", () => {
+  test("accumulates lines under the cap", () => {
+    const buffer = createOutputBuffer(100);
+    buffer.push("one");
+    buffer.push("two");
+    expect(buffer.text).toBe("one\ntwo");
+    expect(buffer.truncated).toBe(false);
+  });
+
+  test("truncates once the cap is hit", () => {
+    const buffer = createOutputBuffer(10);
+    buffer.push("123456789012345");
+    expect(buffer.truncated).toBe(true);
+    expect(buffer.text).toBe("1234567890…");
+    buffer.push("ignored");
+    expect(buffer.text).toBe("1234567890…");
+  });
+});
+
+describe("runJsInSandbox", () => {
+  test("computes and returns the completion value", async () => {
+    const run = await runJsInSandbox("[1, 2, 3].reduce((a, b) => a + b, 0)");
+    expect(run.success).toBe(true);
+    expect(run.result).toBe("6");
+  });
+
+  test("captures console output", async () => {
+    const run = await runJsInSandbox(
+      'console.log("a", 1); console.warn("careful"); console.error("bad")'
+    );
+    expect(run.success).toBe(true);
+    expect(run.logs).toBe("a 1\n[warn] careful\n[error] bad");
+  });
+
+  test("supports exact BigInt math", async () => {
+    const run = await runJsInSandbox("17n ** 23n");
+    expect(run.success).toBe(true);
+    expect(run.result).toBe("19967568900859523802559065713n");
+  });
+
+  test("resolves synchronous async/await code", async () => {
+    const run = await runJsInSandbox(
+      "async function f() { return 40 + 2 } f()"
+    );
+    expect(run.success).toBe(true);
+    expect(run.result).toBe("42");
+  });
+
+  test("reports thrown errors", async () => {
+    const run = await runJsInSandbox('throw new Error("boom")');
+    expect(run.success).toBe(false);
+    expect(run.error).toBe("Error: boom");
+  });
+
+  test("reports rejected promises", async () => {
+    const run = await runJsInSandbox('Promise.reject(new Error("nope"))');
+    expect(run.success).toBe(false);
+    expect(run.error).toBe("Error: nope");
+  });
+
+  test("fails never-settling promises instead of hanging", async () => {
+    const run = await runJsInSandbox("new Promise(() => {})");
+    expect(run.success).toBe(false);
+    expect(run.error).toContain("never settles");
+  });
+
+  test("interrupts infinite loops at the timeout", async () => {
+    const run = await runJsInSandbox("while (true) {}", { timeoutMs: 500 });
+    expect(run.success).toBe(false);
+    expect(run.error).toBe("Execution timed out after 500ms");
+    expect(run.durationMs).toBeLessThan(5_000);
+  });
+
+  test("has no host APIs (fetch, process, timers)", async () => {
+    for (const expression of ["fetch", "process", "setTimeout", "require"]) {
+      const run = await runJsInSandbox(`${expression}("x")`);
+      expect(run.success).toBe(false);
+      expect(run.error).toContain("not defined");
+    }
+  });
+
+  test(
+    "enforces the memory limit",
+    async () => {
+      const run = await runJsInSandbox(
+        "const a = []; while (true) a.push(new Array(1e6).fill(0))",
+        { timeoutMs: 15_000 }
+      );
+      expect(run.success).toBe(false);
+      expect(run.error).toContain("memory limit");
+    },
+    { timeout: 20_000 }
+  );
+
+  test("truncates oversized console output", async () => {
+    const run = await runJsInSandbox(
+      'for (let i = 0; i < 100; i++) console.log("x".repeat(1000))',
+      { maxOutputChars: 5_000 }
+    );
+    expect(run.success).toBe(true);
+    expect(run.truncated).toBe(true);
+    expect(run.logs.length).toBeLessThanOrEqual(5_001);
+  });
+
+  test("runs are stateless between calls", async () => {
+    await runJsInSandbox("globalThis.leak = 123");
+    const run = await runJsInSandbox("typeof globalThis.leak");
+    expect(run.result).toBe("undefined");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Gives the Ryo chat agent a code-running sandbox: a new server-executed `runJs` tool that runs pure JavaScript (ES2023) in a QuickJS (WASM) interpreter with zero host access — no filesystem, network, timers, or Node/Bun APIs. The agent is prompted to use it for math, loops, and data processing, and to combine it with `webFetch`/search output by inlining data as literals.

### Sandbox (`api/chat/tools/js-sandbox.ts`)
- QuickJS-on-WASM via `quickjs-emscripten`; fresh runtime + context per run (stateless, disposed after each call)
- `console` shim is the only injected binding; log output captured and capped (~16KB, truncation flagged)
- Interrupt-handler deadline kills infinite loops (default 5s, max 15s); 64MB memory limit; async/await works, never-settling promises fail fast instead of hanging
- BigInt supported for exact large-integer math

### Tool wiring
- `runJsSchema` (code ≤ 20KB + optional `timeoutSeconds`), `TOOL_DESCRIPTIONS.runJs`, executor with per-user rate limit (60/hour), registered in both the web (`all`) and `telegram` profiles, and marked server-executed in `src/shared/tools/serverExecuted.ts`
- System prompt gains a "Scripting & Calculations" section steering the model to script computations and pipe in data from other tools

### Chat UI
- New `JsRunCard` renders output-first: status + duration header, console logs / completion value / error in a monospace block
- Code stays collapsed behind an icon-only show-code toggle; the icon-only save button writes the script to `/Documents/*.js` and opens it in TextEdit (both buttons have tooltips + aria-labels)
- Localized in all 11 languages (machine-translated via `i18n:translate`; shell bundle regenerated)

## Walkthrough

![JsRunCard with icon-only buttons](https://cursor.com/artifacts/c/art-1e932931-f341-4198-b51f-721970db47e7)

Ryo answers "sum of the squares of the first 25 primes" by calling `runJs`; the card shows "Script ran in 5ms", logged primes, and `→ 65796`, with icon-only show-code and save buttons in the header.

![Code expanded via icon toggle](https://cursor.com/artifacts/c/art-bc3372fa-cd66-485e-aa5f-d4964db38919)

![Saved script in TextEdit](https://cursor.com/artifacts/c/art-b4425ef3-43d0-4547-86c3-47f4d52bb6cb)

The code icon toggles the source view (pressed state highlighted); the floppy-disk icon saves `script-*.js` to /Documents and opens it in TextEdit.

## Testing

- ✅ `bun test tests/test-run-js.test.ts` — 24 unit tests: schema validation, output buffering, and real sandbox runs (compute, console capture, BigInt, async, thrown/rejected errors, timeout interrupt, missing host APIs, memory limit, output truncation, statelessness)
- ✅ `bun run test:unit` — 2493 pass (after regenerating the i18n shell bundle)
- ✅ `bun run test:api` — 347/348; the 2 flaky failures (`test-auth-recovery`, `test-iframe-check`) pass in isolation and are unrelated (registration rate-limit + upstream 503)
- ✅ `bun run typecheck`, `bun run lint` (changed files), `bun run test:registration`, `bun run i18n:audit`
- ✅ Live `/api/chat` end-to-end: model called `runJs` for a primes question (result `65796`, 22ms) and chained `webFetch` → `runJs` to count words on example.com (see `runjs_webfetch_chain_e2e.log`)
- ✅ Browser UI verified via the Chats app: signed up, triggered `runJs`, verified card render, icon-only Show Code toggle, and Save → TextEdit (screenshots above)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3ce9-3ee7-7add-a015-4c918bff9856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3ce9-3ee7-7add-a015-4c918bff9856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

