### PR TITLE
fix(chats): jump to bottom instantly when restoring history

### DIFF
--- a/src/apps/chats/components/chat-messages/ChatMessages.tsx
+++ b/src/apps/chats/components/chat-messages/ChatMessages.tsx
@@ -62,7 +62,10 @@ export function ChatMessages({
   return (
     <StickToBottom
       className="flex-1 relative flex flex-col overflow-hidden size-full"
-      resize="smooth"
+      // Instant resize: restored/hydrated history must land at the bottom
+      // without a spring scroll. New messages still animate via the explicit
+      // scrollToBottom("smooth") trigger in ChatMessagesContent.
+      resize="instant"
       initial="instant"
     >
       <StickToBottom.Content className="flex flex-col gap-1 p-3 pt-12 pb-14">

--- a/src/apps/chats/components/chat-messages/ChatMessagesContent.tsx
+++ b/src/apps/chats/components/chat-messages/ChatMessagesContent.tsx
@@ -96,13 +96,15 @@ export const ChatMessagesContent = memo(function ChatMessagesContent({
     }
   }, [messages]);
 
-  // Effect to trigger scroll to bottom
+  // Effect to trigger scroll to bottom (smooth) when new messages are added.
+  // Restored history relies on StickToBottom's resize="instant" instead —
+  // do not animate that path.
   const isInitialMount = useRef(true);
   useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
     } else {
-      scrollToBottom();
+      void scrollToBottom("smooth");
     }
   }, [scrollToBottomTrigger, scrollToBottom]);
 

--- a/src/apps/chats/components/chat-messages/ScrollToBottomButton.tsx
+++ b/src/apps/chats/components/chat-messages/ScrollToBottomButton.tsx
@@ -35,7 +35,7 @@ export function ScrollToBottomButton() {
             border: isMacTheme ? undefined : "1px solid rgba(0,0,0,0.3)",
             backdropFilter: isMacTheme ? "blur(2px)" : undefined,
           }}
-          onClick={() => scrollToBottom()}
+          onClick={() => void scrollToBottom("smooth")}
           aria-label={t("apps.chats.status.scrollToBottom")}
         >
           {isMacTheme && (

--- a/tests/unit/chat/test-chat-scroll-restore-instant.test.ts
+++ b/tests/unit/chat/test-chat-scroll-restore-instant.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const readSource = (relativePath: string): string =>
+  readFileSync(join(process.cwd(), relativePath), "utf8");
+
+describe("Chats scroll-to-bottom on restore vs new messages", () => {
+  test("StickToBottom uses instant resize so restored history does not animate", () => {
+    const source = readSource(
+      "src/apps/chats/components/chat-messages/ChatMessages.tsx"
+    );
+    expect(source).toContain('resize="instant"');
+    expect(source).toContain('initial="instant"');
+    expect(source).not.toContain('resize="smooth"');
+  });
+
+  test("new-message scroll trigger and button request smooth scroll", () => {
+    const content = readSource(
+      "src/apps/chats/components/chat-messages/ChatMessagesContent.tsx"
+    );
+    const button = readSource(
+      "src/apps/chats/components/chat-messages/ScrollToBottomButton.tsx"
+    );
+    expect(content).toContain('scrollToBottom("smooth")');
+    expect(button).toContain('scrollToBottom("smooth")');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
When chats hydrate/restore on launch, StickToBottom was using `resize="smooth"`, so the message list animated its scroll to the bottom as history loaded. That felt wrong for restore — history should just appear already at the bottom.

## Changes
- Set `StickToBottom` `resize="instant"` (keep `initial="instant"`) so restored/hydrated content lands at the bottom without a spring scroll.
- Keep smooth scrolling for explicit new-message paths: `scrollToBottom("smooth")` on the message-send trigger and the scroll-to-bottom button.
- Add a small wiring test covering the restore vs new-message behavior.

## Testing
- `bun test tests/unit/chat/test-chat-scroll-restore-instant.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5239-a1e6-7307-9823-ae53bb2146f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5239-a1e6-7307-9823-ae53bb2146f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

