### PR TITLE
fix(chats): respect user timezone in message timestamps

### DIFF
--- a/src/apps/chats/components/chat-messages/chat-message-item/ChatMessageItemMeta.tsx
+++ b/src/apps/chats/components/chat-messages/chat-message-item/ChatMessageItemMeta.tsx
@@ -14,10 +14,13 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useEffectiveTimezone } from "@/hooks/useEffectiveTimezone";
+import { formatChatMessageTimestamp } from "../../../utils/formatMessageTimestamp";
 import { MOTION_BTN_INITIAL } from "../constants";
 import type { ChatMessageItemViewModel } from "./useChatMessageItem";
 
 export function ChatMessageItemMeta({ vm }: { vm: ChatMessageItemViewModel }) {
+  const timeZone = useEffectiveTimezone();
   const {
     t,
     message,
@@ -106,23 +109,10 @@ export function ChatMessageItemMeta({ vm }: { vm: ChatMessageItemViewModel }) {
       </span>{" "}
       <span className="text-neutral-400 select-text">
         {message.metadata?.createdAt ? (
-          (() => {
-            const messageDate = new Date(message.metadata.createdAt);
-            const today = new Date();
-            const isBeforeToday =
-              messageDate.getDate() !== today.getDate() ||
-              messageDate.getMonth() !== today.getMonth() ||
-              messageDate.getFullYear() !== today.getFullYear();
-            return isBeforeToday
-              ? messageDate.toLocaleDateString([], {
-                  month: "short",
-                  day: "numeric",
-                })
-              : messageDate.toLocaleTimeString([], {
-                  hour: "numeric",
-                  minute: "2-digit",
-                });
-          })()
+          formatChatMessageTimestamp(
+            new Date(message.metadata.createdAt),
+            timeZone
+          )
         ) : (
           <ActivityIndicator size="xs" />
         )}

--- a/src/apps/chats/utils/formatMessageTimestamp.ts
+++ b/src/apps/chats/utils/formatMessageTimestamp.ts
@@ -1,0 +1,41 @@
+import {
+  formatInTimeZone,
+  formatZonedDateString,
+} from "@/lib/timezoneConfig";
+
+/** Whether `date` falls on a calendar day before `now` in `timeZone`. */
+export function isZonedDayBeforeToday(
+  date: Date,
+  timeZone: string,
+  now: Date = new Date()
+): boolean {
+  return (
+    formatZonedDateString(date, timeZone) !==
+    formatZonedDateString(now, timeZone)
+  );
+}
+
+/**
+ * Compact chat message timestamp: time-of-day for messages from today in the
+ * user's timezone, otherwise a short month/day label. Matches the previous
+ * `toLocaleTimeString` / `toLocaleDateString` display style while honoring
+ * {@link timeZone}.
+ */
+export function formatChatMessageTimestamp(
+  date: Date,
+  timeZone: string,
+  locale?: string,
+  now: Date = new Date()
+): string {
+  if (isZonedDayBeforeToday(date, timeZone, now)) {
+    return formatInTimeZone(date, timeZone, locale, {
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  return formatInTimeZone(date, timeZone, locale, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/tests/unit/chat/test-chat-message-timestamp.test.ts
+++ b/tests/unit/chat/test-chat-message-timestamp.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatChatMessageTimestamp,
+  isZonedDayBeforeToday,
+} from "../../../src/apps/chats/utils/formatMessageTimestamp";
+
+describe("formatChatMessageTimestamp", () => {
+  test("isZonedDayBeforeToday compares calendar days in the target zone", () => {
+    const now = new Date("2023-01-15T14:00:00Z");
+    const earlierSameDay = new Date("2023-01-15T01:00:00Z");
+    const previousDay = new Date("2023-01-14T12:00:00Z");
+
+    expect(
+      isZonedDayBeforeToday(earlierSameDay, "Asia/Taipei", now)
+    ).toBe(false);
+    expect(isZonedDayBeforeToday(previousDay, "Asia/Taipei", now)).toBe(true);
+  });
+
+  test("formats same-day messages as time in the selected timezone", () => {
+    const now = new Date("2023-01-15T14:00:00Z");
+    const message = new Date("2023-01-15T12:00:00Z");
+
+    const taipei = formatChatMessageTimestamp(
+      message,
+      "Asia/Taipei",
+      "en-US",
+      now
+    );
+    const newYork = formatChatMessageTimestamp(
+      message,
+      "America/New_York",
+      "en-US",
+      now
+    );
+
+    expect(taipei).toMatch(/8:00|08:00|20:00|8/);
+    expect(newYork).toMatch(/7:00|07:00|7/);
+    expect(taipei).not.toBe(newYork);
+  });
+
+  test("formats older messages as short month/day in the selected timezone", () => {
+    const now = new Date("2023-01-15T14:00:00Z");
+    const message = new Date("2023-01-10T12:00:00Z");
+
+    const formatted = formatChatMessageTimestamp(
+      message,
+      "Asia/Taipei",
+      "en-US",
+      now
+    );
+
+    expect(formatted).toMatch(/Jan/);
+    expect(formatted).toMatch(/10|11/);
+    expect(formatted).not.toMatch(/AM|PM|:/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Chat message timestamps in the Chats app ignored the International timezone preference and always formatted using the browser/local timezone.

This change routes all rendered chat message timestamps through a shared `formatChatMessageTimestamp` helper that uses the existing `formatInTimeZone` / `formatZonedDateString` utilities and the reactive `useEffectiveTimezone` hook.

## Changes

- Add `src/apps/chats/utils/formatMessageTimestamp.ts` for centralized chat timestamp formatting
- Update `ChatMessageItemMeta` to subscribe to timezone changes and format stored/new messages in the selected zone
- Add unit tests for same-day vs prior-day formatting across timezones

## Acceptance criteria

- [x] Changing timezone in settings immediately affects chat timestamps after re-render (`useEffectiveTimezone` subscription)
- [x] Stored message timestamps use the selected timezone, not machine timezone
- [x] New outgoing/incoming messages use the same formatter (all messages flow through `ChatMessageItemMeta`)
- [x] Calendar/weather/system clock paths unchanged (they already use `useEffectiveTimezone` + `formatInTimeZone`)

## Testing

```bash
bun test tests/unit/chat/test-chat-message-timestamp.test.ts
bun test tests/unit/i18n/test-timezone-config.test.ts
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f45bd90b-e566-4f44-9aa1-ff1d53d8c9cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f45bd90b-e566-4f44-9aa1-ff1d53d8c9cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

