### PR TITLE
Fix OG share metadata for all apps, applets, and listen sessions

### DIFF
--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -2,13 +2,15 @@ import { getAppPublicOrigin } from "./runtime-config.js";
 import { parseYouTubeTitleSimple } from "./parse-youtube-title.js";
 import { redisKeys } from "../../src/shared/redisKeys.js";
 
-// App display names for OG titles
+// Keep in sync with `appIds` / `appNames` in src/config/appRegistryData.ts.
+// Descriptions are share-card copy (may be richer than in-app About text).
 const APP_NAMES: Record<string, string> = {
   finder: "Finder",
   soundboard: "Soundboard",
   "internet-explorer": "Internet Explorer",
   chats: "Chats",
   textedit: "TextEdit",
+  preview: "Preview",
   paint: "Paint",
   "photo-booth": "Photo Booth",
   minesweeper: "Minesweeper",
@@ -21,6 +23,7 @@ const APP_NAMES: Record<string, string> = {
   terminal: "Terminal",
   "applet-viewer": "Applet Store",
   "control-panels": "Control Panels",
+  admin: "Admin",
   stickies: "Stickies",
   "infinite-mac": "Infinite Mac",
   winamp: "Winamp",
@@ -29,15 +32,16 @@ const APP_NAMES: Record<string, string> = {
   dashboard: "Dashboard",
   maps: "Maps",
   books: "Books",
+  calculator: "Calculator",
 };
 
-// App descriptions
 const APP_DESCRIPTIONS: Record<string, string> = {
   finder: "Browse and manage files",
-  soundboard: "Record and trigger custom sounds",
+  soundboard: "Play and record custom sound effects",
   "internet-explorer": "Browse the web through time",
   chats: "Talk to Ryo and neighbors online",
   textedit: "Write and edit documents",
+  preview: "View images, PDFs, and documents",
   paint: "Draw and edit art, like it's 1984",
   "photo-booth": "Take photos with shader effects",
   minesweeper: "Play this classic puzzle game",
@@ -50,6 +54,7 @@ const APP_DESCRIPTIONS: Record<string, string> = {
   terminal: "Command line interface with Ryo AI",
   "applet-viewer": "Explore and install community applets",
   "control-panels": "Set themes, sounds, and system preferences",
+  admin: "System administration panel",
   stickies: "Colorful sticky notes for reminders and quick notes",
   "infinite-mac": "Run classic Mac OS and NeXT in your browser",
   winamp: "Classic Winamp media player in your browser",
@@ -58,15 +63,16 @@ const APP_DESCRIPTIONS: Record<string, string> = {
   dashboard: "Widgets dashboard with clock, calendar, and weather",
   maps: "Find places with Apple Maps",
   books: "Read EPUB books",
+  calculator: "Basic, scientific, and unit conversion calculator",
 };
 
-// App ID to macOS icon mapping
 const APP_ICONS: Record<string, string> = {
   finder: "mac.png",
   soundboard: "sound.png",
   "internet-explorer": "ie.png",
   chats: "chats.png",
   textedit: "textedit.png",
+  preview: "preview.png",
   paint: "paint.png",
   "photo-booth": "photo-booth.png",
   minesweeper: "minesweeper.png",
@@ -79,6 +85,7 @@ const APP_ICONS: Record<string, string> = {
   terminal: "terminal.png",
   "applet-viewer": "app.png",
   "control-panels": "control-panels/appearance-manager/app.png",
+  admin: "admin.png",
   stickies: "stickies.png",
   "infinite-mac": "infinite-mac.png",
   winamp: "winamp.png",
@@ -87,12 +94,26 @@ const APP_ICONS: Record<string, string> = {
   dashboard: "dashboard.png",
   maps: "maps.png",
   books: "books.png",
+  calculator: "calculator.png",
 };
 
 export type SongShareMetadata = {
   title: string;
   artist: string | null;
   cover: string | null;
+};
+
+export type AppletShareMetadata = {
+  title: string;
+  description: string | null;
+  imageUrl: string | null;
+};
+
+export type ListenShareMetadata = {
+  title: string;
+  description: string;
+  imageUrl: string | null;
+  hostUsername: string | null;
 };
 
 function generateOgHtml(options: {
@@ -128,7 +149,7 @@ function generateOgHtml(options: {
   <meta name="twitter:title" content="${escapeHtml(title)}">
   <meta name="twitter:description" content="${escapeHtml(description)}">
   <meta name="twitter:image" content="${escapeHtml(imageUrl)}">
-  <script>location.replace("${escapeHtml(redirectUrl)}")</script>
+  <script>location.replace(${JSON.stringify(redirectUrl)})</script>
 </head>
 </html>`;
 }
@@ -265,18 +286,17 @@ export function getSongShareMetadataFromRaw(
   };
 }
 
-async function createSongRedisClient(): Promise<{
+async function createOgRedisClient(): Promise<{
   get<T = unknown>(key: string): Promise<T | null>;
 } | null> {
   // Delegate to the canonical Redis factory so the OG read path resolves the
-  // exact same backend (Upstash REST vs standard REDIS_URL) that the song API
-  // writes to. Picking a backend independently here used to silently diverge
-  // — e.g. when REDIS_URL (and/or REDIS_PROVIDER=redis-url) is set but stale
-  // Upstash vars also linger — causing reads to hit an empty store and
-  // previews to always fall back. The dynamic import keeps the standard-Redis
-  // (ioredis) dependency out of bundles that only use Upstash REST.
-  // `createRedis` throws when nothing is configured, which the caller treats
-  // as "no metadata".
+  // exact same backend (Upstash REST vs standard REDIS_URL) that writers use.
+  // Picking a backend independently here used to silently diverge — e.g. when
+  // REDIS_URL (and/or REDIS_PROVIDER=redis-url) is set but stale Upstash vars
+  // also linger — causing reads to hit an empty store and previews to always
+  // fall back. The dynamic import keeps the standard-Redis (ioredis) dependency
+  // out of bundles that only use Upstash REST. `createRedis` throws when
+  // nothing is configured, which the caller treats as "no metadata".
   const { createRedis } = await import("./redis.js");
   return createRedis();
 }
@@ -286,13 +306,156 @@ async function getSongFromRedis(
   songId: string
 ): Promise<SongShareMetadata | null> {
   try {
-    const redis = await createSongRedisClient();
+    const redis = await createOgRedisClient();
     if (!redis) return null;
 
     // Fetch song metadata (split storage format) from the canonical
     // `media:song:…:meta` key.
     const raw = await redis.get(redisKeys.media.songMeta(songId));
     return getSongShareMetadataFromRaw(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve an applet icon into an absolute image URL for og:image.
+ * Applets often store emoji glyphs (not usable as OG images) — those return null.
+ */
+export function resolveAppletShareImageUrl(
+  icon: string | null | undefined,
+  publicOrigin: string
+): string | null {
+  const value = asNonEmptyString(icon);
+  if (!value) return null;
+
+  if (/^https?:\/\//i.test(value) || value.startsWith("data:image/")) {
+    return value.replace(/^http:\/\//i, "https://");
+  }
+
+  if (value.startsWith("/")) {
+    return `${publicOrigin}${value}`;
+  }
+
+  // Emoji / short glyph icons cannot be used as og:image.
+  return null;
+}
+
+export function getAppletShareMetadataFromRaw(
+  raw: unknown,
+  publicOrigin: string
+): AppletShareMetadata | null {
+  if (!raw) return null;
+
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  const meta = getRecord(parsed);
+  if (!meta) return null;
+
+  const title =
+    asNonEmptyString(meta.title) ||
+    asNonEmptyString(meta.name) ||
+    null;
+  if (!title) return null;
+
+  const createdBy = asNonEmptyString(meta.createdBy);
+  const description = createdBy
+    ? `Shared by ${createdBy} on ryOS`
+    : "Open applet in ryOS";
+
+  return {
+    title: `${title} on ryOS`,
+    description,
+    imageUrl: resolveAppletShareImageUrl(
+      asNonEmptyString(meta.icon),
+      publicOrigin
+    ),
+  };
+}
+
+async function getAppletFromRedis(
+  appletId: string,
+  publicOrigin: string
+): Promise<AppletShareMetadata | null> {
+  try {
+    const redis = await createOgRedisClient();
+    if (!redis) return null;
+    const raw = await redis.get(redisKeys.media.appletShare(appletId));
+    return getAppletShareMetadataFromRaw(raw, publicOrigin);
+  } catch {
+    return null;
+  }
+}
+
+export function getListenShareMetadataFromRaw(
+  raw: unknown,
+  options: { appHint?: string | null; publicOrigin: string }
+): ListenShareMetadata | null {
+  if (!raw) return null;
+
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  const session = getRecord(parsed);
+  if (!session) return null;
+
+  const hostUsername = asNonEmptyString(session.hostUsername);
+  const trackMeta = getRecord(session.currentTrackMeta);
+  const trackTitle = asNonEmptyString(trackMeta?.title);
+  const trackArtist = asNonEmptyString(trackMeta?.artist);
+  const trackCover = formatMusicCoverUrl(
+    asNonEmptyString(trackMeta?.cover),
+    400
+  );
+
+  const isIpod = options.appHint === "ipod";
+  const appLabel = isIpod ? "iPod" : "Karaoke";
+
+  let title: string;
+  if (trackTitle && trackArtist) {
+    title = `${trackTitle} - ${trackArtist}`;
+  } else if (trackTitle) {
+    title = trackTitle;
+  } else if (hostUsername) {
+    title = `${hostUsername}'s Live Session on ryOS`;
+  } else {
+    return null;
+  }
+
+  const description = hostUsername
+    ? `Join ${hostUsername}'s live session on ryOS ${appLabel}`
+    : `Listen together in real-time on ryOS ${appLabel}`;
+
+  return {
+    title,
+    description,
+    imageUrl: trackCover,
+    hostUsername,
+  };
+}
+
+async function getListenSessionFromRedis(
+  sessionId: string,
+  options: { appHint?: string | null; publicOrigin: string }
+): Promise<ListenShareMetadata | null> {
+  try {
+    const redis = await createOgRedisClient();
+    if (!redis) return null;
+    const raw = await redis.get(redisKeys.session.listen(sessionId));
+    return getListenShareMetadataFromRaw(raw, options);
   } catch {
     return null;
   }
@@ -384,6 +547,14 @@ export async function createOgShareResponse(
   request: Request,
   options: {
     getSong?: (songId: string) => Promise<SongShareMetadata | null>;
+    getApplet?: (
+      appletId: string,
+      publicOrigin: string
+    ) => Promise<AppletShareMetadata | null>;
+    getListenSession?: (
+      sessionId: string,
+      opts: { appHint?: string | null; publicOrigin: string }
+    ) => Promise<ListenShareMetadata | null>;
   } = {}
 ): Promise<Response | null> {
   if (request.method !== "GET" && request.method !== "HEAD") {
@@ -496,17 +667,51 @@ export async function createOgShareResponse(
 
   const listenMatch = pathname.match(/^\/listen\/([a-zA-Z0-9_-]+)$/);
   if (listenMatch) {
-    imageUrl = `${publicOrigin}/icons/macosx/karaoke.png`;
+    const sessionId = listenMatch[1];
+    const appHint = url.searchParams.get("app")?.toLowerCase() || null;
+    const isIpod = appHint === "ipod";
+    const fallbackAppId = isIpod ? "ipod" : "karaoke";
+    const appLabel = isIpod ? "iPod" : "Karaoke";
+
+    imageUrl = getAppIconUrl(publicOrigin, fallbackAppId);
     title = "Join Live Session on ryOS";
-    description = "Listen together in real-time on ryOS Karaoke";
+    description = `Listen together in real-time on ryOS ${appLabel}`;
+    // Live sessions change frequently — keep CDN cache short.
+    cacheMaxAge = FALLBACK_CACHE_SECONDS;
+
+    const getListen = options.getListenSession || getListenSessionFromRedis;
+    const sessionMeta = await getListen(sessionId, {
+      appHint,
+      publicOrigin,
+    });
+    if (sessionMeta) {
+      title = sessionMeta.title;
+      description = sessionMeta.description;
+      if (sessionMeta.imageUrl) {
+        imageUrl = sessionMeta.imageUrl;
+      }
+    }
     matched = true;
   }
 
   const appletMatch = pathname.match(/^\/applet-viewer\/([a-zA-Z0-9_-]+)$/);
   if (appletMatch) {
+    const appletId = appletMatch[1];
     imageUrl = `${publicOrigin}/icons/macosx/applet.png`;
     title = "Shared Applet on ryOS";
     description = "Open applet in ryOS";
+
+    const getApplet = options.getApplet || getAppletFromRedis;
+    const appletMeta = await getApplet(appletId, publicOrigin);
+    if (appletMeta) {
+      title = appletMeta.title;
+      description = appletMeta.description || description;
+      if (appletMeta.imageUrl) {
+        imageUrl = appletMeta.imageUrl;
+      }
+    } else {
+      cacheMaxAge = FALLBACK_CACHE_SECONDS;
+    }
     matched = true;
   }
 
@@ -558,8 +763,20 @@ export async function createOgShareResponse(
     return null;
   }
 
-  const pageUrl = `${publicOrigin}${pathname}`;
-  const redirectUrl = `${pageUrl}?_ryo=1`;
+  const pageUrl = `${publicOrigin}${pathname}${
+    // Preserve share-significant query params (e.g. /listen/…?app=ipod) in
+    // the canonical OG URL so crawlers and copy-paste keep the app hint.
+    url.searchParams.get("app")
+      ? `?app=${encodeURIComponent(url.searchParams.get("app")!)}`
+      : ""
+  }`;
+  const redirectParams = new URLSearchParams();
+  for (const [key, value] of url.searchParams.entries()) {
+    if (key === "_ryo") continue;
+    redirectParams.set(key, value);
+  }
+  redirectParams.set("_ryo", "1");
+  const redirectUrl = `${publicOrigin}${pathname}?${redirectParams.toString()}`;
   const html = generateOgHtml({
     title,
     description,

--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -490,8 +490,9 @@ async function getYouTubeInfo(
 
     if (!response.ok) return null;
 
-    const data = await response.json();
-    const rawTitle = data.title || "";
+    const data = (await response.json()) as { title?: unknown };
+    const rawTitle =
+      typeof data.title === "string" ? data.title : "";
     const parsed = parseYouTubeTitleSimple(rawTitle);
 
     return { title: parsed.title, artist: parsed.artist || null };

--- a/api/_utils/redis.ts
+++ b/api/_utils/redis.ts
@@ -379,15 +379,23 @@ class StandardRedisAdapter implements RedisLike {
     cursor: number | string,
     options?: RedisScanOptions
   ): Promise<[string | number, string[]]> {
-    const args: Array<string | number> = [String(cursor)];
+    const cursorKey = String(cursor);
+    if (options?.match && typeof options.count === "number") {
+      return await this.client.scan(
+        cursorKey,
+        "MATCH",
+        options.match,
+        "COUNT",
+        options.count
+      );
+    }
     if (options?.match) {
-      args.push("MATCH", options.match);
+      return await this.client.scan(cursorKey, "MATCH", options.match);
     }
     if (typeof options?.count === "number") {
-      args.push("COUNT", options.count);
+      return await this.client.scan(cursorKey, "COUNT", options.count);
     }
-    const [nextCursor, keys] = await this.client.scan(...args);
-    return [nextCursor, keys];
+    return await this.client.scan(cursorKey);
   }
 
   pipeline(): RedisPipelineLike {

--- a/tests/unit/admin/test-og-share.test.ts
+++ b/tests/unit/admin/test-og-share.test.ts
@@ -9,11 +9,14 @@ import {
 } from "bun:test";
 import {
   createOgShareResponse,
+  getAppletShareMetadataFromRaw,
+  getListenShareMetadataFromRaw,
   getSongShareMetadataFromRaw,
   resolveSongShareId,
 } from "../../../api/_utils/og-share";
 import { UpdateSongSchema } from "../../../api/songs/_constants";
 import { redisKeys } from "../../../src/shared/redisKeys";
+import { appIds, appNames } from "../../../src/config/appRegistryData";
 import { FakeRedis } from "../../helpers/fake-redis";
 import * as actualRedis from "../../../api/_utils/redis";
 
@@ -100,6 +103,24 @@ describe("og share response", () => {
         description: "Read EPUB books",
         icon: "books.png",
       },
+      {
+        id: "preview",
+        title: "Preview on ryOS",
+        description: "View images, PDFs, and documents",
+        icon: "preview.png",
+      },
+      {
+        id: "calculator",
+        title: "Calculator on ryOS",
+        description: "Basic, scientific, and unit conversion calculator",
+        icon: "calculator.png",
+      },
+      {
+        id: "admin",
+        title: "Admin on ryOS",
+        description: "System administration panel",
+        icon: "admin.png",
+      },
     ];
 
     for (const app of appCases) {
@@ -120,6 +141,191 @@ describe("og share response", () => {
       );
       expect(body).toContain(
         `location.replace("https://os.example.com/${app.id}?_ryo=1")`
+      );
+    }
+  });
+
+  test("uses stored applet title and creator for shared applet OG tags", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const response = await createOgShareResponse(
+      new Request("https://os.example.com/applet-viewer/abc123share"),
+      {
+        getApplet: async (appletId, publicOrigin) => {
+          expect(appletId).toBe("abc123share");
+          expect(publicOrigin).toBe("https://os.example.com");
+          return {
+            title: "Pixel Painter on ryOS",
+            description: "Shared by ryo on ryOS",
+            imageUrl: "https://os.example.com/icons/custom/pixel.png",
+          };
+        },
+      }
+    );
+
+    expect(response).not.toBeNull();
+    const body = await response!.text();
+    expect(body).toContain(
+      '<meta property="og:title" content="Pixel Painter on ryOS">'
+    );
+    expect(body).toContain(
+      '<meta property="og:description" content="Shared by ryo on ryOS">'
+    );
+    expect(body).toContain(
+      '<meta property="og:image" content="https://os.example.com/icons/custom/pixel.png">'
+    );
+    expect(body).not.toContain("Shared Applet on ryOS");
+  });
+
+  test("falls back to generic applet OG when Redis has no metadata", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const response = await createOgShareResponse(
+      new Request("https://os.example.com/applet-viewer/missing"),
+      { getApplet: async () => null }
+    );
+
+    expect(response).not.toBeNull();
+    const body = await response!.text();
+    expect(body).toContain(
+      '<meta property="og:title" content="Shared Applet on ryOS">'
+    );
+    expect(body).toContain(
+      '<meta property="og:image" content="https://os.example.com/icons/macosx/applet.png">'
+    );
+    expect(response?.headers.get("cache-control")).toBe(
+      "no-store, s-maxage=60"
+    );
+  });
+
+  test("uses listen session track and host for live session OG tags", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const response = await createOgShareResponse(
+      new Request("https://os.example.com/listen/sess123?app=ipod"),
+      {
+        getListenSession: async (sessionId, opts) => {
+          expect(sessionId).toBe("sess123");
+          expect(opts.appHint).toBe("ipod");
+          return {
+            title: "七里香 - 周杰倫",
+            description: "Join ryo's live session on ryOS iPod",
+            imageUrl: "https://imge.kugou.com/stdmusic/400/album.jpg",
+            hostUsername: "ryo",
+          };
+        },
+      }
+    );
+
+    expect(response).not.toBeNull();
+    const body = await response!.text();
+    expect(body).toContain(
+      '<meta property="og:title" content="七里香 - 周杰倫">'
+    );
+    expect(body).toContain(
+      '<meta property="og:description" content="Join ryo&#039;s live session on ryOS iPod">'
+    );
+    expect(body).toContain(
+      '<meta property="og:image" content="https://imge.kugou.com/stdmusic/400/album.jpg">'
+    );
+    expect(body).toContain(
+      '<meta property="og:url" content="https://os.example.com/listen/sess123?app=ipod">'
+    );
+    expect(body).toContain(
+      'location.replace("https://os.example.com/listen/sess123?app=ipod&_ryo=1")'
+    );
+    expect(response?.headers.get("cache-control")).toBe(
+      "no-store, s-maxage=60"
+    );
+  });
+
+  test("falls back to karaoke branding for listen sessions without Redis data", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const response = await createOgShareResponse(
+      new Request("https://os.example.com/listen/sess456"),
+      { getListenSession: async () => null }
+    );
+
+    expect(response).not.toBeNull();
+    const body = await response!.text();
+    expect(body).toContain(
+      '<meta property="og:title" content="Join Live Session on ryOS">'
+    );
+    expect(body).toContain(
+      '<meta property="og:description" content="Listen together in real-time on ryOS Karaoke">'
+    );
+    expect(body).toContain(
+      '<meta property="og:image" content="https://os.example.com/icons/macosx/karaoke.png">'
+    );
+  });
+
+  test("parses applet and listen metadata from Redis payloads", () => {
+    expect(
+      getAppletShareMetadataFromRaw(
+        {
+          title: "Clock",
+          name: "Clock Applet",
+          icon: "🕐",
+          createdBy: "alice",
+        },
+        "https://os.example.com"
+      )
+    ).toEqual({
+      title: "Clock on ryOS",
+      description: "Shared by alice on ryOS",
+      imageUrl: null,
+    });
+
+    expect(
+      getAppletShareMetadataFromRaw(
+        {
+          name: "Gallery",
+          icon: "/icons/macosx/applet.png",
+        },
+        "https://os.example.com"
+      )
+    ).toEqual({
+      title: "Gallery on ryOS",
+      description: "Open applet in ryOS",
+      imageUrl: "https://os.example.com/icons/macosx/applet.png",
+    });
+
+    expect(
+      getListenShareMetadataFromRaw(
+        {
+          hostUsername: "bob",
+          currentTrackMeta: {
+            title: "Song",
+            artist: "Artist",
+            cover: "http://cdn.example.com/{size}/cover.jpg",
+          },
+        },
+        { appHint: null, publicOrigin: "https://os.example.com" }
+      )
+    ).toEqual({
+      title: "Song - Artist",
+      description: "Join bob's live session on ryOS Karaoke",
+      imageUrl: "https://cdn.example.com/400/cover.jpg",
+      hostUsername: "bob",
+    });
+  });
+
+  test("covers every registered app id with an OG share card", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    for (const appId of appIds) {
+      const response = await createOgShareResponse(
+        new Request(`https://os.example.com/${appId}`)
+      );
+      expect(response).not.toBeNull();
+      const body = await response!.text();
+      expect(body).toContain(
+        `<meta property="og:title" content="${appNames[appId]} on ryOS">`
+      );
+      expect(body).toContain("/icons/macosx/");
+      expect(body).toContain(
+        `location.replace("https://os.example.com/${appId}?_ryo=1")`
       );
     }
   });
@@ -449,5 +655,69 @@ describe("og share song-key canonical cutover", () => {
     const body = await response!.text();
     expect(body).not.toContain("Legacy Song");
     expect(body).not.toContain("https://example.com/legacy.jpg");
+  });
+});
+
+describe("og share applet and listen redis reads", () => {
+  test("reads applet share metadata from Redis", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    const appletId = "appletShare99";
+    await fake.set(
+      redisKeys.media.appletShare(appletId),
+      JSON.stringify({
+        title: "Neon Clock",
+        icon: "https://cdn.example.com/neon.png",
+        createdBy: "ryo",
+        content: "<html></html>",
+      })
+    );
+
+    const response = await createOgShareResponse(
+      new Request(`https://os.example.com/applet-viewer/${appletId}`)
+    );
+    const body = await response!.text();
+    expect(body).toContain(
+      '<meta property="og:title" content="Neon Clock on ryOS">'
+    );
+    expect(body).toContain(
+      '<meta property="og:description" content="Shared by ryo on ryOS">'
+    );
+    expect(body).toContain(
+      '<meta property="og:image" content="https://cdn.example.com/neon.png">'
+    );
+  });
+
+  test("reads listen session track metadata from Redis", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    const sessionId = "liveSess01";
+    await fake.set(
+      redisKeys.session.listen(sessionId),
+      JSON.stringify({
+        id: sessionId,
+        hostUsername: "djryo",
+        djUsername: "djryo",
+        currentTrackMeta: {
+          title: "Night Drive",
+          artist: "Synthwave",
+          cover: "https://cdn.example.com/{w}x{h}/cover.jpg",
+        },
+        isPlaying: true,
+        users: [],
+      })
+    );
+
+    const response = await createOgShareResponse(
+      new Request(`https://os.example.com/listen/${sessionId}`)
+    );
+    const body = await response!.text();
+    expect(body).toContain(
+      '<meta property="og:title" content="Night Drive - Synthwave">'
+    );
+    expect(body).toContain(
+      '<meta property="og:description" content="Join djryo&#039;s live session on ryOS Karaoke">'
+    );
+    expect(body).toContain(
+      '<meta property="og:image" content="https://cdn.example.com/400x400/cover.jpg">'
+    );
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -439,6 +439,72 @@ export default defineConfig({
         });
       },
     },
+    // Mirror production OG share HTML in Vite dev so /finder, /ipod/…, etc.
+    // return crawler-friendly meta instead of the SPA shell's default tags.
+    // Browsers still redirect to ?_ryo=1 and load the app as usual.
+    ...(isDev
+      ? [
+          {
+            name: "serve-og-share-dev",
+            configureServer(server: ViteDevServer) {
+              server.middlewares.use((
+                req: IncomingMessage,
+                res: ServerResponse,
+                next: (err?: unknown) => void
+              ) => {
+                if (req.method !== "GET" && req.method !== "HEAD") {
+                  next();
+                  return;
+                }
+
+                const host = req.headers.host || "localhost:5173";
+                const requestUrl = new URL(req.url || "/", `http://${host}`);
+                if (requestUrl.searchParams.has("_ryo")) {
+                  next();
+                  return;
+                }
+                if (
+                  requestUrl.pathname.startsWith("/api") ||
+                  requestUrl.pathname.startsWith("/@") ||
+                  requestUrl.pathname.startsWith("/src") ||
+                  requestUrl.pathname.startsWith("/node_modules") ||
+                  requestUrl.pathname.includes(".")
+                ) {
+                  next();
+                  return;
+                }
+
+                void import("./api/_utils/og-share.ts")
+                  .then(async ({ createOgShareResponse }) => {
+                    const response = await createOgShareResponse(
+                      new Request(requestUrl.toString(), {
+                        method: req.method || "GET",
+                        headers: req.headers as HeadersInit,
+                      })
+                    );
+                    if (!response) {
+                      next();
+                      return;
+                    }
+
+                    res.statusCode = response.status;
+                    response.headers.forEach((value, key) => {
+                      res.setHeader(key, value);
+                    });
+                    if (req.method === "HEAD") {
+                      res.end();
+                      return;
+                    }
+                    res.end(Buffer.from(await response.arrayBuffer()));
+                  })
+                  .catch((error: unknown) => {
+                    next(error);
+                  });
+              });
+            },
+          },
+        ]
+      : []),
     react(),
     tailwindcss(),
     // Only include PWA plugin in production builds (not dev)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -479,7 +479,6 @@ export default defineConfig({
                     const response = await createOgShareResponse(
                       new Request(requestUrl.toString(), {
                         method: req.method || "GET",
-                        headers: req.headers as HeadersInit,
                       })
                     );
                     if (!response) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes gaps in Open Graph share cards served by `api/_utils/og-share.ts` (and Vite dev):

- **Missing apps:** `preview`, `calculator`, and `admin` now get dedicated OG cards at `/{appId}`.
- **Applet shares:** `/applet-viewer/{id}` reads Redis for title, creator, and image URL (emoji icons fall back to `applet.png`).
- **Listen sessions:** `/listen/{id}` uses current track + host from Redis; `?app=ipod` is preserved on redirect and switches branding to iPod.
- **Vite dev:** middleware mirrors production OG HTML so deep links on the Vite port are not stuck with generic SPA meta.
- **Coverage guard:** unit test asserts every `appIds` entry has an OG card.
- **CI:** typecheck fixes for oEmbed `unknown` JSON, Vite `HeadersInit`, and ioredis `scan` overloads.

## Test plan

- [x] `bun test tests/unit/admin/test-og-share.test.ts` (23 pass)
- [x] `bun run typecheck` (clean)
- [x] Live smoke: `bun run dev:api` curl `/preview`, `/calculator`, `/admin`, `/listen/…?app=ipod`, `/applet-viewer/…`
- [x] Vite middleware smoke: `/preview` → app OG; `/preview?_ryo=1` → SPA shell
- [ ] CI Build (Bun 1.3.9) green after typecheck fix

[og_smoke_test.log](https://cursor.com/artifacts/c/art-8b9e0e7f-29ac-4555-8a0d-f9280fd62b20)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f48cb-df73-7157-aea0-2fa16a78e897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f48cb-df73-7157-aea0-2fa16a78e897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

