### PR TITLE
Cut Redis round trips on auth, chat send, and songs version probe

### DIFF
--- a/api/_utils/_rate-limit.ts
+++ b/api/_utils/_rate-limit.ts
@@ -23,7 +23,7 @@ export const AI_LIMIT_ANON_PER_DAY = 3;
 export const AI_WINDOW_AUTHENTICATED = 5 * 60 * 60; // 5 hours in seconds
 export const AI_WINDOW_ANONYMOUS = 24 * 60 * 60; // 24 hours in seconds
 
-const INCREMENT_WITH_TTL_SCRIPT = `
+export const INCREMENT_WITH_TTL_SCRIPT = `
 local count = redis.call("INCR", KEYS[1])
 if count == 1 then
   redis.call("EXPIRE", KEYS[1], ARGV[1])
@@ -145,19 +145,18 @@ export async function checkCounterLimit({
   // ATOMIC approach: increment first, then check
   // This prevents race conditions where two concurrent requests both read
   // the same count and both pass the limit check
-  const newCount = await client.incr(key);
-
-  // Set TTL only if this is the first increment (count became 1)
-  // This is safe because INCR is atomic - only one request will see newCount === 1
-  if (newCount === 1) {
-    await client.expire(key, windowSeconds);
-  }
-
-  const ttl = await client.ttl(key);
-  const resetSeconds = typeof ttl === "number" && ttl > 0 ? ttl : windowSeconds;
+  // Atomic incr+expire in one round trip (avoids orphaned keys without TTL).
+  const newCount = await client.eval<number>(
+    INCREMENT_WITH_TTL_SCRIPT,
+    [key],
+    [windowSeconds]
+  );
 
   // Check if the NEW count exceeds the limit
   if (newCount > limit) {
+    // Only fetch exact TTL on the denied path (used for Retry-After).
+    const ttl = await client.ttl(key);
+    const resetSeconds = typeof ttl === "number" && ttl > 0 ? ttl : windowSeconds;
     return {
       allowed: false,
       count: newCount,
@@ -174,7 +173,8 @@ export async function checkCounterLimit({
     limit,
     remaining: Math.max(0, limit - newCount),
     windowSeconds,
-    resetSeconds,
+    // Approximate on the allowed path — callers rarely need exact reset.
+    resetSeconds: windowSeconds,
   };
 }
 

--- a/api/_utils/_song-service.ts
+++ b/api/_utils/_song-service.ts
@@ -310,6 +310,24 @@ export async function getSong(
 }
 
 /**
+ * Bump the denormalized catalog version stamp used by getSongsVersionInfo.
+ * Kept as a best-effort side write so pollers stay O(1).
+ */
+async function bumpSongsVersion(redis: Redis, stamp: number): Promise<void> {
+  const key = redisKeys.media.songsVersion();
+  const current = await redis.get<number | string>(key);
+  const currentNum =
+    typeof current === "number"
+      ? current
+      : current
+        ? parseInt(String(current), 10) || 0
+        : 0;
+  if (stamp > currentNum) {
+    await redis.set(key, stamp);
+  }
+}
+
+/**
  * Save a song to Redis (split storage: metadata + content)
  */
 export async function saveSong(
@@ -397,6 +415,9 @@ export async function saveSong(
   // Add to the set of all song IDs
   await redis.sadd(redisKeys.media.songIds(), song.id);
 
+  // Keep the O(1) version probe current for catalog pollers.
+  await bumpSongsVersion(redis, meta.updatedAt);
+
   // Return combined document
   return { ...meta, ...content };
 }
@@ -416,6 +437,9 @@ export async function deleteSong(redis: Redis, id: string): Promise<boolean> {
 
   // Remove from the set
   await redis.srem(redisKeys.media.songIds(), id);
+
+  // Deletion is a catalog change — advance the version stamp.
+  await bumpSongsVersion(redis, Date.now());
 
   return true;
 }
@@ -437,8 +461,8 @@ export async function deleteAllSongs(redis: Redis): Promise<number> {
   const contentKeys = songIds.map((id) => getSongContentKey(id));
   await redis.del(...metaKeys, ...contentKeys);
 
-  // Clear the set
-  await redis.del(redisKeys.media.songIds());
+  // Clear the set and version stamp
+  await redis.del(redisKeys.media.songIds(), redisKeys.media.songsVersion());
 
   return songIds.length;
 }
@@ -454,12 +478,46 @@ export interface SongsVersionInfo {
  * Lightweight version summary of the song catalog, so clients can poll for
  * changes (~50 byte response) instead of downloading the full metadata list
  * every interval.
+ *
+ * Unfiltered probes are O(1) via a denormalized version stamp + SCARD.
+ * `createdBy` filters still scan metadata (admin/owner views).
  */
 export async function getSongsVersionInfo(
   redis: Redis,
   options: { createdBy?: string } = {}
 ): Promise<SongsVersionInfo> {
   const { createdBy } = options;
+
+  // Fast path: global catalog probe (the common iPod poller case).
+  if (!createdBy) {
+    const versionRaw = await redis.get<number | string>(
+      redisKeys.media.songsVersion()
+    );
+    const version =
+      typeof versionRaw === "number"
+        ? versionRaw
+        : versionRaw
+          ? parseInt(String(versionRaw), 10) || 0
+          : 0;
+    const count = await redis.scard(redisKeys.media.songIds());
+    // Cold start / pre-migration: fall back to a one-time full scan and seed.
+    if (version === 0 && count > 0) {
+      const songIds = await getSongIds(redis);
+      const metaRows = await getSongMetaRows(redis, songIds);
+      let scannedVersion = 0;
+      for (const { meta } of metaRows) {
+        const stamp = meta.updatedAt || meta.createdAt || 0;
+        if (stamp > scannedVersion) scannedVersion = stamp;
+      }
+      if (scannedVersion > 0) {
+        await bumpSongsVersion(redis, scannedVersion);
+      }
+      return { version: scannedVersion, count: metaRows.length };
+    }
+    return { version, count };
+  }
+
+  // Filtered path: still needs metadata (owner-scoped admin views).
   const songIds = await getSongIds(redis);
   if (!songIds || songIds.length === 0) {
     return { version: 0, count: 0 };
@@ -470,7 +528,7 @@ export async function getSongsVersionInfo(
   let version = 0;
   let count = 0;
   for (const { meta } of metaRows) {
-    if (createdBy && meta.createdBy !== createdBy) continue;
+    if (meta.createdBy !== createdBy) continue;
     count++;
     const stamp = meta.updatedAt || meta.createdAt || 0;
     if (stamp > version) version = stamp;

--- a/api/_utils/api-handler.ts
+++ b/api/_utils/api-handler.ts
@@ -229,7 +229,8 @@ export function apiHandler<TBody = unknown>(
       if (user) {
         const timeZoneHeader = getHeader(req, "x-user-timezone");
         if (timeZoneHeader) {
-          await updateStoredUserTimeZone(redis, user.username, timeZoneHeader).catch(
+          // Best-effort side effect — don't block the response on a Redis write.
+          void updateStoredUserTimeZone(redis, user.username, timeZoneHeader).catch(
             (error) => {
               logger.warn("Failed to update user timezone from request header", {
                 username: user?.username,

--- a/api/_utils/auth/_tokens.ts
+++ b/api/_utils/auth/_tokens.ts
@@ -23,6 +23,14 @@ export async function getCanonicalSessionKey(token: string): Promise<string> {
 }
 
 /**
+ * Build the Redis session key from a precomputed token hash.
+ * Prefer this when the caller already hashed the token (avoids a second SHA-256).
+ */
+export function getCanonicalSessionKeyFromHash(tokenHash: string): string {
+  return redisKeys.auth.session(tokenHash);
+}
+
+/**
  * Build the Redis key for grace-period token storage
  */
 export function getLastTokenKey(username: string): string {

--- a/api/_utils/auth/_validate.ts
+++ b/api/_utils/auth/_validate.ts
@@ -12,7 +12,7 @@ import {
   TOKEN_GRACE_PERIOD,
 } from "./_constants.js";
 import {
-  getCanonicalSessionKey,
+  getCanonicalSessionKeyFromHash,
   getLastTokenKey,
 } from "./_tokens.js";
 import { redisKeys, sha256RedisIdentifier } from "../../../src/shared/redisKeys.js";
@@ -58,18 +58,24 @@ export async function validateAuth(
 
   // 1. Check canonical active token:
   // auth:session:{sha256(token)} + auth:user:{username}:sessions membership.
+  // Hash once and reuse — getCanonicalSessionKey used to re-hash the same token.
   const tokenHash = await sha256RedisIdentifier(token);
-  const canonicalSessionKey = await getCanonicalSessionKey(token);
-  const canonicalSessionExists = await redis.exists(canonicalSessionKey);
-  if (canonicalSessionExists) {
-    const sessionHashes = await redis.smembers<string[]>(
-      redisKeys.auth.userSessions(normalizedUsername)
-    );
-    if (sessionHashes.includes(tokenHash)) {
-      await redis.expire(canonicalSessionKey, USER_TTL_SECONDS);
-      await redis.expire(redisKeys.auth.userSessions(normalizedUsername), USER_TTL_SECONDS);
-      return { valid: true, expired: false };
-    }
+  const canonicalSessionKey = getCanonicalSessionKeyFromHash(tokenHash);
+  const sessionsKey = redisKeys.auth.userSessions(normalizedUsername);
+
+  // Parallel exists + smembers (auto-pipelined on Upstash into one HTTPS RT).
+  const [canonicalSessionExists, sessionHashes] = await Promise.all([
+    redis.exists(canonicalSessionKey),
+    redis.smembers<string[]>(sessionsKey),
+  ]);
+
+  if (canonicalSessionExists && sessionHashes.includes(tokenHash)) {
+    // Pipeline both TTL refreshes into one round trip.
+    const expirePipeline = redis.pipeline();
+    expirePipeline.expire(canonicalSessionKey, USER_TTL_SECONDS);
+    expirePipeline.expire(sessionsKey, USER_TTL_SECONDS);
+    await expirePipeline.exec();
+    return { valid: true, expired: false };
   }
 
   // 2. Check grace period for recently expired tokens (if allowed)
@@ -99,4 +105,3 @@ export async function validateAuth(
 
   return { valid: false };
 }
-

--- a/api/_utils/redis.ts
+++ b/api/_utils/redis.ts
@@ -39,6 +39,8 @@ export interface RedisPipelineLike {
   ttl(key: string): this;
   sadd(key: string, ...members: string[]): this;
   srem(key: string, ...members: string[]): this;
+  lpush(key: string, ...values: string[]): this;
+  ltrim(key: string, start: number, stop: number): this;
   zremrangebyscore(key: string, min: number | string, max: number | string): this;
   zadd(key: string, entry: RedisSortedSetEntry): this;
   zcard(key: string): this;
@@ -69,6 +71,7 @@ export interface RedisLike {
   ): Promise<[string | number, string[]]>;
   pipeline(): RedisPipelineLike;
   smembers<T = string[]>(key: string): Promise<T>;
+  scard(key: string): Promise<number>;
   sadd(key: string, ...members: string[]): Promise<number>;
   srem(key: string, ...members: string[]): Promise<number>;
   lpush(key: string, ...values: string[]): Promise<number>;
@@ -111,6 +114,7 @@ export interface RedisLike {
 
 const redisClientCache = globalThis as typeof globalThis & {
   __ryosStandardRedis?: IORedis;
+  __ryosUpstashRedis?: Redis;
 };
 
 const redisPubSubCache = globalThis as typeof globalThis & {
@@ -230,6 +234,18 @@ class StandardRedisPipelineAdapter implements RedisPipelineLike {
     if (members.length > 0) {
       this.pipelineClient.srem(key, ...members);
     }
+    return this;
+  }
+
+  lpush(key: string, ...values: string[]): this {
+    if (values.length > 0) {
+      this.pipelineClient.lpush(key, ...values);
+    }
+    return this;
+  }
+
+  ltrim(key: string, start: number, stop: number): this {
+    this.pipelineClient.ltrim(key, start, stop);
     return this;
   }
 
@@ -380,6 +396,10 @@ class StandardRedisAdapter implements RedisLike {
 
   async smembers<T = string[]>(key: string): Promise<T> {
     return (await this.client.smembers(key)) as T;
+  }
+
+  async scard(key: string): Promise<number> {
+    return await this.client.scard(key);
   }
 
   async sadd(key: string, ...members: string[]): Promise<number> {
@@ -554,14 +574,24 @@ function getStandardRedisClient(): IORedis {
 }
 
 function createUpstashRedis(): Redis {
-  const config = getUpstashConfig();
-  if (!config) {
-    throw new Error(
-      "Missing Redis configuration. Set REDIS_KV_REST_API_URL and REDIS_KV_REST_API_TOKEN environment variables."
-    );
+  if (!redisClientCache.__ryosUpstashRedis) {
+    const config = getUpstashConfig();
+    if (!config) {
+      throw new Error(
+        "Missing Redis configuration. Set REDIS_KV_REST_API_URL and REDIS_KV_REST_API_TOKEN environment variables."
+      );
+    }
+
+    // Cache one client per process (mirrors the ioredis path) and enable
+    // auto-pipelining so Promise.all of Redis commands collapses into fewer
+    // HTTPS round trips on Upstash REST.
+    redisClientCache.__ryosUpstashRedis = new Redis({
+      ...config,
+      enableAutoPipelining: true,
+    });
   }
 
-  return new Redis(config);
+  return redisClientCache.__ryosUpstashRedis;
 }
 
 /**

--- a/api/listen/_helpers/_redis.ts
+++ b/api/listen/_helpers/_redis.ts
@@ -46,12 +46,17 @@ export async function getSession(
 export async function setSession(
   sessionId: string,
   session: ListenSession,
-  client: Redis = createRedisClient()
+  client: Redis = createRedisClient(),
+  options: { registerInIndex?: boolean } = {}
 ): Promise<void> {
+  const { registerInIndex = true } = options;
   await client.set(redisKeys.session.listen(sessionId), JSON.stringify(session), {
     ex: LISTEN_SESSION_TTL_SECONDS,
   });
-  await client.sadd(redisKeys.session.listenIds(), sessionId);
+  // SADD is only needed on create/join — skip on high-frequency sync ticks.
+  if (registerInIndex) {
+    await client.sadd(redisKeys.session.listenIds(), sessionId);
+  }
 }
 
 export async function deleteSession(

--- a/api/listen/sessions/[id]/sync.ts
+++ b/api/listen/sessions/[id]/sync.ts
@@ -167,7 +167,7 @@ export default apiHandler(
         });
       }
 
-      await setSession(sessionId, session, redis);
+      await setSession(sessionId, session, redis, { registerInIndex: false });
 
       const listenerCount = session.users.length + (session.anonymousListeners?.length ?? 0);
 

--- a/api/presence/heartbeat.ts
+++ b/api/presence/heartbeat.ts
@@ -26,8 +26,8 @@ export default apiHandler(
         member: username,
       });
 
-      // Broadcast to the global presence channel
-      await triggerRealtimeEvent(GLOBAL_PRESENCE_CHANNEL, "user-heartbeat", {
+      // Broadcast is best-effort — don't block the heartbeat response.
+      void triggerRealtimeEvent(GLOBAL_PRESENCE_CHANNEL, "user-heartbeat", {
         username,
         timestamp: now,
       }).catch(() => {});

--- a/api/rooms/[id]/messages.ts
+++ b/api/rooms/[id]/messages.ts
@@ -21,6 +21,7 @@ import {
   CHAT_MIN_INTERVAL_SECONDS,
 } from "../_helpers/_constants.js";
 import { makeKey } from "../../_utils/_rate-limit-key.js";
+import { INCREMENT_WITH_TTL_SCRIPT } from "../../_utils/_rate-limit.js";
 import { ensureUserExists } from "../_helpers/_users.js";
 import { addMessage, generateId, getCurrentTimestamp, getLastMessage, getMessages, getRoom, setUser } from "../_helpers/_redis.js";
 import { setRoomPresence } from "../_helpers/_presence.js";
@@ -142,8 +143,20 @@ export default apiHandler(
         const longKey = makeKey(["rl", "chat:burst", "long", roomId, "user", username]);
         const lastKey = makeKey(["rl", "chat:burst", "last", roomId, "user", username]);
 
-        const shortCount = await redis.incr(shortKey);
-        if (shortCount === 1) await redis.expire(shortKey, CHAT_BURST_SHORT_WINDOW_SECONDS);
+        // Atomic incr+expire (one RT each) — avoids orphaned keys without TTL.
+        const [shortCount, longCount] = await Promise.all([
+          redis.eval<number>(
+            INCREMENT_WITH_TTL_SCRIPT,
+            [shortKey],
+            [CHAT_BURST_SHORT_WINDOW_SECONDS]
+          ),
+          redis.eval<number>(
+            INCREMENT_WITH_TTL_SCRIPT,
+            [longKey],
+            [CHAT_BURST_LONG_WINDOW_SECONDS]
+          ),
+        ]);
+
         if (shortCount > CHAT_BURST_SHORT_LIMIT) {
           logger.warn("Short burst rate limit exceeded", { username, roomId });
           logger.response(429, Date.now() - startTime);
@@ -151,8 +164,6 @@ export default apiHandler(
           return;
         }
 
-        const longCount = await redis.incr(longKey);
-        if (longCount === 1) await redis.expire(longKey, CHAT_BURST_LONG_WINDOW_SECONDS);
         if (longCount > CHAT_BURST_LONG_LIMIT) {
           logger.warn("Long burst rate limit exceeded", { username, roomId });
           logger.response(429, Date.now() - startTime);
@@ -228,11 +239,16 @@ export default apiHandler(
       // setUser's plain SET clears any legacy TTL: user records persist
       // forever (an old expire call here used to attach one on each send).
       const updatedUser = { ...userData, lastActive: getCurrentTimestamp() };
-      await setUser(username, updatedUser, redis);
-      await setRoomPresence(roomId, username, redis);
+      // Presence + lastActive are independent of the response body — run in parallel.
+      await Promise.all([
+        setUser(username, updatedUser, redis),
+        setRoomPresence(roomId, username, redis),
+      ]);
 
-      await broadcastNewMessage(roomId, message, roomData);
-      logger.info("Pusher room-message broadcast sent", { roomId, messageId: message.id });
+      // Broadcast is best-effort — don't block the 201 on Pusher latency.
+      void broadcastNewMessage(roomId, message, roomData).then(() => {
+        logger.info("Pusher room-message broadcast sent", { roomId, messageId: message.id });
+      });
 
       // If this is an IRC room, forward the message to the IRC bridge. Send
       // the unescaped content so the IRC side doesn't see HTML entities.

--- a/api/rooms/[id]/typing.ts
+++ b/api/rooms/[id]/typing.ts
@@ -48,7 +48,8 @@ export default apiHandler(
       const body = req.body || {};
       const isTyping = body.isTyping !== false;
 
-      await broadcastTypingIndicator(roomId, { username, isTyping }, roomData.type);
+      // Broadcast is best-effort — respond immediately after access checks.
+      void broadcastTypingIndicator(roomId, { username, isTyping }, roomData.type);
 
       logger.response(200, Date.now() - startTime);
       res.status(200).json({ success: true });

--- a/api/rooms/_helpers/_redis.ts
+++ b/api/rooms/_helpers/_redis.ts
@@ -246,8 +246,10 @@ export async function addMessage(
 ): Promise<void> {
   const serialized = JSON.stringify(message);
   const messagesKey = redisKeys.chat.roomMessages(roomId);
-  await client.lpush(messagesKey, serialized);
-  await client.ltrim(messagesKey, 0, 99);
+  const pipeline = client.pipeline();
+  pipeline.lpush(messagesKey, serialized);
+  pipeline.ltrim(messagesKey, 0, 99);
+  await pipeline.exec();
 }
 
 /**

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -189,6 +189,8 @@ export const redisKeys = {
     songIds: () => redisKey("media", "song", "ids"),
     songMeta: (songId: string) => songKey(songId, "meta"),
     songContent: (songId: string) => songKey(songId, "content"),
+    /** Catalog version stamp (max updatedAt) for O(1) poll probes. */
+    songsVersion: () => redisKey("media", "song", "version"),
   },
   cache: {
     appleArtwork: (catalogId: string) =>

--- a/tests/fake-redis.ts
+++ b/tests/fake-redis.ts
@@ -40,6 +40,16 @@ export class FakeRedisPipeline {
     return this;
   }
 
+  lpush(key: string, ...values: string[]): this {
+    this.operations.push(() => this.redis.lpushSync(key, ...values));
+    return this;
+  }
+
+  ltrim(key: string, start: number, stop: number): this {
+    this.operations.push(() => this.redis.ltrimSync(key, start, stop));
+    return this;
+  }
+
   sadd(key: string, ...members: string[]): this {
     this.operations.push(() => this.redis.saddSync(key, ...members));
     return this;
@@ -295,12 +305,44 @@ export class FakeRedis {
     return next;
   }
 
+  /**
+   * Minimal Lua eval supporting the INCREMENT_WITH_TTL_SCRIPT used by
+   * rate limiting (INCR + conditional EXPIRE).
+   */
+  async eval<T = unknown>(
+    script: string,
+    keys: string[],
+    args: Array<string | number>
+  ): Promise<T> {
+    const normalized = script.replace(/\s+/g, " ");
+    if (
+      normalized.includes('redis.call("INCR"') &&
+      normalized.includes('redis.call("EXPIRE"')
+    ) {
+      const key = keys[0];
+      if (!key) throw new Error("FakeRedis.eval: missing key");
+      const ttl = Number(args[0]);
+      const count = await this.incr(key);
+      if (count === 1 && Number.isFinite(ttl)) {
+        await this.expire(key, ttl);
+      }
+      return count as T;
+    }
+    throw new Error(
+      `FakeRedis.eval: unsupported script: ${script.slice(0, 80)}...`
+    );
+  }
+
   async mget<T = unknown>(...keys: string[]): Promise<(T | null)[]> {
     return keys.map((key) => (this.kv.get(key) as T | undefined) ?? null);
   }
 
   async smembers<T = string[]>(key: string): Promise<T> {
     return Array.from(this.sets.get(key) || []) as T;
+  }
+
+  async scard(key: string): Promise<number> {
+    return (this.sets.get(key) || new Set()).size;
   }
 
   async sadd(key: string, ...members: string[]): Promise<number> {
@@ -402,11 +444,15 @@ export class FakeRedis {
     return list.length;
   }
 
-  async lpush(key: string, ...values: string[]): Promise<number> {
+  lpushSync(key: string, ...values: string[]): number {
     const list = this.lists.get(key) || [];
     list.unshift(...values.reverse());
     this.lists.set(key, list);
     return list.length;
+  }
+
+  async lpush(key: string, ...values: string[]): Promise<number> {
+    return this.lpushSync(key, ...values);
   }
 
   async lrange<T = unknown>(key: string, start: number, stop: number): Promise<T[]> {
@@ -416,12 +462,16 @@ export class FakeRedis {
     return list.slice(normalizedStart, normalizedStop + 1) as T[];
   }
 
-  async ltrim(key: string, start: number, stop: number): Promise<string> {
+  ltrimSync(key: string, start: number, stop: number): string {
     const list = this.lists.get(key) || [];
     const normalizedStart = start < 0 ? Math.max(0, list.length + start) : start;
     const normalizedStop = stop < 0 ? list.length + stop : stop;
     this.lists.set(key, list.slice(normalizedStart, normalizedStop + 1));
     return "OK";
+  }
+
+  async ltrim(key: string, start: number, stop: number): Promise<string> {
+    return this.ltrimSync(key, start, stop);
   }
 
   async llen(key: string): Promise<number> {

--- a/tests/test-api-hotpath-perf.test.ts
+++ b/tests/test-api-hotpath-perf.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit/wiring coverage for the Redis hot-path optimizations:
+ * - Upstash client caching + auto-pipelining
+ * - validateAuth single-hash + pipelined TTL refresh
+ * - chat burst Lua incr+expire
+ * - checkCounterLimit TTL only on deny
+ * - O(1) songs version probe
+ * - addMessage lpush+ltrim pipeline
+ * - listen sync skips SADD
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Redis } from "../api/_utils/redis";
+import { validateAuth } from "../api/_utils/auth/_validate";
+import { storeToken } from "../api/_utils/auth/_tokens";
+import {
+  checkCounterLimit,
+  INCREMENT_WITH_TTL_SCRIPT,
+} from "../api/_utils/_rate-limit";
+import {
+  getSongsVersionInfo,
+  saveSong,
+} from "../api/_utils/_song-service";
+import { addMessage } from "../api/rooms/_helpers/_redis";
+import { setSession } from "../api/listen/_helpers/_redis";
+import { redisKeys } from "../src/shared/redisKeys";
+import { FakeRedis } from "./fake-redis";
+import type { ListenSession } from "../api/listen/_helpers/_types";
+import type { Message } from "../api/rooms/_helpers/_types";
+
+const readSource = (relPath: string): string =>
+  readFileSync(resolve(process.cwd(), relPath), "utf-8");
+
+describe("API hot-path wiring", () => {
+  test("Upstash client is process-cached with auto-pipelining", () => {
+    const source = readSource("api/_utils/redis.ts");
+    expect(source).toContain("__ryosUpstashRedis");
+    expect(source).toContain("enableAutoPipelining: true");
+  });
+
+  test("validateAuth hashes once and pipelines TTL refreshes", () => {
+    const source = readSource("api/_utils/auth/_validate.ts");
+    expect(source).toContain("getCanonicalSessionKeyFromHash");
+    expect(source).toContain("sha256RedisIdentifier(token)");
+    expect(source).not.toContain("getCanonicalSessionKey(token)");
+    expect(source).toContain("expirePipeline");
+    expect(source).toContain("Promise.all");
+  });
+
+  test("chat burst limiter uses INCREMENT_WITH_TTL_SCRIPT", () => {
+    const source = readSource("api/rooms/[id]/messages.ts");
+    expect(source).toContain("INCREMENT_WITH_TTL_SCRIPT");
+    expect(source).not.toMatch(/await redis\.incr\(shortKey\)/);
+    expect(source).not.toMatch(/await redis\.incr\(longKey\)/);
+    expect(source).toContain("void broadcastNewMessage");
+  });
+
+  test("checkCounterLimit skips TTL on allowed path", () => {
+    const source = readSource("api/_utils/_rate-limit.ts");
+    expect(source).toContain("INCREMENT_WITH_TTL_SCRIPT");
+    expect(source).toMatch(/if \(newCount > limit\)[\s\S]*client\.ttl\(key\)/);
+    expect(source).toContain("resetSeconds: windowSeconds");
+  });
+
+  test("apiHandler does not await timezone updates", () => {
+    const source = readSource("api/_utils/api-handler.ts");
+    expect(source).toContain("void updateStoredUserTimeZone");
+    expect(source).not.toMatch(/await updateStoredUserTimeZone/);
+  });
+
+  test("presence heartbeat and typing do not await broadcasts", () => {
+    const heartbeat = readSource("api/presence/heartbeat.ts");
+    expect(heartbeat).toContain("void triggerRealtimeEvent");
+    expect(heartbeat).not.toMatch(/await triggerRealtimeEvent/);
+
+    const typing = readSource("api/rooms/[id]/typing.ts");
+    expect(typing).toContain("void broadcastTypingIndicator");
+    expect(typing).not.toMatch(/await broadcastTypingIndicator/);
+  });
+
+  test("listen sync skips SADD on setSession", () => {
+    const sync = readSource("api/listen/sessions/[id]/sync.ts");
+    expect(sync).toContain("registerInIndex: false");
+    const helper = readSource("api/listen/_helpers/_redis.ts");
+    expect(helper).toContain("registerInIndex");
+  });
+});
+
+describe("API hot-path behavior", () => {
+  test("validateAuth accepts a stored token and refreshes TTLs", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const username = "hotpathuser";
+    const token = "a".repeat(64);
+
+    await storeToken(redis, username, token);
+    const result = await validateAuth(redis, username, token);
+    expect(result).toEqual({ valid: true, expired: false });
+
+    const tokenHash = await import("../src/shared/redisKeys").then((m) =>
+      m.sha256RedisIdentifier(token)
+    );
+    expect(fake.ttls.get(redisKeys.auth.session(tokenHash))).toBeGreaterThan(0);
+    expect(
+      fake.ttls.get(redisKeys.auth.userSessions(username))
+    ).toBeGreaterThan(0);
+  });
+
+  test("validateAuth rejects unknown tokens", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const result = await validateAuth(redis, "nobody", "b".repeat(64));
+    expect(result.valid).toBe(false);
+  });
+
+  test("checkCounterLimit allows under limit without TTL read", async () => {
+    class TtlCountingRedis extends FakeRedis {
+      ttlCalls = 0;
+      override async ttl(key: string): Promise<number> {
+        this.ttlCalls += 1;
+        return super.ttl(key);
+      }
+    }
+    const fake = new TtlCountingRedis();
+    const redis = fake as unknown as Redis;
+
+    const result = await checkCounterLimit({
+      key: "rl:test:allowed",
+      windowSeconds: 60,
+      limit: 5,
+      redis,
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.count).toBe(1);
+    expect(result.resetSeconds).toBe(60);
+    expect(fake.ttlCalls).toBe(0);
+  });
+
+  test("checkCounterLimit denies over limit and returns TTL", async () => {
+    class TtlCountingRedis extends FakeRedis {
+      ttlCalls = 0;
+      override async ttl(key: string): Promise<number> {
+        this.ttlCalls += 1;
+        return super.ttl(key);
+      }
+    }
+    const fake = new TtlCountingRedis();
+    const redis = fake as unknown as Redis;
+    const key = "rl:test:denied";
+
+    for (let i = 0; i < 3; i++) {
+      await checkCounterLimit({ key, windowSeconds: 30, limit: 2, redis });
+    }
+    const denied = await checkCounterLimit({
+      key,
+      windowSeconds: 30,
+      limit: 2,
+      redis,
+    });
+    expect(denied.allowed).toBe(false);
+    expect(denied.count).toBe(4);
+    expect(fake.ttlCalls).toBeGreaterThan(0);
+  });
+
+  test("INCREMENT_WITH_TTL_SCRIPT is exported for chat burst reuse", () => {
+    expect(INCREMENT_WITH_TTL_SCRIPT).toContain("INCR");
+    expect(INCREMENT_WITH_TTL_SCRIPT).toContain("EXPIRE");
+  });
+
+  test("addMessage pipelines lpush+ltrim", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const message: Message = {
+      id: "m1",
+      roomId: "public",
+      username: "alice",
+      content: "hello",
+      timestamp: Date.now(),
+    };
+    await addMessage("public", message, redis);
+    const list = await redis.lrange(redisKeys.chat.roomMessages("public"), 0, -1);
+    expect(list).toHaveLength(1);
+    expect(JSON.parse(list[0] as string).id).toBe("m1");
+  });
+
+  test("getSongsVersionInfo unfiltered path is O(1) after saveSong", async () => {
+    class CountingRedis extends FakeRedis {
+      getCalls = 0;
+      mgetCalls = 0;
+      override async get<T = unknown>(key: string): Promise<T | null> {
+        this.getCalls += 1;
+        return super.get<T>(key);
+      }
+      override async mget<T = unknown>(...keys: string[]): Promise<(T | null)[]> {
+        this.mgetCalls += 1;
+        return super.mget<T>(...keys);
+      }
+    }
+    const fake = new CountingRedis();
+    const redis = fake as unknown as Redis;
+
+    const savedA = await saveSong(redis, {
+      id: "am:1",
+      title: "A",
+      createdAt: 1_700_000_000_001,
+    });
+    const savedB = await saveSong(redis, {
+      id: "am:2",
+      title: "B",
+      createdAt: 1_700_000_000_002,
+    });
+
+    fake.getCalls = 0;
+    fake.mgetCalls = 0;
+    const info = await getSongsVersionInfo(redis);
+    expect(info.count).toBe(2);
+    // saveSong stamps updatedAt with Date.now(); version is the max stamp.
+    expect(info.version).toBe(Math.max(savedA.updatedAt, savedB.updatedAt));
+    expect(fake.mgetCalls).toBe(0);
+    // One GET for the version stamp (+ SCARD which is not a get/mget).
+    expect(fake.getCalls).toBe(1);
+  });
+
+  test("setSession can skip index SADD", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const session: ListenSession = {
+      id: "sess1",
+      host: "alice",
+      dj: "alice",
+      users: ["alice"],
+      createdAt: Date.now(),
+      lastSyncAt: Date.now(),
+      mediaType: "ipod",
+      mediaId: "track-1",
+      positionMs: 0,
+      isPlaying: false,
+    };
+
+    await setSession("sess1", session, redis, { registerInIndex: false });
+    expect(await redis.scard(redisKeys.session.listenIds())).toBe(0);
+
+    await setSession("sess1", session, redis, { registerInIndex: true });
+    expect(await redis.scard(redisKeys.session.listenIds())).toBe(1);
+  });
+});

--- a/tests/test-redis-runtime-cutover.test.ts
+++ b/tests/test-redis-runtime-cutover.test.ts
@@ -148,6 +148,17 @@ describe("runtime Redis canonical cutover", () => {
     expect(fake.getCalls).toBe(0);
     expect(fake.mgetCalls).toBe(2);
     expect(fake.maxMgetKeys).toBeLessThanOrEqual(100);
+
+    // Unfiltered probe is O(1) via denormalized version stamp + SCARD.
+    await redis.set(redisKeys.media.songsVersion(), 1_718_180_001_124);
+    fake.resetCounts();
+    const globalVersion = await getSongsVersionInfo(redis);
+    expect(globalVersion).toEqual({
+      count: 125,
+      version: 1_718_180_001_124,
+    });
+    expect(fake.getCalls).toBe(1);
+    expect(fake.mgetCalls).toBe(0);
   });
 
   test("sync2 reads/writes canonical state only and ignores legacy-only users", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Highest-impact backend Redis/API hot-path optimizations after the #1851 frontend render-perf pass.

### Changes
- **Upstash client**: process-cached on `globalThis` (like ioredis) + `enableAutoPipelining: true`
- **`validateAuth`**: hash token once; parallel `exists`+`smembers`; pipeline TTL refreshes
- **Rate limits**: export/reuse `INCREMENT_WITH_TTL_SCRIPT`; skip `TTL` fetch on allowed path
- **Chat send**: atomic burst incr+expire; parallel presence writes; fire-and-forget Pusher broadcast
- **`addMessage`**: pipeline `lpush`+`ltrim`
- **Songs version probe**: denormalized `media:song:version` stamp → O(1) unfiltered polls
- **Presence/typing/timezone/listen sync**: stop awaiting fire-and-forget work; skip redundant `SADD` on sync ticks

### Testing
- Unit: `tests/test-api-hotpath-perf.test.ts` + `tests/test-redis-runtime-cutover.test.ts` (20/20)
- API integration with `bun run dev:api`: auth/messages/songs/listen/presence suites green; full `bun run test:api` 343/348 then remaining 5 telegram tests green after restart with Telegram mock env (`TELEGRAM_BOT_API_BASE_URL`)
- `bun run typecheck` clean

Companion frontend PR: #1852

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f436d-4f53-724b-b25d-e2b87c6597ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f436d-4f53-724b-b25d-e2b87c6597ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

