### PR TITLE
Fix AI rate limits appearing broken and failing open

### DIFF
--- a/api/_utils/_analytics.ts
+++ b/api/_utils/_analytics.ts
@@ -781,6 +781,10 @@ export async function getAnalyticsDetail(
     .slice(0, 20);
 
   // ── AI rate-limit lookups (small optional pipeline) ──
+  // Authenticated users share one counter per username. Anonymous chat
+  // budget is per-IP (`anon:<ip>`), so there is no single "anonymous"
+  // counter to display — omit it rather than hardcoding 0/3 (which made
+  // working limits look broken in the admin dashboard).
   const aiRateLimits: AIRateLimitInfo[] = [];
   const nonAnonUsers = aiByUser.filter((u) => u.username !== "anonymous");
   if (nonAnonUsers.length > 0) {
@@ -798,14 +802,6 @@ export async function getAnalyticsDetail(
         windowLabel: "5h",
       });
     }
-  }
-  if (aiuMap.has("anonymous")) {
-    aiRateLimits.push({
-      identifier: "anonymous",
-      currentCount: 0,
-      limit: 3,
-      windowLabel: "24h",
-    });
   }
 
   const product = await getProductAnalyticsDetail(redis, days);

--- a/api/_utils/_rate-limit.ts
+++ b/api/_utils/_rate-limit.ts
@@ -31,10 +31,14 @@ end
 return count
 `;
 
-// Helper function to get rate limit key for a user
+// Helper function to get rate limit key for a user.
+// Identifiers are lowercased so username casing cannot split the bucket
+// (auth already normalizes, but analytics/admin lookups and older callers
+// may pass mixed-case names).
 export const getAIRateLimitKey = (identifier: string): string => {
-  const scope = identifier.startsWith("anon:") ? "anon" : "user";
-  return makeCanonicalRateKey(["ai", scope, identifier]);
+  const normalized = identifier.trim().toLowerCase();
+  const scope = normalized.startsWith("anon:") ? "anon" : "user";
+  return makeCanonicalRateKey(["ai", scope, normalized]);
 };
 
 interface AIRateLimitResult {
@@ -49,23 +53,27 @@ export async function checkAndIncrementAIMessageCount(
   isAuthenticated: boolean,
   authToken: string | null = null
 ): Promise<AIRateLimitResult> {
-  const key = getAIRateLimitKey(identifier);
+  const normalizedIdentifier = identifier.trim().toLowerCase();
+  const key = getAIRateLimitKey(normalizedIdentifier);
 
   // Determine if user is anonymous (identifier starts with "anon:")
-  const isAnonymous = identifier.startsWith("anon:");
+  const isAnonymous = normalizedIdentifier.startsWith("anon:");
 
   // Set limit and window based on authentication status
   const limit = isAnonymous ? AI_LIMIT_ANON_PER_DAY : AI_LIMIT_PER_5_HOURS;
   const ttlSeconds = isAnonymous ? AI_WINDOW_ANONYMOUS : AI_WINDOW_AUTHENTICATED;
 
   // Identify privileged user (ryo)
-  const isRyo = identifier === "ryo";
+  const isRyo = normalizedIdentifier === "ryo";
 
   // --- Authentication validation section ---
   // If authenticated, validate the token
   if (isAuthenticated && authToken) {
-    const lower = identifier.toLowerCase();
-    const validation = await validateAuth(getRedis(), lower, authToken);
+    const validation = await validateAuth(
+      getRedis(),
+      normalizedIdentifier,
+      authToken
+    );
     if (!validation.valid) {
       // Invalid token for this user – treat as unauthenticated (use anon limit)
       return {

--- a/api/applet-ai.ts
+++ b/api/applet-ai.ts
@@ -448,7 +448,14 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
         });
       }
     } catch (error) {
+      // Fail closed: a Redis/limiter outage must not unlock unlimited
+      // text/image generation.
       logger.error("Rate limit check failed:", error);
+      logger.response(503, Date.now() - startTime);
+      return res.status(503).json({
+        error: "rate_limit_unavailable",
+        message: "Rate limiting is temporarily unavailable. Please try again shortly.",
+      });
     }
   }
 

--- a/api/audio-transcribe.ts
+++ b/api/audio-transcribe.ts
@@ -96,7 +96,15 @@ export default async function handler(
         return;
       }
     } catch (rlErr) {
+      // Fail closed: a Redis/limiter outage must not unlock unlimited
+      // transcription.
       logger.error("Rate limit check failed", rlErr);
+      logger.response(503, Date.now() - startTime);
+      res.status(503).json({
+        error: "rate_limit_unavailable",
+        message: "Rate limiting is temporarily unavailable. Please try again shortly.",
+      });
+      return;
     }
 
     // Parse form data

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -314,12 +314,15 @@ export default apiHandler<{
           `Rate limit exceeded: ${identifier} (${rateLimitResult.count}/${rateLimitResult.limit})`
         );
 
+        const windowLabel = isAuthenticated
+          ? "this 5-hour window"
+          : "the last 24 hours";
         const errorResponse = {
           error: "rate_limit_exceeded",
           isAuthenticated,
           count: rateLimitResult.count,
           limit: rateLimitResult.limit,
-          message: `You've hit your limit of ${rateLimitResult.limit} messages in this 5-hour window. Please wait a few hours and try again.`,
+          message: `You've hit your limit of ${rateLimitResult.limit} messages in ${windowLabel}. Please wait a while and try again.`,
         };
 
         res.status(429).json(errorResponse);

--- a/api/chat/tools/_tool-rate-limit.ts
+++ b/api/chat/tools/_tool-rate-limit.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Redis } from "../../_utils/redis.js";
-import { checkCounterLimit } from "../../_utils/_rate-limit.js";
+import { checkCounterLimit, makeKey } from "../../_utils/_rate-limit.js";
 
 export type RateLimitedToolName =
   | "webFetch"
@@ -55,7 +55,7 @@ export async function checkToolRateLimit(
   const { limit, windowSeconds } = TOOL_RATE_LIMITS[tool];
   try {
     const result = await checkCounterLimit({
-      key: `ratelimit:tool:${tool}:${username.toLowerCase()}`,
+      key: makeKey(["rl", "tool", tool, "user", username.toLowerCase()]),
       windowSeconds,
       limit,
       ...(redis ? { redis } : {}),
@@ -69,8 +69,12 @@ export async function checkToolRateLimit(
     }
     return { allowed: true };
   } catch (error) {
-    // Fail open: a Redis hiccup should not take down tool execution.
+    // Fail closed for tool quota: returning "allowed" here would let a
+    // Redis outage burn external API quota unbounded through tool loops.
     logError(`[${tool}] rate limit check failed`, error);
-    return { allowed: true };
+    return {
+      allowed: false,
+      message: `Rate limiting is temporarily unavailable for ${tool}. Please try again shortly.`,
+    };
   }
 }

--- a/api/ie-generate.ts
+++ b/api/ie-generate.ts
@@ -204,8 +204,14 @@ export default apiHandler<IEGenerateRequestBody>(
         });
       }
     } catch (e) {
-      // Fail open on limiter error to avoid blocking
+      // Fail closed: a Redis/limiter outage must not unlock unlimited
+      // IE generation.
       logger.error("IE generate rate-limit error", e);
+      logger.response(503, Date.now() - startTime);
+      return res.status(503).json({
+        error: "rate_limit_unavailable",
+        message: "Rate limiting is temporarily unavailable. Please try again shortly.",
+      });
     }
 
     // Extract query parameters

--- a/api/speech.ts
+++ b/api/speech.ts
@@ -119,7 +119,14 @@ export default apiHandler<SpeechRequest>(
         logger.info("Rate limit bypassed for authenticated ryo user");
       }
     } catch (e) {
+      // Fail closed: a Redis/limiter outage must not unlock unlimited TTS.
       logger.error("Rate limit check failed (tts)", e);
+      logger.response(503, Date.now() - startTime);
+      res.status(503).json({
+        error: "rate_limit_unavailable",
+        message: "Rate limiting is temporarily unavailable. Please try again shortly.",
+      });
+      return;
     }
 
     try {

--- a/tests/unit/admin/test-analytics-keys.test.ts
+++ b/tests/unit/admin/test-analytics-keys.test.ts
@@ -141,4 +141,30 @@ describe("analytics Redis keys", () => {
     const alice = detail.aiRateLimits.find((r) => r.identifier === "alice");
     expect(alice).toMatchObject({ currentCount: 9, limit: 15, windowLabel: "5h" });
   });
+
+  test("does not invent a fake anonymous 0/3 rate-limit badge", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const today = new Date().toISOString().slice(0, 10);
+
+    // Anonymous AI usage is tracked in analytics, but the chat budget is
+    // per-IP — there is no single anonymous counter to display.
+    await redis.hset(`analytics:api:aiu:${today}`, {
+      anonymous: "12",
+      alice: "2",
+    });
+    await redis.set(getAIRateLimitKey("alice"), "2");
+
+    const detail = await getAnalyticsDetail(redis, 1);
+    expect(detail.aiByUser).toEqual([
+      { username: "anonymous", count: 12 },
+      { username: "alice", count: 2 },
+    ]);
+    expect(
+      detail.aiRateLimits.find((r) => r.identifier === "anonymous")
+    ).toBeUndefined();
+    expect(detail.aiRateLimits.find((r) => r.identifier === "alice")).toMatchObject(
+      { currentCount: 2, limit: 15 }
+    );
+  });
 });

--- a/tests/unit/ai/test-shared-ai-chat-wiring.test.ts
+++ b/tests/unit/ai/test-shared-ai-chat-wiring.test.ts
@@ -133,6 +133,9 @@ describe("server AI chat lifecycle wiring", () => {
     expect(source).toMatch(
       /if \(shouldRateLimit\) \{\s*const rateLimitResult = await checkAndIncrementAIMessageCount/
     );
+    expect(source).toContain('isAuthenticated');
+    expect(source).toContain('"this 5-hour window"');
+    expect(source).toContain('"the last 24 hours"');
   });
 
   test("forwards disconnects to the model while keeping the persistence consumer", () => {

--- a/tests/unit/api/test-rate-limit-keys.test.ts
+++ b/tests/unit/api/test-rate-limit-keys.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { Redis } from "../../../api/_utils/redis";
-import { makeKey } from "../../../api/_utils/_rate-limit";
+import {
+  getAIRateLimitKey,
+  makeKey,
+} from "../../../api/_utils/_rate-limit";
 import { deleteLegacyRedisKeys } from "../../../scripts/lib/redis-key-migration";
 import { FakeRedis } from "../../helpers/fake-redis";
 
@@ -11,6 +14,20 @@ describe("rate-limit Redis keys", () => {
     expect(key).toMatch(/^rate:parse-title:burst:ip:[a-f0-9]{64}$/);
     expect(key.startsWith("rl:")).toBe(false);
     expect(key).not.toContain("203.0.113.9");
+  });
+
+  test("AI chat rate-limit keys ignore username casing", () => {
+    expect(getAIRateLimitKey("Alice")).toBe(getAIRateLimitKey("alice"));
+    expect(getAIRateLimitKey("ALICE")).toBe(getAIRateLimitKey("alice"));
+    expect(getAIRateLimitKey("anon:203.0.113.9")).toBe(
+      getAIRateLimitKey("ANON:203.0.113.9")
+    );
+  });
+
+  test("tool rate-limit keys land under the canonical rate: namespace", () => {
+    const key = makeKey(["rl", "tool", "webFetch", "user", "alice"]);
+    expect(key).toMatch(/^rate:tool:webfetch:user:[a-f0-9]{64}$/);
+    expect(key.startsWith("ratelimit:")).toBe(false);
   });
 
   test("legacy rl cleanup does not delete newly generated runtime counters", async () => {

--- a/tests/unit/chat/test-chat-tools-improvements.test.ts
+++ b/tests/unit/chat/test-chat-tools-improvements.test.ts
@@ -284,8 +284,9 @@ describe("checkToolRateLimit", () => {
     expect(blocked.message).toContain("Rate limit reached for searchSongs");
   });
 
-  test("fails open when the redis client errors", async () => {
+  test("fails closed when the redis client errors", async () => {
     const throwingRedis = {
+      eval: () => Promise.reject(new Error("redis down")),
       incr: () => Promise.reject(new Error("redis down")),
     } as unknown as Redis;
     const logError = mock(() => {});
@@ -294,7 +295,8 @@ describe("checkToolRateLimit", () => {
       redis: throwingRedis,
       logError,
     });
-    expect(result.allowed).toBe(true);
+    expect(result.allowed).toBe(false);
+    expect(result.message).toContain("temporarily unavailable");
     expect(logError).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated reports that AI rate limits “don’t seem to be applying.” `/api/chat` itself was enforcing correctly (anon 3/day, auth 15/5h). The misleading signals and real bypasses were elsewhere.

### Findings
- **Admin dashboard** always showed anonymous AI usage as `0/3`, even when per-IP limits were working (anon budget is per-IP, so there is no single anonymous counter).
- **Fail-open** on Redis/limiter errors in `/api/applet-ai`, `/api/ie-generate`, `/api/speech`, `/api/audio-transcribe`, and per-tool chat quotas — a Redis hiccup unlocked unlimited generation.
- Anonymous chat 429 copy always said “5-hour window” even though anon is 24h.
- AI rate-limit key hashing was case-sensitive (auth already lowercases, but admin/analytics lookups could diverge).

### Fixes
- Omit the fake anonymous `0/3` badge from admin AI rate-limit lookups.
- Fail closed with `503 rate_limit_unavailable` when AI route limiters error.
- Fail closed for per-tool rate limits; move tool keys onto the canonical `rate:` namespace.
- Normalize AI rate-limit identifiers to lowercase.
- Correct anonymous vs authenticated 429 window copy.

### Verification
- Live `/api/chat` anon: 3×200 then 429 with updated 24h message.
- Live `/api/chat` auth: 15×200 then 429.
- Unit tests for analytics badge, key casing, tool fail-closed, and chat wiring.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f43fb-ff89-72a5-903f-4fb50390a49e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f43fb-ff89-72a5-903f-4fb50390a49e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

