### PR TITLE
Add rich weather card for getWeather chat tool results

### DIFF
--- a/src/components/assistant/assistantBubbleTools.ts
+++ b/src/components/assistant/assistantBubbleTools.ts
@@ -2,12 +2,13 @@ import type { ToolInvocationPart } from "@/components/shared/tool-invocation-mes
 
 /**
  * Tool calls that get a rich inline embed inside the assistant's speech
- * bubble (the same cards the Chats app renders): map place results, HTML
- * preview applets, and Cursor cloud-agent runs. Other tools keep their
- * ticker-only treatment.
+ * bubble (the same cards the Chats app renders): map place results, weather
+ * cards, HTML preview applets, and Cursor cloud-agent runs. Other tools keep
+ * their ticker-only treatment.
  */
 export const ASSISTANT_BUBBLE_TOOL_NAMES: ReadonlySet<string> = new Set([
   "mapsSearchPlaces",
+  "getWeather",
   "generateHtml",
   "cursorCloudAgent",
   "listCursorCloudAgentRuns",

--- a/src/components/layout/dashboard/WeatherWidget.tsx
+++ b/src/components/layout/dashboard/WeatherWidget.tsx
@@ -10,6 +10,7 @@ import {
   getWeatherEmoji,
   searchCities as searchCitiesApi,
 } from "@/lib/weather/openMeteo";
+import { getSkyGradient } from "@/lib/weather/skyGradient";
 import { coordKey, SF_LAT, SF_LON } from "@/stores/useWeatherStore";
 import type { CityResult, WeatherLocation } from "@/lib/weather/types";
 import { formatCountryDisplay } from "@/utils/formatCountryDisplay";
@@ -30,41 +31,6 @@ function getPopularCities(t: TFunction): CityResult[] {
   ];
 }
 
-
-function getSkyGradient(code: number, isDay: boolean): string {
-  if (!isDay) {
-    if (code === 0)
-      return "linear-gradient(180deg, #0B1A2E 0%, #1A2D4A 40%, #2A3F5C 100%)";
-    if (code <= 3)
-      return "linear-gradient(180deg, #0F1F35 0%, #1E3250 40%, #2E4462 100%)";
-    if (code <= 48)
-      return "linear-gradient(180deg, #1A1E25 0%, #2A303A 40%, #3A424D 100%)";
-    if (code <= 67)
-      return "linear-gradient(180deg, #0E151E 0%, #1C2630 40%, #2A3540 100%)";
-    if (code <= 77)
-      return "linear-gradient(180deg, #151C28 0%, #252F3E 40%, #354050 100%)";
-    if (code <= 86)
-      return "linear-gradient(180deg, #121922 0%, #222C38 40%, #323E4A 100%)";
-    if (code <= 99)
-      return "linear-gradient(180deg, #0A0F15 0%, #181E28 40%, #252D38 100%)";
-    return "linear-gradient(180deg, #0B1A2E 0%, #1A2D4A 40%, #2A3F5C 100%)";
-  }
-  if (code === 0)
-    return "linear-gradient(180deg, #4A90C4 0%, #7AB4D8 40%, #A8CBE0 100%)";
-  if (code <= 3)
-    return "linear-gradient(180deg, #5A8AAF 0%, #8BAFC5 40%, #B0C8D8 100%)";
-  if (code <= 48)
-    return "linear-gradient(180deg, #6B7B8D 0%, #8A96A3 40%, #A5AEB8 100%)";
-  if (code <= 67)
-    return "linear-gradient(180deg, #4A5A6A 0%, #6A7A8A 40%, #8A95A0 100%)";
-  if (code <= 77)
-    return "linear-gradient(180deg, #7A8A9A 0%, #9AABB8 40%, #C0CDD5 100%)";
-  if (code <= 86)
-    return "linear-gradient(180deg, #6A7A8A 0%, #8A9AAA 40%, #B0BCC5 100%)";
-  if (code <= 99)
-    return "linear-gradient(180deg, #3A4550 0%, #505E6A 40%, #6A7880 100%)";
-  return "linear-gradient(180deg, #4A90C4 0%, #7AB4D8 40%, #A8CBE0 100%)";
-}
 
 function formatCityLabel(city: CityResult, locale: string): string {
   const parts = [city.name];

--- a/src/components/shared/WeatherToolCard.tsx
+++ b/src/components/shared/WeatherToolCard.tsx
@@ -22,8 +22,6 @@ export interface WeatherToolCardProps {
 }
 
 const HERO_TEXT_SHADOW = "0 1px 3px rgba(0,0,0,0.4)";
-const HERO_FONT =
-  "'Helvetica Neue', Helvetica, Arial, sans-serif" as const;
 
 /**
  * Inline chat card rendered when the assistant calls `getWeather`.
@@ -77,7 +75,6 @@ export function WeatherToolCard({
         className="relative flex items-center gap-3 px-3 py-2.5 text-white"
         style={{
           background: getSkyGradient(current.weatherCode, current.isDay),
-          fontFamily: HERO_FONT,
         }}
       >
         <Emoji

--- a/src/components/shared/WeatherToolCard.tsx
+++ b/src/components/shared/WeatherToolCard.tsx
@@ -1,0 +1,163 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { Emoji } from "@/components/shared/Emoji";
+import { getWeatherEmoji } from "@/lib/weather/openMeteo";
+import { getSkyGradient } from "@/lib/weather/skyGradient";
+import { weatherCodeToFamily } from "@/utils/dynamicWallpaper";
+import type {
+  GetWeatherCurrent,
+  GetWeatherForecastDay,
+  GetWeatherOutput,
+} from "@/shared/tools/weather";
+import { cn } from "@/lib/utils";
+import { toolInlineCardShellClassName } from "@/components/shared/toolInlineCardShell";
+
+export interface WeatherToolCardProps {
+  location?: GetWeatherOutput["location"];
+  current: GetWeatherCurrent;
+  forecast?: GetWeatherForecastDay[];
+  /** Extra classes merged onto the card shell (e.g. compact-host overrides). */
+  className?: string;
+}
+
+const HERO_TEXT_SHADOW = "0 1px 3px rgba(0,0,0,0.4)";
+const HERO_FONT =
+  "'Helvetica Neue', Helvetica, Arial, sans-serif" as const;
+
+/**
+ * Inline chat card rendered when the assistant calls `getWeather`.
+ *
+ * Mirrors the look of the dashboard weather widget inside the same themed
+ * card shell as the Maps places card: a sky-gradient hero band with the
+ * city, condition, and current temperature, plus an upcoming-days forecast
+ * strip on the card surface.
+ */
+export function WeatherToolCard({
+  location,
+  current,
+  forecast,
+  className,
+}: WeatherToolCardProps) {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language || "en";
+  const { isMacOSTheme, isWindowsTheme, isSystem7Theme, isWin98 } =
+    useThemeFlags();
+
+  const conditionLabel = t(
+    `apps.dashboard.weather.conditions.${weatherCodeToFamily(current.weatherCode)}`,
+    { defaultValue: current.condition }
+  );
+
+  // The tool's forecast starts with today: today's high/low feed the hero
+  // band and the strip shows the upcoming days, like the dashboard widget.
+  const today = forecast?.[0];
+  const upcomingDays = useMemo(() => {
+    if (!forecast || forecast.length <= 1) return [];
+    const dayFmt = new Intl.DateTimeFormat(locale, { weekday: "short" });
+    return forecast.slice(1).map((day) => ({
+      ...day,
+      dayLabel: dayFmt.format(new Date(`${day.date}T00:00:00`)).toUpperCase(),
+    }));
+  }, [forecast, locale]);
+
+  return (
+    <div
+      className={cn(
+        toolInlineCardShellClassName({
+          isMacOSTheme,
+          isSystem7Theme,
+          isWindowsTheme,
+          isWin98,
+        }),
+        className
+      )}
+    >
+      <div
+        className="relative flex items-center gap-3 px-3 py-2.5 text-white"
+        style={{
+          background: getSkyGradient(current.weatherCode, current.isDay),
+          fontFamily: HERO_FONT,
+        }}
+      >
+        <Emoji
+          emoji={getWeatherEmoji(current.weatherCode, current.isDay)}
+          size={38}
+          className="shrink-0"
+          style={{ filter: "drop-shadow(0 2px 4px rgba(0,0,0,0.3))" }}
+        />
+        <div className="min-w-0 flex-1">
+          {location?.city && (
+            <div
+              className="truncate text-[13px] font-bold leading-tight"
+              style={{ textShadow: HERO_TEXT_SHADOW }}
+            >
+              {location.city}
+            </div>
+          )}
+          <div
+            className="truncate text-[11px] font-medium leading-snug"
+            style={{ color: "rgba(255,255,255,0.9)", textShadow: HERO_TEXT_SHADOW }}
+          >
+            {conditionLabel}
+          </div>
+          {today && (
+            <div
+              className="text-[11px] font-medium leading-snug"
+              style={{ color: "rgba(255,255,255,0.8)", textShadow: HERO_TEXT_SHADOW }}
+            >
+              {t("apps.dashboard.weather.high")} {today.tempMaxC}°{" "}
+              {t("apps.dashboard.weather.low")} {today.tempMinC}°
+            </div>
+          )}
+        </div>
+        <div className="flex shrink-0 flex-col items-end">
+          <span
+            className="font-light leading-none"
+            style={{
+              fontSize: 34,
+              letterSpacing: "-0.03em",
+              textShadow: "0 2px 8px rgba(0,0,0,0.25)",
+            }}
+          >
+            {Math.round(current.temperatureC)}°
+          </span>
+          <span
+            className="mt-0.5 text-[11px] font-medium leading-none"
+            style={{ color: "rgba(255,255,255,0.8)", textShadow: HERO_TEXT_SHADOW }}
+          >
+            {Math.round(current.temperatureF)}°F
+          </span>
+        </div>
+      </div>
+
+      {upcomingDays.length > 0 && (
+        <div
+          className={cn(
+            "flex border-t border-black/10 px-1 py-1.5",
+            "os-mac-aqua-dark:border-[color:var(--os-color-separator)]"
+          )}
+        >
+          {upcomingDays.map((day) => (
+            <div
+              key={day.date}
+              className="flex flex-1 flex-col items-center gap-0.5"
+              title={day.condition}
+            >
+              <span className="text-[10px] font-bold tracking-wide text-os-text-secondary">
+                {day.dayLabel}
+              </span>
+              <Emoji emoji={getWeatherEmoji(day.weatherCode)} size={20} />
+              <span className="text-[11px] leading-none">
+                <span className="font-semibold text-os-text-primary">
+                  {day.tempMaxC}°
+                </span>{" "}
+                <span className="text-os-text-secondary">{day.tempMinC}°</span>
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx
+++ b/src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx
@@ -12,6 +12,8 @@ import {
   type MapsSearchPlaceCardData,
 } from "@/components/shared/MapsSearchPlacesCard";
 import { JsRunCard, type JsRunCardData } from "@/components/shared/JsRunCard";
+import { WeatherToolCard } from "@/components/shared/WeatherToolCard";
+import type { GetWeatherOutput } from "@/shared/tools/weather";
 import { ActivityIndicator } from "@/components/ui/activity-indicator";
 import { APPROVAL_GATED_TOOL_NAME_SET } from "@/shared/tools/approvalGated";
 import { ToolApprovalCard } from "./ToolApprovalCard";
@@ -260,6 +262,25 @@ export function tryRenderToolInvocationSpecialContent(
               })}
             </span>
           </ToolInvocationStatusRow>
+        </div>
+      );
+    }
+  }
+
+  // Special handling for getWeather — sky-gradient weather card (current
+  // conditions + upcoming forecast). Failures keep the default status row,
+  // whose result message already surfaces the tool's error text.
+  if (state === "output-available" && toolName === "getWeather") {
+    const out = output as Partial<GetWeatherOutput> | undefined;
+    if (out && out.success === true && out.current) {
+      return (
+        <div key={partKey} className="mb-0 px-1 py-0.5 text-[12px]">
+          <WeatherToolCard
+            location={out.location}
+            current={out.current}
+            forecast={out.forecast}
+            className={compactCardClassName}
+          />
         </div>
       );
     }

--- a/src/lib/weather/skyGradient.ts
+++ b/src/lib/weather/skyGradient.ts
@@ -1,0 +1,38 @@
+/**
+ * Sky gradient backgrounds keyed by WMO weather code + day/night, shared by
+ * the dashboard weather widget and the chat `getWeather` tool card.
+ */
+export function getSkyGradient(code: number, isDay: boolean): string {
+  if (!isDay) {
+    if (code === 0)
+      return "linear-gradient(180deg, #0B1A2E 0%, #1A2D4A 40%, #2A3F5C 100%)";
+    if (code <= 3)
+      return "linear-gradient(180deg, #0F1F35 0%, #1E3250 40%, #2E4462 100%)";
+    if (code <= 48)
+      return "linear-gradient(180deg, #1A1E25 0%, #2A303A 40%, #3A424D 100%)";
+    if (code <= 67)
+      return "linear-gradient(180deg, #0E151E 0%, #1C2630 40%, #2A3540 100%)";
+    if (code <= 77)
+      return "linear-gradient(180deg, #151C28 0%, #252F3E 40%, #354050 100%)";
+    if (code <= 86)
+      return "linear-gradient(180deg, #121922 0%, #222C38 40%, #323E4A 100%)";
+    if (code <= 99)
+      return "linear-gradient(180deg, #0A0F15 0%, #181E28 40%, #252D38 100%)";
+    return "linear-gradient(180deg, #0B1A2E 0%, #1A2D4A 40%, #2A3F5C 100%)";
+  }
+  if (code === 0)
+    return "linear-gradient(180deg, #4A90C4 0%, #7AB4D8 40%, #A8CBE0 100%)";
+  if (code <= 3)
+    return "linear-gradient(180deg, #5A8AAF 0%, #8BAFC5 40%, #B0C8D8 100%)";
+  if (code <= 48)
+    return "linear-gradient(180deg, #6B7B8D 0%, #8A96A3 40%, #A5AEB8 100%)";
+  if (code <= 67)
+    return "linear-gradient(180deg, #4A5A6A 0%, #6A7A8A 40%, #8A95A0 100%)";
+  if (code <= 77)
+    return "linear-gradient(180deg, #7A8A9A 0%, #9AABB8 40%, #C0CDD5 100%)";
+  if (code <= 86)
+    return "linear-gradient(180deg, #6A7A8A 0%, #8A9AAA 40%, #B0BCC5 100%)";
+  if (code <= 99)
+    return "linear-gradient(180deg, #3A4550 0%, #505E6A 40%, #6A7880 100%)";
+  return "linear-gradient(180deg, #4A90C4 0%, #7AB4D8 40%, #A8CBE0 100%)";
+}

--- a/tests/test-assistant-bubble-tool-parts.test.ts
+++ b/tests/test-assistant-bubble-tool-parts.test.ts
@@ -74,11 +74,12 @@ describe("getAssistantBubbleToolParts", () => {
     expect(getAssistantBubbleToolParts(undefined)).toEqual([]);
   });
 
-  test("covers exactly the map, HTML preview, Cursor, and approval-gated tools", () => {
+  test("covers exactly the map, weather, HTML preview, Cursor, and approval-gated tools", () => {
     expect([...ASSISTANT_BUBBLE_TOOL_NAMES].sort()).toEqual([
       "cursorCloudAgent",
       "generateHtml",
       "getPreciseLocation",
+      "getWeather",
       "listCursorCloudAgentRuns",
       "mapsSearchPlaces",
     ]);

--- a/tests/test-weather-tool-card.test.ts
+++ b/tests/test-weather-tool-card.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getSkyGradient } from "../src/lib/weather/skyGradient";
+import { weatherCodeToFamily } from "../src/utils/dynamicWallpaper";
+
+const specialContentSource = readFileSync(
+  join(
+    import.meta.dir,
+    "../src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx"
+  ),
+  "utf8"
+);
+const weatherCardSource = readFileSync(
+  join(import.meta.dir, "../src/components/shared/WeatherToolCard.tsx"),
+  "utf8"
+);
+const weatherWidgetSource = readFileSync(
+  join(
+    import.meta.dir,
+    "../src/components/layout/dashboard/WeatherWidget.tsx"
+  ),
+  "utf8"
+);
+
+describe("getSkyGradient", () => {
+  test("day and night render different skies for the same code", () => {
+    expect(getSkyGradient(0, true)).not.toBe(getSkyGradient(0, false));
+  });
+
+  test("clear and thunderstorm days render different skies", () => {
+    expect(getSkyGradient(0, true)).not.toBe(getSkyGradient(95, true));
+  });
+
+  test("out-of-range codes fall back to the clear-sky gradient", () => {
+    expect(getSkyGradient(12345, true)).toBe(getSkyGradient(0, true));
+    expect(getSkyGradient(12345, false)).toBe(getSkyGradient(0, false));
+  });
+});
+
+describe("weather tool card wiring", () => {
+  test("special content renders WeatherToolCard for successful getWeather output", () => {
+    expect(specialContentSource).toContain('toolName === "getWeather"');
+    expect(specialContentSource).toContain("WeatherToolCard");
+    // Failures must fall through to the default status row.
+    expect(specialContentSource).toContain(
+      "out && out.success === true && out.current"
+    );
+  });
+
+  test("card uses the shared inline-card shell and the sky gradient", () => {
+    expect(weatherCardSource).toContain("toolInlineCardShellClassName");
+    expect(weatherCardSource).toContain("getSkyGradient");
+    expect(weatherCardSource).toContain("getWeatherEmoji");
+  });
+
+  test("card localizes the condition by weather-code family", () => {
+    expect(weatherCardSource).toContain("weatherCodeToFamily");
+    expect(weatherCardSource).toContain("apps.dashboard.weather.conditions.");
+  });
+
+  test("compact hosts can override the card chrome", () => {
+    expect(specialContentSource).toContain("className={compactCardClassName}");
+    expect(weatherCardSource).toContain("className?: string");
+  });
+
+  test("dashboard widget reuses the shared sky gradient helper", () => {
+    expect(weatherWidgetSource).toContain(
+      'from "@/lib/weather/skyGradient"'
+    );
+    expect(weatherWidgetSource).not.toContain("function getSkyGradient");
+  });
+
+  test("condition families all resolve to a known translation suffix", () => {
+    const families = new Set(
+      [0, 2, 45, 51, 63, 71, 95].map((code) => weatherCodeToFamily(code))
+    );
+    expect([...families].sort()).toEqual([
+      "clear",
+      "drizzle",
+      "fog",
+      "partlyCloudy",
+      "rain",
+      "snow",
+      "thunderstorm",
+    ]);
+  });
+});

--- a/tests/test-weather-tool-card.test.ts
+++ b/tests/test-weather-tool-card.test.ts
@@ -54,6 +54,13 @@ describe("weather tool card wiring", () => {
     expect(weatherCardSource).toContain("getWeatherEmoji");
   });
 
+  test("card inherits the themed font from the card shell (no hardcoded stacks)", () => {
+    // The shell's font-geneva-12 resolves per theme (Lucida Grande on Aqua,
+    // Geneva/Chicago pixel fonts elsewhere); the card must not override it.
+    expect(weatherCardSource).not.toContain("Helvetica");
+    expect(weatherCardSource).not.toContain("fontFamily");
+  });
+
   test("card localizes the condition by weather-code family", () => {
     expect(weatherCardSource).toContain("weatherCodeToFamily");
     expect(weatherCardSource).toContain("apps.dashboard.weather.conditions.");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `getWeather` chat tool result now renders a rich inline weather card (inspired by the `mapsSearchPlaces` place card) instead of a plain one-line status row:

- New `WeatherToolCard` shared component using the same themed `toolInlineCardShellClassName` shell as the Maps card, with a sky-gradient hero band (city, localized condition, today's H/L, current temp in °C with °F secondary, Apple-style weather emoji) and an upcoming-days forecast strip.
- The card inherits the shell's themed font stack (`font-geneva-12` → Lucida Grande on macOS Aqua, pixel Geneva/Chicago on System 7, Tahoma/MS Sans Serif on Windows themes) — no hardcoded font families.
- Extracted the dashboard widget's sky gradient into `src/lib/weather/skyGradient.ts` and reused it in both the widget and the card.
- Wired the card into `tryRenderToolInvocationSpecialContent` for successful `getWeather` outputs; failures keep the default status row with the tool's error message.
- Added `getWeather` to `ASSISTANT_BUBBLE_TOOL_NAMES` so the desktop assistant bubble embeds the same card in compact mode.
- Condition labels localize via `weatherCodeToFamily` → existing `apps.dashboard.weather.conditions.*` keys (no new locale strings needed).

## Screenshots

Weather card on macOS Aqua (Lucida Grande) after asking Ryo for Tokyo weather:

![Weather card on macOS Aqua with themed font](https://cursor.com/artifacts/c/art-492a6d4b-3745-421e-8162-5b8cf87faed9)

Same card on the System 7 theme (pixel Geneva/Chicago fonts):

![Weather card on System 7 with pixel fonts](https://cursor.com/artifacts/c/art-557e450d-c109-49b1-82f8-23a0ff9effcb)

Coordinate-based result (no resolvable city → city line omitted; per-day condition shows as a hover tooltip):

![Weather card without city](https://cursor.com/artifacts/c/art-1411a8ee-640b-412d-b40c-6f1d9acc6573)

## Testing

- `bun test tests/test-weather-tool-card.test.ts` (new unit/wiring suite, incl. a no-hardcoded-font guard)
- `bun run test:unit` — 2572 pass / 0 fail
- `bun run test:registration`
- `bunx tsc --noEmit` and `eslint` on changed files — clean
- Manual end-to-end check in the Chats app (`bun run dev`, signed-in user): asked Ryo for Tokyo/Sydney weather; the real `getWeather` tool call rendered the card with hero band + forecast strip in the with-city and no-city cases, and the card was verified on both the macOS Aqua and System 7 themes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3dee-1855-7ca2-9fc0-d14a0712f40d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3dee-1855-7ca2-9fc0-d14a0712f40d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

