### PR TITLE
Fix AI analytics over-counting and per-render conversation re-fetch loop

### DIFF
--- a/api/_utils/_analytics.ts
+++ b/api/_utils/_analytics.ts
@@ -38,17 +38,32 @@ function pk(suffix: string, date: string): string {
   return redisKeys.analytics.productMetric(suffix, date);
 }
 
+// Only endpoints that actually invoke an AI model. `/api/ai/…` also hosts
+// non-AI plumbing — conversation snapshot/delta reads (fired on every
+// hydration/focus event), attachments, cursor-run polling — which must NOT
+// count as AI usage or they dwarf the real numbers in the admin dashboard.
 const AI_PATH_PREFIXES = [
   "/api/chat",
   "/api/applet-ai",
   "/api/ie-generate",
-  "/api/ai/",
   "/api/speech",
   "/api/audio-transcribe",
+  "/api/ai/ryo-reply",
+  "/api/ai/extract-memories",
+  "/api/ai/process-daily-notes",
 ];
 
-function isAIEndpoint(path: string): boolean {
-  return AI_PATH_PREFIXES.some((prefix) => path.startsWith(prefix));
+// Proactive greeting generation is the one model-invoking route under
+// `/api/ai/conversations/…`.
+const AI_CONVERSATION_GREETING_RE =
+  /^\/api\/ai\/conversations\/[^/]+\/greeting$/;
+
+export function isAIEndpoint(rawPath: string): boolean {
+  const path = rawPath.split("?")[0];
+  return (
+    AI_PATH_PREFIXES.some((prefix) => path.startsWith(prefix)) ||
+    AI_CONVERSATION_GREETING_RE.test(path)
+  );
 }
 
 function normaliseEndpoint(rawPath: string): string {

--- a/src/hooks/useServerAIConversation.ts
+++ b/src/hooks/useServerAIConversation.ts
@@ -1,9 +1,18 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useChatsStore } from "@/stores/useChatsStore";
 import { loadAIConversation } from "@/api/aiConversations";
 import { useAIConversationRealtime } from "@/hooks/useAIConversationRealtime";
 import type { AIConversationChannel } from "@/shared/contracts/aiConversation";
 import type { AIChatMessage } from "@/types/chat";
+
+/**
+ * Minimum time between focus/visibility-triggered revalidations. Realtime
+ * events already push genuine cross-device updates the moment they happen,
+ * so the focus refresh is only a safety net for missed events — it doesn't
+ * need to fire on every alt-tab (and `focus` + `visibilitychange` both fire
+ * on the same tab activation).
+ */
+export const FOCUS_REFRESH_MIN_INTERVAL_MS = 30_000;
 
 export interface UseServerAIConversationInput {
   channel: AIConversationChannel;
@@ -35,9 +44,25 @@ export function useServerAIConversation({
   const identity =
     username && isAuthenticated ? username.toLowerCase() : null;
 
+  // Callers pass inline closures for these; route them through refs so
+  // `hydrate` stays referentially stable across renders. Otherwise the
+  // hydration effect below re-runs — and re-fetches the conversation — on
+  // every render of the calling component.
+  const isChatReadyRef = useRef(isChatReady);
+  isChatReadyRef.current = isChatReady;
+  const applyMessagesRef = useRef(applyMessages);
+  applyMessagesRef.current = applyMessages;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  const lastRefreshAtRef = useRef(0);
+
   const hydrate = useCallback(
     async (force = false) => {
       if (!identity) return;
+      // Every hydration counts as a refresh: push the next focus-triggered
+      // revalidation out by the full interval.
+      lastRefreshAtRef.current = Date.now();
       const loaded = await loadAIConversation({
         channel,
         username: identity,
@@ -48,33 +73,38 @@ export function useServerAIConversation({
         loaded.stale ||
         currentAuth.username?.toLowerCase() !== loaded.owner ||
         !currentAuth.isAuthenticated ||
-        !isChatReady()
+        !isChatReadyRef.current()
       ) {
         return;
       }
-      applyMessages(loaded.messages);
+      applyMessagesRef.current(loaded.messages);
     },
-    [channel, identity, isChatReady, applyMessages]
+    [channel, identity]
   );
 
   useEffect(() => {
     if (!identity) return;
     let cancelled = false;
     void hydrate(true).catch((error) => {
-      if (!cancelled) onError(error, "hydrate");
+      if (!cancelled) onErrorRef.current(error, "hydrate");
     });
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [identity, hydrate]);
 
   useEffect(() => {
     if (!identity) return;
     const refresh = () => {
-      if (document.visibilityState === "visible" && isChatReady()) {
-        void hydrate(true).catch((error) => onError(error, "refresh"));
+      if (document.visibilityState !== "visible" || !isChatReadyRef.current()) {
+        return;
       }
+      const now = Date.now();
+      if (now - lastRefreshAtRef.current < FOCUS_REFRESH_MIN_INTERVAL_MS) {
+        return;
+      }
+      lastRefreshAtRef.current = now;
+      void hydrate(true).catch((error) => onErrorRef.current(error, "refresh"));
     };
     window.addEventListener("focus", refresh);
     document.addEventListener("visibilitychange", refresh);
@@ -82,8 +112,7 @@ export function useServerAIConversation({
       window.removeEventListener("focus", refresh);
       document.removeEventListener("visibilitychange", refresh);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [identity, hydrate, isChatReady]);
+  }, [identity, hydrate]);
 
   // Live cross-device updates: re-hydrate as soon as another signed-in
   // device changes the canonical conversation.
@@ -91,8 +120,8 @@ export function useServerAIConversation({
     channel,
     username: identity,
     onRemoteUpdate: () => {
-      if (!isChatReady()) return;
-      void hydrate(true).catch((error) => onError(error, "realtime"));
+      if (!isChatReadyRef.current()) return;
+      void hydrate(true).catch((error) => onErrorRef.current(error, "realtime"));
     },
   });
 

--- a/tests/test-analytics-aggregation.test.ts
+++ b/tests/test-analytics-aggregation.test.ts
@@ -2,7 +2,10 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  getAnalyticsSummary,
   getProductAnalyticsDetail,
+  isAIEndpoint,
+  recordAnalyticsEvent,
   recordProductAnalyticsEvents,
   sanitizeProductAnalyticsEvent,
 } from "../api/_utils/_analytics";
@@ -84,6 +87,68 @@ class FakeRedis {
     return new FakePipeline(this);
   }
 }
+
+describe("API analytics AI classification", () => {
+  test("counts only model-invoking endpoints as AI", () => {
+    // Real AI-generation endpoints.
+    expect(isAIEndpoint("/api/chat")).toBe(true);
+    expect(isAIEndpoint("/api/applet-ai")).toBe(true);
+    expect(isAIEndpoint("/api/ie-generate")).toBe(true);
+    expect(isAIEndpoint("/api/speech")).toBe(true);
+    expect(isAIEndpoint("/api/audio-transcribe")).toBe(true);
+    expect(isAIEndpoint("/api/ai/ryo-reply")).toBe(true);
+    expect(isAIEndpoint("/api/ai/extract-memories")).toBe(true);
+    expect(isAIEndpoint("/api/ai/process-daily-notes")).toBe(true);
+    expect(isAIEndpoint("/api/ai/conversations/chat/greeting")).toBe(true);
+    expect(isAIEndpoint("/api/ai/conversations/assistant/greeting")).toBe(true);
+
+    // Server-owned conversation plumbing: hydration reads fire on every
+    // sign-in / focus / realtime event and must not count as AI usage.
+    expect(isAIEndpoint("/api/ai/conversations/chat")).toBe(false);
+    expect(isAIEndpoint("/api/ai/conversations/assistant")).toBe(false);
+    expect(isAIEndpoint("/api/ai/conversations/chat?afterSeq=42")).toBe(false);
+    expect(isAIEndpoint("/api/ai/conversations/chat/reset")).toBe(false);
+    expect(isAIEndpoint("/api/ai/attachments")).toBe(false);
+    expect(isAIEndpoint("/api/ai/attachments/some-id")).toBe(false);
+    expect(isAIEndpoint("/api/ai/cursor-run-status?runId=x")).toBe(false);
+    expect(isAIEndpoint("/api/ai/cursor-run-followup")).toBe(false);
+
+    // Non-AI endpoints stay non-AI.
+    expect(isAIEndpoint("/api/presence/heartbeat")).toBe(false);
+    expect(isAIEndpoint("/api/rooms")).toBe(false);
+  });
+
+  test("conversation hydration reads do not inflate the daily AI total", async () => {
+    const redis = new FakeRedis();
+    const base = {
+      method: "GET",
+      status: 200,
+      latencyMs: 5,
+      ip: "8.8.8.8",
+      username: "alice",
+    };
+
+    recordAnalyticsEvent(redis as unknown as Redis, {
+      ...base,
+      path: "/api/ai/conversations/chat?afterSeq=10",
+    });
+    recordAnalyticsEvent(redis as unknown as Redis, {
+      ...base,
+      path: "/api/ai/conversations/assistant",
+    });
+    recordAnalyticsEvent(redis as unknown as Redis, {
+      ...base,
+      path: "/api/chat",
+      method: "POST",
+    });
+
+    await Promise.resolve();
+
+    const summary = await getAnalyticsSummary(redis as unknown as Redis, 1);
+    expect(summary.totals.calls).toBe(3);
+    expect(summary.totals.ai).toBe(1);
+  });
+});
 
 describe("product analytics aggregation", () => {
   test("sanitizes sensitive properties and invalid dimensions", () => {

--- a/tests/test-server-ai-conversation-hook.test.tsx
+++ b/tests/test-server-ai-conversation-hook.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Regression tests for `useServerAIConversation` request efficiency.
+ *
+ * The Ryo (`chat`) and desktop-assistant (`assistant`) threads each mount
+ * this hook, and its callers pass inline closures for `isChatReady` /
+ * `applyMessages` / `onError`. A previous version keyed its hydration
+ * effect on those closures, so every re-render of a chat component fired a
+ * forced `GET /api/ai/conversations/:channel` — hundreds of thousands of
+ * requests per day in production. These tests pin the fixed behavior:
+ *
+ * - exactly one hydration per identity, regardless of re-renders
+ * - focus/visibility refreshes throttled to FOCUS_REFRESH_MIN_INTERVAL_MS
+ *   (`focus` + `visibilitychange` fire together on tab activation)
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  setSystemTime,
+  test,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import {
+  FOCUS_REFRESH_MIN_INTERVAL_MS,
+  useServerAIConversation,
+} from "../src/hooks/useServerAIConversation";
+import { clearAIConversationSessionCache } from "../src/api/aiConversations";
+import { useChatsStore } from "../src/stores/useChatsStore";
+
+let registeredDomForSuite = false;
+let host: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+const originalFetch = globalThis.fetch;
+
+interface FakeRealtimeChannel {
+  name: string;
+  bind: () => void;
+  unbind: () => void;
+}
+
+const globalWithPusher = globalThis as typeof globalThis & {
+  __pusherClient?: unknown;
+  __pusherChannelRefCounts?: Record<string, number>;
+};
+
+function installFakePusherClient(): void {
+  const channels = new Map<string, FakeRealtimeChannel>();
+  const ensure = (name: string): FakeRealtimeChannel => {
+    let channel = channels.get(name);
+    if (!channel) {
+      channel = { name, bind: () => undefined, unbind: () => undefined };
+      channels.set(name, channel);
+    }
+    return channel;
+  };
+  globalWithPusher.__pusherClient = {
+    connection: { bind: () => undefined, unbind: () => undefined },
+    subscribe: (name: string) => ensure(name),
+    unsubscribe: () => undefined,
+    channel: (name: string) => channels.get(name),
+  };
+  globalWithPusher.__pusherChannelRefCounts = {};
+}
+
+let conversationRequestCount = 0;
+
+function installConversationFetchMock(owner: () => string): void {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (!url.includes("/api/ai/conversations/")) {
+      throw new Error(`Unexpected fetch in test: ${url}`);
+    }
+    conversationRequestCount += 1;
+    return Response.json({
+      owner: owner(),
+      conversation: {
+        id: "11111111-1111-4111-8111-111111111111",
+        channel: "chat",
+        revision: 0,
+        createdAt: "2026-07-06T00:00:00.000Z",
+        updatedAt: "2026-07-06T00:00:00.000Z",
+        messageCount: 0,
+        oldestSeq: null,
+        newestSeq: null,
+        historyTruncated: false,
+      },
+      messages: [],
+    });
+  }) as typeof fetch;
+}
+
+function ConversationProbe({
+  username,
+  tick,
+}: {
+  username: string;
+  tick: number;
+}) {
+  // Inline closures on purpose: this mirrors the real callers (useAiChat,
+  // useAssistantChat) and is exactly what made hydration re-run per render.
+  useServerAIConversation({
+    channel: "chat",
+    username,
+    isAuthenticated: true,
+    isChatReady: () => true,
+    applyMessages: () => undefined,
+    onError: () => undefined,
+  });
+  return <span data-tick={tick} />;
+}
+
+async function renderProbe(username: string, tick: number): Promise<void> {
+  await act(async () => {
+    root?.render(<ConversationProbe username={username} tick={tick} />);
+  });
+}
+
+async function dispatchWindowEvent(type: string): Promise<void> {
+  await act(async () => {
+    if (type === "visibilitychange") {
+      document.dispatchEvent(new Event(type));
+    } else {
+      window.dispatchEvent(new Event(type));
+    }
+  });
+}
+
+beforeAll(() => {
+  if (typeof document === "undefined") {
+    GlobalRegistrator.register();
+    registeredDomForSuite = true;
+  }
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+    configurable: true,
+    value: true,
+  });
+});
+
+beforeEach(() => {
+  clearAIConversationSessionCache();
+  installFakePusherClient();
+  conversationRequestCount = 0;
+  useChatsStore.setState({ username: "alice", isAuthenticated: true });
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+});
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount());
+  }
+  root = null;
+  host?.remove();
+  host = null;
+  globalThis.fetch = originalFetch;
+  setSystemTime();
+  delete globalWithPusher.__pusherClient;
+  delete globalWithPusher.__pusherChannelRefCounts;
+  clearAIConversationSessionCache();
+  useChatsStore.setState({ username: null, isAuthenticated: false });
+});
+
+afterAll(() => {
+  Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  if (registeredDomForSuite && GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.unregister();
+  }
+});
+
+describe("useServerAIConversation request efficiency", () => {
+  test("hydrates once per identity even when the caller re-renders", async () => {
+    installConversationFetchMock(() => "alice");
+
+    await renderProbe("alice", 0);
+    expect(conversationRequestCount).toBe(1);
+
+    // Re-render repeatedly with fresh inline closures (the worst case that
+    // previously re-fetched on every render).
+    for (let tick = 1; tick <= 5; tick += 1) {
+      await renderProbe("alice", tick);
+    }
+    expect(conversationRequestCount).toBe(1);
+  });
+
+  test("throttles focus/visibility refreshes to the minimum interval", async () => {
+    installConversationFetchMock(() => "alice");
+    const baseTime = new Date("2026-07-07T12:00:00.000Z");
+    setSystemTime(baseTime);
+
+    await renderProbe("alice", 0);
+    expect(conversationRequestCount).toBe(1);
+
+    // Tab activation fires both events; within the interval neither should
+    // trigger a request.
+    await dispatchWindowEvent("focus");
+    await dispatchWindowEvent("visibilitychange");
+    expect(conversationRequestCount).toBe(1);
+
+    // Past the interval a single refresh goes through, and the paired
+    // visibilitychange from the same activation is still deduplicated.
+    setSystemTime(
+      new Date(baseTime.getTime() + FOCUS_REFRESH_MIN_INTERVAL_MS + 1_000)
+    );
+    await dispatchWindowEvent("focus");
+    await dispatchWindowEvent("visibilitychange");
+    expect(conversationRequestCount).toBe(2);
+  });
+
+  test("re-hydrates when the authenticated identity changes", async () => {
+    let owner = "alice";
+    installConversationFetchMock(() => owner);
+
+    await renderProbe("alice", 0);
+    expect(conversationRequestCount).toBe(1);
+
+    owner = "bob";
+    useChatsStore.setState({ username: "bob", isAuthenticated: true });
+    await renderProbe("bob", 1);
+    expect(conversationRequestCount).toBe(2);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The admin dashboard was reporting ~304K "AI requests" out of ~313K total daily calls, with `GET /api/ai/conversations/assistant` and `/api/ai/conversations/chat` at ~150K each. Two separate bugs:

### 1. Analytics counted all of `/api/ai/` as AI usage

The classifier in `api/_utils/_analytics.ts` counts any path starting with `/api/ai/` as an AI request. That prefix was accurate when added (March, `3cfd29a`), but the server-owned conversation rework (#1817, #1821, #1823, #1824) later moved high-volume **non-AI** plumbing under it: conversation snapshot/delta reads, `/api/ai/attachments`, and cursor-run polling. This inflated the daily `ai` counter and polluted the per-user `aiu` hash feeding the admin "AI by user" and rate-limit views.

The actual AI rate limit is unaffected — `checkAndIncrementAIMessageCount` (3/day anon, 15/5h authed) only runs inside `/api/chat` on new user turns/regenerations.

### 2. The request volume itself was a client-side render loop

`useServerAIConversation` keyed its hydration effect on `hydrate`, whose `useCallback` deps included the caller-supplied `isChatReady` / `applyMessages` closures. Both callers (`useAiChat`, `useAssistantChat`) pass **inline arrows**, so `hydrate` was a new function on every render and the effect re-ran — firing a forced `GET /api/ai/conversations/:channel` — on **every re-render** of the Chats app, Terminal, or desktop assistant (which re-render constantly while typing/streaming). Deduping only happened while a request was in flight. Additionally, `focus` and `visibilitychange` both fire on each tab activation, each triggering an unthrottled forced revalidation.

## Fix

- **Analytics**: replace the `/api/ai/` catch-all with an explicit list of model-invoking endpoints (`ryo-reply`, `extract-memories`, `process-daily-notes`, `conversations/:channel/greeting`), strip query strings before matching, export `isAIEndpoint` for tests.
- **Hook**: route `isChatReady` / `applyMessages` / `onError` through refs so `hydrate` is referentially stable — one hydration per identity change instead of one per render.
- **Hook**: throttle focus/visibility revalidation to once per 30s (`FOCUS_REFRESH_MIN_INTERVAL_MS`); realtime events already push genuine cross-device updates immediately, and any hydration (mount, realtime) resets the throttle window. This also dedupes the paired `focus`+`visibilitychange` double-fire.

Expected effect: conversation read traffic drops from ~render-rate to roughly one read per sign-in/identity change, plus at most two per 30s of active tab switching, plus genuine realtime updates.

## Testing

- ✅ `bun test tests/test-server-ai-conversation-hook.test.tsx` — new regression suite renders the real hook (happy-dom + fake realtime client + mocked fetch): one hydration across repeated re-renders with fresh inline closures, focus/visibility throttling, and re-hydration on identity change
- ✅ Verified the new suite **fails against the previous hook implementation** (re-fetches on re-render)
- ✅ `bun test tests/test-analytics-aggregation.test.ts tests/test-analytics-keys.test.ts` (10 pass)
- ✅ `bun run test:unit` (2524 pass across 312 files)
- ✅ `bun run build` (tsc + Vite)
- ✅ `bunx eslint` on changed files
- ✅ Live verification against the running standalone API server: 5 authed `GET /api/ai/conversations/chat` reads incremented `calls` by 5 and `ai` by 0
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3d91-7ed4-706f-89f2-ccfa20150c4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3d91-7ed4-706f-89f2-ccfa20150c4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

