### PR TITLE
Keep Aqua button drop shadows when disabled

### DIFF
--- a/src/styles/themes/aqua.css
+++ b/src/styles/themes/aqua.css
@@ -356,6 +356,11 @@
       rgba(33, 160, 196, 0.28)
     )
   );
+  /* Keep outer drop shadow; soften inset bevels to match washed fill. */
+  box-shadow: 0 2px 3px rgba(0, 0, 0, 0.3),
+    0 1px 1px var(--os-accent-button-edge, rgba(0, 78, 187, 0.5)),
+    inset 0 1px 3px rgba(0, 17, 49, 0.28),
+    inset 0 2px 3px 1px var(--os-accent-button-inner-disabled, rgba(0, 78, 187, 0.28));
 }
 
 .aqua-button.primary:disabled,
@@ -368,6 +373,8 @@
     rgba(160, 160, 160, 0.28),
     rgba(255, 255, 255, 0.28)
   );
+  box-shadow: 0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3),
+    inset 0 1px 2px rgba(0, 0, 0, 0.14), inset 0 2px 3px 1px rgba(187, 187, 187, 0.4);
 }
 
 .aqua-button.secondary:disabled,
@@ -381,6 +388,9 @@
     rgba(254, 197, 64, 0.38),
     rgba(255, 219, 128, 0.38)
   );
+  box-shadow: 0 2px 3px rgba(0, 0, 0, 0.3), 0 1px 1px rgba(250, 172, 4, 0.5),
+    inset 0 1px 3px rgba(120, 65, 0, 0.28),
+    inset 0 2px 3px 1px rgba(250, 172, 4, 0.28);
 }
 
 .aqua-button.orange:disabled,
@@ -394,6 +404,9 @@
     rgba(225, 53, 62, 0.4),
     rgba(248, 125, 130, 0.4)
   );
+  box-shadow: 0 2px 3px rgba(0, 0, 0, 0.3), 0 1px 1px rgba(150, 0, 10, 0.55),
+    inset 0 1px 3px rgba(92, 0, 7, 0.3),
+    inset 0 2px 3px 1px rgba(225, 53, 62, 0.28);
 }
 
 .aqua-button.destructive:disabled,

--- a/src/styles/themes/aqua.css
+++ b/src/styles/themes/aqua.css
@@ -325,15 +325,80 @@
   font-smooth: auto;
 }
 
+/* Disabled Aqua buttons must keep their drop shadow. Element-level
+   `opacity` / `filter` would mute `box-shadow`, so dim the face instead:
+   washed fills, faded gloss pseudos, and faded label color. */
 .aqua-button:disabled {
   cursor: default;
-  opacity: 0.5;
-  filter: grayscale(0.3);
   pointer-events: none;
+  /* Beat Tailwind `disabled:opacity-50` without muffling the shadow. */
+  opacity: 1 !important;
+  filter: none;
+}
+
+.aqua-button:disabled::before,
+.aqua-button:disabled::after {
+  opacity: 0.4;
+}
+
+/* Icon glyphs as direct children (text nodes inherit muted `color`). */
+.aqua-button:disabled > svg {
+  opacity: 0.5;
 }
 
 .aqua-button.primary:disabled {
   animation: none;
+  background: var(
+    --os-accent-button-bg-disabled,
+    linear-gradient(
+      rgba(0, 65, 184, 0.28),
+      rgba(45, 115, 199, 0.28),
+      rgba(33, 160, 196, 0.28)
+    )
+  );
+}
+
+.aqua-button.primary:disabled,
+.aqua-button.primary:disabled span {
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.aqua-button.secondary:disabled {
+  background: linear-gradient(
+    rgba(160, 160, 160, 0.28),
+    rgba(255, 255, 255, 0.28)
+  );
+}
+
+.aqua-button.secondary:disabled,
+.aqua-button.secondary:disabled span {
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.aqua-button.orange:disabled {
+  background: linear-gradient(
+    rgba(250, 172, 4, 0.38),
+    rgba(254, 197, 64, 0.38),
+    rgba(255, 219, 128, 0.38)
+  );
+}
+
+.aqua-button.orange:disabled,
+.aqua-button.orange:disabled span {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.aqua-button.destructive:disabled {
+  background: linear-gradient(
+    rgba(177, 20, 30, 0.4),
+    rgba(225, 53, 62, 0.4),
+    rgba(248, 125, 130, 0.4)
+  );
+}
+
+.aqua-button.destructive:disabled,
+.aqua-button.destructive:disabled span {
+  color: rgba(255, 255, 255, 0.55);
 }
 
 /* Aqua button pulse animation - classic Mac OS X pulsing effect */

--- a/src/styles/themes/dark-aqua.css
+++ b/src/styles/themes/dark-aqua.css
@@ -314,6 +314,42 @@
   text-shadow: 0 2px 2px rgba(0, 0, 0, 0.4) !important;
 }
 
+/* Disabled labels stay readable without element-level opacity (which would
+   mute the button drop shadow). Dim the text only. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .aqua-button.primary:disabled,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .aqua-button.primary:disabled span,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .aqua-button.secondary:disabled,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .aqua-button.secondary:disabled span {
+  color: rgba(255, 255, 255, 0.45) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .aqua-button.secondary:disabled {
+  background: linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.1) 0%,
+        rgba(255, 255, 255, 0.03) 58%,
+        rgba(255, 255, 255, 0) 100%
+      )
+      top / 100% 50% no-repeat,
+    linear-gradient(
+        to top,
+        rgba(255, 255, 255, 0.05) 0%,
+        rgba(255, 255, 255, 0.02) 52%,
+        rgba(255, 255, 255, 0) 100%
+      )
+      bottom / 100% 42% no-repeat,
+    linear-gradient(
+      to bottom,
+      rgba(72, 72, 78, 0.14),
+      rgba(34, 34, 38, 0.14)
+    ) !important;
+}
+
 /* Native <select> uses `background:` shorthand to layer a chevron SVG on
    top of the light gradient. The dark gradient rule above blew away the
    chevron — re-layer a light-colored chevron over the new dark gradient. */

--- a/tests/test-aqua-button-disabled-shadow.test.ts
+++ b/tests/test-aqua-button-disabled-shadow.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const aquaCss = readFileSync(
+  join(import.meta.dir, "../src/styles/themes/aqua.css"),
+  "utf8"
+);
+const darkAquaCss = readFileSync(
+  join(import.meta.dir, "../src/styles/themes/dark-aqua.css"),
+  "utf8"
+);
+
+function extractRuleBlock(css: string, selector: string): string {
+  const start = css.indexOf(selector);
+  if (start === -1) return "";
+  const braceStart = css.indexOf("{", start);
+  if (braceStart === -1) return "";
+  let depth = 0;
+  for (let i = braceStart; i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) return css.slice(start, i + 1);
+    }
+  }
+  return "";
+}
+
+describe("aqua disabled button shadow", () => {
+  test("disabled aqua buttons keep opacity fully on so box-shadow stays visible", () => {
+    const block = extractRuleBlock(aquaCss, ".aqua-button:disabled");
+    expect(block.length).toBeGreaterThan(0);
+    expect(block).toContain("opacity: 1 !important");
+    expect(block).toContain("filter: none");
+    expect(block).not.toMatch(/opacity:\s*0\.[0-9]/);
+    expect(block).not.toContain("grayscale");
+  });
+
+  test("disabled aqua buttons dim face layers instead of the whole control", () => {
+    expect(aquaCss).toContain(".aqua-button:disabled::before");
+    expect(aquaCss).toContain(".aqua-button:disabled::after");
+    expect(aquaCss).toContain(".aqua-button:disabled > svg");
+    expect(aquaCss).toContain(".aqua-button.primary:disabled");
+    expect(aquaCss).toContain(".aqua-button.secondary:disabled");
+    expect(aquaCss).toContain(".aqua-button.orange:disabled");
+    expect(aquaCss).toContain(".aqua-button.destructive:disabled");
+    expect(aquaCss).not.toContain(".aqua-button:disabled > *");
+  });
+
+  test("dark mode disabled labels stay dim without muffling shadows", () => {
+    expect(darkAquaCss).toContain(".aqua-button.primary:disabled");
+    expect(darkAquaCss).toContain(".aqua-button.secondary:disabled");
+    expect(darkAquaCss).toContain("color: rgba(255, 255, 255, 0.45) !important");
+  });
+});

--- a/tests/test-aqua-button-disabled-shadow.test.ts
+++ b/tests/test-aqua-button-disabled-shadow.test.ts
@@ -48,6 +48,28 @@ describe("aqua disabled button shadow", () => {
     expect(aquaCss).not.toContain(".aqua-button:disabled > *");
   });
 
+  test("disabled aqua buttons keep outer drop shadow and lighten inset bevels", () => {
+    const primary = extractRuleBlock(aquaCss, ".aqua-button.primary:disabled");
+    const secondary = extractRuleBlock(aquaCss, ".aqua-button.secondary:disabled");
+    const orange = extractRuleBlock(aquaCss, ".aqua-button.orange:disabled");
+    const destructive = extractRuleBlock(
+      aquaCss,
+      ".aqua-button.destructive:disabled"
+    );
+
+    for (const block of [primary, secondary, orange, destructive]) {
+      expect(block).toContain("box-shadow:");
+      expect(block).toContain("0 2px 3px");
+      expect(block).toContain("inset");
+    }
+
+    expect(primary).toContain("inset 0 1px 3px rgba(0, 17, 49, 0.28)");
+    expect(primary).not.toContain("inset 0 1px 3px rgba(0, 17, 49, 0.8)");
+    expect(secondary).toContain("inset 0 1px 2px rgba(0, 0, 0, 0.14)");
+    expect(orange).toContain("inset 0 1px 3px rgba(120, 65, 0, 0.28)");
+    expect(destructive).toContain("inset 0 1px 3px rgba(92, 0, 7, 0.3)");
+  });
+
   test("dark mode disabled labels stay dim without muffling shadows", () => {
     expect(darkAquaCss).toContain(".aqua-button.primary:disabled");
     expect(darkAquaCss).toContain(".aqua-button.secondary:disabled");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Disabled `.aqua-button` controls were using element-level `opacity` / `filter`, which also muted their `box-shadow`. Disabled faces are now dimmed via washed fills, faded gloss, muted labels, and lightened inset bevels so the outer drop shadow stays fully visible.

## Changes

- Update `.aqua-button:disabled` in `aqua.css` to keep `opacity: 1` and dim face layers instead
- Soften inset shadow alphas on disabled primary/secondary/orange/destructive while keeping outer drop shadows
- Add dark-mode disabled label/fill overrides in `dark-aqua.css`
- Add wiring test coverage for the disabled-shadow contract

## Evidence

After (outer shadow kept, inset lightened):
![Disabled Aqua buttons with lightened inset shadows](https://cursor.com/artifacts/c/art-d29bfe94-9254-45d9-9011-e56feff79031)

Before regression (element opacity mutes all shadows):
![Old disabled Aqua buttons with muted shadow](https://cursor.com/artifacts/c/art-3f4125b5-77dc-4685-8552-dce206815c3e)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f411b-2d0f-716f-978b-5d521943468f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f411b-2d0f-716f-978b-5d521943468f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

