### PR TITLE
Fix message_id_conflict on tool continuations and bricked conversations after dangling tool calls

### DIFF
--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -1006,8 +1006,14 @@ export async function prepareRyoConversationModelInput(
     ),
     tools,
   });
+  // `ignoreIncompleteToolCalls` drops dangling client tool calls that never
+  // received their output (e.g. the user typed a new message instead, or the
+  // completing continuation request failed). Without it, one dangling
+  // `input-available` part in the stored history makes every subsequent
+  // model call throw AI_MissingToolResultsError, bricking the conversation.
   const modelMessages = await convertToModelMessages(uiMessages, {
     tools,
+    ignoreIncompleteToolCalls: true,
   });
 
   // Three-tier system message structure for optimal prompt caching:

--- a/api/ai/conversations/_helpers/store.ts
+++ b/api/ai/conversations/_helpers/store.ts
@@ -585,6 +585,24 @@ const PENDING_CLIENT_TOOL_STATES = new Set([
   "approval-responded",
 ]);
 
+/**
+ * JSON.stringify with recursively sorted object keys. The server-persisted
+ * copy of a message part and the client's streamed copy are built by
+ * different code paths, so plain JSON.stringify equality is sensitive to
+ * harmless key-order drift.
+ */
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, entry: unknown) => {
+    if (!isRecord(entry)) return entry;
+    return Object.keys(entry)
+      .sort()
+      .reduce<Record<string, unknown>>((sorted, key) => {
+        sorted[key] = entry[key];
+        return sorted;
+      }, {});
+  });
+}
+
 function getClientToolPart(value: unknown): Record<string, unknown> | null {
   if (!isRecord(value)) return null;
   const type = getString(value.type);
@@ -597,6 +615,23 @@ function getClientToolPart(value: unknown): Record<string, unknown> | null {
     return null;
   }
   return value;
+}
+
+/**
+ * Provider-executed tool parts (e.g. OpenAI `web_search`) run inside the
+ * model provider; the client can never legitimately change them, but its
+ * streamed copy routinely differs from the server-persisted one (provider
+ * metadata, field presence). Continuations tolerate that drift and keep the
+ * stored copy canonical.
+ */
+function isProviderExecutedToolPart(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const type = getString(value.type);
+  return (
+    (type === "dynamic-tool" || !!type?.startsWith("tool-")) &&
+    typeof value.toolCallId === "string" &&
+    value.providerExecuted === true
+  );
 }
 
 function isTerminalClientToolPart(part: Record<string, unknown>): boolean {
@@ -625,10 +660,18 @@ function getClientToolIdentity(part: Record<string, unknown>): unknown {
   };
 }
 
-function assertValidAssistantContinuation(
+/**
+ * Validate an assistant continuation against the stored latest assistant
+ * message and return the canonical merged message: stored parts stay
+ * authoritative everywhere except for valid pending→terminal client tool
+ * transitions, which adopt the incoming part. Benign drift in
+ * provider-executed tool parts is tolerated (stored copy kept); any other
+ * content change is rejected so a client cannot rewrite assistant content.
+ */
+function buildValidatedAssistantContinuation(
   document: StoredConversation,
   message: unknown,
-): void {
+): Omit<AIConversationMessage, "seq"> {
   const [incoming] = sanitizeAIConversationMessages([message]);
   const latest = document.messages.at(-1);
   if (
@@ -647,10 +690,11 @@ function assertValidAssistantContinuation(
   }
 
   let advancedClientTool = false;
-  for (let index = 0; index < latest.parts.length; index += 1) {
-    const existingPart = latest.parts[index];
+  const mergedParts = latest.parts.map((existingPart, index) => {
     const incomingPart = incoming.parts[index];
-    if (JSON.stringify(existingPart) === JSON.stringify(incomingPart)) continue;
+    if (stableStringify(existingPart) === stableStringify(incomingPart)) {
+      return existingPart;
+    }
 
     const existingTool = getClientToolPart(existingPart);
     const incomingTool = getClientToolPart(incomingPart);
@@ -660,17 +704,28 @@ function assertValidAssistantContinuation(
       PENDING_CLIENT_TOOL_STATES.has(String(existingTool.state)) &&
       isTerminalClientToolPart(incomingTool) &&
       incomingTool.preliminary !== true &&
-      JSON.stringify(getClientToolIdentity(existingTool)) ===
-        JSON.stringify(getClientToolIdentity(incomingTool));
-    if (!transitionIsValid) {
-      throw new AIConversationError(
-        "message_id_conflict",
-        422,
-        "Assistant continuation may only complete pending client tool calls",
-      );
+      stableStringify(getClientToolIdentity(existingTool)) ===
+        stableStringify(getClientToolIdentity(incomingTool));
+    if (transitionIsValid) {
+      advancedClientTool = true;
+      return incomingPart;
     }
-    advancedClientTool = true;
-  }
+
+    if (
+      isProviderExecutedToolPart(existingPart) &&
+      isProviderExecutedToolPart(incomingPart) &&
+      Reflect.get(existingPart, "toolCallId") ===
+        Reflect.get(incomingPart, "toolCallId")
+    ) {
+      return existingPart;
+    }
+
+    throw new AIConversationError(
+      "message_id_conflict",
+      422,
+      "Assistant continuation may only complete pending client tool calls",
+    );
+  });
 
   if (!advancedClientTool) {
     throw new AIConversationError(
@@ -679,6 +734,13 @@ function assertValidAssistantContinuation(
       "Assistant continuation must complete a pending client tool call",
     );
   }
+
+  return {
+    id: latest.id,
+    role: latest.role,
+    parts: mergedParts,
+    createdAt: latest.createdAt,
+  };
 }
 
 /**
@@ -810,13 +872,16 @@ async function writeAIConversationMessages(
         return { document, operationApplied: false };
       }
       assertExpectedDocument(document, input);
+      let messagesToMerge = input.messages;
       if (input.requireAssistantContinuation) {
-        assertValidAssistantContinuation(document, input.messages[0]);
+        messagesToMerge = [
+          buildValidatedAssistantContinuation(document, input.messages[0]),
+        ];
       }
 
       const messagesChanged = mergeConversationMessages(
         document,
-        input.messages,
+        messagesToMerge,
       );
       appendOperation(document, input.operationId);
       if (messagesChanged) {

--- a/src/apps/chats/tools/toolApprovals.ts
+++ b/src/apps/chats/tools/toolApprovals.ts
@@ -24,10 +24,10 @@
 
 import {
   lastAssistantMessageIsCompleteWithApprovalResponses,
+  lastAssistantMessageIsCompleteWithToolCalls,
   type UIMessage,
 } from "ai";
 import { APPROVAL_GATED_TOOL_NAME_SET } from "@/shared/tools/approvalGated";
-import { SERVER_EXECUTED_TOOL_NAME_SET } from "@/shared/tools/serverExecuted";
 import { aiChatLog as log } from "../logging";
 import { summarizeChatMessage } from "./chatDebug";
 import {
@@ -70,51 +70,6 @@ function approvalPartToolName(part: ApprovalToolPart): string {
   return part.type.startsWith("tool-") ? part.type.slice(5) : part.type;
 }
 
-const TERMINAL_CLIENT_TOOL_STATES = new Set([
-  "output-available",
-  "output-error",
-  "output-denied",
-]);
-
-function isClientExecutedToolPart(part: ApprovalToolPart): boolean {
-  if (
-    typeof part.type !== "string" ||
-    (!part.type.startsWith("tool-") && part.type !== "dynamic-tool")
-  ) {
-    return false;
-  }
-  if (
-    (part as { providerExecuted?: boolean }).providerExecuted === true
-  ) {
-    return false;
-  }
-  return !SERVER_EXECUTED_TOOL_NAME_SET.has(approvalPartToolName(part));
-}
-
-/**
- * True when the last assistant message has finished all client-executed tool
- * calls. Provider-executed tools (e.g. OpenAI `web_search`) and server-side
- * tools complete inside `/api/chat`, so they must not trigger the follow-up
- * auto-send that posts an assistant continuation to the conversation store.
- */
-function lastAssistantMessageIsCompleteWithClientToolCalls(options: {
-  messages: UIMessage[];
-}): boolean {
-  const message = options.messages[options.messages.length - 1];
-  if (!message || message.role !== "assistant" || !Array.isArray(message.parts)) {
-    return false;
-  }
-  const clientToolParts = (message.parts as ApprovalToolPart[]).filter(
-    isClientExecutedToolPart
-  );
-  if (clientToolParts.length === 0) return false;
-  return clientToolParts.every(
-    (part) =>
-      typeof part.state === "string" &&
-      TERMINAL_CLIENT_TOOL_STATES.has(part.state)
-  );
-}
-
 /**
  * `sendAutomaticallyWhen` predicate for chats hosting approval-gated tools:
  * auto-send when all tool calls completed (the standard behavior) OR when
@@ -149,8 +104,8 @@ function decideAutoSend(options: { messages: UIMessage[] }): {
   send: boolean;
   reason: string;
 } {
-  if (lastAssistantMessageIsCompleteWithClientToolCalls(options)) {
-    return { send: true, reason: "client tool calls complete" };
+  if (lastAssistantMessageIsCompleteWithToolCalls(options)) {
+    return { send: true, reason: "all tool calls complete" };
   }
   if (!lastAssistantMessageIsCompleteWithApprovalResponses(options)) {
     return { send: false, reason: "approvals or tool outputs still pending" };

--- a/src/apps/chats/tools/toolApprovals.ts
+++ b/src/apps/chats/tools/toolApprovals.ts
@@ -24,10 +24,10 @@
 
 import {
   lastAssistantMessageIsCompleteWithApprovalResponses,
-  lastAssistantMessageIsCompleteWithToolCalls,
   type UIMessage,
 } from "ai";
 import { APPROVAL_GATED_TOOL_NAME_SET } from "@/shared/tools/approvalGated";
+import { SERVER_EXECUTED_TOOL_NAME_SET } from "@/shared/tools/serverExecuted";
 import { aiChatLog as log } from "../logging";
 import { summarizeChatMessage } from "./chatDebug";
 import {
@@ -70,6 +70,51 @@ function approvalPartToolName(part: ApprovalToolPart): string {
   return part.type.startsWith("tool-") ? part.type.slice(5) : part.type;
 }
 
+const TERMINAL_CLIENT_TOOL_STATES = new Set([
+  "output-available",
+  "output-error",
+  "output-denied",
+]);
+
+function isClientExecutedToolPart(part: ApprovalToolPart): boolean {
+  if (
+    typeof part.type !== "string" ||
+    (!part.type.startsWith("tool-") && part.type !== "dynamic-tool")
+  ) {
+    return false;
+  }
+  if (
+    (part as { providerExecuted?: boolean }).providerExecuted === true
+  ) {
+    return false;
+  }
+  return !SERVER_EXECUTED_TOOL_NAME_SET.has(approvalPartToolName(part));
+}
+
+/**
+ * True when the last assistant message has finished all client-executed tool
+ * calls. Provider-executed tools (e.g. OpenAI `web_search`) and server-side
+ * tools complete inside `/api/chat`, so they must not trigger the follow-up
+ * auto-send that posts an assistant continuation to the conversation store.
+ */
+function lastAssistantMessageIsCompleteWithClientToolCalls(options: {
+  messages: UIMessage[];
+}): boolean {
+  const message = options.messages[options.messages.length - 1];
+  if (!message || message.role !== "assistant" || !Array.isArray(message.parts)) {
+    return false;
+  }
+  const clientToolParts = (message.parts as ApprovalToolPart[]).filter(
+    isClientExecutedToolPart
+  );
+  if (clientToolParts.length === 0) return false;
+  return clientToolParts.every(
+    (part) =>
+      typeof part.state === "string" &&
+      TERMINAL_CLIENT_TOOL_STATES.has(part.state)
+  );
+}
+
 /**
  * `sendAutomaticallyWhen` predicate for chats hosting approval-gated tools:
  * auto-send when all tool calls completed (the standard behavior) OR when
@@ -104,8 +149,8 @@ function decideAutoSend(options: { messages: UIMessage[] }): {
   send: boolean;
   reason: string;
 } {
-  if (lastAssistantMessageIsCompleteWithToolCalls(options)) {
-    return { send: true, reason: "all tool calls complete" };
+  if (lastAssistantMessageIsCompleteWithClientToolCalls(options)) {
+    return { send: true, reason: "client tool calls complete" };
   }
   if (!lastAssistantMessageIsCompleteWithApprovalResponses(options)) {
     return { send: false, reason: "approvals or tool outputs still pending" };

--- a/src/components/assistant/useAssistantChat.ts
+++ b/src/components/assistant/useAssistantChat.ts
@@ -40,6 +40,7 @@ import {
   buildAIConversationRequestBody,
   getAIConversationRequestContext,
   invalidateAIConversationSession,
+  loadAIConversation,
   resetAIConversationSession,
 } from "@/api/aiConversations";
 import { useServerAIConversation } from "@/hooks/useServerAIConversation";
@@ -398,6 +399,8 @@ export function useAssistantChat(): AssistantChatHandle {
     },
     [setMessages]
   );
+  const applyServerMessagesRef = useRef(applyServerMessages);
+  applyServerMessagesRef.current = applyServerMessages;
 
   // Server conversation sync for the assistant thread: hydration on sign-in,
   // focus/visibility refresh, and realtime cross-device updates.
@@ -457,6 +460,41 @@ export function useAssistantChat(): AssistantChatHandle {
         message.includes("AI_TypeValidationError") ||
         message.includes("Type validation failed")
       ) {
+        return;
+      }
+      if (message.includes("message_id_conflict")) {
+        const owner = requestOwnerRef.current;
+        log.warn(
+          "Assistant conversation rejected an invalid continuation; re-syncing from server",
+          { owner }
+        );
+        if (owner) {
+          invalidateAIConversationSession("assistant", owner);
+          void loadAIConversation({
+            channel: "assistant",
+            username: owner,
+            force: true,
+          })
+            .then((loaded) => {
+              if (
+                loaded.stale ||
+                useChatsStore.getState().username?.toLowerCase() !==
+                  loaded.owner ||
+                !useChatsStore.getState().isAuthenticated ||
+                chat.status === "streaming" ||
+                chat.status === "submitted"
+              ) {
+                return;
+              }
+              applyServerMessagesRef.current(loaded.messages);
+              clearError();
+            })
+            .catch((syncError) => {
+              log.warn("Failed to recover assistant conversation", {
+                error: syncError,
+              });
+            });
+        }
         return;
       }
       // Always-printed context for bug reports: the failing message states

--- a/src/components/assistant/useAssistantChat.ts
+++ b/src/components/assistant/useAssistantChat.ts
@@ -462,11 +462,21 @@ export function useAssistantChat(): AssistantChatHandle {
       ) {
         return;
       }
-      if (message.includes("message_id_conflict")) {
+      // Self-heal rejected assistant continuations (auto-sends after client
+      // tool calls): the server keeps its canonical state, so re-sync it and
+      // clear the error instead of surfacing it. User-message sends are NOT
+      // recovered this way — silently replacing the thread would eat the
+      // message the user just typed.
+      if (
+        (message.includes("message_id_conflict") ||
+          message.includes("revision_conflict") ||
+          message.includes("conversation_changed")) &&
+        chat.messages.at(-1)?.role === "assistant"
+      ) {
         const owner = requestOwnerRef.current;
         log.warn(
-          "Assistant conversation rejected an invalid continuation; re-syncing from server",
-          { owner }
+          "Assistant continuation rejected as out of sync; re-syncing from server",
+          { owner, error: message }
         );
         if (owner) {
           invalidateAIConversationSession("assistant", owner);

--- a/tests/test-ai-conversation-store.test.ts
+++ b/tests/test-ai-conversation-store.test.ts
@@ -956,6 +956,124 @@ describe("AI conversation store", () => {
     ).rejects.toMatchObject({ code: "message_id_conflict", status: 422 });
   });
 
+  test("continuation tolerates benign drift in provider-executed and reordered parts", async () => {
+    const redis = new MemoryConversationRedis();
+    const started = await beginAIConversationTurn({
+      redis,
+      username: "alice",
+      channel: "chat",
+      operationId: "one",
+      action: {
+        kind: "user-message",
+        message: message("u1", "user", "search then open Finder"),
+      },
+    });
+    // Server-persisted turn: a provider-executed web_search (already
+    // complete) plus a pending client launchApp call.
+    const firstResponse = await completeAIConversationTurn({
+      redis,
+      username: "alice",
+      channel: "chat",
+      operationId: getAIConversationTurnCompletionOperationId("one"),
+      expectedConversationId: started.document.id,
+      responseMessage: {
+        ...message("a1", "assistant", "Opening Finder"),
+        parts: [
+          {
+            type: "tool-web_search",
+            toolCallId: "ws_1",
+            state: "output-available",
+            providerExecuted: true,
+            input: { query: "ryOS" },
+            output: { status: "completed" },
+            callProviderMetadata: { openai: { itemId: "ws_1" } },
+          },
+          { type: "text", text: "Opening Finder" },
+          {
+            type: "tool-launchApp",
+            toolCallId: "tool-1",
+            state: "input-available",
+            input: { id: "finder" },
+          },
+        ],
+      },
+    });
+
+    // The client's copy of the same message drifts in ways it cannot
+    // control: reordered keys on the text part and a provider-executed part
+    // whose metadata differs from what the server persisted.
+    const continuation = await beginAIConversationTurn({
+      redis,
+      username: "alice",
+      channel: "chat",
+      operationId: "two",
+      expectedConversationId: firstResponse.id,
+      expectedRevision: firstResponse.revision,
+      action: {
+        kind: "assistant-continuation",
+        message: {
+          ...message("a1", "assistant", "Opening Finder"),
+          parts: [
+            {
+              type: "tool-web_search",
+              toolCallId: "ws_1",
+              state: "output-available",
+              providerExecuted: true,
+              input: { query: "ryOS" },
+              output: { status: "completed", extraClientField: true },
+            },
+            { text: "Opening Finder", type: "text" },
+            {
+              type: "tool-launchApp",
+              toolCallId: "tool-1",
+              state: "output-available",
+              input: { id: "finder" },
+              output: { success: true },
+            },
+          ],
+        },
+      },
+    });
+
+    const merged = continuation.document.messages.at(-1);
+    // The client tool transition is adopted…
+    expect(merged?.parts[2]).toMatchObject({
+      state: "output-available",
+      output: { success: true },
+    });
+    // …while the stored provider-executed part stays canonical (the client's
+    // drifted copy is discarded).
+    expect(merged?.parts[0]).toEqual({
+      type: "tool-web_search",
+      toolCallId: "ws_1",
+      state: "output-available",
+      providerExecuted: true,
+      input: { query: "ryOS" },
+      output: { status: "completed" },
+      callProviderMetadata: { openai: { itemId: "ws_1" } },
+    });
+
+    // Drift in a provider-executed part alone is not a continuation: with no
+    // pending client tool completed, the request is still rejected.
+    await expect(
+      beginAIConversationTurn({
+        redis,
+        username: "alice",
+        channel: "chat",
+        operationId: "drift-only",
+        action: {
+          kind: "assistant-continuation",
+          message: {
+            ...message("a1", "assistant", "Opening Finder"),
+            parts: merged?.parts.map((part, index) =>
+              index === 0 ? { ...part, output: { status: "tampered" } } : part,
+            ),
+          },
+        },
+      }),
+    ).rejects.toMatchObject({ code: "message_id_conflict", status: 422 });
+  });
+
   test("bounds retained history without resetting sequence numbers", async () => {
     const redis = new MemoryConversationRedis();
     let document = await seedTurn(redis, "alice", "chat", "turn-0", "message 0");

--- a/tests/test-weather-location-tools.test.ts
+++ b/tests/test-weather-location-tools.test.ts
@@ -233,6 +233,59 @@ describe("sendAutomaticallyWhenApprovalsSettled", () => {
     ];
     expect(sendAutomaticallyWhenApprovalsSettled({ messages })).toBe(true);
   });
+
+  test("does not send when only a provider-executed web_search tool completed", () => {
+    const messages = [
+      assistantMessage([
+        { type: "step-start" },
+        {
+          type: "tool-web_search",
+          toolCallId: "ws_abc",
+          state: "output-available",
+          providerExecuted: true,
+          output: { sources: [] },
+        },
+      ]),
+    ];
+    expect(sendAutomaticallyWhenApprovalsSettled({ messages })).toBe(false);
+  });
+
+  test("does not send when only a server-executed tool completed", () => {
+    const messages = [
+      assistantMessage([
+        {
+          type: "tool-getWeather",
+          toolCallId: "weather-1",
+          state: "output-available",
+          input: { location: "San Francisco" },
+          output: { temperature: 65 },
+        },
+      ]),
+    ];
+    expect(sendAutomaticallyWhenApprovalsSettled({ messages })).toBe(false);
+  });
+
+  test("still sends when a client tool completed alongside provider tools", () => {
+    const messages = [
+      assistantMessage([
+        {
+          type: "tool-web_search",
+          toolCallId: "ws_abc",
+          state: "output-available",
+          providerExecuted: true,
+          output: { sources: [] },
+        },
+        {
+          type: "tool-stickiesControl",
+          toolCallId: "sticky-1",
+          state: "output-available",
+          input: { action: "list" },
+          output: "No stickies",
+        },
+      ]),
+    ];
+    expect(sendAutomaticallyWhenApprovalsSettled({ messages })).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/test-weather-location-tools.test.ts
+++ b/tests/test-weather-location-tools.test.ts
@@ -234,6 +234,9 @@ describe("sendAutomaticallyWhenApprovalsSettled", () => {
     expect(sendAutomaticallyWhenApprovalsSettled({ messages })).toBe(true);
   });
 
+  // The AI SDK's lastAssistantMessageIsCompleteWithToolCalls excludes
+  // provider-executed tools (e.g. OpenAI web_search): they complete inside
+  // the provider, so they never require a follow-up client send.
   test("does not send when only a provider-executed web_search tool completed", () => {
     const messages = [
       assistantMessage([
@@ -244,21 +247,6 @@ describe("sendAutomaticallyWhenApprovalsSettled", () => {
           state: "output-available",
           providerExecuted: true,
           output: { sources: [] },
-        },
-      ]),
-    ];
-    expect(sendAutomaticallyWhenApprovalsSettled({ messages })).toBe(false);
-  });
-
-  test("does not send when only a server-executed tool completed", () => {
-    const messages = [
-      assistantMessage([
-        {
-          type: "tool-getWeather",
-          toolCallId: "weather-1",
-          state: "output-available",
-          input: { location: "San Francisco" },
-          output: { temperature: 65 },
         },
       ]),
     ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the two failure modes from the production Assistant logs:

1. `message_id_conflict` when the auto-send continuation after a client tool call follows a turn that also ran provider-executed `web_search`.
2. Every later turn failing with a masked "An error occurred." stream error, leaving the conversation bricked.

## Root causes (verified against a live server)

**1. Continuation validation is byte-equality brittle.** `assertValidAssistantContinuation` compared every stored part against the client's copy with `JSON.stringify` equality. The server-persisted copy and the client's streamed copy of a provider-executed tool part (OpenAI `web_search`) are assembled by different code paths, so harmless drift (key order, metadata presence) failed the comparison — and since `getClientToolPart` excludes `providerExecuted` parts, the drift could never qualify as a valid tool transition, so legitimate continuations were rejected with HTTP 422 `message_id_conflict`. This matches the logs: the earlier `stickiesControl` continuation succeeded; the first turn containing `web_search` failed.

**2. Dangling tool calls brick the conversation.** After a rejected continuation, the stored history keeps the client tool part in `input-available` forever. Every subsequent model call then throws `AI_MissingToolResultsError` inside the stream — reproduced end-to-end (`startx1, errorx1` with empty assistant replies, exactly as in the logs).

## Fixes

- `api/ai/conversations/_helpers/store.ts`: continuation validation now uses stable (key-sorted) stringify, tolerates drift in provider-executed parts, and returns a canonical merged message — stored parts stay authoritative except for valid pending→terminal client tool transitions. A client still cannot rewrite assistant content (the existing tamper-rejection tests pass unchanged; the client's drifted provider part is discarded in favor of the stored copy).
- `api/_utils/ryo-conversation.ts`: `convertToModelMessages` runs with `ignoreIncompleteToolCalls: true`, so dangling `input-available` calls are dropped from model input (still stored for the UI). This also un-bricks existing conversations already in this state.
- `src/components/assistant/useAssistantChat.ts`: if a continuation is still rejected (e.g. cross-device race), the assistant bubble self-heals by re-syncing the canonical server conversation instead of surfacing a generic error. User-message sends still surface errors so typed input is never silently dropped.

An earlier revision of this PR changed the client auto-send predicate; that was based on a wrong premise (`ai@6.0.214` already excludes provider-executed tools from `lastAssistantMessageIsCompleteWithToolCalls`) and has been reverted to the SDK helper.

## Testing

- New store unit test: continuation with reordered keys + drifted provider part is accepted with the stored provider part kept canonical; drift-only (no tool transition) is still rejected. Fails on the previous store code, passes now.
- E2E against `bun run dev:api` with real keys (gpt-5.5): reproduced both bugs pre-fix (rejected continuation path → `AI_MissingToolResultsError` on the next turn), then verified post-fix that a drifted continuation completing a pending `launchApp` call is accepted and follow-up turns work, including after a deliberately abandoned tool call.
- `bun run test:unit`: 2560 pass / 0 fail. `bun run test:api`: 345/348 — the 3 failures (`audio-transcribe` validation x2, image round-trip flake) also occur on clean `main` code and are unrelated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9bafeb71-7f8d-4205-aecb-99e0e5c1af0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bafeb71-7f8d-4205-aecb-99e0e5c1af0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

