### PR TITLE
Disable sheet dialogs for About and About Finder

### DIFF
--- a/src/components/dialogs/AboutDialog.tsx
+++ b/src/components/dialogs/AboutDialog.tsx
@@ -130,6 +130,9 @@ export function AboutDialog({
       <DialogContent
         className={cn("w-fit min-w-[280px] max-w-[400px]", isWindowsTheme && "p-0 overflow-hidden")}
         style={isWindowsTheme ? { fontSize: "11px" } : undefined}
+        // About is a reference panel, not an in-window action sheet — always
+        // present as a centered modal even on Aqua.
+        disableSheet
       >
         {isWindowsTheme ? (
           <>

--- a/src/components/dialogs/AboutFinderDialog.tsx
+++ b/src/components/dialogs/AboutFinderDialog.tsx
@@ -431,6 +431,9 @@ export function AboutFinderDialog({
       <DialogContent
         className={cn("max-w-[400px]", isWindowsTheme && "p-0 overflow-hidden")}
         style={isWindowsTheme ? { fontSize: "11px" } : undefined}
+        // About This Computer is a system reference panel, not an in-window
+        // action sheet — always present as a centered modal even on Aqua.
+        disableSheet
       >
         {isWindowsTheme ? (
           <>

--- a/tests/unit/theme/test-sheet-window-pin.test.ts
+++ b/tests/unit/theme/test-sheet-window-pin.test.ts
@@ -60,6 +60,25 @@ describe("aqua sheet dialog wiring", () => {
     expect(source).toMatch(/disableSheet/);
   });
 
+  test("AboutDialog opts out of sheet presentation", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../../../src/components/dialogs/AboutDialog.tsx"),
+      "utf8"
+    );
+    expect(source).toMatch(/disableSheet/);
+  });
+
+  test("AboutFinderDialog opts out of sheet presentation", () => {
+    const source = readFileSync(
+      join(
+        import.meta.dir,
+        "../../../src/components/dialogs/AboutFinderDialog.tsx"
+      ),
+      "utf8"
+    );
+    expect(source).toMatch(/disableSheet/);
+  });
+
   test("sheet path paints a window-local scrim under the titlebar", () => {
     const dialog = readFileSync(
       join(import.meta.dir, "../../../src/components/ui/dialog.tsx"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

About and About Finder (About This Computer) dialogs now always present as centered modals on Aqua, matching Help — they no longer slide out as macOS sheets from the parent window titlebar.

## Changes

- Set `disableSheet` on `AboutDialog` and `AboutFinderDialog` `DialogContent`
- Extended the aqua sheet wiring unit tests to assert both dialogs opt out

## Testing

- `bun test tests/unit/theme/test-sheet-window-pin.test.ts` (9 pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f43fa-1d7f-7cfa-9179-58bd1daf9240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f43fa-1d7f-7cfa-9179-58bd1daf9240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

