### PR TITLE
feat(admin): hide Cursor agents older than a week behind load more

### DIFF
--- a/src/apps/admin/components/CursorAgentsPanel.tsx
+++ b/src/apps/admin/components/CursorAgentsPanel.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/hooks/useAuth";
 import {
@@ -21,10 +28,12 @@ import {
   adminCursorAgentRunningSelectedRowClass,
   adminCursorAgentSelectedRowClass,
   adminCursorAgentsPanelClass,
+  adminLoadMoreBtnClass,
   adminSurfaceClass,
   adminTableRowClass,
   adminToolbarClass,
 } from "../utils/adminStyles";
+import { partitionCursorAgentRunsByRecency } from "../utils/cursorAgentRunVisibility";
 import type { AdminInitialData } from "../types";
 
 export interface AdminCursorAgentRunRow {
@@ -174,6 +183,16 @@ export function CursorAgentsPanel({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const [showOlderRuns, setShowOlderRuns] = useState(false);
+
+  const { recent: recentRuns, older: olderRuns } = useMemo(
+    () => partitionCursorAgentRunsByRecency(runs),
+    [runs],
+  );
+  const visibleRuns = showOlderRuns
+    ? [...recentRuns, ...olderRuns]
+    : recentRuns;
+  const hiddenOlderCount = showOlderRuns ? 0 : olderRuns.length;
 
   const selectedRun = runs.find((r) => r.runId === selectedRunId) ?? null;
   const selectedHeaderTitle =
@@ -187,6 +206,7 @@ export function CursorAgentsPanel({
     try {
       const data = await getAdminCursorAgentRuns<CursorAgentsResponse>(80);
       setRuns(data.runs ?? []);
+      setShowOlderRuns(false);
       setTruncated(!!data.truncated);
       setScanIncomplete(!!data.scanIncomplete);
       onTotalCountChange?.(data.totalCount ?? data.runs?.length ?? 0);
@@ -207,6 +227,15 @@ export function CursorAgentsPanel({
   useEffect(() => {
     fetchRuns();
   }, [fetchRuns, refreshSignal]);
+
+  useEffect(() => {
+    if (
+      selectedRunId &&
+      olderRuns.some((run) => run.runId === selectedRunId)
+    ) {
+      setShowOlderRuns(true);
+    }
+  }, [selectedRunId, olderRuns]);
 
   const handleRefreshClick = () => {
     void fetchRuns();
@@ -376,7 +405,7 @@ export function CursorAgentsPanel({
         <div className="min-h-0 min-w-0 overflow-auto">
       <Table>
         <TableBody className="text-[11px]">
-          {runs.map((run) => {
+          {visibleRuns.map((run) => {
             const summaryLine =
               run.summaryPreview ||
               run.errorPreview ||
@@ -491,6 +520,18 @@ export function CursorAgentsPanel({
           })}
         </TableBody>
       </Table>
+      {hiddenOlderCount > 0 ? (
+        <div className="pt-2 pb-1 flex justify-center">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowOlderRuns(true)}
+            className={adminLoadMoreBtnClass}
+          >
+            {t("apps.admin.loadMore", { remaining: hiddenOlderCount })}
+          </Button>
+        </div>
+      ) : null}
         </div>
         {selectedRunId ? (
           <div className={cn("flex h-full min-h-0 min-w-0 flex-col overflow-hidden border-l border-os-separator", adminSurfaceClass)}>

--- a/src/apps/admin/utils/cursorAgentRunVisibility.ts
+++ b/src/apps/admin/utils/cursorAgentRunVisibility.ts
@@ -1,0 +1,38 @@
+import type { AdminCursorAgentRunRow } from "../components/CursorAgentsPanel";
+
+export const CURSOR_AGENT_RECENT_MS = 7 * 24 * 60 * 60 * 1000;
+
+function runActivityTimestamp(run: AdminCursorAgentRunRow): number | null {
+  return run.updatedAt ?? run.createdAt ?? null;
+}
+
+export function isCursorAgentRunRecent(
+  run: AdminCursorAgentRunRow,
+  cutoffMs: number,
+  now = Date.now(),
+): boolean {
+  if (run.status.toLowerCase() === "running") return true;
+  const ts = runActivityTimestamp(run);
+  if (ts == null) return true;
+  return ts >= cutoffMs;
+}
+
+export function partitionCursorAgentRunsByRecency(
+  runs: AdminCursorAgentRunRow[],
+  maxAgeMs = CURSOR_AGENT_RECENT_MS,
+  now = Date.now(),
+): { recent: AdminCursorAgentRunRow[]; older: AdminCursorAgentRunRow[] } {
+  const cutoffMs = now - maxAgeMs;
+  const recent: AdminCursorAgentRunRow[] = [];
+  const older: AdminCursorAgentRunRow[] = [];
+
+  for (const run of runs) {
+    if (isCursorAgentRunRecent(run, cutoffMs, now)) {
+      recent.push(run);
+    } else {
+      older.push(run);
+    }
+  }
+
+  return { recent, older };
+}

--- a/src/apps/admin/utils/cursorAgentRunVisibility.ts
+++ b/src/apps/admin/utils/cursorAgentRunVisibility.ts
@@ -9,7 +9,6 @@ function runActivityTimestamp(run: AdminCursorAgentRunRow): number | null {
 export function isCursorAgentRunRecent(
   run: AdminCursorAgentRunRow,
   cutoffMs: number,
-  now = Date.now(),
 ): boolean {
   if (run.status.toLowerCase() === "running") return true;
   const ts = runActivityTimestamp(run);
@@ -27,7 +26,7 @@ export function partitionCursorAgentRunsByRecency(
   const older: AdminCursorAgentRunRow[] = [];
 
   for (const run of runs) {
-    if (isCursorAgentRunRecent(run, cutoffMs, now)) {
+    if (isCursorAgentRunRecent(run, cutoffMs)) {
       recent.push(run);
     } else {
       older.push(run);

--- a/tests/test-cursor-agent-run-visibility.test.ts
+++ b/tests/test-cursor-agent-run-visibility.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CURSOR_AGENT_RECENT_MS,
+  isCursorAgentRunRecent,
+  partitionCursorAgentRunsByRecency,
+} from "../src/apps/admin/utils/cursorAgentRunVisibility";
+import type { AdminCursorAgentRunRow } from "../src/apps/admin/components/CursorAgentsPanel";
+
+function makeRun(
+  overrides: Partial<AdminCursorAgentRunRow> & Pick<AdminCursorAgentRunRow, "runId">,
+): AdminCursorAgentRunRow {
+  return {
+    agentId: "agent-1",
+    status: "finished",
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+describe("cursorAgentRunVisibility", () => {
+  const now = 1_700_000_000_000;
+  const cutoff = now - CURSOR_AGENT_RECENT_MS;
+
+  test("treats runs updated within a week as recent", () => {
+    const run = makeRun({
+      runId: "recent",
+      updatedAt: cutoff + 1,
+    });
+    expect(isCursorAgentRunRecent(run, cutoff, now)).toBe(true);
+  });
+
+  test("treats runs older than a week as not recent", () => {
+    const run = makeRun({
+      runId: "old",
+      updatedAt: cutoff - 1,
+    });
+    expect(isCursorAgentRunRecent(run, cutoff, now)).toBe(false);
+  });
+
+  test("always keeps running agents visible even when old", () => {
+    const run = makeRun({
+      runId: "running-old",
+      status: "running",
+      updatedAt: cutoff - 10_000,
+    });
+    expect(isCursorAgentRunRecent(run, cutoff, now)).toBe(true);
+  });
+
+  test("falls back to createdAt when updatedAt is missing", () => {
+    const run = makeRun({
+      runId: "created-only",
+      createdAt: cutoff + 5,
+      updatedAt: null,
+    });
+    expect(isCursorAgentRunRecent(run, cutoff, now)).toBe(true);
+  });
+
+  test("shows runs with unknown timestamps by default", () => {
+    const run = makeRun({ runId: "unknown-age" });
+    expect(isCursorAgentRunRecent(run, cutoff, now)).toBe(true);
+  });
+
+  test("partitions runs into recent and older buckets", () => {
+    const runs = [
+      makeRun({ runId: "recent", updatedAt: cutoff + 1 }),
+      makeRun({ runId: "old", updatedAt: cutoff - 1 }),
+      makeRun({
+        runId: "running-old",
+        status: "running",
+        updatedAt: cutoff - 1,
+      }),
+    ];
+
+    const { recent, older } = partitionCursorAgentRunsByRecency(
+      runs,
+      CURSOR_AGENT_RECENT_MS,
+      now,
+    );
+
+    expect(recent.map((r) => r.runId)).toEqual(["recent", "running-old"]);
+    expect(older.map((r) => r.runId)).toEqual(["old"]);
+  });
+});

--- a/tests/test-cursor-agent-run-visibility.test.ts
+++ b/tests/test-cursor-agent-run-visibility.test.ts
@@ -27,7 +27,7 @@ describe("cursorAgentRunVisibility", () => {
       runId: "recent",
       updatedAt: cutoff + 1,
     });
-    expect(isCursorAgentRunRecent(run, cutoff, now)).toBe(true);
+    expect(isCursorAgentRunRecent(run, cutoff)).toBe(true);
   });
 
   test("treats runs older than a week as not recent", () => {
@@ -35,7 +35,7 @@ describe("cursorAgentRunVisibility", () => {
       runId: "old",
       updatedAt: cutoff - 1,
     });
-    expect(isCursorAgentRunRecent(run, cutoff, now)).toBe(false);
+    expect(isCursorAgentRunRecent(run, cutoff)).toBe(false);
   });
 
   test("always keeps running agents visible even when old", () => {
@@ -44,7 +44,7 @@ describe("cursorAgentRunVisibility", () => {
       status: "running",
       updatedAt: cutoff - 10_000,
     });
-    expect(isCursorAgentRunRecent(run, cutoff, now)).toBe(true);
+    expect(isCursorAgentRunRecent(run, cutoff)).toBe(true);
   });
 
   test("falls back to createdAt when updatedAt is missing", () => {
@@ -53,12 +53,12 @@ describe("cursorAgentRunVisibility", () => {
       createdAt: cutoff + 5,
       updatedAt: null,
     });
-    expect(isCursorAgentRunRecent(run, cutoff, now)).toBe(true);
+    expect(isCursorAgentRunRecent(run, cutoff)).toBe(true);
   });
 
   test("shows runs with unknown timestamps by default", () => {
     const run = makeRun({ runId: "unknown-age" });
-    expect(isCursorAgentRunRecent(run, cutoff, now)).toBe(true);
+    expect(isCursorAgentRunRecent(run, cutoff)).toBe(true);
   });
 
   test("partitions runs into recent and older buckets", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The admin Cursor Agents list now shows only runs from the last 7 days by default. Older finished runs are collapsed behind the existing admin **Load more** button.

- Running agents always stay visible, even when older than a week.
- Selecting a hidden older run auto-expands the list.
- Refresh resets the collapsed state.

## Implementation

- Added `partitionCursorAgentRunsByRecency` helper in `src/apps/admin/utils/cursorAgentRunVisibility.ts`.
- Wired the helper into `CursorAgentsPanel` with `showOlderRuns` state and the shared `adminLoadMoreBtnClass` button.
- Recency uses `updatedAt`, falling back to `createdAt`.

## CI fix

- Removed unused `now` parameter from `isCursorAgentRunRecent` (TS6133) that caused **Build (Bun 1.3.9)** to fail.

## Testing

- `bun test tests/test-cursor-agent-run-visibility.test.ts` — 6/6 pass
- `bun run build` — pass locally after CI fix
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-330ca037-1c1f-4de7-8192-bbbfdecc2240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-330ca037-1c1f-4de7-8192-bbbfdecc2240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

