### PR TITLE
Default Cursor SDK cloud agents to Grok 4.5

### DIFF
--- a/api/chat/tools/cursor-repo-agent.ts
+++ b/api/chat/tools/cursor-repo-agent.ts
@@ -53,19 +53,36 @@ export function pickPrUrlFromRunGit(git: unknown): string | undefined {
 /** Default repo for ryOS Cursor Cloud runs (override with CURSOR_CLOUD_REPO_URL). */
 export const DEFAULT_RYOS_GITHUB_REPO_URL = "https://github.com/ryokun6/ryos";
 
-/** Default cloud model — Composer 2.5 Fast (`fast` is default; set explicitly for clarity). */
-export const DEFAULT_CURSOR_SDK_MODEL_ID = "composer-2.5";
+/**
+ * Default cloud model — Grok 4.5 (high effort + fast).
+ * Matches the `isDefault` variant from `Cursor.models.list()`.
+ */
+export const DEFAULT_CURSOR_SDK_MODEL_ID = "grok-4.5";
 
 export const DEFAULT_CURSOR_SDK_MODEL: import("@cursor/sdk").ModelSelection = {
   id: DEFAULT_CURSOR_SDK_MODEL_ID,
+  params: [
+    { id: "effort", value: "high" },
+    { id: "fast", value: "true" },
+  ],
+};
+
+/** Composer 2.5 Fast — kept for explicit / legacy model ids. */
+const COMPOSER_25_FAST: import("@cursor/sdk").ModelSelection = {
+  id: "composer-2.5",
   params: [{ id: "fast", value: "true" }],
 };
 
-const LEGACY_FAST_MODEL_IDS = new Set(["composer-2.5-fast", "composer-2-fast"]);
+const LEGACY_COMPOSER_FAST_IDS = new Set([
+  "composer-2",
+  "composer-2-fast",
+  "composer-2.5",
+  "composer-2.5-fast",
+]);
 
 /**
  * Resolve a dashboard/env model id to SDK `ModelSelection`.
- * Maps legacy `composer-2` / `composer-*-fast` aliases to Composer 2.5 Fast.
+ * Unset → Grok 4.5 high+fast. Legacy Composer ids → Composer 2.5 Fast.
  */
 export function resolveCursorSdkModelSelection(
   modelIdOverride?: string | null
@@ -75,16 +92,10 @@ export function resolveCursorSdkModelSelection(
     process.env.CURSOR_SDK_MODEL?.trim() ||
     "";
   if (!raw) return DEFAULT_CURSOR_SDK_MODEL;
-  if (raw === "composer-2") {
-    return DEFAULT_CURSOR_SDK_MODEL;
+  if (LEGACY_COMPOSER_FAST_IDS.has(raw)) {
+    return COMPOSER_25_FAST;
   }
-  if (LEGACY_FAST_MODEL_IDS.has(raw)) {
-    return {
-      id: raw.replace(/-fast$/, ""),
-      params: [{ id: "fast", value: "true" }],
-    };
-  }
-  if (raw === DEFAULT_CURSOR_SDK_MODEL_ID) {
+  if (raw === DEFAULT_CURSOR_SDK_MODEL_ID || raw === "grok-4.5-fast") {
     return DEFAULT_CURSOR_SDK_MODEL;
   }
   return { id: raw };
@@ -142,7 +153,7 @@ export const cursorCloudAgentSchema = z.object({
     .min(1)
     .optional()
     .describe(
-      "Optional model id (default composer-2.5 fast). Use Cursor.models.list() for valid ids; fast is a param on composer-2.5, not a separate id."
+      "Optional model id (default grok-4.5 high effort + fast). Use Cursor.models.list() for valid ids; effort/fast are params on grok-4.5, not separate ids."
     ),
 });
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@ai-sdk/react": "^4.0.17",
         "@aws-sdk/client-s3": "^3.1081.0",
         "@aws-sdk/s3-request-presigner": "^3.1081.0",
-        "@cursor/sdk": "1.0.23",
+        "@cursor/sdk": "^1.0.23",
         "@paper-design/shaders-react": "^0.0.77",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-checkbox": "^1.3.7",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@ai-sdk/react": "^4.0.17",
     "@aws-sdk/client-s3": "^3.1081.0",
     "@aws-sdk/s3-request-presigner": "^3.1081.0",
-    "@cursor/sdk": "1.0.23",
+    "@cursor/sdk": "^1.0.23",
     "@paper-design/shaders-react": "^0.0.77",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-checkbox": "^1.3.7",

--- a/tests/unit/cursor/test-cursor-repo-agent-tool.test.ts
+++ b/tests/unit/cursor/test-cursor-repo-agent-tool.test.ts
@@ -55,27 +55,43 @@ describe("cursorCloudAgent gate", () => {
 
 describe("resolveCursorSdkModelSelection", () => {
   const prevEnv = process.env.CURSOR_SDK_MODEL;
+  const composer25Fast = {
+    id: "composer-2.5",
+    params: [{ id: "fast", value: "true" }],
+  };
 
-  test("defaults to Composer 2.5 fast when unset", () => {
+  test("defaults to Grok 4.5 high+fast when unset", () => {
     delete process.env.CURSOR_SDK_MODEL;
     expect(resolveCursorSdkModelSelection()).toEqual(DEFAULT_CURSOR_SDK_MODEL);
-    expect(DEFAULT_CURSOR_SDK_MODEL_ID).toBe("composer-2.5");
+    expect(DEFAULT_CURSOR_SDK_MODEL_ID).toBe("grok-4.5");
+    expect(DEFAULT_CURSOR_SDK_MODEL.params).toEqual([
+      { id: "effort", value: "high" },
+      { id: "fast", value: "true" },
+    ]);
   });
 
-  test("maps legacy composer-2 to Composer 2.5 fast", () => {
+  test("maps legacy composer ids to Composer 2.5 fast", () => {
     expect(resolveCursorSdkModelSelection("composer-2")).toEqual(
+      composer25Fast
+    );
+    expect(resolveCursorSdkModelSelection("composer-2.5")).toEqual(
+      composer25Fast
+    );
+    expect(resolveCursorSdkModelSelection("composer-2.5-fast")).toEqual(
+      composer25Fast
+    );
+  });
+
+  test("maps grok-4.5 and grok-4.5-fast to default params", () => {
+    expect(resolveCursorSdkModelSelection("grok-4.5")).toEqual(
+      DEFAULT_CURSOR_SDK_MODEL
+    );
+    expect(resolveCursorSdkModelSelection("grok-4.5-fast")).toEqual(
       DEFAULT_CURSOR_SDK_MODEL
     );
   });
 
-  test("maps composer-2.5-fast alias to ModelSelection params", () => {
-    expect(resolveCursorSdkModelSelection("composer-2.5-fast")).toEqual({
-      id: "composer-2.5",
-      params: [{ id: "fast", value: "true" }],
-    });
-  });
-
-  test("respects explicit non-composer model ids", () => {
+  test("respects explicit non-default model ids", () => {
     expect(resolveCursorSdkModelSelection("claude-4.6-sonnet")).toEqual({
       id: "claude-4.6-sonnet",
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Relax `@cursor/sdk` to `^1.0.23` (already on latest published `1.0.23`).
- Change the unset / default Cursor Cloud agent model from Composer 2.5 Fast to **Grok 4.5** with `effort=high` and `fast=true` (matches the `isDefault` variant from `Cursor.models.list()`).
- Keep explicit Composer 2.x ids resolving to Composer 2.5 Fast so existing overrides still work.

## Test plan
- [x] `bun test tests/unit/cursor/` (59 pass)
- [x] Confirmed `grok-4.5` default variant via `Cursor.models.list()` against live API key
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5231-2ee7-71c4-88b6-724c72ae7dc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5231-2ee7-71c4-88b6-724c72ae7dc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

