### PR TITLE
Present dialogs as Mac OS X sheets sliding from the parent window titlebar

### DIFF
--- a/src/apps/base/app-manager/AppManagerView.tsx
+++ b/src/apps/base/app-manager/AppManagerView.tsx
@@ -12,6 +12,7 @@ import { SpotlightSearch } from "@/components/layout/SpotlightSearch";
 import { AppSwitcher } from "@/components/layout/AppSwitcher";
 import { useAssistantStore } from "@/stores/useAssistantStore";
 import { AppErrorBoundary } from "@/components/errors/ErrorBoundaries";
+import { DialogParentWindowContext } from "@/components/shared/DialogParentWindowContext";
 import { getTranslatedAppName } from "@/utils/i18n";
 import { isTextEditInitialData } from "@/types/appInitialData";
 import {
@@ -280,20 +281,22 @@ const ManagedAppInstance = memo(function ManagedAppInstance({
         }}
       >
         {shouldMount ? (
-          <ManagedAppRoot
-            AppComponent={AppComponent}
-            isWindowOpen={instance.isOpen}
-            isForeground={effectiveIsForeground}
-            onClose={handleClose}
-            className="pointer-events-auto"
-            helpItems={app?.helpItems}
-            skipInitialSound={isInitialMount}
-            initialData={instance.initialData}
-            instanceId={instance.instanceId}
-            title={instance.title}
-            onNavigateNext={handleNavigateNext}
-            onNavigatePrevious={handleNavigatePrevious}
-          />
+          <DialogParentWindowContext.Provider value={instance.instanceId}>
+            <ManagedAppRoot
+              AppComponent={AppComponent}
+              isWindowOpen={instance.isOpen}
+              isForeground={effectiveIsForeground}
+              onClose={handleClose}
+              className="pointer-events-auto"
+              helpItems={app?.helpItems}
+              skipInitialSound={isInitialMount}
+              initialData={instance.initialData}
+              instanceId={instance.instanceId}
+              title={instance.title}
+              onNavigateNext={handleNavigateNext}
+              onNavigatePrevious={handleNavigatePrevious}
+            />
+          </DialogParentWindowContext.Provider>
         ) : null}
       </AppErrorBoundary>
     </div>

--- a/src/components/shared/DialogParentWindowContext.ts
+++ b/src/components/shared/DialogParentWindowContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+/**
+ * Window instance id that "owns" dialogs rendered in the subtree. On the
+ * macOS Aqua theme, dialogs use it to attach to the initiating window as a
+ * Mac OS X style sheet sliding out from under its titlebar. Null outside app
+ * windows (shell-level dialogs stay centered).
+ */
+export const DialogParentWindowContext = createContext<string | null>(null);

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -250,6 +250,10 @@ const DialogContent = (
           onCloseAutoFocus={cleanupPointerEvents}
           {...props}
         >
+          {/* Shadow the titlebar casts onto the emerging sheet — painted
+              above the window frame and the sheet so the sheet reads as
+              sliding out of a slot under the titlebar. */}
+          <div aria-hidden className="macosx-sheet-titlebar-shadow" />
           <div
             className={cn(
               "macosx-sheet-body pointer-events-auto grid w-full min-w-0 max-w-lg gap-4 border bg-os-window-bg p-0 overflow-hidden",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -73,6 +73,13 @@ interface SheetAnchor {
   width: number;
 }
 
+/**
+ * True when the dialog renders as a macOS sheet; sheets have no titlebar of
+ * their own (they slide out from the parent window's titlebar), so
+ * DialogHeader renders nothing.
+ */
+const DialogSheetContext = React.createContext(false);
+
 function measureSheetAnchor(parentInstanceId: string): SheetAnchor | null {
   const frame = document.querySelector<HTMLElement>(
     `[data-window-instance-id="${CSS.escape(parentInstanceId)}"]`
@@ -266,7 +273,9 @@ const DialogContent = (
                 backgroundImage: "var(--os-pinstripe-window)",
               }}
             >
-              {children}
+              <DialogSheetContext.Provider value={true}>
+                {children}
+              </DialogSheetContext.Provider>
             </div>
           </div>
         </DialogPrimitive.Content>
@@ -317,7 +326,14 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => {
   const { t } = useTranslation();
   const { isWinXp, isWindowsTheme, isMacOSTheme } = useThemeFlags();
+  const isSheet = React.useContext(DialogSheetContext);
   const closeRef = React.useRef<HTMLButtonElement>(null);
+
+  // macOS sheets have no titlebar — they slide out from the parent window's
+  // titlebar. Titles stay accessible via the callers' (sr-only) DialogTitle.
+  if (isSheet) {
+    return null;
+  }
 
   if (isWindowsTheme) {
     return (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -115,19 +115,36 @@ const DialogContent = (
   const hasMeasuredAnchor =
     sheetAnchor !== null && sheetAnchor !== "unavailable";
 
+  // Only commit state when the measurement actually changed: Radix recomposes
+  // its internal ref chain on every render (detach + reattach), so this
+  // callback fires repeatedly and an unconditional set would loop forever.
+  const updateSheetAnchor = React.useCallback(() => {
+    if (!parentWindowInstanceId) return;
+    const next = measureSheetAnchor(parentWindowInstanceId) ?? "unavailable";
+    setSheetAnchor((prev) => {
+      if (prev === next) return prev;
+      if (
+        typeof prev === "object" &&
+        prev !== null &&
+        typeof next === "object" &&
+        prev.left === next.left &&
+        prev.top === next.top &&
+        prev.width === next.width
+      ) {
+        return prev;
+      }
+      return next;
+    });
+  }, [parentWindowInstanceId]);
+
   // Measure the parent window when the (portaled) content mounts. The ref
   // callback runs before paint, so the pre-measure hidden frame never shows.
   const measureRef = React.useCallback(
     (node: HTMLDivElement | null) => {
-      if (!node) {
-        // Content unmounted (dialog closed) — re-measure on next open.
-        setSheetAnchor(null);
-        return;
-      }
-      if (!wantsSheet || !parentWindowInstanceId) return;
-      setSheetAnchor(measureSheetAnchor(parentWindowInstanceId) ?? "unavailable");
+      if (!node || !wantsSheet) return;
+      updateSheetAnchor();
     },
-    [wantsSheet, parentWindowInstanceId]
+    [wantsSheet, updateSheetAnchor]
   );
 
   const composedContentRef = React.useCallback(
@@ -144,15 +161,10 @@ const DialogContent = (
 
   // Keep the sheet attached if the viewport (and thus window layout) changes.
   React.useEffect(() => {
-    if (!hasMeasuredAnchor || !parentWindowInstanceId) return;
-    const remeasure = () => {
-      setSheetAnchor(
-        measureSheetAnchor(parentWindowInstanceId) ?? "unavailable"
-      );
-    };
-    window.addEventListener("resize", remeasure);
-    return () => window.removeEventListener("resize", remeasure);
-  }, [hasMeasuredAnchor, parentWindowInstanceId]);
+    if (!hasMeasuredAnchor) return;
+    window.addEventListener("resize", updateSheetAnchor);
+    return () => window.removeEventListener("resize", updateSheetAnchor);
+  }, [hasMeasuredAnchor, updateSheetAnchor]);
 
   // Fall back to the centered modal when the parent window can't be found.
   const isSheet = wantsSheet && sheetAnchor !== "unavailable";

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -7,6 +7,7 @@ import { useSound, Sounds } from "@/hooks/useSound";
 import { useVibration } from "@/hooks/useVibration";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { TrafficLightButton } from "@/components/shared/TrafficLightButton";
+import { DialogParentWindowContext } from "@/components/shared/DialogParentWindowContext";
 
 const Dialog = ({
   children,
@@ -58,6 +59,32 @@ const DialogClose = DialogPrimitive.Close;
 interface DialogContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   overlayClassName?: string;
+  /**
+   * Opt out of the macOS sheet presentation (dialog slides out from the
+   * parent window titlebar) and always render as a centered modal.
+   */
+  disableSheet?: boolean;
+}
+
+/** Viewport-space anchor line a sheet slides out from (parent titlebar). */
+interface SheetAnchor {
+  left: number;
+  top: number;
+  width: number;
+}
+
+function measureSheetAnchor(parentInstanceId: string): SheetAnchor | null {
+  const frame = document.querySelector<HTMLElement>(
+    `[data-window-instance-id="${CSS.escape(parentInstanceId)}"]`
+  );
+  if (!frame) return null;
+  // `.window` is the visible chrome; the outer frame carries mobile padding.
+  const chrome = frame.querySelector<HTMLElement>(".window") ?? frame;
+  const rect = chrome.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return null;
+  const titleBar = chrome.querySelector<HTMLElement>(":scope > .title-bar");
+  const top = titleBar ? titleBar.getBoundingClientRect().bottom : rect.top;
+  return { left: rect.left, top, width: rect.width };
 }
 
 const DialogContent = (
@@ -66,12 +93,69 @@ const DialogContent = (
     className,
     children,
     overlayClassName,
+    disableSheet = false,
+    style,
     ...props
   }: DialogContentProps & {
     ref?: React.Ref<React.ElementRef<typeof DialogPrimitive.Content>>;
   }
 ) => {
   const { isWindowsTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
+  const parentWindowInstanceId = React.useContext(DialogParentWindowContext);
+
+  // Mac OS X sheet behavior: when a dialog is opened from inside an app
+  // window on the Aqua theme, attach it to that window and slide it out from
+  // under the titlebar instead of showing a centered modal.
+  const wantsSheet =
+    isMacOSTheme && !disableSheet && parentWindowInstanceId !== null;
+
+  const [sheetAnchor, setSheetAnchor] = React.useState<
+    SheetAnchor | "unavailable" | null
+  >(null);
+  const hasMeasuredAnchor =
+    sheetAnchor !== null && sheetAnchor !== "unavailable";
+
+  // Measure the parent window when the (portaled) content mounts. The ref
+  // callback runs before paint, so the pre-measure hidden frame never shows.
+  const measureRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node) {
+        // Content unmounted (dialog closed) — re-measure on next open.
+        setSheetAnchor(null);
+        return;
+      }
+      if (!wantsSheet || !parentWindowInstanceId) return;
+      setSheetAnchor(measureSheetAnchor(parentWindowInstanceId) ?? "unavailable");
+    },
+    [wantsSheet, parentWindowInstanceId]
+  );
+
+  const composedContentRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      measureRef(node);
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      }
+    },
+    [measureRef, ref]
+  );
+
+  // Keep the sheet attached if the viewport (and thus window layout) changes.
+  React.useEffect(() => {
+    if (!hasMeasuredAnchor || !parentWindowInstanceId) return;
+    const remeasure = () => {
+      setSheetAnchor(
+        measureSheetAnchor(parentWindowInstanceId) ?? "unavailable"
+      );
+    };
+    window.addEventListener("resize", remeasure);
+    return () => window.removeEventListener("resize", remeasure);
+  }, [hasMeasuredAnchor, parentWindowInstanceId]);
+
+  // Fall back to the centered modal when the parent window can't be found.
+  const isSheet = wantsSheet && sheetAnchor !== "unavailable";
 
   // Function to clean up pointer-events
   const cleanupPointerEvents = React.useCallback(() => {
@@ -112,12 +196,79 @@ const DialogContent = (
     );
   };
 
+  if (isSheet) {
+    const anchor = hasMeasuredAnchor ? (sheetAnchor as SheetAnchor) : null;
+    return (
+      <DialogPortal>
+        {/* Sheets don't dim the desktop; the overlay only blocks interaction */}
+        <DialogPrimitive.Overlay
+          className={cn("fixed inset-0 z-50 bg-transparent", overlayClassName)}
+        />
+        {/* Full-window-width strip below the titlebar; overflow-hidden clips
+            the sheet while it slides out from behind the titlebar. Pointer
+            events pass through the strip padding to the overlay. */}
+        <DialogPrimitive.Content
+          ref={composedContentRef}
+          className="macosx-sheet-strip fixed z-50 flex flex-col items-center overflow-hidden px-4 pb-10"
+          style={
+            anchor
+              ? {
+                  left: anchor.left,
+                  top: anchor.top,
+                  width: anchor.width,
+                  pointerEvents: "none",
+                }
+              : {
+                  left: 0,
+                  top: 0,
+                  width: "100%",
+                  visibility: "hidden",
+                  pointerEvents: "none",
+                }
+          }
+          onEscapeKeyDown={cleanupPointerEvents}
+          onPointerDownOutside={cleanupPointerEvents}
+          onCloseAutoFocus={cleanupPointerEvents}
+          {...props}
+        >
+          <div
+            className={cn(
+              "macosx-sheet-body pointer-events-auto grid w-full min-w-0 max-w-lg gap-4 border bg-os-window-bg p-0 overflow-hidden",
+              "border-[length:var(--os-metrics-border-width)] border-os-window macosx-dialog [&_button]:text-[length:var(--os-typography-button)]",
+              className
+            )}
+            style={{
+              ...(anchor
+                ? { maxHeight: `calc(100dvh - ${anchor.top}px - 12px)` }
+                : undefined),
+              ...style,
+            }}
+          >
+            <div
+              className={cn(
+                "flex min-h-0 min-w-0 w-full max-w-full flex-1 flex-col overflow-x-hidden",
+                OS_SHELL_TEXT_SCALE_CLASS
+              )}
+              style={{
+                backgroundColor: "var(--os-color-window-bg)",
+                backgroundImage: "var(--os-pinstripe-window)",
+              }}
+            >
+              {children}
+            </div>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    );
+  }
+
   return (
     <DialogPortal>
       <DialogPrimitive.Overlay className={cn("fixed inset-0 z-50 bg-black/30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0", overlayClassName)} />
       <DialogPrimitive.Content
-        ref={ref}
+        ref={composedContentRef}
         className={getDialogContentClasses()}
+        style={style}
         onEscapeKeyDown={cleanupPointerEvents}
         onPointerDownOutside={cleanupPointerEvents}
         onCloseAutoFocus={cleanupPointerEvents}

--- a/src/styles/themes/aqua-glass.css
+++ b/src/styles/themes/aqua-glass.css
@@ -1574,6 +1574,13 @@
   border-radius: var(--os-glass-r-dialog) !important;
 }
 
+/* Sheets slide out from under the parent titlebar — keep their top edge
+   square so they read as emerging from a slot (bottom corners stay glassy). */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .macosx-sheet-body.macosx-dialog {
+  border-radius: 0 0 var(--os-glass-r-dialog) var(--os-glass-r-dialog) !important;
+}
+
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"] .macosx-dialog-header {
   border-radius: var(--os-glass-r-dialog) var(--os-glass-r-dialog) 0 0 !important;
 }

--- a/src/styles/themes/aqua.css
+++ b/src/styles/themes/aqua.css
@@ -2216,14 +2216,13 @@
   border-radius: 7.2px 7.2px 0px 0px !important;
 }
 
-/* Mac OS X sheet dialogs — slide out from under the parent window titlebar */
+/* Mac OS X sheet dialogs — slide out from under the parent window titlebar.
+   No top border and a tight shadow so the sheet reads as emerging from the
+   titlebar rather than floating above the window. */
 :root[data-os-theme="macosx"] .macosx-sheet-body.macosx-dialog {
   border-radius: 0 0 7.2px 7.2px !important;
-  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.5);
-}
-
-:root[data-os-theme="macosx"] .macosx-sheet-body .macosx-dialog-header {
-  border-radius: 0 !important;
+  border-top-width: 0 !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
 }
 
 @keyframes macosx-sheet-in {

--- a/src/styles/themes/aqua.css
+++ b/src/styles/themes/aqua.css
@@ -2271,6 +2271,55 @@
     forwards;
 }
 
+/* Shadow cast by the titlebar onto the sheet sliding out beneath it.
+   Absolutely positioned at the strip top (the titlebar's bottom edge),
+   spanning the full window width, painted above the sheet body. */
+:root[data-os-theme="macosx"] .macosx-sheet-titlebar-shadow {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 8px;
+  z-index: 10;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0.28) 0%,
+    rgba(0, 0, 0, 0.12) 45%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+@keyframes macosx-sheet-shadow-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes macosx-sheet-shadow-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+:root[data-os-theme="macosx"]
+  .macosx-sheet-strip[data-state="open"]
+  .macosx-sheet-titlebar-shadow {
+  animation: macosx-sheet-shadow-in 200ms ease-out;
+}
+
+:root[data-os-theme="macosx"]
+  .macosx-sheet-strip[data-state="closed"]
+  .macosx-sheet-titlebar-shadow {
+  animation: macosx-sheet-shadow-out 220ms ease-in forwards;
+}
+
 /* macOS Aqua Tab Styles */
 .aqua-tab {
   position: relative;

--- a/src/styles/themes/aqua.css
+++ b/src/styles/themes/aqua.css
@@ -2216,6 +2216,62 @@
   border-radius: 7.2px 7.2px 0px 0px !important;
 }
 
+/* Mac OS X sheet dialogs — slide out from under the parent window titlebar */
+:root[data-os-theme="macosx"] .macosx-sheet-body.macosx-dialog {
+  border-radius: 0 0 7.2px 7.2px !important;
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.5);
+}
+
+:root[data-os-theme="macosx"] .macosx-sheet-body .macosx-dialog-header {
+  border-radius: 0 !important;
+}
+
+@keyframes macosx-sheet-in {
+  from {
+    transform: translateY(-101%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes macosx-sheet-out {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-101%);
+  }
+}
+
+/* No-op animation on the Radix content element so it waits for the sheet
+   retract animation (running on the child) before unmounting. */
+@keyframes macosx-sheet-hold {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+:root[data-os-theme="macosx"] .macosx-sheet-strip[data-state="closed"] {
+  animation: macosx-sheet-hold 260ms linear;
+}
+
+:root[data-os-theme="macosx"]
+  .macosx-sheet-strip[data-state="open"]
+  .macosx-sheet-body {
+  animation: macosx-sheet-in 320ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+:root[data-os-theme="macosx"]
+  .macosx-sheet-strip[data-state="closed"]
+  .macosx-sheet-body {
+  animation: macosx-sheet-out 260ms cubic-bezier(0.55, 0.06, 0.68, 0.19)
+    forwards;
+}
+
 /* macOS Aqua Tab Styles */
 .aqua-tab {
   position: relative;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the macOS Aqua theme, dialogs opened from inside an app window now present as classic Mac OS X **sheets**: they slide out from under the initiating window's titlebar, horizontally centered on that window, with square top corners and rounded bottom corners. Sheets are headerless — no titlebar or traffic lights of their own — with no top border and a tight shadow. A subtle shadow band under the window's titlebar is painted above both the window frame and the sheet, and the entry/exit animation is clipped at the titlebar line, so the sheet reads as sliding out of a slot beneath the titlebar. Closing retracts the sheet back up behind it.

- `DialogParentWindowContext` (new) carries the owning window `instanceId`; `AppManagerView` provides it around each mounted app instance, so every dialog rendered from an app tree knows its parent window.
- `DialogContent` measures the parent window chrome (`[data-window-instance-id]` → `.window` → titlebar) when the portal mounts and renders a clipping strip anchored below the titlebar; the sheet body slides within it (masked at the titlebar line), with the `macosx-sheet-titlebar-shadow` overlay layered on top. Falls back to the existing centered modal when no parent window is found (shell-level dialogs, crash dialogs) and on all other themes (System 7, XP, Win98). A `disableSheet` prop is available as an opt-out.
- In sheet mode `DialogHeader` renders nothing (dialog titles stay accessible via the callers' sr-only `DialogTitle`s); sheets close via their buttons, Escape, or clicking outside.
- Sheets keep interaction modal but don't dim the whole desktop (transparent overlay), matching classic sheet behavior.
- Slide-in/slide-out keyframes, titlebar shadow band, and sheet corner/shadow overrides live in `aqua.css`.

![Sheet with titlebar-cast shadow band (Aqua)](https://cursor.com/artifacts/c/art-d7cad19e-0a0a-4536-8ecb-17a5490d2d41)
![Zoom: shadow band under the titlebar above the sheet](https://cursor.com/artifacts/c/art-7f0cc57e-20de-4c80-8301-24ef6c2de182)
![Entry animation frozen midway — sheet clipped at the titlebar line](https://cursor.com/artifacts/c/art-3b7a9138-b585-467b-899b-f79b1d138193)
![Zoom: frozen mid-entry, top half masked behind the titlebar](https://cursor.com/artifacts/c/art-ff43581c-76fb-41aa-a79d-745373d8b9da)
![Sheet stays attached to an off-center window](https://cursor.com/artifacts/c/art-29b0dfc6-e2ee-4314-8e2a-a69520f70dcb)
![Windows XP theme keeps centered modal dialogs](https://cursor.com/artifacts/c/art-56522f9e-88fe-497a-a1b0-4124201648a4)

## Testing

- `bunx tsc --noEmit` — clean
- `bunx eslint` on changed files — clean
- `bun run test:unit` — 2594 pass / 0 fail
- Manual browser testing (Aqua): TextEdit File → Save and Help dialogs slide from the titlebar with no sheet titlebar, attach to off-center windows, retract on Cancel/Escape, and the app stays functional afterward; no console errors.
- Entry masking verified deterministically by freezing the animation at 50% via injected CSS: only the sheet's lower half is visible, hard-clipped at the titlebar's bottom edge, with the shadow band on top.
- Manual regression (Windows XP theme): dialogs remain centered screen modals with their normal title bars; crash dialogs remain centered.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3e5e-e559-7760-9a56-d9a11096964e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3e5e-e559-7760-9a56-d9a11096964e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

