### PR TITLE
Zoom minimizing windows to their dock icon's live position

### DIFF
--- a/src/components/layout/window-frame/WindowFrame.tsx
+++ b/src/components/layout/window-frame/WindowFrame.tsx
@@ -198,12 +198,13 @@ export function WindowFrame({
     updateInstanceWindowState,
   });
 
-  const { dockIconOffset, launchOriginOffset } = useWindowFrameDockOffsets({
-    appId,
-    instanceId,
-    windowPosition,
-    windowSize,
-  });
+  const { dockIconOffset, getDockIconOffset, launchOriginOffset } =
+    useWindowFrameDockOffsets({
+      appId,
+      instanceId,
+      windowPosition,
+      windowSize,
+    });
 
   const exposeTransform = useWindowFrameExposeTransform({
     exposeMode,
@@ -338,7 +339,7 @@ export function WindowFrame({
               }}
               exit={getExitAnimation({
                 keepMountedWhenMinimized,
-                dockIconOffset,
+                getDockIconOffset,
               })}
               className={cn(
                 "size-full select-none",

--- a/src/components/layout/window-frame/hooks/useWindowFrameDockOffsets.ts
+++ b/src/components/layout/window-frame/hooks/useWindowFrameDockOffsets.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useAppStore } from "@/stores/useAppStore";
 
 type DockOffsetsParams = {
@@ -8,43 +8,80 @@ type DockOffsetsParams = {
   windowSize: { width: number; height: number };
 };
 
+export type WindowGeometry = Pick<
+  DockOffsetsParams,
+  "windowPosition" | "windowSize"
+>;
+
+function findDockTargetElement(
+  appId: string,
+  instanceId?: string
+): Element | null {
+  // Applet-viewer windows get one dock icon per instance keyed by
+  // instanceId, so prefer that over the per-app lookup.
+  if (instanceId) {
+    const instanceIcon = document.querySelector(
+      `[data-dock-icon="${instanceId}"]`
+    );
+    if (instanceIcon) return instanceIcon;
+  }
+
+  const dockIcon = document.querySelector(`[data-dock-icon="${appId}"]`);
+  if (dockIcon) return dockIcon;
+
+  return instanceId
+    ? document.querySelector(`[data-taskbar-item="${instanceId}"]`)
+    : null;
+}
+
+/**
+ * Offset from the window center to the dock icon (or taskbar item) center.
+ *
+ * Measured from the live DOM on every call: dock icons appear only after the
+ * app has launched and shift whenever the dock re-centers, so a cached
+ * position would send minimizing windows to the wrong place.
+ */
+export function computeDockIconOffset(
+  appId: string,
+  instanceId: string | undefined,
+  { windowPosition, windowSize }: WindowGeometry
+): { x: number; y: number } {
+  const windowCenterX = windowPosition.x + windowSize.width / 2;
+  const windowCenterY = windowPosition.y + windowSize.height / 2;
+
+  const target = findDockTargetElement(appId, instanceId);
+  if (target) {
+    const rect = target.getBoundingClientRect();
+    return {
+      x: rect.left + rect.width / 2 - windowCenterX,
+      y: rect.top + rect.height / 2 - windowCenterY,
+    };
+  }
+
+  // No dock icon or taskbar item (e.g. System 7): slide straight down
+  // off the bottom of the screen.
+  return { x: 0, y: window.innerHeight - windowPosition.y };
+}
+
 export function useWindowFrameDockOffsets({
   appId,
   instanceId,
   windowPosition,
   windowSize,
 }: DockOffsetsParams) {
-  const dockIconCenter = useMemo(() => {
-    const dockIcon = document.querySelector(`[data-dock-icon="${appId}"]`);
-    if (dockIcon) {
-      const rect = dockIcon.getBoundingClientRect();
-      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
-    }
+  // Fresh measurement each render so `initial` (restore-from-dock) and
+  // `animate` (keep-mounted minimize) target the icon's current position.
+  const dockIconOffset = computeDockIconOffset(appId, instanceId, {
+    windowPosition,
+    windowSize,
+  });
 
-    const taskbarItem = instanceId
-      ? document.querySelector(`[data-taskbar-item="${instanceId}"]`)
-      : null;
-    if (taskbarItem) {
-      const rect = taskbarItem.getBoundingClientRect();
-      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
-    }
-
-    return null;
-  }, [appId, instanceId]);
-
-  const dockIconOffset = useMemo(() => {
-    const windowCenterX = windowPosition.x + windowSize.width / 2;
-    const windowCenterY = windowPosition.y + windowSize.height / 2;
-
-    if (dockIconCenter) {
-      return {
-        x: dockIconCenter.x - windowCenterX,
-        y: dockIconCenter.y - windowCenterY,
-      };
-    }
-
-    return { x: 0, y: window.innerHeight - windowPosition.y };
-  }, [dockIconCenter, windowPosition, windowSize]);
+  // Lazy getter for the exit animation, which Motion resolves when the
+  // window is actually removed — after this component's last render.
+  const getDockIconOffset = useCallback(
+    () => computeDockIconOffset(appId, instanceId, { windowPosition, windowSize }),
+    [appId, instanceId, windowPosition, windowSize]
+  );
 
   const launchOrigin = useAppStore((state) =>
     instanceId ? state.instances[instanceId]?.launchOrigin : undefined
@@ -64,5 +101,5 @@ export function useWindowFrameDockOffsets({
     };
   }, [launchOrigin, windowPosition, windowSize]);
 
-  return { dockIconOffset, launchOriginOffset };
+  return { dockIconOffset, getDockIconOffset, launchOriginOffset };
 }

--- a/src/components/layout/window-frame/windowFrameAnimations.ts
+++ b/src/components/layout/window-frame/windowFrameAnimations.ts
@@ -1,3 +1,5 @@
+import type { TargetAndTransition } from "motion/react";
+
 export const shakeTransition = {
   duration: 0.4,
   ease: "easeInOut" as const,
@@ -37,9 +39,9 @@ export function getInitialAnimation(params: {
 
 export function getExitAnimation(params: {
   keepMountedWhenMinimized: boolean;
-  dockIconOffset: DockIconOffset;
-}) {
-  const { keepMountedWhenMinimized, dockIconOffset } = params;
+  getDockIconOffset: () => DockIconOffset;
+}): TargetAndTransition {
+  const { keepMountedWhenMinimized, getDockIconOffset } = params;
   if (keepMountedWhenMinimized) {
     return {
       scale: 0.95,
@@ -49,13 +51,23 @@ export function getExitAnimation(params: {
       transition: { duration: 0.2, ease: [0.32, 0, 0.67, 0] as const },
     };
   }
-  return {
-    scale: 0.1,
-    opacity: 0,
-    x: dockIconOffset.x,
-    y: dockIconOffset.y,
-    transition: { duration: 0.25, ease: [0.32, 0, 0.67, 0] as const },
+  // Motion resolves function-valued exit definitions when the exit animation
+  // starts (see motion-dom's resolveVariantFromProps), so the dock icon is
+  // measured at minimize time — icons shift as apps open/close and the dock
+  // re-centers, and the icon may not even exist yet when the window mounts.
+  const resolveMinimizeExit = () => {
+    const dockIconOffset = getDockIconOffset();
+    return {
+      scale: 0.1,
+      opacity: 0,
+      x: dockIconOffset.x,
+      y: dockIconOffset.y,
+      transition: { duration: 0.25, ease: [0.32, 0, 0.67, 0] as const },
+    };
   };
+  // The public `exit` prop type doesn't include lazy resolvers even though
+  // the runtime supports them, hence the cast.
+  return resolveMinimizeExit as unknown as TargetAndTransition;
 }
 
 export function getAnimateState(params: {

--- a/tests/test-window-minimize-dock-offset.test.ts
+++ b/tests/test-window-minimize-dock-offset.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Minimize-to-dock targeting: `computeDockIconOffset` must measure the dock
+ * icon from the live DOM (icons appear after launch and shift as the dock
+ * re-centers), and `getExitAnimation` must defer that measurement until the
+ * exit animation actually starts.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+let registeredDomHere = false;
+
+beforeAll(() => {
+  if (typeof document === "undefined") {
+    GlobalRegistrator.register();
+    registeredDomHere = true;
+  }
+});
+
+afterAll(() => {
+  if (registeredDomHere && GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.unregister();
+  }
+});
+
+const { computeDockIconOffset } = await import(
+  "../src/components/layout/window-frame/hooks/useWindowFrameDockOffsets"
+);
+const { getExitAnimation } = await import(
+  "../src/components/layout/window-frame/windowFrameAnimations"
+);
+
+type Rect = { left: number; top: number; width: number; height: number };
+
+function addTarget(attr: string, value: string, rect: Rect): HTMLElement {
+  const el = document.createElement("div");
+  el.setAttribute(attr, value);
+  el.getBoundingClientRect = () =>
+    ({
+      ...rect,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      x: rect.left,
+      y: rect.top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  document.body.appendChild(el);
+  return el;
+}
+
+// Window centered at (500, 400)
+const geometry = {
+  windowPosition: { x: 300, y: 200 },
+  windowSize: { width: 400, height: 400 },
+};
+
+describe("computeDockIconOffset", () => {
+  test("targets the app's dock icon center relative to the window center", () => {
+    const el = addTarget("data-dock-icon", "finder", {
+      left: 100,
+      top: 700,
+      width: 48,
+      height: 48,
+    });
+    try {
+      const offset = computeDockIconOffset("finder", "finder-1", geometry);
+      // Icon center (124, 724) minus window center (500, 400)
+      expect(offset).toEqual({ x: -376, y: 324 });
+    } finally {
+      el.remove();
+    }
+  });
+
+  test("prefers the per-instance dock icon over the per-app icon (applets)", () => {
+    const appIcon = addTarget("data-dock-icon", "applet-viewer", {
+      left: 0,
+      top: 700,
+      width: 48,
+      height: 48,
+    });
+    const instanceIcon = addTarget("data-dock-icon", "instance-42", {
+      left: 200,
+      top: 700,
+      width: 48,
+      height: 48,
+    });
+    try {
+      const offset = computeDockIconOffset(
+        "applet-viewer",
+        "instance-42",
+        geometry
+      );
+      // Instance icon center (224, 724) minus window center (500, 400)
+      expect(offset).toEqual({ x: -276, y: 324 });
+    } finally {
+      appIcon.remove();
+      instanceIcon.remove();
+    }
+  });
+
+  test("falls back to the taskbar item when no dock icon exists", () => {
+    const el = addTarget("data-taskbar-item", "finder-1", {
+      left: 60,
+      top: 740,
+      width: 160,
+      height: 28,
+    });
+    try {
+      const offset = computeDockIconOffset("finder", "finder-1", geometry);
+      // Taskbar item center (140, 754) minus window center (500, 400)
+      expect(offset).toEqual({ x: -360, y: 354 });
+    } finally {
+      el.remove();
+    }
+  });
+
+  test("slides straight down when no dock icon or taskbar item exists", () => {
+    const offset = computeDockIconOffset("finder", "finder-1", geometry);
+    expect(offset).toEqual({
+      x: 0,
+      y: window.innerHeight - geometry.windowPosition.y,
+    });
+  });
+
+  test("re-measures the icon on every call (no caching)", () => {
+    const el = addTarget("data-dock-icon", "finder", {
+      left: 100,
+      top: 700,
+      width: 48,
+      height: 48,
+    });
+    try {
+      const before = computeDockIconOffset("finder", undefined, geometry);
+      // Dock re-centered: icon moved right by 100px.
+      el.getBoundingClientRect = () =>
+        ({
+          left: 200,
+          top: 700,
+          width: 48,
+          height: 48,
+          right: 248,
+          bottom: 748,
+          x: 200,
+          y: 700,
+          toJSON: () => ({}),
+        }) as DOMRect;
+      const after = computeDockIconOffset("finder", undefined, geometry);
+      expect(after.x).toBe(before.x + 100);
+      expect(after.y).toBe(before.y);
+    } finally {
+      el.remove();
+    }
+  });
+});
+
+describe("getExitAnimation", () => {
+  test("keep-mounted windows keep the static shrink-in-place exit", () => {
+    const exit = getExitAnimation({
+      keepMountedWhenMinimized: true,
+      getDockIconOffset: () => {
+        throw new Error("should not measure the dock for keep-mounted exits");
+      },
+    });
+    expect(typeof exit).toBe("object");
+    expect(exit).toMatchObject({ scale: 0.95, opacity: 0, x: 0, y: 0 });
+  });
+
+  test("minimize exit defers dock measurement until the animation starts", () => {
+    let calls = 0;
+    let offset = { x: -376, y: 324 };
+    const exit = getExitAnimation({
+      keepMountedWhenMinimized: false,
+      getDockIconOffset: () => {
+        calls += 1;
+        return offset;
+      },
+    });
+
+    // Motion resolves function-valued exit definitions lazily; nothing should
+    // be measured at render time.
+    expect(typeof exit).toBe("function");
+    expect(calls).toBe(0);
+
+    const resolve = exit as unknown as () => {
+      scale: number;
+      opacity: number;
+      x: number;
+      y: number;
+    };
+
+    expect(resolve()).toMatchObject({
+      scale: 0.1,
+      opacity: 0,
+      x: -376,
+      y: 324,
+    });
+    expect(calls).toBe(1);
+
+    // The dock icon moved before the user minimized: the resolver must pick
+    // up the new position.
+    offset = { x: 24, y: 300 };
+    expect(resolve()).toMatchObject({ x: 24, y: 300 });
+  });
+});

--- a/tests/test-window-minimize-exit-resolution.test.tsx
+++ b/tests/test-window-minimize-exit-resolution.test.tsx
@@ -70,16 +70,20 @@ test("motion resolves the lazy minimize exit when the window unmounts", async ()
     },
   });
 
+  // Mirror WindowFrame's structure: the exit definition lives on a nested
+  // motion div, not on the direct AnimatePresence child.
   function Harness({ show }: { show: boolean }) {
     return (
       <AnimatePresence>
         {show && (
-          <motion.div
-            data-testid="window"
-            initial={false}
-            animate={{ scale: 1, opacity: 1, x: 0, y: 0 }}
-            exit={exitDefinition}
-          />
+          <motion.div key="pos" initial={false} animate={{ x: 10, y: 10 }}>
+            <motion.div
+              data-testid="window"
+              initial={false}
+              animate={{ scale: 1, opacity: 1, x: 0, y: 0 }}
+              exit={exitDefinition}
+            />
+          </motion.div>
         )}
       </AnimatePresence>
     );

--- a/tests/test-window-minimize-exit-resolution.test.tsx
+++ b/tests/test-window-minimize-exit-resolution.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * WindowFrame's minimize exit relies on Motion resolving function-valued
+ * `exit` definitions when the exit animation starts (motion-dom's
+ * resolveVariantFromProps). That behavior is undocumented in the public
+ * types, so pin it here against the installed motion version: if a motion
+ * upgrade drops it, minimizing windows would silently stop zooming to the
+ * dock icon.
+ */
+import { afterAll, afterEach, beforeAll, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+let registeredDomHere = false;
+
+beforeAll(() => {
+  if (typeof document === "undefined") {
+    GlobalRegistrator.register();
+    registeredDomHere = true;
+  }
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+    true;
+});
+
+afterAll(() => {
+  if (registeredDomHere && GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.unregister();
+  }
+});
+
+const { AnimatePresence, motion } = await import("motion/react");
+const { getExitAnimation } = await import(
+  "../src/components/layout/window-frame/windowFrameAnimations"
+);
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+afterEach(async () => {
+  if (root) {
+    const r = root;
+    await act(async () => r.unmount());
+    root = null;
+  }
+  container?.remove();
+  container = null;
+});
+
+async function nextFrames(count: number) {
+  for (let i = 0; i < count; i++) {
+    await act(async () => {
+      await new Promise<void>((resolve) =>
+        requestAnimationFrame(() => resolve())
+      );
+    });
+  }
+}
+
+test("motion resolves the lazy minimize exit when the window unmounts", async () => {
+  let measurements = 0;
+  let offset = { x: -120, y: 480 };
+  let lastMeasured: { x: number; y: number } | null = null;
+
+  const exitDefinition = getExitAnimation({
+    keepMountedWhenMinimized: false,
+    getDockIconOffset: () => {
+      measurements += 1;
+      lastMeasured = offset;
+      return offset;
+    },
+  });
+
+  function Harness({ show }: { show: boolean }) {
+    return (
+      <AnimatePresence>
+        {show && (
+          <motion.div
+            data-testid="window"
+            initial={false}
+            animate={{ scale: 1, opacity: 1, x: 0, y: 0 }}
+            exit={exitDefinition}
+          />
+        )}
+      </AnimatePresence>
+    );
+  }
+
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root!.render(<Harness show={true} />);
+  });
+  await nextFrames(2);
+
+  // Nothing measured while the window is visible.
+  expect(measurements).toBe(0);
+
+  // The dock icon moved after mount (dock re-centered); the exit must pick
+  // up the position at minimize time, not a stale render-time snapshot.
+  offset = { x: 64, y: 512 };
+
+  await act(async () => {
+    root!.render(<Harness show={false} />);
+  });
+  await nextFrames(3);
+
+  // Motion invoked the lazy resolver at exit time, after the icon moved, so
+  // the animation targets the icon's current position.
+  expect(measurements).toBeGreaterThanOrEqual(1);
+  expect(lastMeasured).toEqual({ x: 64, y: 512 });
+
+  // The exiting element stays mounted while the exit animation runs
+  // (AnimatePresence waits for it). Animation completion timing is not
+  // reliable under happy-dom, so don't wait for the unmount itself.
+  expect(
+    container.querySelector<HTMLElement>('[data-testid="window"]')
+  ).not.toBeNull();
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Windows now zoom into their actual dock icon when minimized (and back out of it on restore), instead of sliding straight down off the bottom of the screen.

### Root cause

`useWindowFrameDockOffsets` measured the dock icon once, at `WindowFrame` mount, via `useMemo` keyed only on `appId`/`instanceId`. For non-pinned apps the open-section dock icon doesn't exist yet at mount, so the lookup returned `null` and every animation used the "slide off the bottom" fallback forever. Even when the icon existed, the cached position went stale whenever the dock re-centered as apps opened/closed.

### Changes

- `useWindowFrameDockOffsets.ts`: extracted `computeDockIconOffset`, which measures the dock icon / taskbar item from the live DOM on every call. The hook computes `dockIconOffset` fresh each render (used by the restore `initial` animation and the keep-mounted-minimize `animate` path) and returns a `getDockIconOffset` getter for exit-time resolution. Per-instance dock icons (`data-dock-icon="<instanceId>"`, used by applet-viewer) are now preferred over the per-app icon so applet windows target their own icon.
- `windowFrameAnimations.ts`: `getExitAnimation` now returns a function-valued exit definition for the minimize case. Motion resolves these lazily when the exit animation starts, so the dock icon is measured at minimize time rather than captured from the last render before removal.
- `WindowFrame.tsx`: passes `getDockIconOffset` into the exit definition.

Behavior on themes without a dock is unchanged: Windows themes target the per-instance taskbar button; System 7 keeps the slide-down fallback (it has no minimize target).

### Tests

- `tests/test-window-minimize-dock-offset.test.ts`: offset math against dock icon / per-instance icon / taskbar item / fallback, and that measurement is uncached.
- `tests/test-window-minimize-exit-resolution.test.tsx`: pins the motion runtime behavior the fix relies on — a function-valued `exit` on a nested motion div (mirroring `WindowFrame`'s structure) is resolved when the exit starts, picking up an icon position that changed after render.

- ✅ `bun run test:unit` (2602 pass / 0 fail, 318 files)
- ✅ `bun run test:registration`
- ✅ `bun run lint` (0 errors; pre-existing warnings only, none in touched files)
- ✅ `bun run build`
- ✅ `bunx tsc --noEmit -p tsconfig.app.json`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3e5f-4530-7c16-8685-7a7964eee878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3e5f-4530-7c16-8685-7a7964eee878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

