### PR TITLE
Allow user-created root folders and save-anywhere VFS

### DIFF
--- a/src/apps/finder/components/FinderMenuBar.tsx
+++ b/src/apps/finder/components/FinderMenuBar.tsx
@@ -15,6 +15,7 @@ import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { getTranslatedFolderName } from "@/utils/i18n";
 import { useTranslation } from "react-i18next";
 import { useInstanceUndoRedo } from "@/hooks/useUndoRedo";
+import { isProtectedSystemPath } from "@/services/vfs/pathPolicy";
 
 export type ViewType = "small" | "large" | "list";
 export type SortType = "name" | "date" | "size" | "kind";
@@ -97,9 +98,11 @@ export function FinderMenuBar({
     selectedFile &&
     selectedFile.path !== "/Trash" &&
     !selectedFile.path.startsWith("/Trash/") &&
-    // Prevent root folders from being moved to trash
-    selectedFile.path !== "/Applications" &&
-    selectedFile.path !== "/Documents" &&
+    // Prevent system-managed root folders from being moved to trash
+    // (user-created root folders remain trashable)
+    !isProtectedSystemPath(selectedFile.path) &&
+    // Prevent virtual items (apps, songs, sites) from being moved to trash
+    !selectedFile.type?.includes("virtual") &&
     // Prevent applications from being moved to trash
     !selectedFile.path.startsWith("/Applications/");
 

--- a/src/apps/finder/components/file-list/useFileList.ts
+++ b/src/apps/finder/components/file-list/useFileList.ts
@@ -32,7 +32,6 @@ export function useFileList({
   onFileDrop,
   onDropToCurrentDirectory,
   canDropFiles = false,
-  currentPath = "/",
   onRenameRequest,
   onItemContextMenu,
 }: FileListProps) {
@@ -410,14 +409,10 @@ export function useFileList({
   }, []);
 
   const handleContainerDragOver = useCallback((e: React.DragEvent<HTMLElement>) => {
-    if (
-      canDropFiles &&
-      draggedFileRef.current &&
-      (currentPath === "/Documents" || currentPath === "/Images")
-    ) {
+    if (canDropFiles && draggedFileRef.current) {
       e.preventDefault();
     }
-  }, [canDropFiles, currentPath]);
+  }, [canDropFiles]);
 
   const handleContainerDragLeave = useCallback(() => {}, []);
 
@@ -429,16 +424,12 @@ export function useFileList({
       return;
     }
 
-    if (
-      draggedFileRef.current &&
-      onDropToCurrentDirectory &&
-      (currentPath === "/Documents" || currentPath === "/Images")
-    ) {
+    if (draggedFileRef.current && onDropToCurrentDirectory && canDropFiles) {
       onDropToCurrentDirectory(draggedFileRef.current);
     }
 
     draggedFileRef.current = null;
-  }, [currentPath, dropTargetPath, onDropToCurrentDirectory]);
+  }, [canDropFiles, dropTargetPath, onDropToCurrentDirectory]);
 
   const getDisplayName = useCallback(
     (file: FileItem): string => getFinderDisplayName(file),

--- a/src/apps/finder/components/finder-app/FinderHiddenFileInput.tsx
+++ b/src/apps/finder/components/finder-app/FinderHiddenFileInput.tsx
@@ -19,7 +19,7 @@ export function FinderHiddenFileInput({
           ? ".app,.gz,.html,.htm"
           : currentPath === "/Books"
           ? ".epub,application/epub+zip"
-          : ".app,.gz,.txt,.md,.pdf,.png,.jpg,.jpeg,.gif,.webp,.bmp,.svg,.html,.htm,.json,.csv,.xml,text/*,image/*,application/pdf"
+          : ".app,.gz,.epub,.txt,.md,.pdf,.png,.jpg,.jpeg,.gif,.webp,.bmp,.svg,.html,.htm,.json,.csv,.xml,text/*,image/*,application/pdf"
       }
       onChange={onChange}
     />

--- a/src/apps/finder/hooks/useFileSystem.ts
+++ b/src/apps/finder/hooks/useFileSystem.ts
@@ -17,6 +17,7 @@ import { useVideoStoreShallow } from "@/stores/useVideoStore";
 import { listVirtualMusicOrVideosPath } from "@/services/vfs/virtualTrees";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { getStoreForFile, type StoredContent } from "@/utils/indexedDBOperations";
+import { isWritablePath } from "@/services/vfs/pathPolicy";
 import {
   emitCloudSyncDomainChange,
   emitCloudSyncDomainChanges,
@@ -603,12 +604,18 @@ export function useFileSystem(
           modifiedAt: item.modifiedAt ? new Date(item.modifiedAt) : undefined,
         }));
 
-        // --- START EDIT: Fetch content URLs for /Images path and its subdirectories ---
-        if (currentPath === "/Images" || currentPath.startsWith("/Images/")) {
+        // --- START EDIT: Fetch content URLs for image files (any writable path) ---
+        const resolvesToImagesStore = (item: FileSystemItem) =>
+          !item.isDirectory &&
+          getStoreForFile(item.path, {
+            name: item.name,
+            type: item.type,
+          }) === STORES.IMAGES;
+        if (itemsMetadata.some(resolvesToImagesStore)) {
           displayFiles = await Promise.all(
             itemsMetadata.map(async (item) => {
               let contentUrl: string | undefined;
-              if (!item.isDirectory && item.uuid) {
+              if (!item.isDirectory && item.uuid && resolvesToImagesStore(item)) {
                 try {
                   log.debug("Fetching image content for display", {
                     name: item.name,
@@ -1077,10 +1084,12 @@ export function useFileSystem(
       const nextApplied = state.categoryStatus.files.lastAppliedRemoteAt;
       const prevApplied = prevState.categoryStatus.files.lastAppliedRemoteAt;
 
+      // Refresh writable directories so image thumbnails pick up remotely
+      // synced content (blob URLs are only created during loadFiles).
       if (
         nextApplied &&
         nextApplied !== prevApplied &&
-        (currentPath === "/Images" || currentPath.startsWith("/Images/"))
+        isWritablePath(currentPath)
       ) {
         loadFiles();
       }
@@ -1385,6 +1394,13 @@ export function useFileSystem(
             );
             // Delete from source store
             await dbOperations.delete(sourceStoreName, sourceFile.uuid);
+            const sourceDeletionBucket =
+              getCloudSyncDeletionBucketForContentStore(sourceStoreName);
+            if (sourceDeletionBucket) {
+              useCloudSyncStore
+                .getState()
+                .markDeletedKeys(sourceDeletionBucket, [sourceFile.uuid]);
+            }
             const sourceSyncDomain =
               getCloudSyncDomainForContentStore(sourceStoreName);
             const targetSyncDomain =
@@ -1445,29 +1461,57 @@ export function useFileSystem(
         ...getFinderAnalyticsPathInfo(newPath, itemToRename.type),
       });
 
-      // 2. Update content metadata (name field) in IndexedDB if it's a file with content
+      // 2. Update content metadata (name field) in IndexedDB if it's a file with content.
+      // If the rename changes the resolved content store (e.g. extension
+      // change in an extension-routed folder), move the content across stores.
       if (!itemToRename.isDirectory && itemToRename.uuid) {
         const storeName = getStoreForFile(oldPath, {
           name: itemToRename.name,
           type: itemToRename.type,
         });
+        const newStoreName = getStoreForFile(newPath, {
+          name: newName,
+          type: itemToRename.type,
+        });
         if (storeName) {
+          const targetStoreName = newStoreName || storeName;
           try {
             const content = await dbOperations.get<DocumentContent>(
               storeName,
               itemToRename.uuid // Use UUID
             );
             if (content) {
-              // Update the name field in the content
+              // Write (with updated name) to the resolved target store
               await dbOperations.put<DocumentContent>(
-                storeName,
+                targetStoreName,
                 {
                   ...content,
                   name: newName,
                 },
                 itemToRename.uuid
               ); // Keep same UUID
-              const syncDomain = getCloudSyncDomainForContentStore(storeName);
+              if (targetStoreName !== storeName) {
+                await dbOperations.delete(storeName, itemToRename.uuid);
+                const sourceDeletionBucket =
+                  getCloudSyncDeletionBucketForContentStore(storeName);
+                if (sourceDeletionBucket) {
+                  useCloudSyncStore
+                    .getState()
+                    .markDeletedKeys(sourceDeletionBucket, [
+                      itemToRename.uuid,
+                    ]);
+                }
+                const sourceSyncDomain =
+                  getCloudSyncDomainForContentStore(storeName);
+                if (sourceSyncDomain) {
+                  emitCloudSyncContentChange(
+                    sourceSyncDomain,
+                    itemToRename.uuid
+                  );
+                }
+              }
+              const syncDomain =
+                getCloudSyncDomainForContentStore(targetStoreName);
               if (syncDomain) {
                 emitCloudSyncContentChange(syncDomain, itemToRename.uuid);
               }

--- a/src/apps/finder/hooks/useFinderLogic.ts
+++ b/src/apps/finder/hooks/useFinderLogic.ts
@@ -9,7 +9,7 @@ import type {
 import { useTranslation } from "react-i18next";
 import { ViewType, SortType } from "../components/FinderMenuBar";
 import { useFileSystem, DocumentContent } from "./useFileSystem";
-import { STORES, dbOperations } from "@/utils/indexedDB";
+import { dbOperations } from "@/utils/indexedDB";
 import {
   calculateStorageSpace,
   estimateStorageSpace,
@@ -47,6 +47,12 @@ import {
 import { useAirDropStore } from "@/stores/useAirDropStore";
 import { useChatsStore } from "@/stores/useChatsStore";
 import { createClientLogger } from "@/utils/logger";
+import {
+  isWritablePath,
+  isProtectedSystemPath,
+  validateNewRootFolderName,
+} from "@/services/vfs/pathPolicy";
+import { getStoreForFile } from "@/utils/indexedDBOperations";
 
 const log = createClientLogger("Finder");
 
@@ -573,8 +579,8 @@ export function useFinderLogic({
       return;
     }
 
-    // Only allow drops in the Documents directory
-    if (currentPath !== "/Documents") {
+    // Only allow drops in writable directories
+    if (!isWritablePath(currentPath)) {
       return;
     }
 
@@ -592,7 +598,8 @@ export function useFinderLogic({
                 type: file.type || undefined,
               })
             : await file.text();
-        const filePath = `/Documents/${file.name}`;
+        const basePath = currentPath === "/" ? "" : currentPath;
+        const filePath = `${basePath}/${file.name}`;
 
         await saveFile({
           name: file.name,
@@ -903,7 +910,12 @@ export function useFinderLogic({
               })
             : await file.text();
           const fileName = file.name;
-          const basePath = currentPath === "/" ? "" : currentPath;
+          // Import into the current directory when writable; otherwise fall
+          // back to /Documents (e.g. importing while viewing /Music).
+          const targetDir = isWritablePath(currentPath)
+            ? currentPath
+            : "/Documents";
+          const basePath = targetDir === "/" ? "" : targetDir;
           const filePath = `${basePath}/${fileName}`;
 
           await saveFile({
@@ -911,6 +923,10 @@ export function useFinderLogic({
             path: filePath,
             content,
           });
+
+          if (targetDir !== currentPath) {
+            navigateToPath(targetDir);
+          }
 
           // Notify file was added
           emitFileUpdated({
@@ -942,6 +958,24 @@ export function useFinderLogic({
     const trimmedNewName = newName.trim();
     if (selectedFile.name === trimmedNewName) {
       setIsRenameDialogOpen(false);
+      return;
+    }
+
+    // Renamed root folders must not collide with system/virtual root names
+    if (currentPath === "/" && selectedFile.isDirectory) {
+      const validation = validateNewRootFolderName(trimmedNewName);
+      if (!validation.ok) {
+        toast.error(
+          validation.reason === "reserved"
+            ? t("apps.finder.messages.reservedFolderName", {
+                name: trimmedNewName,
+              })
+            : t("apps.finder.messages.invalidFolderName")
+        );
+        return;
+      }
+    } else if (trimmedNewName.includes("/")) {
+      toast.error(t("apps.finder.messages.invalidFolderName"));
       return;
     }
 
@@ -1001,11 +1035,10 @@ export function useFinderLogic({
       // Fetch content for the selected file using UUID
       let contentToCopy: string | Blob | undefined;
       // Determine store based on selectedFile.path, not currentPath
-      const storeName = selectedFile.path.startsWith("/Documents/")
-        ? STORES.DOCUMENTS
-        : selectedFile.path.startsWith("/Images/")
-        ? STORES.IMAGES
-        : null;
+      const storeName = getStoreForFile(selectedFile.path, {
+        name: selectedFile.name,
+        type: selectedFile.type,
+      });
       if (storeName) {
         const contentData = await dbOperations.get<DocumentContent>(
           storeName,
@@ -1063,8 +1096,34 @@ export function useFinderLogic({
   const handleNewFolderSubmit = (name: string) => {
     if (!name || !name.trim()) return;
     const trimmedName = name.trim();
+
+    // Root-level folders must not collide with system/virtual root names
+    if (currentPath === "/") {
+      const validation = validateNewRootFolderName(trimmedName);
+      if (!validation.ok) {
+        toast.error(
+          validation.reason === "reserved"
+            ? t("apps.finder.messages.reservedFolderName", {
+                name: trimmedName,
+              })
+            : t("apps.finder.messages.invalidFolderName")
+        );
+        return;
+      }
+    } else if (trimmedName.includes("/")) {
+      toast.error(t("apps.finder.messages.invalidFolderName"));
+      return;
+    }
+
     const basePath = currentPath === "/" ? "" : currentPath;
     const newPath = `${basePath}/${trimmedName}`;
+
+    if (getFileItem(newPath)) {
+      toast.error(
+        t("apps.finder.messages.folderExists", { name: trimmedName })
+      );
+      return;
+    }
 
     // Use the createFolder function from the hook
     createFolder({ path: newPath, name: trimmedName });
@@ -1072,14 +1131,10 @@ export function useFinderLogic({
     setIsNewFolderDialogOpen(false);
   };
 
-  // Determine if folder creation (and thus file movement) is allowed in the current path
-  const canCreateFolder =
-    currentPath === "/Documents" ||
-    currentPath === "/Images" ||
-    currentPath === "/Books" ||
-    currentPath.startsWith("/Documents/") ||
-    currentPath.startsWith("/Images/") ||
-    currentPath.startsWith("/Books/");
+  // Determine if folder creation (and thus file movement) is allowed in the
+  // current path. Writable paths include "/" (user-created root folders),
+  // the writable system subtrees, and any user root folder subtree.
+  const canCreateFolder = isWritablePath(currentPath);
 
   // Get all root folders for the Go menu using fileStore
   // This will always show root folders regardless of current path
@@ -1105,20 +1160,8 @@ export function useFinderLogic({
     // Only allow rename in paths where file creation is allowed
     if (!canCreateFolder) return;
 
-    // Prevent renaming virtual files and special folders
-    if (
-      file.type?.includes("virtual") ||
-      file.path === "/Documents" ||
-      file.path === "/Desktop" ||
-      file.path === "/Downloads" ||
-      file.path === "/Images" ||
-      file.path === "/Books" ||
-      file.path === "/Applications" ||
-      file.path === "/Trash" ||
-      file.path === "/Music" ||
-      file.path === "/Videos" ||
-      file.path === "/Sites"
-    ) {
+    // Prevent renaming virtual files and system-managed folders
+    if (file.type?.includes("virtual") || isProtectedSystemPath(file.path)) {
       return;
     }
 
@@ -1204,6 +1247,7 @@ export function useFinderLogic({
               type: "item" as const,
               label: t("apps.finder.contextMenu.newFolder"),
               onSelect: handleNewFolder,
+              disabled: !isWritablePath(currentPath),
             },
           ]),
     ],
@@ -1457,10 +1501,9 @@ export function useFinderLogic({
             onSelect: () => trackedMoveToTrash(file),
             disabled:
               file.path.startsWith("/Trash") ||
-              file.path === "/Documents" ||
-              file.path === "/Images" ||
-              file.path === "/Books" ||
-              file.path === "/Applications",
+              file.path.startsWith("/Applications/") ||
+              file.type?.includes("virtual") ||
+              isProtectedSystemPath(file.path),
           },
     ];
   };
@@ -1482,13 +1525,10 @@ export function useFinderLogic({
 
       let content: string = "";
       if (fileMetadata.uuid) {
-        const storeName = filePath.startsWith("/Documents")
-          ? STORES.DOCUMENTS
-          : filePath.startsWith("/Images")
-            ? STORES.IMAGES
-            : filePath.startsWith("/Applets")
-              ? STORES.APPLETS
-              : null;
+        const storeName = getStoreForFile(filePath, {
+          name: fileMetadata.name,
+          type: fileMetadata.type,
+        });
         if (storeName) {
           const doc = await dbOperations.get<DocumentContent>(
             storeName,

--- a/src/apps/paint/components/PaintAppComponent.tsx
+++ b/src/apps/paint/components/PaintAppComponent.tsx
@@ -8,7 +8,7 @@ import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { AppProps, PaintInitialData } from "../../base/types";
 import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
-import { InputDialog } from "@/components/dialogs/InputDialog";
+import { SaveFileDialog } from "@/components/dialogs/SaveFileDialog";
 import { appMetadata } from "..";
 import { usePaintLogic } from "../hooks/usePaintLogic";
 import { useRegisterUndoRedo } from "@/hooks/useUndoRedo";
@@ -133,7 +133,7 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
       }}
       trailing={
         <>
-          <InputDialog
+          <SaveFileDialog
             isOpen={isSaveDialogOpen}
             onOpenChange={setIsSaveDialogOpen}
             onSubmit={handleSaveSubmit}
@@ -141,6 +141,7 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
             description="Enter a name for your image"
             value={saveFileName}
             onChange={setSaveFileName}
+            defaultDirectory="/Images"
           />
           <AppHelpAboutDialogs
             appId="paint"

--- a/src/apps/paint/hooks/usePaintLogic.ts
+++ b/src/apps/paint/hooks/usePaintLogic.ts
@@ -266,12 +266,16 @@ export function usePaintLogic({ initialData, instanceId }: UsePaintLogicProps) {
     }
   };
 
-  const handleSaveSubmit = async (fileName: string) => {
+  const handleSaveSubmit = async (
+    fileName: string,
+    directoryPath: string = "/Images"
+  ) => {
     if (!canvasRef.current) return;
 
     try {
       const blob = await canvasRef.current.exportCanvas();
-      const filePath = `/Images/${fileName}${
+      const basePath = directoryPath === "/" ? "" : directoryPath;
+      const filePath = `${basePath}/${fileName}${
         fileName.endsWith(".png") ? "" : ".png"
       }`;
 

--- a/src/apps/preview/components/PreviewAppComponent.tsx
+++ b/src/apps/preview/components/PreviewAppComponent.tsx
@@ -4,7 +4,7 @@ import type { AppProps } from "@/apps/base/types";
 import type { PreviewInitialData } from "..";
 import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
-import { InputDialog } from "@/components/dialogs/InputDialog";
+import { SaveFileDialog } from "@/components/dialogs/SaveFileDialog";
 import { cn } from "@/lib/utils";
 import { PREVIEW_FILE_ACCEPT } from "@/utils/fileAssociations";
 import { appMetadata } from "../metadata";
@@ -262,14 +262,17 @@ export function PreviewAppComponent({
       }
       trailing={
         <>
-          <InputDialog
+          <SaveFileDialog
             isOpen={isSaveAsDialogOpen}
             onOpenChange={setIsSaveAsDialogOpen}
-            onSubmit={(value) => void handleSaveAsSubmit(value)}
+            onSubmit={(value, directoryPath) =>
+              void handleSaveAsSubmit(value, directoryPath)
+            }
             title={t("apps.preview.saveAs.title")}
             description={t("apps.preview.saveAs.description")}
             value={saveAsFileName}
             onChange={setSaveAsFileName}
+            defaultDirectory={isImage ? "/Images" : "/Documents"}
             isLoading={isSaving}
           />
           <AppHelpAboutDialogs

--- a/src/apps/preview/hooks/usePreviewLogic.ts
+++ b/src/apps/preview/hooks/usePreviewLogic.ts
@@ -283,7 +283,7 @@ export function usePreviewLogic({
   }, [content, currentPath, t]);
 
   const handleSaveAsSubmit = useCallback(
-    async (requestedName: string) => {
+    async (requestedName: string, directoryPath?: string) => {
       if (content === null) return;
       const trimmedName = requestedName.trim().replace(/[\\/]/g, "-");
       if (!trimmedName) return;
@@ -293,8 +293,10 @@ export function usePreviewLogic({
         currentExtension && !getFileExtension(trimmedName)
           ? `${trimmedName}.${currentExtension}`
           : trimmedName;
-      const directory = kind === "image" ? "/Images" : "/Documents";
-      const path = `${directory}/${fileName}`;
+      const directory =
+        directoryPath || (kind === "image" ? "/Images" : "/Documents");
+      const basePath = directory === "/" ? "" : directory;
+      const path = `${basePath}/${fileName}`;
 
       setIsSaving(true);
       try {

--- a/src/apps/textedit/components/DialogManager.tsx
+++ b/src/apps/textedit/components/DialogManager.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
-import { InputDialog } from "@/components/dialogs/InputDialog";
+import { SaveFileDialog } from "@/components/dialogs/SaveFileDialog";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { appMetadata, helpItems } from "..";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
@@ -26,8 +26,8 @@ interface DialogManagerProps {
   setSaveFileName: (name: string) => void;
   closeSaveFileName: string;
   setCloseSaveFileName: (name: string) => void;
-  onSaveSubmit: (fileName: string) => Promise<void>;
-  onCloseSave: (fileName: string) => Promise<void>;
+  onSaveSubmit: (fileName: string, directoryPath: string) => Promise<void>;
+  onCloseSave: (fileName: string, directoryPath: string) => Promise<void>;
   onCloseDelete: () => void;
   onConfirmNew: () => void;
   onCancelConfirmNew: () => void;
@@ -89,7 +89,7 @@ export function DialogManager({
 
   return (
     <>
-      <InputDialog
+      <SaveFileDialog
         isOpen={isSaveDialogOpen}
         onOpenChange={setIsSaveDialogOpen}
         onSubmit={onSaveSubmit}
@@ -97,6 +97,7 @@ export function DialogManager({
         description={t("apps.textedit.dialogs.enterANameForYourFile")}
         value={saveFileName}
         onChange={setSaveFileName}
+        defaultDirectory="/Documents"
       />
 
       <ConfirmDialog
@@ -113,7 +114,7 @@ export function DialogManager({
         description={t("apps.textedit.dialogs.doYouWantToDiscardYourChangesAndCreateANewFile")}
       />
 
-      <InputDialog
+      <SaveFileDialog
         isOpen={isCloseSaveDialogOpen}
         onOpenChange={setIsCloseSaveDialogOpen}
         onSubmit={onCloseSave}
@@ -125,6 +126,7 @@ export function DialogManager({
         }
         value={closeSaveFileName}
         onChange={setCloseSaveFileName}
+        defaultDirectory="/Documents"
         submitLabel={t("common.dialog.save")}
         additionalActions={[
           {

--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -455,9 +455,9 @@ function TextEditContent({
     }
   };
 
-  const handleSaveSubmit = async (fileName: string) => {
+  const handleSaveSubmit = async (fileName: string, directoryPath?: string) => {
     try {
-      await handleSaveAs(fileName);
+      await handleSaveAs(fileName, directoryPath);
       dialogControls?.closeSaveDialog();
     } catch (error) {
       console.error("Save failed:", error);
@@ -547,12 +547,12 @@ function TextEditContent({
     );
   };
 
-  const handleCloseSave = async (fileName: string) => {
+  const handleCloseSave = async (fileName: string, directoryPath?: string) => {
     try {
       if (currentFilePath) {
         await handleSave();
       } else {
-        await handleSaveAs(fileName);
+        await handleSaveAs(fileName, directoryPath);
       }
       dialogControls?.closeCloseSaveDialog();
       window.dispatchEvent(

--- a/src/apps/textedit/hooks/useFileOperations.ts
+++ b/src/apps/textedit/hooks/useFileOperations.ts
@@ -67,10 +67,14 @@ export function useFileOperations({
   }, [editor, currentFilePath, saveFile, onSaveSuccess]);
 
   const handleSaveAs = useCallback(
-    async (fileName: string): Promise<string> => {
+    async (
+      fileName: string,
+      directoryPath: string = "/Documents"
+    ): Promise<string> => {
       if (!editor) throw new Error("Editor not available");
 
-      const filePath = `/Documents/${fileName}${
+      const basePath = directoryPath === "/" ? "" : directoryPath;
+      const filePath = `${basePath}/${fileName}${
         fileName.endsWith(".md") ? "" : ".md"
       }`;
 

--- a/src/components/dialogs/InputDialog.tsx
+++ b/src/components/dialogs/InputDialog.tsx
@@ -10,6 +10,13 @@ import {
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 
@@ -32,6 +39,11 @@ interface InputDialogProps {
   }>;
   submitLabel?: string;
   showCancel?: boolean;
+  // Optional select rendered below the input (e.g. save-location picker)
+  selectLabel?: string;
+  selectOptions?: Array<{ label: string; value: string }>;
+  selectValue?: string;
+  onSelectChange?: (value: string) => void;
 }
 
 export function InputDialog({
@@ -47,6 +59,10 @@ export function InputDialog({
   additionalActions = [],
   submitLabel,
   showCancel = true,
+  selectLabel,
+  selectOptions,
+  selectValue,
+  onSelectChange,
 }: InputDialogProps) {
   const { t } = useTranslation();
   const {
@@ -117,6 +133,51 @@ export function InputDialog({
         }}
         disabled={isLoading}
       />
+      {selectOptions && onSelectChange && (
+        <div className="mt-2 flex items-center gap-2">
+          {selectLabel && (
+            <span
+              className={cn(
+                "text-neutral-500 shrink-0",
+                isWindowsTheme
+                  ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
+                  : "font-geneva-12 text-[12px]"
+              )}
+              style={{
+                fontFamily: isWindowsTheme
+                  ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
+                  : undefined,
+                fontSize: isWindowsTheme ? "11px" : undefined,
+              }}
+            >
+              {selectLabel}
+            </span>
+          )}
+          <Select
+            value={selectValue}
+            onValueChange={onSelectChange}
+            disabled={isLoading}
+          >
+            <SelectTrigger
+              className={cn(
+                "flex-1 min-w-0",
+                isWindowsTheme
+                  ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px] h-7"
+                  : "font-geneva-12 text-[12px] h-7"
+              )}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {selectOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
       {errorMessage && (
         <p className="text-red-600 text-sm mt-1">{errorMessage}</p>
       )}

--- a/src/components/dialogs/SaveFileDialog.tsx
+++ b/src/components/dialogs/SaveFileDialog.tsx
@@ -1,49 +1,18 @@
 import { useEffect, useMemo, useState } from "react";
 import { InputDialog } from "@/components/dialogs/InputDialog";
 import { useFilesStore } from "@/stores/useFilesStore";
-import { isWritablePath } from "@/services/vfs/pathPolicy";
+import { listWritableDirectories } from "@/services/vfs/pathPolicy";
+
 import { getTranslatedFolderName } from "@/utils/i18n";
 import { useTranslation } from "react-i18next";
-
-interface WritableDirectory {
-  path: string;
-  name: string;
-  depth: number;
-}
-
-const getParentPath = (path: string): string => {
-  if (path === "/") return "/";
-  const lastSlash = path.lastIndexOf("/");
-  return lastSlash <= 0 ? "/" : path.substring(0, lastSlash);
-};
 
 /**
  * All writable directories in the VFS, depth-first, so the list reads like an
  * indented tree (system folders like /Documents plus user-created folders).
  */
-export function useWritableDirectories(): WritableDirectory[] {
+function useWritableDirectories() {
   const items = useFilesStore((state) => state.items);
-
-  return useMemo(() => {
-    const result: WritableDirectory[] = [];
-    const directories = Object.values(items).filter(
-      (item) => item.isDirectory && item.status === "active"
-    );
-
-    const walk = (parent: string, depth: number) => {
-      const children = directories
-        .filter((item) => getParentPath(item.path) === parent)
-        .sort((a, b) => a.name.localeCompare(b.name));
-      for (const child of children) {
-        if (!isWritablePath(child.path)) continue;
-        result.push({ path: child.path, name: child.name, depth });
-        walk(child.path, depth + 1);
-      }
-    };
-
-    walk("/", 0);
-    return result;
-  }, [items]);
+  return useMemo(() => listWritableDirectories(items), [items]);
 }
 
 interface SaveFileDialogProps {

--- a/src/components/dialogs/SaveFileDialog.tsx
+++ b/src/components/dialogs/SaveFileDialog.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useMemo, useState } from "react";
+import { InputDialog } from "@/components/dialogs/InputDialog";
+import { useFilesStore } from "@/stores/useFilesStore";
+import { isWritablePath } from "@/services/vfs/pathPolicy";
+import { getTranslatedFolderName } from "@/utils/i18n";
+import { useTranslation } from "react-i18next";
+
+interface WritableDirectory {
+  path: string;
+  name: string;
+  depth: number;
+}
+
+const getParentPath = (path: string): string => {
+  if (path === "/") return "/";
+  const lastSlash = path.lastIndexOf("/");
+  return lastSlash <= 0 ? "/" : path.substring(0, lastSlash);
+};
+
+/**
+ * All writable directories in the VFS, depth-first, so the list reads like an
+ * indented tree (system folders like /Documents plus user-created folders).
+ */
+export function useWritableDirectories(): WritableDirectory[] {
+  const items = useFilesStore((state) => state.items);
+
+  return useMemo(() => {
+    const result: WritableDirectory[] = [];
+    const directories = Object.values(items).filter(
+      (item) => item.isDirectory && item.status === "active"
+    );
+
+    const walk = (parent: string, depth: number) => {
+      const children = directories
+        .filter((item) => getParentPath(item.path) === parent)
+        .sort((a, b) => a.name.localeCompare(b.name));
+      for (const child of children) {
+        if (!isWritablePath(child.path)) continue;
+        result.push({ path: child.path, name: child.name, depth });
+        walk(child.path, depth + 1);
+      }
+    };
+
+    walk("/", 0);
+    return result;
+  }, [items]);
+}
+
+interface SaveFileDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (fileName: string, directoryPath: string) => void;
+  title: string;
+  description: string;
+  value: string;
+  onChange: (value: string) => void;
+  /** Directory preselected when the dialog opens (e.g. "/Documents"). */
+  defaultDirectory: string;
+  isLoading?: boolean;
+  errorMessage?: string | null;
+  additionalActions?: Array<{
+    label: string;
+    onClick: () => void;
+    variant?: "retro" | "destructive";
+    position?: "left" | "right";
+  }>;
+  submitLabel?: string;
+}
+
+/**
+ * Filename prompt with a save-location picker listing all writable VFS
+ * directories (system folders and user-created folders).
+ */
+export function SaveFileDialog({
+  isOpen,
+  onOpenChange,
+  onSubmit,
+  title,
+  description,
+  value,
+  onChange,
+  defaultDirectory,
+  isLoading,
+  errorMessage,
+  additionalActions,
+  submitLabel,
+}: SaveFileDialogProps) {
+  const { t } = useTranslation();
+  const directories = useWritableDirectories();
+  const [directory, setDirectory] = useState(defaultDirectory);
+
+  // Re-anchor to the default whenever the dialog is (re)opened
+  useEffect(() => {
+    if (isOpen) {
+      setDirectory(defaultDirectory);
+    }
+  }, [isOpen, defaultDirectory]);
+
+  const options = useMemo(() => {
+    const seen = new Set<string>();
+    const opts = directories.map((dir) => {
+      seen.add(dir.path);
+      const translated =
+        dir.depth === 0 ? getTranslatedFolderName(dir.path) : dir.name;
+      return {
+        value: dir.path,
+        label: `${"\u00A0".repeat(dir.depth * 3)}${translated}`,
+      };
+    });
+    // Keep the current default selectable even if it's not in the writable
+    // list (e.g. an app-managed location).
+    if (defaultDirectory && !seen.has(defaultDirectory)) {
+      opts.unshift({ value: defaultDirectory, label: defaultDirectory });
+    }
+    return opts;
+  }, [directories, defaultDirectory]);
+
+  return (
+    <InputDialog
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      onSubmit={(fileName) => onSubmit(fileName, directory)}
+      title={title}
+      description={description}
+      value={value}
+      onChange={onChange}
+      isLoading={isLoading}
+      errorMessage={errorMessage}
+      additionalActions={additionalActions}
+      submitLabel={submitLabel}
+      selectLabel={t("common.dialog.where")}
+      selectOptions={options}
+      selectValue={directory}
+      onSelectChange={setDirectory}
+    />
+  );
+}

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -2515,12 +2515,15 @@
         "appletImported": "Applet importiert!",
         "appletImportedDesc": "{{name}} wurde in /Applets gespeichert{{iconText}}",
         "appletImportedIconText": " mit dem Symbol {{icon}}",
+        "folderExists": "Ein Objekt mit dem Namen „{{name}}“ existiert bereits.",
         "importFailed": "Import fehlgeschlagen",
         "importFailedAppletDesc": "Die Applet-Datei konnte nicht importiert werden.",
         "importFailedDesc": "Die Datei konnte nicht importiert werden.",
         "invalidFileType": "Ungültiger Dateityp",
         "invalidFileTypeDesc": "Nur .app-, .gz- und .html-Dateien können in Applets importiert werden",
-        "loading": "Laden …"
+        "invalidFolderName": "Dieser Name kann nicht verwendet werden. Versuche es mit einem anderen Namen.",
+        "loading": "Laden …",
+        "reservedFolderName": "„{{name}}“ ist ein reservierter Name. Wähle einen anderen Namen."
       },
       "name": "Finder",
       "placeholders": {
@@ -4757,7 +4760,8 @@
       "version": "Version",
       "viewChangelog": "Änderungsprotokoll",
       "viewDocs": "Dokumentation anzeigen",
-      "welcomeTo": "Willkommen bei {{appName}}"
+      "welcomeTo": "Willkommen bei {{appName}}",
+      "where": "Ort:"
     },
     "dock": {
       "addToDock": "Zum Dock hinzufügen",

--- a/src/lib/locales/en/shell.json
+++ b/src/lib/locales/en/shell.json
@@ -75,6 +75,7 @@
       "adding": "Adding…",
       "saveFile": "Save File",
       "enterFileName": "Enter a name for your file",
+      "where": "Where:",
       "discardChanges": "Discard Changes",
       "discardChangesDesc": "Do you want to discard your changes and create a new file?",
       "keepNewDocument": "Keep New Document",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -75,6 +75,7 @@
       "adding": "Adding…",
       "saveFile": "Save File",
       "enterFileName": "Enter a name for your file",
+      "where": "Where:",
       "discardChanges": "Discard Changes",
       "discardChangesDesc": "Do you want to discard your changes and create a new file?",
       "keepNewDocument": "Keep New Document",
@@ -527,7 +528,10 @@
         "importFailedDesc": "Couldn't import the file.",
         "importFailedAppletDesc": "Couldn't import the applet file.",
         "invalidFileType": "Invalid file type",
-        "invalidFileTypeDesc": "Only .app, .gz, and .html files can be imported to Applets"
+        "invalidFileTypeDesc": "Only .app, .gz, and .html files can be imported to Applets",
+        "reservedFolderName": "\"{{name}}\" is a reserved name. Choose another name.",
+        "invalidFolderName": "That name can't be used. Try a different name.",
+        "folderExists": "An item named \"{{name}}\" already exists."
       },
       "tableHeaders": {
         "name": "Name",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -2517,12 +2517,15 @@
         "appletImported": "Applet importado!",
         "appletImportedDesc": "{{name}} guardado en /Applets{{iconText}}",
         "appletImportedIconText": " con {{icon}} icono",
+        "folderExists": "Ya existe un ítem llamado \"{{name}}\".",
         "importFailed": "Importación fallida",
         "importFailedAppletDesc": "No se pudo importar el archivo de applet.",
         "importFailedDesc": "No se pudo importar el archivo.",
         "invalidFileType": "Tipo de archivo no válido",
         "invalidFileTypeDesc": "Solo se pueden importar archivos .app, .gz y .html a Applets",
-        "loading": "Cargando…"
+        "invalidFolderName": "No se puede utilizar ese nombre. Prueba con otro.",
+        "loading": "Cargando…",
+        "reservedFolderName": "\"{{name}}\" es un nombre reservado. Elige otro nombre."
       },
       "name": "Finder",
       "placeholders": {
@@ -4761,7 +4764,8 @@
       "version": "Versión",
       "viewChangelog": "Registro de cambios",
       "viewDocs": "Ver documentación",
-      "welcomeTo": "Bienvenido a {{appName}}"
+      "welcomeTo": "Bienvenido a {{appName}}",
+      "where": "Dónde:"
     },
     "dock": {
       "addToDock": "Añadir al Dock",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -2517,12 +2517,15 @@
         "appletImported": "Applet importée !",
         "appletImportedDesc": "{{name}} enregistrée dans /Applets{{iconText}}",
         "appletImportedIconText": " avec l’icône {{icon}}",
+        "folderExists": "Un élément nommé « {{name}} » existe déjà.",
         "importFailed": "Échec de l’importation",
         "importFailedAppletDesc": "Impossible d'importer le fichier d'applet.",
         "importFailedDesc": "Impossible d’importer le fichier.",
         "invalidFileType": "Type de fichier invalide",
         "invalidFileTypeDesc": "Seuls les fichiers .app, .gz et .html peuvent être importés dans les Applets",
-        "loading": "Chargement…"
+        "invalidFolderName": "Ce nom ne peut pas être utilisé. Essayez d’utiliser un autre nom.",
+        "loading": "Chargement…",
+        "reservedFolderName": "« {{name}} » est un nom réservé. Choisissez un autre nom."
       },
       "name": "Finder",
       "placeholders": {
@@ -4761,7 +4764,8 @@
       "version": "Version",
       "viewChangelog": "Journal des modifications",
       "viewDocs": "Voir la documentation",
-      "welcomeTo": "Bienvenue dans {{appName}}"
+      "welcomeTo": "Bienvenue dans {{appName}}",
+      "where": "Où :"
     },
     "dock": {
       "addToDock": "Ajouter au Dock",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -2517,12 +2517,15 @@
         "appletImported": "Applet importata!",
         "appletImportedDesc": "{{name}} salvato in /Applets{{iconText}}",
         "appletImportedIconText": " con icona {{icon}}",
+        "folderExists": "Esiste già un elemento con il nome \"{{name}}\".",
         "importFailed": "Importazione non riuscita",
         "importFailedAppletDesc": "Impossibile importare il file applet.",
         "importFailedDesc": "Impossibile importare il file.",
         "invalidFileType": "Tipo di file non valido",
         "invalidFileTypeDesc": "Solo i file .app, .gz e .html possono essere importati in Applet",
-        "loading": "Carico…"
+        "invalidFolderName": "Non puoi utilizzare questo nome. Prova a usarne un altro.",
+        "loading": "Carico…",
+        "reservedFolderName": "\"{{name}}\" è un nome riservato. Scegline un altro."
       },
       "name": "Finder",
       "placeholders": {
@@ -4761,7 +4764,8 @@
       "version": "Versione",
       "viewChangelog": "Registro modifiche",
       "viewDocs": "Visualizza documentazione",
-      "welcomeTo": "Benvenuto in {{appName}}"
+      "welcomeTo": "Benvenuto in {{appName}}",
+      "where": "Situato in:"
     },
     "dock": {
       "addToDock": "Aggiungi al Dock",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -2515,12 +2515,15 @@
         "appletImported": "アプレットをインポートしました！",
         "appletImportedDesc": "{{name}}は /Applets に保存されました{{iconText}}",
         "appletImportedIconText": "{{icon}}アイコン付き",
+        "folderExists": "“{{name}}”という名前の項目がすでに存在します。",
         "importFailed": "インポートに失敗しました",
         "importFailedAppletDesc": "アプレットファイルをインポートできませんでした。",
         "importFailedDesc": "ファイルをインポートできませんでした。",
         "invalidFileType": "無効なファイルタイプ",
         "invalidFileTypeDesc": "アプレットにインポートできるのは、.app、.gz、.htmlファイルのみです。",
-        "loading": "読み込み中…"
+        "invalidFolderName": "その名前は使用できません。別の名前を使用してください。",
+        "loading": "読み込み中…",
+        "reservedFolderName": "“{{name}}”は予約済みの名前です。別の名前を選択してください。"
       },
       "name": "Finder",
       "placeholders": {
@@ -4757,7 +4760,8 @@
       "version": "バージョン",
       "viewChangelog": "変更履歴",
       "viewDocs": "ドキュメント",
-      "welcomeTo": "{{appName}}へようこそ"
+      "welcomeTo": "{{appName}}へようこそ",
+      "where": "場所:"
     },
     "dock": {
       "addToDock": "Dockに追加",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -2515,12 +2515,15 @@
         "appletImported": "애플릿 가져오기 완료!",
         "appletImportedDesc": "{{name}}이(가) /Applets에 저장되었습니다{{iconText}}",
         "appletImportedIconText": " {{icon}} 아이콘으로",
+        "folderExists": "\"{{name}}\"(이)라는 이름의 항목이 이미 있습니다.",
         "importFailed": "가져오기 실패",
         "importFailedAppletDesc": "애플릿 파일을 가져올 수 없습니다.",
         "importFailedDesc": "파일을 가져올 수 없습니다.",
         "invalidFileType": "잘못된 파일 형식",
         "invalidFileTypeDesc": ".app, .gz, .html 파일만 Applets로 가져올 수 있습니다.",
-        "loading": "로드 중…"
+        "invalidFolderName": "이 이름은 사용할 수 없습니다. 다른 이름을 사용해 보십시오.",
+        "loading": "로드 중…",
+        "reservedFolderName": "\"{{name}}\"은(는) 예약된 이름입니다. 다른 이름을 선택하십시오."
       },
       "name": "Finder",
       "placeholders": {
@@ -4757,7 +4760,8 @@
       "version": "버전",
       "viewChangelog": "변경 내역",
       "viewDocs": "문서 보기",
-      "welcomeTo": "{{appName}}에 오신 것을 환영합니다"
+      "welcomeTo": "{{appName}}에 오신 것을 환영합니다",
+      "where": "위치:"
     },
     "dock": {
       "addToDock": "Dock에 추가",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -2517,12 +2517,15 @@
         "appletImported": "Applet importado!",
         "appletImportedDesc": "{{name}} salvo em /Applets{{iconText}}",
         "appletImportedIconText": " com o ícone {{icon}}",
+        "folderExists": "Já existe um item chamado \"{{name}}\".",
         "importFailed": "Falha na importação",
         "importFailedAppletDesc": "Não foi possível importar o arquivo do applet.",
         "importFailedDesc": "Não foi possível importar o arquivo.",
         "invalidFileType": "Tipo de arquivo inválido",
         "invalidFileTypeDesc": "Apenas arquivos .app, .gz e .html podem ser importados para Applets",
-        "loading": "Carregando…"
+        "invalidFolderName": "Este nome não pode ser usado. Tente usar outro nome.",
+        "loading": "Carregando…",
+        "reservedFolderName": "\"{{name}}\" é um nome reservado. Escolha outro nome."
       },
       "name": "Finder",
       "placeholders": {
@@ -4761,7 +4764,8 @@
       "version": "Versão",
       "viewChangelog": "Registro de alterações",
       "viewDocs": "Ver documentação",
-      "welcomeTo": "Bem-vindo ao {{appName}}"
+      "welcomeTo": "Bem-vindo ao {{appName}}",
+      "where": "Onde:"
     },
     "dock": {
       "addToDock": "Adicionar ao Dock",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -2522,12 +2522,15 @@
         "appletImported": "Апплет импортирован!",
         "appletImportedDesc": "{{name}} сохранено в /Applets{{iconText}}",
         "appletImportedIconText": " с {{icon}} значком",
+        "folderExists": "Объект с именем «{{name}}» уже существует.",
         "importFailed": "Импорт не удался",
         "importFailedAppletDesc": "Не удалось импортировать файл апплета.",
         "importFailedDesc": "Не удалось импортировать файл.",
         "invalidFileType": "Недопустимый тип файла",
         "invalidFileTypeDesc": "Только файлы .app, .gz и .html можно импортировать в Апплеты",
-        "loading": "Загрузка…"
+        "invalidFolderName": "Это имя нельзя использовать. Попробуйте другое имя.",
+        "loading": "Загрузка…",
+        "reservedFolderName": "«{{name}}» — зарезервированное имя. Выберите другое имя."
       },
       "name": "Finder",
       "placeholders": {
@@ -4768,7 +4771,8 @@
       "version": "Версия",
       "viewChangelog": "Журнал изменений",
       "viewDocs": "Смотреть документацию",
-      "welcomeTo": "Добро пожаловать в {{appName}}"
+      "welcomeTo": "Добро пожаловать в {{appName}}",
+      "where": "Где:"
     },
     "dock": {
       "addToDock": "Добавить в Dock",

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -2515,12 +2515,15 @@
         "appletImported": "小程序已导入！",
         "appletImportedDesc": "{{name}} 已保存到 /Applets{{iconText}}",
         "appletImportedIconText": "，图标为 {{icon}}",
+        "folderExists": "已存在名为“{{name}}”的项目。",
         "importFailed": "导入失败",
         "importFailedAppletDesc": "无法导入小程序文件。",
         "importFailedDesc": "无法导入文件。",
         "invalidFileType": "无效的文件类型",
         "invalidFileTypeDesc": "只有 .app、.gz 和 .html 文件可以导入 Applets",
-        "loading": "加载中…"
+        "invalidFolderName": "不能使用该名称。请尝试使用其他名称。",
+        "loading": "加载中…",
+        "reservedFolderName": "“{{name}}”是保留名称。请选取其他名称。"
       },
       "name": "Finder",
       "placeholders": {
@@ -4757,7 +4760,8 @@
       "version": "版本",
       "viewChangelog": "更新日志",
       "viewDocs": "查看文档",
-      "welcomeTo": "欢迎使用{{appName}}"
+      "welcomeTo": "欢迎使用{{appName}}",
+      "where": "位置："
     },
     "dock": {
       "addToDock": "添加到程序坞",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -2515,12 +2515,15 @@
         "appletImported": "小程式已匯入！",
         "appletImportedDesc": "{{name}} 已儲存至 /Applets{{iconText}}",
         "appletImportedIconText": "附有 {{icon}} 圖示",
+        "folderExists": "名稱為「{{name}}」的項目已存在。",
         "importFailed": "匯入失敗",
         "importFailedAppletDesc": "無法匯入小程式檔案。",
         "importFailedDesc": "無法匯入檔案。",
         "invalidFileType": "無效的檔案類型",
         "invalidFileTypeDesc": "只有 .app、.gz 和 .html 檔案可以匯入到 Applets",
-        "loading": "載入中⋯"
+        "invalidFolderName": "無法使用該名稱。請嘗試使用其他名稱。",
+        "loading": "載入中⋯",
+        "reservedFolderName": "「{{name}}」是保留名稱。請選擇其他名稱。"
       },
       "name": "Finder",
       "placeholders": {
@@ -4757,7 +4760,8 @@
       "version": "版本",
       "viewChangelog": "更新日誌",
       "viewDocs": "查看文檔",
-      "welcomeTo": "歡迎使用{{appName}}"
+      "welcomeTo": "歡迎使用{{appName}}",
+      "where": "位置："
     },
     "dock": {
       "addToDock": "加入Dock中",

--- a/src/services/vfs/pathPolicy.ts
+++ b/src/services/vfs/pathPolicy.ts
@@ -1,0 +1,121 @@
+/**
+ * VFS Path Policy
+ *
+ * Single source of truth for which paths in the virtual file system are
+ * writable, which roots are system-managed (protected from rename/trash),
+ * and which names are reserved at the root level.
+ *
+ * Terminology:
+ * - "Virtual roots" are computed listings backed by other stores
+ *   (app registry, iPod/Videos libraries, IE favorites) — never writable.
+ * - "System roots" are the default folders seeded from filesystem.json —
+ *   they cannot be renamed or trashed, but some of them are writable inside.
+ * - "User roots" are root-level folders created by the user — fully
+ *   writable, renamable, and trashable.
+ */
+
+/** Roots whose listings are computed from other stores (never writable). */
+export const VIRTUAL_ROOTS = [
+  "/Applications",
+  "/Music",
+  "/Videos",
+  "/Sites",
+] as const;
+
+/** Special roots with dedicated semantics (never general-purpose writable). */
+export const SPECIAL_ROOTS = ["/Trash", "/Desktop"] as const;
+
+/** All roots seeded by default (filesystem.json + required /Downloads). */
+export const SYSTEM_ROOTS = [
+  "/Applications",
+  "/Documents",
+  "/Downloads",
+  "/Images",
+  "/Books",
+  "/Music",
+  "/Videos",
+  "/Sites",
+  "/Applets",
+  "/Trash",
+  "/Desktop",
+] as const;
+
+/** Legacy virtual root still handled by Finder's loadFiles. */
+const LEGACY_ROOTS = ["/Favorites"] as const;
+
+const NON_WRITABLE_ROOTS = new Set<string>([
+  ...VIRTUAL_ROOTS,
+  ...SPECIAL_ROOTS,
+  ...LEGACY_ROOTS,
+  // Applets are import-only (managed by the Applet Viewer / Finder import).
+  "/Applets",
+]);
+
+const SYSTEM_ROOT_SET = new Set<string>(SYSTEM_ROOTS);
+
+const RESERVED_ROOT_NAMES = new Set<string>(
+  [...SYSTEM_ROOTS, ...LEGACY_ROOTS].map((path) =>
+    path.slice(1).toLowerCase()
+  )
+);
+
+/** Return the top-level root segment of a path (e.g. "/Docs/a.md" -> "/Docs"). */
+export function getRootSegment(path: string): string | null {
+  if (!path.startsWith("/") || path === "/") return null;
+  const secondSlash = path.indexOf("/", 1);
+  return secondSlash === -1 ? path : path.slice(0, secondSlash);
+}
+
+/**
+ * Whether files/folders can be created, moved, renamed, or imported at the
+ * given directory path. True for the root itself (creating new root folders
+ * and root-level files), the writable system subtrees, and any user-created
+ * root folder subtree.
+ */
+export function isWritablePath(path: string): boolean {
+  if (!path.startsWith("/")) return false;
+  if (path === "/") return true;
+  const root = getRootSegment(path);
+  if (!root) return false;
+  return !NON_WRITABLE_ROOTS.has(root);
+}
+
+/** Whether a path is a system-managed root that cannot be renamed or trashed. */
+export function isProtectedSystemPath(path: string): boolean {
+  return path === "/" || SYSTEM_ROOT_SET.has(path);
+}
+
+/**
+ * Whether content for a file at this path can live in the IndexedDB content
+ * stores. Virtual/special subtrees have no user content; everything else
+ * routes by path prefix or extension (see getStoreForFile).
+ */
+export function canPathHaveContent(path: string): boolean {
+  if (!path.startsWith("/") || path === "/") return false;
+  const root = getRootSegment(path);
+  if (!root) return false;
+  return !NON_WRITABLE_ROOTS.has(root);
+}
+
+export type RootFolderNameValidation =
+  | { ok: true }
+  | { ok: false; reason: "empty" | "invalid" | "reserved" };
+
+/**
+ * Validate a new root-level folder name. Rejects empty names, path
+ * separators, and names colliding (case-insensitively) with system or
+ * virtual roots.
+ */
+export function validateNewRootFolderName(
+  name: string
+): RootFolderNameValidation {
+  const trimmed = name.trim();
+  if (!trimmed) return { ok: false, reason: "empty" };
+  if (trimmed.includes("/") || trimmed === "." || trimmed === "..") {
+    return { ok: false, reason: "invalid" };
+  }
+  if (RESERVED_ROOT_NAMES.has(trimmed.toLowerCase())) {
+    return { ok: false, reason: "reserved" };
+  }
+  return { ok: true };
+}

--- a/src/services/vfs/pathPolicy.ts
+++ b/src/services/vfs/pathPolicy.ts
@@ -97,6 +97,55 @@ export function canPathHaveContent(path: string): boolean {
   return !NON_WRITABLE_ROOTS.has(root);
 }
 
+export interface WritableDirectoryEntry {
+  path: string;
+  name: string;
+  depth: number;
+}
+
+interface DirectoryLikeItem {
+  path: string;
+  name: string;
+  isDirectory: boolean;
+  status?: string;
+}
+
+/**
+ * List all writable directories depth-first (an indented tree), given the
+ * files-store items map. Used by save-location pickers.
+ */
+export function listWritableDirectories(
+  items: Record<string, DirectoryLikeItem>
+): WritableDirectoryEntry[] {
+  const result: WritableDirectoryEntry[] = [];
+  const directories = Object.values(items).filter(
+    (item) =>
+      item.isDirectory &&
+      item.status !== "trashed" &&
+      // The root "/" is its own parent; exclude it so the walk terminates.
+      item.path !== "/"
+  );
+
+  const parentOf = (path: string): string => {
+    const lastSlash = path.lastIndexOf("/");
+    return lastSlash <= 0 ? "/" : path.substring(0, lastSlash);
+  };
+
+  const walk = (parent: string, depth: number) => {
+    const children = directories
+      .filter((item) => parentOf(item.path) === parent)
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const child of children) {
+      if (!isWritablePath(child.path)) continue;
+      result.push({ path: child.path, name: child.name, depth });
+      walk(child.path, depth + 1);
+    }
+  };
+
+  walk("/", 0);
+  return result;
+}
+
 export type RootFolderNameValidation =
   | { ok: true }
   | { ok: false; reason: "empty" | "invalid" | "reserved" };

--- a/src/utils/indexedDBOperations.ts
+++ b/src/utils/indexedDBOperations.ts
@@ -6,6 +6,7 @@
  */
 
 import { ensureIndexedDBInitialized, STORES } from "./indexedDB";
+import { canPathHaveContent } from "@/services/vfs/pathPolicy";
 
 // Structure for content stored in IndexedDB
 export interface StoredContent {
@@ -233,8 +234,14 @@ export function getStoreForFile(
   if (filePath.startsWith("/Images/")) return STORES.IMAGES;
   if (filePath.startsWith("/Books/")) return STORES.BOOKS;
   if (filePath.startsWith("/Applets/")) return STORES.APPLETS;
-  if (!filePath.startsWith("/Downloads/")) return null;
+  // Virtual/special subtrees (/Applications, /Music, /Videos, /Sites,
+  // /Trash, /Desktop, ...) carry no user content.
+  if (!canPathHaveContent(filePath)) return null;
 
+  // Everything else (/Downloads, user-created root folders, root-level
+  // files) routes by extension/MIME type. This routing depends only on the
+  // filename, so it resolves identically on every device (cloud sync reads
+  // content back through this same function).
   const extension = getExtension(options.name || filePath);
   const normalizedType = options.type?.toLowerCase() || "";
 

--- a/tests/test-vfs-path-policy.test.ts
+++ b/tests/test-vfs-path-policy.test.ts
@@ -10,6 +10,7 @@ import {
   isProtectedSystemPath,
   canPathHaveContent,
   validateNewRootFolderName,
+  listWritableDirectories,
 } from "@/services/vfs/pathPolicy";
 import { getStoreForFile } from "@/utils/indexedDBOperations";
 import { STORES } from "@/utils/indexedDB";
@@ -223,6 +224,51 @@ describe("getStoreForFile routing", () => {
       name: "photo.png",
     });
     expect(saveTime).toBe(readTime);
+  });
+});
+
+describe("pathPolicy.listWritableDirectories", () => {
+  const dir = (path: string, name: string) => ({
+    path,
+    name,
+    isDirectory: true,
+    status: "active",
+  });
+
+  test("lists writable directories depth-first with depths", () => {
+    const items = {
+      "/": dir("/", "Macintosh HD"),
+      "/Documents": dir("/Documents", "Documents"),
+      "/Documents/Notes": dir("/Documents/Notes", "Notes"),
+      "/Music": dir("/Music", "Music"),
+      "/MyStuff": dir("/MyStuff", "MyStuff"),
+      "/MyStuff/Photos": dir("/MyStuff/Photos", "Photos"),
+      "/Trash": dir("/Trash", "Trash"),
+    };
+    const result = listWritableDirectories(items);
+    expect(result).toEqual([
+      { path: "/Documents", name: "Documents", depth: 0 },
+      { path: "/Documents/Notes", name: "Notes", depth: 1 },
+      { path: "/MyStuff", name: "MyStuff", depth: 0 },
+      { path: "/MyStuff/Photos", name: "Photos", depth: 1 },
+    ]);
+  });
+
+  test("does not recurse infinitely on the root item (its own parent)", () => {
+    // Regression: "/" is its own parent path, which previously caused a
+    // "Maximum call stack size exceeded" crash in the save dialog.
+    const items = { "/": dir("/", "Macintosh HD") };
+    expect(listWritableDirectories(items)).toEqual([]);
+  });
+
+  test("skips trashed directories", () => {
+    const items = {
+      "/Old": { ...dir("/Old", "Old"), status: "trashed" },
+      "/Kept": dir("/Kept", "Kept"),
+    };
+    expect(listWritableDirectories(items)).toEqual([
+      { path: "/Kept", name: "Kept", depth: 0 },
+    ]);
   });
 });
 

--- a/tests/test-vfs-path-policy.test.ts
+++ b/tests/test-vfs-path-policy.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Unit tests for the VFS path policy (user-created root folders) and the
+ * extension-based content-store routing that makes files outside the default
+ * folders (e.g. /MyStuff/photo.png) storable, readable, and cloud-syncable.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  getRootSegment,
+  isWritablePath,
+  isProtectedSystemPath,
+  canPathHaveContent,
+  validateNewRootFolderName,
+} from "@/services/vfs/pathPolicy";
+import { getStoreForFile } from "@/utils/indexedDBOperations";
+import { STORES } from "@/utils/indexedDB";
+import {
+  getCloudSyncDomainForContentStore,
+  getCloudSyncDeletionBucketForContentStore,
+} from "@/apps/finder/utils/fileSystemHelpers";
+
+describe("pathPolicy.getRootSegment", () => {
+  test("returns the top-level segment", () => {
+    expect(getRootSegment("/Documents/notes.md")).toBe("/Documents");
+    expect(getRootSegment("/MyStuff/a/b/c.txt")).toBe("/MyStuff");
+    expect(getRootSegment("/MyStuff")).toBe("/MyStuff");
+  });
+
+  test("returns null for root and non-absolute paths", () => {
+    expect(getRootSegment("/")).toBeNull();
+    expect(getRootSegment("relative/path")).toBeNull();
+  });
+});
+
+describe("pathPolicy.isWritablePath", () => {
+  test("allows the root (creating new root folders)", () => {
+    expect(isWritablePath("/")).toBe(true);
+  });
+
+  test("allows writable system subtrees", () => {
+    expect(isWritablePath("/Documents")).toBe(true);
+    expect(isWritablePath("/Documents/Sub Folder")).toBe(true);
+    expect(isWritablePath("/Images")).toBe(true);
+    expect(isWritablePath("/Books")).toBe(true);
+    expect(isWritablePath("/Downloads")).toBe(true);
+  });
+
+  test("allows user-created root folders and their subtrees", () => {
+    expect(isWritablePath("/MyStuff")).toBe(true);
+    expect(isWritablePath("/MyStuff/Photos")).toBe(true);
+  });
+
+  test("rejects virtual and special roots", () => {
+    expect(isWritablePath("/Applications")).toBe(false);
+    expect(isWritablePath("/Music")).toBe(false);
+    expect(isWritablePath("/Music/Artist")).toBe(false);
+    expect(isWritablePath("/Videos")).toBe(false);
+    expect(isWritablePath("/Sites")).toBe(false);
+    expect(isWritablePath("/Sites/Folder")).toBe(false);
+    expect(isWritablePath("/Trash")).toBe(false);
+    expect(isWritablePath("/Desktop")).toBe(false);
+    expect(isWritablePath("/Applets")).toBe(false);
+    expect(isWritablePath("/Favorites")).toBe(false);
+  });
+
+  test("rejects non-absolute paths", () => {
+    expect(isWritablePath("Documents")).toBe(false);
+    expect(isWritablePath("")).toBe(false);
+  });
+});
+
+describe("pathPolicy.isProtectedSystemPath", () => {
+  test("protects all system roots and /", () => {
+    for (const path of [
+      "/",
+      "/Applications",
+      "/Documents",
+      "/Downloads",
+      "/Images",
+      "/Books",
+      "/Music",
+      "/Videos",
+      "/Sites",
+      "/Applets",
+      "/Trash",
+      "/Desktop",
+    ]) {
+      expect(isProtectedSystemPath(path)).toBe(true);
+    }
+  });
+
+  test("does not protect user roots or nested items", () => {
+    expect(isProtectedSystemPath("/MyStuff")).toBe(false);
+    expect(isProtectedSystemPath("/Documents/notes.md")).toBe(false);
+    expect(isProtectedSystemPath("/Documents/Sub Folder")).toBe(false);
+  });
+});
+
+describe("pathPolicy.validateNewRootFolderName", () => {
+  test("accepts normal names", () => {
+    expect(validateNewRootFolderName("My Stuff")).toEqual({ ok: true });
+    expect(validateNewRootFolderName("Projects")).toEqual({ ok: true });
+  });
+
+  test("rejects empty and invalid names", () => {
+    expect(validateNewRootFolderName("")).toEqual({
+      ok: false,
+      reason: "empty",
+    });
+    expect(validateNewRootFolderName("   ")).toEqual({
+      ok: false,
+      reason: "empty",
+    });
+    expect(validateNewRootFolderName("a/b")).toEqual({
+      ok: false,
+      reason: "invalid",
+    });
+    expect(validateNewRootFolderName(".")).toEqual({
+      ok: false,
+      reason: "invalid",
+    });
+    expect(validateNewRootFolderName("..")).toEqual({
+      ok: false,
+      reason: "invalid",
+    });
+  });
+
+  test("rejects reserved system root names (case-insensitive)", () => {
+    for (const name of [
+      "Documents",
+      "documents",
+      "MUSIC",
+      "Sites",
+      "trash",
+      "Desktop",
+      "applets",
+      "Downloads",
+      "Favorites",
+    ]) {
+      expect(validateNewRootFolderName(name)).toEqual({
+        ok: false,
+        reason: "reserved",
+      });
+    }
+  });
+});
+
+describe("pathPolicy.canPathHaveContent", () => {
+  test("content allowed in writable + import-only subtrees", () => {
+    expect(canPathHaveContent("/Documents/notes.md")).toBe(true);
+    expect(canPathHaveContent("/MyStuff/photo.png")).toBe(true);
+    expect(canPathHaveContent("/note.md")).toBe(true);
+    expect(canPathHaveContent("/Downloads/pic.jpg")).toBe(true);
+  });
+
+  test("no content under virtual/special roots", () => {
+    expect(canPathHaveContent("/Music/Artist/Song")).toBe(false);
+    expect(canPathHaveContent("/Applications/Finder")).toBe(false);
+    expect(canPathHaveContent("/Sites/link")).toBe(false);
+    expect(canPathHaveContent("/Trash/old.md")).toBe(false);
+    expect(canPathHaveContent("/Desktop/alias")).toBe(false);
+    expect(canPathHaveContent("/")).toBe(false);
+  });
+});
+
+describe("getStoreForFile routing", () => {
+  test("fixed prefixes keep their stores", () => {
+    expect(getStoreForFile("/Documents/pic.png")).toBe(STORES.DOCUMENTS);
+    expect(getStoreForFile("/Images/notes.md")).toBe(STORES.IMAGES);
+    expect(getStoreForFile("/Books/anything.epub")).toBe(STORES.BOOKS);
+    expect(getStoreForFile("/Applets/thing.html")).toBe(STORES.APPLETS);
+  });
+
+  test("/Downloads routes by extension (unchanged)", () => {
+    expect(getStoreForFile("/Downloads/pic.jpg")).toBe(STORES.IMAGES);
+    expect(getStoreForFile("/Downloads/book.epub")).toBe(STORES.BOOKS);
+    expect(getStoreForFile("/Downloads/page.html")).toBe(STORES.APPLETS);
+    expect(getStoreForFile("/Downloads/notes.md")).toBe(STORES.DOCUMENTS);
+  });
+
+  test("user root folders route by extension", () => {
+    expect(getStoreForFile("/MyStuff/photo.png")).toBe(STORES.IMAGES);
+    expect(getStoreForFile("/MyStuff/book.epub")).toBe(STORES.BOOKS);
+    expect(getStoreForFile("/MyStuff/widget.app")).toBe(STORES.APPLETS);
+    expect(getStoreForFile("/MyStuff/notes.md")).toBe(STORES.DOCUMENTS);
+    expect(getStoreForFile("/MyStuff/no-extension")).toBe(STORES.DOCUMENTS);
+    expect(getStoreForFile("/MyStuff/Nested/Deep/pic.webp")).toBe(
+      STORES.IMAGES
+    );
+  });
+
+  test("root-level files route by extension", () => {
+    expect(getStoreForFile("/note.md")).toBe(STORES.DOCUMENTS);
+    expect(getStoreForFile("/photo.jpeg")).toBe(STORES.IMAGES);
+  });
+
+  test("type option can override when the path has no extension", () => {
+    expect(getStoreForFile("/MyStuff/somefile", { type: "png" })).toBe(
+      STORES.IMAGES
+    );
+    expect(getStoreForFile("/MyStuff/somefile", { type: "epub" })).toBe(
+      STORES.BOOKS
+    );
+  });
+
+  test("virtual/special subtrees have no content store", () => {
+    expect(getStoreForFile("/Music/Artist/Song")).toBeNull();
+    expect(getStoreForFile("/Videos/Clip")).toBeNull();
+    expect(getStoreForFile("/Sites/link")).toBeNull();
+    expect(getStoreForFile("/Applications/Finder")).toBeNull();
+    expect(getStoreForFile("/Trash/old.md")).toBeNull();
+    expect(getStoreForFile("/Desktop/alias.png")).toBeNull();
+    expect(getStoreForFile("/")).toBeNull();
+  });
+
+  test("routing is deterministic from filename alone (sync-safe)", () => {
+    // Receiving devices resolve the same store from path + name without the
+    // original save-time type hint.
+    const saveTime = getStoreForFile("/MyStuff/photo.png", {
+      name: "photo.png",
+      type: "png",
+    });
+    const readTime = getStoreForFile("/MyStuff/photo.png", {
+      name: "photo.png",
+    });
+    expect(saveTime).toBe(readTime);
+  });
+});
+
+describe("cloud sync domain resolution for custom paths", () => {
+  test("custom-path files resolve to a syncable domain", () => {
+    const store = getStoreForFile("/MyStuff/photo.png");
+    expect(store).toBe(STORES.IMAGES);
+    expect(getCloudSyncDomainForContentStore(store!)).toBe("images");
+    expect(getCloudSyncDeletionBucketForContentStore(store!)).toBe(
+      "fileImageKeys"
+    );
+
+    const docStore = getStoreForFile("/MyStuff/notes.md");
+    expect(docStore).toBe(STORES.DOCUMENTS);
+    expect(getCloudSyncDomainForContentStore(docStore!)).toBe("files");
+
+    const bookStore = getStoreForFile("/MyStuff/book.epub");
+    expect(bookStore).toBe(STORES.BOOKS);
+    expect(getCloudSyncDomainForContentStore(bookStore!)).toBe("books");
+    expect(getCloudSyncDeletionBucketForContentStore(bookStore!)).toBe(
+      "fileBookKeys"
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users can now create their own root-level folders (e.g. `/My Stuff`) in the VFS and save, import, move, and rename files (text, images, books, etc.) anywhere writable. Virtual folders (`/Music`, `/Videos`, `/Sites`, `/Applications`) keep their computed listings unchanged.

### Core changes

- **`src/services/vfs/pathPolicy.ts` (new)** — single source of truth: `isWritablePath` (root `/`, `/Documents`/`/Images`/`/Books`/`/Downloads` subtrees, and any user-created root subtree), `isProtectedSystemPath` (system roots can't be renamed/trashed), `validateNewRootFolderName` (reserved names rejected case-insensitively), `listWritableDirectories` (indented tree for save-location pickers).
- **Content routing** — `getStoreForFile` now applies the existing extension/MIME routing (previously `/Downloads`-only) to all non-virtual paths, so files in user folders and at root get real IndexedDB content storage. Routing is deterministic from the filename, so cloud sync peers resolve the same store.
- **Finder** — New Folder works at `/` and in user folders (with reserved-name/duplicate validation); rename/trash/move/duplicate/AirDrop guards use the shared policy; OS drag-drop and Import from Device work in any writable directory; image thumbnails render in any folder.
- **Cross-store integrity** — `moveFile` marks the source deletion bucket for cloud sync; `renameFile` migrates content between stores when an extension change alters the resolved store.
- **Save dialogs** — new shared `SaveFileDialog` with a "Where:" location picker (all writable directories, indented tree), wired into TextEdit, Paint, and Preview Save As.
- **i18n** — new keys added to English and machine-translated to all 10 locales; shell bundle regenerated.

### Cloud sync

The sync engine is path-agnostic (metadata by path, content by UUID), so user-folder files sync end-to-end once content reaches the right store — which the routing fix guarantees. Domain/deletion-bucket resolution for custom paths is covered by unit tests.

### Verification

Manual browser walkthrough (screenshots):

![Reserved name rejected when creating a root folder](https://cursor.com/artifacts/c/art-8db1da7a-380e-4d93-8ef8-887e2d344f20)

Creating a root folder named "Music" is rejected with a toast; "My Stuff" then creates successfully at `/`.

![TextEdit save dialog with Where dropdown](https://cursor.com/artifacts/c/art-56464c70-e947-42ac-8e66-2560129dcb7d)

TextEdit Save shows the new "Where:" picker listing Books, Documents, Downloads, Images, and the user-created My Stuff folder.

![My Stuff folder with saved files and PNG thumbnail](https://cursor.com/artifacts/c/art-573f372e-a7ac-4036-8c5e-d23d80190d4d)

Both a TextEdit `.md` and a Paint `.png` saved into `/My Stuff`; the PNG renders a thumbnail outside `/Images`.

![Music virtual folder still lists artists](https://cursor.com/artifacts/c/art-3da17950-51a3-4baa-b8ad-f657f28072d8)

`/Music` virtual listing unchanged.

![Folder restored from Trash with files intact](https://cursor.com/artifacts/c/art-2af431b0-435f-4619-9024-f3b0d733f279)

The user folder was renamed to "My Projects", trashed, and Put Back with both files intact.

### Testing

- New `tests/test-vfs-path-policy.test.ts` (25 tests): path policy, extension routing for custom paths, writable-directory tree walk (incl. regression for the root-recursion crash), sync domain resolution.
- `bun run test:unit` (2494 pass / 0 fail), `bun run lint` (0 errors), `bun run typecheck`, `bun run build` all pass.
- Manual browser verification of the full flow: create root folder, save from TextEdit/Paint into it, thumbnails, open files, virtual folders, rename/trash/restore.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3cf0-8ec0-71ab-ab9c-eb7506806241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3cf0-8ec0-71ab-ab9c-eb7506806241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

