### PR TITLE
fix(weather): localize geocoded place names for requested locale

### DIFF
--- a/api/chat/tools/weather-executor.ts
+++ b/api/chat/tools/weather-executor.ts
@@ -17,6 +17,7 @@ import {
   reverseGeocodeCity,
   searchCities,
 } from "../../../src/lib/weather/openMeteo.js";
+import { localizePlaceName } from "../../../src/lib/weather/geocodeLocale.js";
 import {
   celsiusToFahrenheit,
   describeWeatherCode,
@@ -170,6 +171,8 @@ export async function executeGetWeather(
     } catch {
       city = null;
     }
+  } else if (input.language) {
+    city = await localizePlaceName(city, input.language);
   }
 
   const condition = describeWeatherCode(payload.weatherCode);

--- a/src/lib/weather/geocodeLocale.ts
+++ b/src/lib/weather/geocodeLocale.ts
@@ -1,0 +1,155 @@
+import type { ConverterFunction } from "opencc-js/core";
+
+export type ChineseScriptVariant = "traditional" | "simplified";
+
+export interface GeocodeLocaleResolution {
+  /** Value for the Nominatim `Accept-Language` header. */
+  acceptLanguage: string | undefined;
+  /** When set, place names with Chinese characters are converted to this script. */
+  chineseScript: ChineseScriptVariant | null;
+}
+
+const CHINESE_TEXT_REGEX = /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]/;
+
+function splitNominatimVariants(raw: string): string[] {
+  return raw
+    .split(";")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+async function pickChineseVariant(
+  variants: string[],
+  script: ChineseScriptVariant
+): Promise<string> {
+  const convert = await loadChineseConverter(script);
+  const isStable = (variant: string) => convert(variant) === variant;
+
+  const stable = variants.find((variant) => CHINESE_TEXT_REGEX.test(variant) && isStable(variant));
+  if (stable) return stable;
+
+  const chinese = variants.find((variant) => CHINESE_TEXT_REGEX.test(variant));
+  return convert(chinese ?? variants[0]);
+}
+
+/**
+ * Nominatim sometimes returns multiple script variants in one string
+ * (e.g. "圣马特奥;聖馬特奧;聖馬刁"). Pick the best label for the locale.
+ */
+export async function resolveNominatimPlaceName(
+  raw: string,
+  locale?: string
+): Promise<string> {
+  const trimmed = raw.trim();
+  if (!trimmed) return raw;
+
+  const variants = splitNominatimVariants(trimmed);
+  const { chineseScript } = resolveGeocodeLocale(locale);
+
+  if (variants.length > 1) {
+    const latin = variants.find((variant) => !CHINESE_TEXT_REGEX.test(variant));
+    if (!chineseScript && latin) return latin;
+    if (chineseScript) return pickChineseVariant(variants, chineseScript);
+    return variants[0];
+  }
+
+  return applyChineseScript(trimmed, locale);
+}
+
+async function applyChineseScript(
+  name: string,
+  locale?: string
+): Promise<string> {
+  const trimmed = name.trim();
+  if (!trimmed) return name;
+
+  const { chineseScript } = resolveGeocodeLocale(locale);
+  if (!chineseScript || !CHINESE_TEXT_REGEX.test(trimmed)) {
+    return name;
+  }
+
+  const convert = await loadChineseConverter(chineseScript);
+  return convert(trimmed);
+}
+
+/**
+ * Pick the most display-friendly address field from a Nominatim reverse payload.
+ * When the city label is a multi-script bundle, prefer the county name instead.
+ */
+export function pickNominatimAddressName(address: {
+  city?: string;
+  town?: string;
+  village?: string;
+  county?: string;
+}): string | null {
+  const city = address.city?.trim();
+  const county = address.county?.trim();
+  if (city && city.includes(";") && county) return county;
+
+  return city || address.town?.trim() || address.village?.trim() || county || null;
+}
+
+let traditionalConverterPromise: Promise<ConverterFunction> | null = null;
+let simplifiedConverterPromise: Promise<ConverterFunction> | null = null;
+
+/**
+ * Map a BCP-47 locale to the best Nominatim `Accept-Language` header and any
+ * post-processing needed for Chinese script variants.
+ */
+export function resolveGeocodeLocale(locale?: string): GeocodeLocaleResolution {
+  if (!locale?.trim()) {
+    return { acceptLanguage: undefined, chineseScript: null };
+  }
+
+  const normalized = locale.trim().replaceAll("_", "-");
+  const lower = normalized.toLowerCase();
+  const subtags = lower.split("-");
+  const langCode = subtags[0];
+
+  if (langCode === "zh") {
+    const isTraditional =
+      subtags.includes("hant") ||
+      subtags.some((subtag) => ["tw", "hk", "mo"].includes(subtag));
+    if (isTraditional) {
+      return { acceptLanguage: "zh-TW,zh;q=0.9", chineseScript: "traditional" };
+    }
+    return { acceptLanguage: "zh-CN,zh;q=0.9", chineseScript: "simplified" };
+  }
+
+  if (langCode === "ja") {
+    return { acceptLanguage: "ja,en;q=0.5", chineseScript: null };
+  }
+
+  if (langCode === "en") {
+    return { acceptLanguage: "en", chineseScript: null };
+  }
+
+  return { acceptLanguage: normalized, chineseScript: null };
+}
+
+async function loadChineseConverter(
+  script: ChineseScriptVariant
+): Promise<ConverterFunction> {
+  if (script === "traditional") {
+    traditionalConverterPromise ??= import("opencc-js/cn2t").then(({ Converter }) =>
+      Converter({ from: "cn", to: "twp" })
+    );
+    return traditionalConverterPromise;
+  }
+
+  simplifiedConverterPromise ??= import("opencc-js/t2cn").then(({ Converter }) =>
+    Converter({ from: "twp", to: "cn" })
+  );
+  return simplifiedConverterPromise;
+}
+
+/**
+ * Apply Chinese script conversion when the requested locale calls for it.
+ * Non-Chinese text (e.g. "San Mateo County", "Suginami") is returned unchanged.
+ */
+export async function localizePlaceName(
+  name: string,
+  locale?: string
+): Promise<string> {
+  return resolveNominatimPlaceName(name, locale);
+}

--- a/src/lib/weather/openMeteo.ts
+++ b/src/lib/weather/openMeteo.ts
@@ -1,5 +1,4 @@
 import {
-  localizePlaceName,
   pickNominatimAddressName,
   resolveGeocodeLocale,
   resolveNominatimPlaceName,
@@ -139,7 +138,7 @@ export async function searchCities(
     );
 
   return Promise.all(
-    filtered.map(async (city) => ({
+    filtered.map(async (city: CityResult) => ({
       ...city,
       name: await resolveNominatimPlaceName(city.name, locale),
       state: city.state

--- a/src/lib/weather/openMeteo.ts
+++ b/src/lib/weather/openMeteo.ts
@@ -1,3 +1,9 @@
+import {
+  localizePlaceName,
+  pickNominatimAddressName,
+  resolveGeocodeLocale,
+  resolveNominatimPlaceName,
+} from "./geocodeLocale";
 import type { CityResult, WeatherSnapshot } from "./types";
 
 export function getWeatherEmoji(code: number, isDay = true): string {
@@ -29,7 +35,8 @@ function geocodeHeaders(
   opts?: GeocodeRequestOptions
 ): HeadersInit | undefined {
   const headers: Record<string, string> = {};
-  if (locale) headers["Accept-Language"] = locale;
+  const { acceptLanguage } = resolveGeocodeLocale(locale);
+  if (acceptLanguage) headers["Accept-Language"] = acceptLanguage;
   if (opts?.userAgent) headers["User-Agent"] = opts.userAgent;
   return Object.keys(headers).length > 0 ? headers : undefined;
 }
@@ -75,13 +82,9 @@ export async function reverseGeocodeCity(
     );
     if (!res.ok) return null;
     const data = await res.json();
-    return (
-      data?.address?.city ||
-      data?.address?.town ||
-      data?.address?.village ||
-      data?.address?.county ||
-      null
-    );
+    const raw = pickNominatimAddressName(data?.address ?? {});
+    if (!raw) return null;
+    return resolveNominatimPlaceName(raw, locale);
   } catch {
     return null;
   }
@@ -102,7 +105,7 @@ export async function searchCities(
   );
   if (!res.ok) return [];
   const data = await res.json();
-  return data
+  const filtered = data
     .filter(
       (r: { type: string; class: string }) =>
         ["city", "town", "village", "administrative"].includes(r.type) ||
@@ -134,4 +137,14 @@ export async function searchCities(
         lon: parseFloat(r.lon),
       })
     );
+
+  return Promise.all(
+    filtered.map(async (city) => ({
+      ...city,
+      name: await resolveNominatimPlaceName(city.name, locale),
+      state: city.state
+        ? await resolveNominatimPlaceName(city.state, locale)
+        : city.state,
+    }))
+  );
 }

--- a/tests/test-weather-geocode-locale.test.ts
+++ b/tests/test-weather-geocode-locale.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  localizePlaceName,
+  pickNominatimAddressName,
+  resolveGeocodeLocale,
+  resolveNominatimPlaceName,
+} from "../src/lib/weather/geocodeLocale";
+import { reverseGeocodeCity } from "../src/lib/weather/openMeteo";
+
+/** Nominatim returns simplified Chinese for US counties regardless of zh-Hant. */
+const SAN_MATEO_COUNTY_SIMPLIFIED = "圣马刁县";
+const SAN_MATEO_COUNTY_TRADITIONAL = "聖馬刁縣";
+
+/** Suginami as returned by Nominatim reverse geocode with ja Accept-Language. */
+const SUGINAMI_JA = "杉並区";
+const SUGINAMI_TRADITIONAL = "杉並區";
+
+const SAN_MATEO_COUNTY_EN = "San Mateo County";
+const SUGINAMI_EN = "Suginami";
+
+describe("resolveGeocodeLocale", () => {
+  test("maps Traditional Chinese tags to zh-TW Accept-Language", () => {
+    for (const locale of ["zh-Hant", "zh-TW", "zh-HK", "zh-MO"]) {
+      expect(resolveGeocodeLocale(locale)).toEqual({
+        acceptLanguage: "zh-TW,zh;q=0.9",
+        chineseScript: "traditional",
+      });
+    }
+  });
+
+  test("maps Simplified Chinese tags to zh-CN Accept-Language", () => {
+    for (const locale of ["zh-Hans", "zh-CN", "zh-SG", "zh"]) {
+      expect(resolveGeocodeLocale(locale)).toEqual({
+        acceptLanguage: "zh-CN,zh;q=0.9",
+        chineseScript: "simplified",
+      });
+    }
+  });
+
+  test("maps Japanese and English tags", () => {
+    expect(resolveGeocodeLocale("ja")).toEqual({
+      acceptLanguage: "ja,en;q=0.5",
+      chineseScript: null,
+    });
+    expect(resolveGeocodeLocale("ja-JP")).toEqual({
+      acceptLanguage: "ja,en;q=0.5",
+      chineseScript: null,
+    });
+    expect(resolveGeocodeLocale("en")).toEqual({
+      acceptLanguage: "en",
+      chineseScript: null,
+    });
+    expect(resolveGeocodeLocale("en-US")).toEqual({
+      acceptLanguage: "en",
+      chineseScript: null,
+    });
+  });
+
+  test("returns no headers when locale is absent", () => {
+    expect(resolveGeocodeLocale()).toEqual({
+      acceptLanguage: undefined,
+      chineseScript: null,
+    });
+    expect(resolveGeocodeLocale("   ")).toEqual({
+      acceptLanguage: undefined,
+      chineseScript: null,
+    });
+  });
+});
+
+describe("localizePlaceName", () => {
+  test("converts San Mateo County simplified upstream text to Traditional for zh-Hant", async () => {
+    expect(
+      await localizePlaceName(SAN_MATEO_COUNTY_SIMPLIFIED, "zh-Hant")
+    ).toBe(SAN_MATEO_COUNTY_TRADITIONAL);
+    expect(await localizePlaceName(SAN_MATEO_COUNTY_SIMPLIFIED, "zh-TW")).toBe(
+      SAN_MATEO_COUNTY_TRADITIONAL
+    );
+  });
+
+  test("keeps San Mateo County simplified for zh-Hans / zh-CN", async () => {
+    expect(
+      await localizePlaceName(SAN_MATEO_COUNTY_SIMPLIFIED, "zh-Hans")
+    ).toBe(SAN_MATEO_COUNTY_SIMPLIFIED);
+    expect(await localizePlaceName(SAN_MATEO_COUNTY_SIMPLIFIED, "zh-CN")).toBe(
+      SAN_MATEO_COUNTY_SIMPLIFIED
+    );
+  });
+
+  test("converts Traditional Suginami labels for zh-Hant when upstream mixed script", async () => {
+    expect(await localizePlaceName(SUGINAMI_JA, "zh-Hant")).toBe(
+      SUGINAMI_TRADITIONAL
+    );
+    expect(await localizePlaceName(SUGINAMI_TRADITIONAL, "zh-Hant")).toBe(
+      SUGINAMI_TRADITIONAL
+    );
+  });
+
+  test("leaves Japanese Suginami unchanged for ja locale", async () => {
+    expect(await localizePlaceName(SUGINAMI_JA, "ja")).toBe(SUGINAMI_JA);
+    expect(await localizePlaceName(SUGINAMI_JA, "ja-JP")).toBe(SUGINAMI_JA);
+  });
+
+  test("leaves English place names unchanged", async () => {
+    expect(await localizePlaceName(SAN_MATEO_COUNTY_EN, "en")).toBe(
+      SAN_MATEO_COUNTY_EN
+    );
+    expect(await localizePlaceName(SUGINAMI_EN, "en")).toBe(SUGINAMI_EN);
+    expect(await localizePlaceName(SAN_MATEO_COUNTY_EN, "zh-Hant")).toBe(
+      SAN_MATEO_COUNTY_EN
+    );
+  });
+
+  test("converts Traditional upstream text to Simplified for zh-Hans", async () => {
+    expect(await localizePlaceName(SAN_MATEO_COUNTY_TRADITIONAL, "zh-Hans")).toBe(
+      SAN_MATEO_COUNTY_SIMPLIFIED
+    );
+  });
+
+  test("picks Traditional variant from Nominatim multi-script city bundles", async () => {
+    expect(
+      await resolveNominatimPlaceName("圣马特奥;聖馬特奧;聖馬刁", "zh-Hant")
+    ).toBe("聖馬特奧");
+    expect(
+      await resolveNominatimPlaceName("圣马特奥;聖馬特奧;聖馬刁", "zh-Hans")
+    ).toBe("圣马特奥");
+  });
+});
+
+describe("pickNominatimAddressName", () => {
+  test("prefers county when city contains multi-script variants", () => {
+    expect(
+      pickNominatimAddressName({
+        city: "圣马特奥;聖馬特奧;聖馬刁",
+        county: SAN_MATEO_COUNTY_SIMPLIFIED,
+      })
+    ).toBe(SAN_MATEO_COUNTY_SIMPLIFIED);
+  });
+
+  test("keeps a single-script city label", () => {
+    expect(
+      pickNominatimAddressName({
+        city: SUGINAMI_JA,
+      })
+    ).toBe(SUGINAMI_JA);
+  });
+});
+
+describe("weather geocode fixtures", () => {
+  test("San Mateo County reverse-geocode fixture localizes per requested locale", async () => {
+    const nominatimFixture = {
+      address: { county: SAN_MATEO_COUNTY_SIMPLIFIED },
+    };
+    const raw = nominatimFixture.address.county;
+
+    expect(await localizePlaceName(raw, "zh-Hant")).toBe(
+      SAN_MATEO_COUNTY_TRADITIONAL
+    );
+    expect(await localizePlaceName(raw, "zh-Hans")).toBe(
+      SAN_MATEO_COUNTY_SIMPLIFIED
+    );
+    expect(await localizePlaceName(SAN_MATEO_COUNTY_EN, "en")).toBe(
+      SAN_MATEO_COUNTY_EN
+    );
+  });
+
+  test("Suginami search fixture localizes per requested locale", async () => {
+    const nominatimFixture = {
+      address: { city: SUGINAMI_TRADITIONAL, country_code: "jp" },
+    };
+    const raw = nominatimFixture.address.city;
+
+    expect(await localizePlaceName(raw, "zh-Hant")).toBe(SUGINAMI_TRADITIONAL);
+    expect(await localizePlaceName(SUGINAMI_JA, "ja")).toBe(SUGINAMI_JA);
+    expect(await localizePlaceName(SUGINAMI_EN, "en")).toBe(SUGINAMI_EN);
+  });
+});
+
+describe("reverseGeocodeCity locale plumbing", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("applies Traditional Chinese conversion to mocked Nominatim county response", async () => {
+    globalThis.fetch = mock(async (_input, init) => {
+      expect((init as RequestInit).headers).toMatchObject({
+        "Accept-Language": "zh-TW,zh;q=0.9",
+      });
+      return new Response(
+        JSON.stringify({
+          address: {
+            city: "圣马特奥;聖馬特奧;聖馬刁",
+            county: SAN_MATEO_COUNTY_SIMPLIFIED,
+          },
+        }),
+        { status: 200 }
+      );
+    }) as typeof fetch;
+
+    const city = await reverseGeocodeCity(37.563, -122.3255, "zh-Hant", {
+      userAgent: "ryOS-test",
+    });
+    expect(city).toBe(SAN_MATEO_COUNTY_TRADITIONAL);
+  });
+
+  test("returns English county name unchanged for en locale", async () => {
+    globalThis.fetch = mock(async (_input, init) => {
+      expect((init as RequestInit).headers).toMatchObject({
+        "Accept-Language": "en",
+      });
+      return new Response(
+        JSON.stringify({ address: { county: SAN_MATEO_COUNTY_EN } }),
+        { status: 200 }
+      );
+    }) as typeof fetch;
+
+    const city = await reverseGeocodeCity(37.563, -122.3255, "en");
+    expect(city).toBe(SAN_MATEO_COUNTY_EN);
+  });
+
+  test("returns Japanese city label unchanged for ja locale", async () => {
+    globalThis.fetch = mock(async (_input, init) => {
+      expect((init as RequestInit).headers).toMatchObject({
+        "Accept-Language": "ja,en;q=0.5",
+      });
+      return new Response(
+        JSON.stringify({ address: { city: SUGINAMI_JA } }),
+        { status: 200 }
+      );
+    }) as typeof fetch;
+
+    const city = await reverseGeocodeCity(35.6995, 139.6364, "ja");
+    expect(city).toBe(SUGINAMI_JA);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `getWeather` returning Simplified Chinese place names (e.g. `圣马刁县`) when the requested locale is Traditional Chinese (`zh-Hant` / `zh-TW`).

**Root cause:** Nominatim ignores `zh-Hant` for many overseas labels and returns Simplified Chinese (or multi-script bundles like `圣马特奥;聖馬特奧;聖馬刁`).

**Fix:**
- Map BCP-47 tags to Nominatim-friendly `Accept-Language` headers (`zh-Hant` → `zh-TW`, `zh-Hans` → `zh-CN`, `ja` → `ja`, etc.)
- Prefer `county` when `city` is a multi-script bundle
- Pick the best semicolon-separated variant for the requested script
- Fall back to `opencc-js` conversion when upstream only returns the wrong script
- Apply localization in shared geocode helpers used by the weather widget, precise-location tool, and `getWeather` executor

## CI fix

Resolved `Build (Bun 1.3.9)` typecheck failures:
- Removed unused `localizePlaceName` import in `openMeteo.ts`
- Added explicit `CityResult` type on `searchCities` map callback

## Testing

- `bun test tests/test-weather-geocode-locale.test.ts` — 18/18 pass
- `bun test tests/test-weather-location-tools.test.ts tests/test-weather-tool-card.test.ts` — no regressions
- `bun run build` — passes locally (typecheck + Vite build)
- Live Nominatim check: `reverseGeocodeCity(37.563, -122.3255, 'zh-Hant')` → `聖馬刁縣` (was `圣马刁县`)

Fixtures cover San Mateo County, Suginami/Tokyo, and English locale cases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c89ca0d-7fb3-47d7-9964-e81def621609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c89ca0d-7fb3-47d7-9964-e81def621609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

