### PR TITLE
Add auto compaction for chat messages

### DIFF
--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -2,6 +2,15 @@ import { openai } from "@ai-sdk/openai";
 import { google } from "@ai-sdk/google";
 import type { Redis } from "./redis.js";
 import {
+  AI_CHAT_COMPACTION_MESSAGE_SAFETY_MAX,
+  AI_CHAT_RESERVED_OUTPUT_TOKENS,
+  getModelConversationTokenBudget,
+} from "../../src/shared/aiModels.js";
+import {
+  compactMessagesByTokenBudget,
+  estimateTextTokens,
+} from "../../src/shared/aiConversationCompaction.js";
+import {
   convertToModelMessages,
   validateUIMessages,
   type LanguageModel,
@@ -196,6 +205,8 @@ export interface PreparedRyoConversation {
   modelId: SupportedModel;
   tools: ToolSet;
   enrichedMessages: ModelMessage[];
+  /** True when conversation history was trimmed to fit the model context. */
+  historyCompacted: boolean;
   loadedSections: string[];
   staticSystemPrompt: string;
   memoryContextPrompt: string;
@@ -1006,15 +1017,43 @@ export async function prepareRyoConversationModelInput(
     ),
     tools,
   });
+
+  // Compact conversation history to the selected model's input budget before
+  // conversion. System prompts + reserved output are excluded from the budget.
+  const systemTokenEstimate =
+    estimateTextTokens(staticSystemPrompt) +
+    estimateTextTokens(memoryContextPrompt) +
+    estimateTextTokens(volatileStatePrompt);
+  const conversationTokenBudget = getModelConversationTokenBudget(model, {
+    maxOutputTokens: AI_CHAT_RESERVED_OUTPUT_TOKENS,
+    systemTokenEstimate,
+  });
+  const compactedHistory = compactMessagesByTokenBudget(uiMessages, {
+    maxTokens: conversationTokenBudget,
+    maxMessages: AI_CHAT_COMPACTION_MESSAGE_SAFETY_MAX,
+  });
+  if (compactedHistory.compacted) {
+    log("Compacted conversation history to fit model context window", {
+      model,
+      before: uiMessages.length,
+      after: compactedHistory.messages.length,
+      estimatedTokens: compactedHistory.estimatedTokens,
+      maxTokens: conversationTokenBudget,
+    });
+  }
+
   // `ignoreIncompleteToolCalls` drops dangling client tool calls that never
   // received their output (e.g. the user typed a new message instead, or the
   // completing continuation request failed). Without it, one dangling
   // `input-available` part in the stored history makes every subsequent
   // model call throw AI_MissingToolResultsError, bricking the conversation.
-  const modelMessages = await convertToModelMessages(uiMessages, {
-    tools,
-    ignoreIncompleteToolCalls: true,
-  });
+  const modelMessages = await convertToModelMessages(
+    compactedHistory.messages as UIMessage[],
+    {
+      tools,
+      ignoreIncompleteToolCalls: true,
+    }
+  );
 
   // Three-tier system message structure for optimal prompt caching:
   //   1. Static instructions — identical across all users/requests (cacheable)
@@ -1046,6 +1085,7 @@ export async function prepareRyoConversationModelInput(
     modelId: model,
     tools,
     enrichedMessages,
+    historyCompacted: compactedHistory.compacted,
     loadedSections,
     staticSystemPrompt,
     memoryContextPrompt,

--- a/api/ai/conversations/_helpers/store.ts
+++ b/api/ai/conversations/_helpers/store.ts
@@ -16,12 +16,21 @@ import {
   parseAIAttachmentUrl,
 } from "../../../../src/shared/contracts/aiAttachment.js";
 import { ASSISTANT_SUMMON_MESSAGE } from "../../../../src/shared/assistantGreeting.js";
+import {
+  AI_CHAT_COMPACTION_MESSAGE_SAFETY_MAX,
+  DEFAULT_AI_MODEL,
+  getModelConversationTokenBudget,
+} from "../../../../src/shared/aiModels.js";
+import {
+  compactMessagesByTokenBudget,
+} from "../../../../src/shared/aiConversationCompaction.js";
 
 const CONVERSATION_TTL_SECONDS = 365 * 24 * 60 * 60;
 const LOCK_TTL_SECONDS = 60;
 const LOCK_ATTEMPTS = 40;
 const LOCK_RETRY_MS = 25;
-const MAX_MESSAGES = 200;
+/** Absolute message-count safety net; token budget is the primary limit. */
+const MAX_MESSAGES = AI_CHAT_COMPACTION_MESSAGE_SAFETY_MAX;
 const MAX_CONVERSATION_BYTES = 4 * 1024 * 1024;
 const MAX_MESSAGE_BYTES = 768 * 1024;
 const MAX_MESSAGE_TEXT_LENGTH = 128_000;
@@ -29,6 +38,11 @@ const MAX_PARTS_PER_MESSAGE = 48;
 const MAX_RECENT_OPERATIONS = 48;
 const MAX_MESSAGE_ID_LENGTH = 160;
 const TURN_COMPLETION_OPERATION_SUFFIX = ":complete";
+
+/** Persistence uses the default model's conversation budget as a shared cap. */
+function getPersistedConversationTokenBudget(): number {
+  return getModelConversationTokenBudget(DEFAULT_AI_MODEL);
+}
 
 export function getAIConversationTurnCompletionOperationId(
   turnId: string,
@@ -548,10 +562,23 @@ function trimConversation(document: StoredConversation): void {
   );
   let removed = false;
 
-  while (
-    document.messages.length > MAX_MESSAGES ||
-    (totalBytes > MAX_CONVERSATION_BYTES && document.messages.length > 1)
+  const compacted = compactMessagesByTokenBudget(document.messages, {
+    maxTokens: getPersistedConversationTokenBudget(),
+    maxMessages: MAX_MESSAGES,
+  });
+  if (
+    compacted.compacted &&
+    compacted.messages.length !== document.messages.length
   ) {
+    document.messages = compacted.messages as StoredConversation["messages"];
+    totalBytes = document.messages.reduce(
+      (total, message) => total + jsonByteLength(message.parts),
+      0,
+    );
+    removed = true;
+  }
+
+  while (totalBytes > MAX_CONVERSATION_BYTES && document.messages.length > 1) {
     const nextTurn = document.messages.findIndex(
       (message, index) => index > 0 && message.role === "user",
     );

--- a/docs/8.1-chat-api.md
+++ b/docs/8.1-chat-api.md
@@ -22,10 +22,13 @@ The server is the canonical history: a normal authenticated request appends one
 user action, loads prior messages from Redis, streams one response, then commits
 only the assembled assistant message. Clients do not resend or overwrite the
 stored transcript. The server assigns sequence numbers, maintains a monotonic
-revision, and keeps at most 200 messages within a 4 MiB history budget. Completed
+revision, and compacts history to the selected model's conversation token
+budget (context window minus reserved output / safety), with a 2,000-message
+safety net and a 4 MiB serialized-parts budget. Completed
 AI SDK message parts are retained, including text, tool state, sources, and
 private image references. A message may contain up to 128,000 text characters
-and 768 KiB of serialized parts.
+and 768 KiB of serialized parts. Model input is also compacted per-request in
+`prepareRyoConversationModelInput` so oversized tool-heavy turns still fit.
 
 `GET /api/ai/conversations/:channel` accepts `limit` (1–100) and an opaque
 `cursor`. Pages contain chronological messages and a `nextCursor`. A cursor

--- a/src/apps/chats/components/chat-messages/chat-message-item/ChatMessageItem.tsx
+++ b/src/apps/chats/components/chat-messages/chat-message-item/ChatMessageItem.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import { motion } from "motion/react";
 import EmojiAquarium from "@/components/shared/EmojiAquarium";
+import { isMessagesCompactedMarker } from "@/apps/chats/utils/messageCompaction";
 import type { ChatMessageItemProps } from "../types";
 import { isUrlOnly } from "../utils";
 import { CHAT_BUBBLE_VARIANTS } from "../constants";
@@ -24,6 +25,30 @@ export const ChatMessageItem = memo(function ChatMessageItem(
     displayContent,
     setIsHovered,
   } = vm;
+
+  if (isMessagesCompactedMarker(message)) {
+    return (
+      <motion.div
+        variants={CHAT_BUBBLE_VARIANTS}
+        initial={isInitialMessage ? "animate" : "initial"}
+        animate="animate"
+        transition={{ duration: 0.15, ease: "easeOut" }}
+        className="flex w-full justify-center z-10 py-1"
+        style={{
+          contentVisibility: "auto",
+          containIntrinsicSize: "auto 20px",
+        }}
+      >
+        <span
+          className={`${
+            props.isMacOSTheme ? "text-[10px]" : "text-[16px]"
+          } chat-messages-meta text-neutral-400 font-['Geneva-9'] antialiased select-text text-center`}
+        >
+          {vm.t("apps.chats.status.previousMessagesCompacted")}
+        </span>
+      </motion.div>
+    );
+  }
 
   return (
     <motion.div

--- a/src/apps/chats/components/chats-app/useChatsAppController.tsx
+++ b/src/apps/chats/components/chats-app/useChatsAppController.tsx
@@ -164,6 +164,7 @@ export function useChatsAppController({
   const fontSize = useChatsStore((state) => state.fontSize);
   const setFontSize = useChatsStore((state) => state.setFontSize);
   const messageRenderLimit = useChatsStore((state) => state.messageRenderLimit);
+  const aiHistoryCompacted = useChatsStore((state) => state.aiHistoryCompacted);
 
   const [isShaking, setIsShaking] = useState(false);
   const {
@@ -531,16 +532,22 @@ export function useChatsAppController({
       buildDisplayMessages({
         currentRoomId,
         currentRoomMessagesLimited,
+        roomHasOlderMessages:
+          !!currentRoomId &&
+          currentRoomMessages.length > currentRoomMessagesLimited.length,
         aiMessages: messages,
         messageRenderLimit,
         username,
+        aiHistoryCompacted,
       }),
     [
       currentRoomId,
+      currentRoomMessages,
       currentRoomMessagesLimited,
       messages,
       messageRenderLimit,
       username,
+      aiHistoryCompacted,
     ]
   );
 

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -365,10 +365,13 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         isError,
         ...summarizeChatMessages(finalMessages),
       });
-      // Anonymous history has no server trim — compact locally when over cap.
+      // Anonymous history has no server trim — compact locally to the
+      // selected model's conversation token budget.
       let syncedMessages = finalMessages;
       if (!useChatsStore.getState().isAuthenticated) {
-        const compacted = compactAiMessages(finalMessages);
+        const compacted = compactAiMessages(finalMessages, {
+          modelId: useAppStore.getState().aiModel,
+        });
         syncedMessages = compacted.messages;
         setAiMessages(syncedMessages);
         if (compacted.compacted) {

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -40,6 +40,7 @@ import {
   uploadAIConversationImage,
 } from "@/api/aiConversations";
 import { useServerAIConversation } from "@/hooks/useServerAIConversation";
+import { compactAiMessages } from "../utils/messageCompaction";
 
 
 // Helper to check if chats app is currently in the foreground
@@ -233,13 +234,19 @@ function getSharedAiChat(): Chat<AIChatMessage> {
 }
 
 export function useAiChat(onPromptSetUsername?: () => void) {
-  const { aiMessages, setAiMessages, username, isAuthenticated } =
-    useChatsStoreShallow((state) => ({
-      aiMessages: state.aiMessages,
-      setAiMessages: state.setAiMessages,
-      username: state.username,
-      isAuthenticated: state.isAuthenticated,
-    }));
+  const {
+    aiMessages,
+    setAiMessages,
+    setAiHistoryCompacted,
+    username,
+    isAuthenticated,
+  } = useChatsStoreShallow((state) => ({
+    aiMessages: state.aiMessages,
+    setAiMessages: state.setAiMessages,
+    setAiHistoryCompacted: state.setAiHistoryCompacted,
+    username: state.username,
+    isAuthenticated: state.isAuthenticated,
+  }));
   const launchApp = useLaunchApp();
   const aiModel = useAppStore((state) => state.aiModel);
   const speechEnabled = useAudioSettingsStore((state) => state.speechEnabled);
@@ -358,9 +365,21 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         isError,
         ...summarizeChatMessages(finalMessages),
       });
-      setAiMessages(finalMessages);
+      // Anonymous history has no server trim — compact locally when over cap.
+      let syncedMessages = finalMessages;
+      if (!useChatsStore.getState().isAuthenticated) {
+        const compacted = compactAiMessages(finalMessages);
+        syncedMessages = compacted.messages;
+        setAiMessages(syncedMessages);
+        if (compacted.compacted) {
+          setAiHistoryCompacted(true);
+          setSdkMessages(syncedMessages);
+        }
+      } else {
+        setAiMessages(finalMessages);
+      }
 
-      const lastMsg = finalMessages.at(-1);
+      const lastMsg = syncedMessages.at(-1);
       if (!lastMsg || lastMsg.role !== "assistant") return;
 
       // Recovery for AI SDK v6 bug (GitHub issue #10291):
@@ -634,7 +653,10 @@ export function useAiChat(onPromptSetUsername?: () => void) {
   });
 
   const applyServerMessages = useCallback(
-    (messages: AIChatMessage[]) => {
+    (
+      messages: AIChatMessage[],
+      options?: { historyTruncated?: boolean }
+    ) => {
       const nextMessages =
         messages.length > 0 ? messages : [createInitialChatMessage()];
       // Hydration replaces the live SDK messages wholesale — log it so races
@@ -645,8 +667,11 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       );
       setAiMessages(nextMessages);
       setSdkMessages(nextMessages);
+      if (typeof options?.historyTruncated === "boolean") {
+        setAiHistoryCompacted(options.historyTruncated);
+      }
     },
-    [setAiMessages, setSdkMessages]
+    [setAiMessages, setAiHistoryCompacted, setSdkMessages]
   );
 
   // Server conversation sync: hydration on sign-in, focus/visibility
@@ -982,8 +1007,10 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     // Update both the Zustand store and the SDK state directly
     setAiMessages([initialMessage]);
     setSdkMessages([initialMessage]);
+    setAiHistoryCompacted(false);
   }, [
     setAiMessages,
+    setAiHistoryCompacted,
     setSdkMessages,
     sdkStop,
     clearError,

--- a/src/apps/chats/utils/messageCompaction.ts
+++ b/src/apps/chats/utils/messageCompaction.ts
@@ -1,0 +1,76 @@
+import type { AIChatMessage } from "@/types/chat";
+import type { DisplayMessage } from "./messages";
+
+/** Stable id for the display-only "Previous messages compacted" marker. */
+export const MESSAGES_COMPACTED_MARKER_ID =
+  "system:previous-messages-compacted";
+
+/** Metadata kind for the compacted-history system row. */
+export const MESSAGES_COMPACTED_KIND = "messages-compacted";
+
+/**
+ * Align with the server conversation cap (`MAX_MESSAGES` in
+ * `api/ai/conversations/_helpers/store.ts`). Anonymous local history is
+ * trimmed to this size so long chats don't grow forever.
+ */
+export const AI_MESSAGE_COMPACTION_MAX = 200;
+
+export function isMessagesCompactedMarker(
+  message: Pick<DisplayMessage, "id" | "role" | "metadata">
+): boolean {
+  return (
+    message.role === "system" &&
+    (message.id === MESSAGES_COMPACTED_MARKER_ID ||
+      message.metadata?.kind === MESSAGES_COMPACTED_KIND)
+  );
+}
+
+/** Singleton so React.memo sees a stable reference across rebuilds. */
+export const COMPACTED_MESSAGES_MARKER: DisplayMessage = {
+  id: MESSAGES_COMPACTED_MARKER_ID,
+  role: "system",
+  parts: [{ type: "text", text: "" }],
+  metadata: {
+    createdAt: new Date(0),
+    kind: MESSAGES_COMPACTED_KIND,
+  },
+};
+
+/**
+ * Drop oldest turns (at user-message boundaries) when history exceeds the
+ * compaction cap. Returns whether any messages were removed.
+ */
+export function compactAiMessages(
+  messages: readonly AIChatMessage[],
+  maxMessages: number = AI_MESSAGE_COMPACTION_MAX
+): { messages: AIChatMessage[]; compacted: boolean } {
+  if (messages.length <= maxMessages || maxMessages < 1) {
+    return { messages: [...messages], compacted: false };
+  }
+
+  let cutIndex = messages.length - maxMessages;
+  // Prefer cutting at a user turn so we don't leave a dangling assistant reply.
+  while (cutIndex < messages.length && messages[cutIndex]?.role !== "user") {
+    cutIndex += 1;
+  }
+  if (cutIndex <= 0 || cutIndex >= messages.length) {
+    return {
+      messages: messages.slice(-maxMessages),
+      compacted: true,
+    };
+  }
+
+  return {
+    messages: messages.slice(cutIndex),
+    compacted: true,
+  };
+}
+
+export function withCompactedMessagesMarker(
+  messages: DisplayMessage[],
+  showMarker: boolean
+): DisplayMessage[] {
+  if (!showMarker || messages.length === 0) return messages;
+  if (messages.some(isMessagesCompactedMarker)) return messages;
+  return [COMPACTED_MESSAGES_MARKER, ...messages];
+}

--- a/src/apps/chats/utils/messageCompaction.ts
+++ b/src/apps/chats/utils/messageCompaction.ts
@@ -15,9 +15,11 @@ export const MESSAGES_COMPACTED_KIND = "messages-compacted";
  */
 export const AI_MESSAGE_COMPACTION_MAX = 200;
 
-export function isMessagesCompactedMarker(
-  message: Pick<DisplayMessage, "id" | "role" | "metadata">
-): boolean {
+export function isMessagesCompactedMarker(message: {
+  id?: string;
+  role: string;
+  metadata?: { kind?: unknown; [key: string]: unknown };
+}): boolean {
   return (
     message.role === "system" &&
     (message.id === MESSAGES_COMPACTED_MARKER_ID ||

--- a/src/apps/chats/utils/messageCompaction.ts
+++ b/src/apps/chats/utils/messageCompaction.ts
@@ -1,5 +1,14 @@
 import type { AIChatMessage } from "@/types/chat";
 import type { DisplayMessage } from "./messages";
+import {
+  compactMessagesByTokenBudget,
+  compactMessagesForModelContext,
+} from "@/shared/aiConversationCompaction";
+import {
+  AI_CHAT_COMPACTION_MESSAGE_SAFETY_MAX,
+  DEFAULT_AI_MODEL,
+  type SupportedModel,
+} from "@/shared/aiModels";
 
 /** Stable id for the display-only "Previous messages compacted" marker. */
 export const MESSAGES_COMPACTED_MARKER_ID =
@@ -9,11 +18,10 @@ export const MESSAGES_COMPACTED_MARKER_ID =
 export const MESSAGES_COMPACTED_KIND = "messages-compacted";
 
 /**
- * Align with the server conversation cap (`MAX_MESSAGES` in
- * `api/ai/conversations/_helpers/store.ts`). Anonymous local history is
- * trimmed to this size so long chats don't grow forever.
+ * Absolute message-count safety net. Primary compaction uses the selected
+ * model's context-window token budget.
  */
-export const AI_MESSAGE_COMPACTION_MAX = 200;
+export const AI_MESSAGE_COMPACTION_MAX = AI_CHAT_COMPACTION_MESSAGE_SAFETY_MAX;
 
 export function isMessagesCompactedMarker(message: {
   id?: string;
@@ -38,33 +46,48 @@ export const COMPACTED_MESSAGES_MARKER: DisplayMessage = {
   },
 };
 
+export interface CompactAiMessagesOptions {
+  modelId?: SupportedModel | null;
+  /** Explicit conversation-history token budget (overrides model derivation). */
+  maxTokens?: number;
+  maxMessages?: number;
+  systemTokenEstimate?: number;
+}
+
 /**
- * Drop oldest turns (at user-message boundaries) when history exceeds the
- * compaction cap. Returns whether any messages were removed.
+ * Drop oldest turns when history exceeds the selected model's conversation
+ * token budget (context window minus reserved output / safety). Cuts only at
+ * user-message boundaries.
  */
 export function compactAiMessages(
   messages: readonly AIChatMessage[],
-  maxMessages: number = AI_MESSAGE_COMPACTION_MAX
-): { messages: AIChatMessage[]; compacted: boolean } {
-  if (messages.length <= maxMessages || maxMessages < 1) {
-    return { messages: [...messages], compacted: false };
-  }
-
-  let cutIndex = messages.length - maxMessages;
-  // Prefer cutting at a user turn so we don't leave a dangling assistant reply.
-  while (cutIndex < messages.length && messages[cutIndex]?.role !== "user") {
-    cutIndex += 1;
-  }
-  if (cutIndex <= 0 || cutIndex >= messages.length) {
+  options: CompactAiMessagesOptions = {}
+): {
+  messages: AIChatMessage[];
+  compacted: boolean;
+  estimatedTokens: number;
+} {
+  if (typeof options.maxTokens === "number") {
+    const budgeted = compactMessagesByTokenBudget(messages, {
+      maxTokens: options.maxTokens,
+      maxMessages: options.maxMessages,
+    });
     return {
-      messages: messages.slice(-maxMessages),
-      compacted: true,
+      messages: budgeted.messages as AIChatMessage[],
+      compacted: budgeted.compacted,
+      estimatedTokens: budgeted.estimatedTokens,
     };
   }
 
+  const result = compactMessagesForModelContext(messages, {
+    modelId: options.modelId ?? DEFAULT_AI_MODEL,
+    maxMessages: options.maxMessages,
+    systemTokenEstimate: options.systemTokenEstimate,
+  });
   return {
-    messages: messages.slice(cutIndex),
-    compacted: true,
+    messages: result.messages as AIChatMessage[],
+    compacted: result.compacted,
+    estimatedTokens: result.estimatedTokens,
   };
 }
 

--- a/src/apps/chats/utils/messages.ts
+++ b/src/apps/chats/utils/messages.ts
@@ -1,4 +1,5 @@
 import type { AIChatMessage, ChatMessage } from "@/types/chat";
+import { withCompactedMessagesMarker } from "./messageCompaction";
 
 export interface DisplayMessage extends Omit<AIChatMessage, "role"> {
   username?: string;
@@ -9,9 +10,13 @@ export interface DisplayMessage extends Omit<AIChatMessage, "role"> {
 interface BuildDisplayMessagesParams {
   currentRoomId: string | null;
   currentRoomMessagesLimited: ChatMessage[];
+  /** True when older room messages exist beyond the render window. */
+  roomHasOlderMessages?: boolean;
   aiMessages: AIChatMessage[];
   messageRenderLimit: number;
   username: string | null;
+  /** True when server (or local) history was truncated/compacted. */
+  aiHistoryCompacted?: boolean;
 }
 
 // Reuse display wrappers keyed by the source message object so that
@@ -74,19 +79,28 @@ const toDisplayMessage = (
 export const buildDisplayMessages = ({
   currentRoomId,
   currentRoomMessagesLimited,
+  roomHasOlderMessages = false,
   aiMessages,
   messageRenderLimit,
   username,
+  aiHistoryCompacted = false,
 }: BuildDisplayMessagesParams): DisplayMessage[] => {
   if (currentRoomId) {
-    return currentRoomMessagesLimited.map((msg, index) =>
+    const roomDisplay = currentRoomMessagesLimited.map((msg, index) =>
       toRoomDisplayMessage(msg, index, username)
     );
+    return withCompactedMessagesMarker(roomDisplay, roomHasOlderMessages);
   }
 
-  return aiMessages
-    .slice(-messageRenderLimit)
-    .map((msg) => toDisplayMessage(msg, username));
+  const visibleAiMessages = aiMessages.slice(-messageRenderLimit);
+  const display = visibleAiMessages.map((msg) =>
+    toDisplayMessage(msg, username)
+  );
+  const wasRenderCompacted = aiMessages.length > visibleAiMessages.length;
+  return withCompactedMessagesMarker(
+    display,
+    aiHistoryCompacted || wasRenderCompacted
+  );
 };
 
 export const extractPreviousUserMessages = (

--- a/src/hooks/useServerAIConversation.ts
+++ b/src/hooks/useServerAIConversation.ts
@@ -21,7 +21,10 @@ export interface UseServerAIConversationInput {
   /** True when the live chat is idle and safe to overwrite with server state. */
   isChatReady: () => boolean;
   /** Apply the canonical server messages to the live chat + local store. */
-  applyMessages: (messages: AIChatMessage[]) => void;
+  applyMessages: (
+    messages: AIChatMessage[],
+    options?: { historyTruncated?: boolean }
+  ) => void;
   onError: (error: unknown, context: string) => void;
 }
 
@@ -77,7 +80,9 @@ export function useServerAIConversation({
       ) {
         return;
       }
-      applyMessagesRef.current(loaded.messages);
+      applyMessagesRef.current(loaded.messages, {
+        historyTruncated: loaded.conversation.historyTruncated,
+      });
     },
     [channel, identity]
   );

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1146,6 +1146,7 @@
         "nudgeSent": "👋 *Stupser gesendet*",
         "pleaseLoginToDeleteRooms": "Bitte melden Sie sich an, um Räume zu löschen.",
         "pleaseLoginToSendMessages": "Bitte melden Sie sich an, um Nachrichten zu senden.",
+        "previousMessagesCompacted": "Vorherige Nachrichten komprimiert",
         "recording": "Aufnahme…",
         "retry": "Wiederholen",
         "ryo": "@ryo",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -921,7 +921,8 @@
         "describeThisImage": "Describe this image",
         "typeOrPushSpace": "Type or push 'space' to talk…",
         "scrollToBottom": "Scroll to bottom",
-        "nudgeSent": "👋 *nudge sent*"
+        "nudgeSent": "👋 *nudge sent*",
+        "previousMessagesCompacted": "Previous messages compacted"
       },
       "notification": {
         "openAction": "Open"

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1148,6 +1148,7 @@
         "nudgeSent": "👋 *toque enviado*",
         "pleaseLoginToDeleteRooms": "Inicia sesión para eliminar salas.",
         "pleaseLoginToSendMessages": "Inicia sesión para enviar mensajes.",
+        "previousMessagesCompacted": "Mensajes anteriores compactados",
         "recording": "Grabando…",
         "retry": "Reintentar",
         "ryo": "@ryo",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1148,6 +1148,7 @@
         "nudgeSent": "👋 *rappel envoyé*",
         "pleaseLoginToDeleteRooms": "Veuillez vous connecter pour supprimer des salons.",
         "pleaseLoginToSendMessages": "Veuillez vous connecter pour envoyer des messages.",
+        "previousMessagesCompacted": "Messages précédents compactés",
         "recording": "Enregistrement…",
         "retry": "Réessayer",
         "ryo": "@ryo",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1148,6 +1148,7 @@
         "nudgeSent": "👋 *sollecito inviato*",
         "pleaseLoginToDeleteRooms": "Accedi per eliminare le stanze.",
         "pleaseLoginToSendMessages": "Accedi per inviare messaggi.",
+        "previousMessagesCompacted": "Messaggi precedenti compattati",
         "recording": "Registrazione…",
         "retry": "Riprova",
         "ryo": "@ryo",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1146,6 +1146,7 @@
         "nudgeSent": "👋 *つつき送信済み*",
         "pleaseLoginToDeleteRooms": "ルームを削除するにはログインしてください",
         "pleaseLoginToSendMessages": "メッセージを送信するにはログインしてください",
+        "previousMessagesCompacted": "以前のメッセージを圧縮しました",
         "recording": "録音中…",
         "retry": "再試行",
         "ryo": "@ryo",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1146,6 +1146,7 @@
         "nudgeSent": "👋 *콕 찌르기 보냄*",
         "pleaseLoginToDeleteRooms": "방을 삭제하려면 로그인하세요.",
         "pleaseLoginToSendMessages": "메시지를 보내려면 로그인하세요.",
+        "previousMessagesCompacted": "이전 메시지가 압축됨",
         "recording": "녹음 중…",
         "retry": "재시도",
         "ryo": "@ryo",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1148,6 +1148,7 @@
         "nudgeSent": "👋 *cutucada enviada*",
         "pleaseLoginToDeleteRooms": "Por favor, faça login para excluir salas.",
         "pleaseLoginToSendMessages": "Por favor, faça login para enviar mensagens.",
+        "previousMessagesCompacted": "Mensagens anteriores compactadas",
         "recording": "Gravando…",
         "retry": "Tentar novamente",
         "ryo": "@ryo",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1150,6 +1150,7 @@
         "nudgeSent": "👋 *подталкивание отправлено*",
         "pleaseLoginToDeleteRooms": "Пожалуйста, войдите, чтобы удалить комнаты.",
         "pleaseLoginToSendMessages": "Пожалуйста, войдите, чтобы отправлять сообщения.",
+        "previousMessagesCompacted": "Предыдущие сообщения сжаты",
         "recording": "Запись…",
         "retry": "Повторить",
         "ryo": "@ryo",

--- a/src/lib/locales/zh-CN/translation.json
+++ b/src/lib/locales/zh-CN/translation.json
@@ -1146,6 +1146,7 @@
         "nudgeSent": "👋 *轻推已发送*",
         "pleaseLoginToDeleteRooms": "请登录以删除聊天室。",
         "pleaseLoginToSendMessages": "请登录以发送消息。",
+        "previousMessagesCompacted": "之前的消息已压缩",
         "recording": "正在录音…",
         "retry": "再试一次",
         "ryo": "@ryo",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1146,6 +1146,7 @@
         "nudgeSent": "👋 *輕推已送出*",
         "pleaseLoginToDeleteRooms": "請登入以刪除聊天室。",
         "pleaseLoginToSendMessages": "請登入以傳送訊息。",
+        "previousMessagesCompacted": "先前的訊息已壓縮",
         "recording": "正在錄音⋯",
         "retry": "再試一次",
         "ryo": "@ryo",

--- a/src/shared/aiConversationCompaction.ts
+++ b/src/shared/aiConversationCompaction.ts
@@ -1,0 +1,213 @@
+/**
+ * Shared token estimation + turn-boundary compaction for AI chat history.
+ *
+ * Runtime-neutral (no React / DOM / Bun-only APIs) so both the Vite client and
+ * the Bun API server can import it. Uses a conservative chars÷4 heuristic —
+ * good enough for budgeting against model context windows without shipping a
+ * tokenizer to the browser.
+ */
+
+import {
+  AI_CHAT_COMPACTION_MESSAGE_SAFETY_MAX,
+  DEFAULT_AI_MODEL,
+  getModelConversationTokenBudget,
+  type SupportedModel,
+} from "./aiModels";
+
+/** Fixed surcharge for image / file parts (vision tokens vary by provider). */
+export const AI_IMAGE_PART_TOKEN_ESTIMATE = 1_024;
+
+export function estimateTextTokens(text: string): number {
+  // Prefer code-point length so emoji / CJK don't under-count vs UTF-16.
+  const codePoints = [...text].length;
+  if (codePoints <= 0) return 0;
+  return Math.ceil(codePoints / 4);
+}
+
+export function estimateJsonTokens(value: unknown): number {
+  try {
+    return estimateTextTokens(JSON.stringify(value));
+  } catch {
+    return 256;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function estimateMessagePartTokens(part: unknown): number {
+  if (!isRecord(part) || typeof part.type !== "string") return 32;
+  const type = part.type;
+
+  if (type === "text" && typeof part.text === "string") {
+    return estimateTextTokens(part.text);
+  }
+  if (type === "reasoning" && typeof part.text === "string") {
+    return estimateTextTokens(part.text);
+  }
+  if (type === "file" || type === "image") {
+    return AI_IMAGE_PART_TOKEN_ESTIMATE;
+  }
+  if (type === "source-url" || type === "source-document") {
+    return 64;
+  }
+  if (type === "step-start") {
+    return 4;
+  }
+
+  // Tool / dynamic-tool / data parts — size the JSON payloads.
+  if (type === "dynamic-tool" || type.startsWith("tool-") || type.startsWith("data-")) {
+    let tokens = 24; // tool name / framing
+    for (const field of ["input", "output", "rawInput", "errorText", "title"] as const) {
+      if (!(field in part) || part[field] === undefined) continue;
+      const value = part[field];
+      tokens +=
+        typeof value === "string"
+          ? estimateTextTokens(value)
+          : estimateJsonTokens(value);
+    }
+    return tokens;
+  }
+
+  return estimateJsonTokens(part);
+}
+
+export function estimateUIMessageTokens(message: {
+  role?: string;
+  parts?: readonly unknown[];
+  content?: unknown;
+}): number {
+  let tokens = 8; // role / message framing
+  if (Array.isArray(message.parts)) {
+    for (const part of message.parts) {
+      tokens += estimateMessagePartTokens(part);
+    }
+    return tokens;
+  }
+  if (typeof message.content === "string") {
+    return tokens + estimateTextTokens(message.content);
+  }
+  if (Array.isArray(message.content)) {
+    for (const part of message.content) {
+      tokens += estimateMessagePartTokens(part);
+    }
+  }
+  return tokens;
+}
+
+export function estimateUIMessagesTokens(
+  messages: readonly {
+    role?: string;
+    parts?: readonly unknown[];
+    content?: unknown;
+  }[]
+): number {
+  return messages.reduce(
+    (total, message) => total + estimateUIMessageTokens(message),
+    0
+  );
+}
+
+export type CompactableMessage = {
+  id?: string;
+  role: string;
+  parts?: readonly unknown[];
+  content?: unknown;
+};
+
+export interface CompactMessagesByTokenBudgetOptions {
+  maxTokens: number;
+  /** Absolute message-count ceiling (defaults to shared safety max). */
+  maxMessages?: number;
+}
+
+/**
+ * Keep the newest turns that fit under a token budget, cutting only at
+ * user-message boundaries so we never leave a dangling assistant reply.
+ */
+export function compactMessagesByTokenBudget<T extends CompactableMessage>(
+  messages: readonly T[],
+  options: CompactMessagesByTokenBudgetOptions
+): { messages: T[]; compacted: boolean; estimatedTokens: number } {
+  const maxTokens = Math.max(1, Math.floor(options.maxTokens));
+  const maxMessages = Math.max(
+    1,
+    Math.floor(options.maxMessages ?? AI_CHAT_COMPACTION_MESSAGE_SAFETY_MAX)
+  );
+
+  if (messages.length === 0) {
+    return { messages: [], compacted: false, estimatedTokens: 0 };
+  }
+
+  const turns: T[][] = [];
+  let current: T[] = [];
+  for (const message of messages) {
+    if (message.role === "user" && current.length > 0) {
+      turns.push(current);
+      current = [];
+    }
+    current.push(message);
+  }
+  if (current.length > 0) turns.push(current);
+
+  const selected: T[] = [];
+  let tokens = 0;
+  let messageCount = 0;
+  let dropped = false;
+
+  for (let index = turns.length - 1; index >= 0; index -= 1) {
+    const turn = turns[index]!;
+    const turnTokens = estimateUIMessagesTokens(turn);
+    const nextCount = messageCount + turn.length;
+    if (
+      selected.length > 0 &&
+      (tokens + turnTokens > maxTokens || nextCount > maxMessages)
+    ) {
+      dropped = true;
+      break;
+    }
+    // Always keep the newest turn even if it alone exceeds the budget — the
+    // caller still needs the current user action to reach the model.
+    selected.unshift(...turn);
+    tokens += turnTokens;
+    messageCount = nextCount;
+    if (index === turns.length - 1 && (tokens > maxTokens || messageCount > maxMessages)) {
+      // Newest turn alone is over budget; keep it and stop.
+      dropped = index > 0;
+      break;
+    }
+  }
+
+  const compacted = dropped || selected.length !== messages.length;
+  return {
+    messages: compacted ? selected : [...messages],
+    compacted,
+    estimatedTokens: tokens,
+  };
+}
+
+export function compactMessagesForModelContext<T extends CompactableMessage>(
+  messages: readonly T[],
+  options?: {
+    modelId?: SupportedModel | null;
+    maxOutputTokens?: number;
+    systemTokenEstimate?: number;
+    safetyTokens?: number;
+    maxMessages?: number;
+  }
+): { messages: T[]; compacted: boolean; estimatedTokens: number; maxTokens: number } {
+  const maxTokens = getModelConversationTokenBudget(
+    options?.modelId ?? DEFAULT_AI_MODEL,
+    {
+      maxOutputTokens: options?.maxOutputTokens,
+      systemTokenEstimate: options?.systemTokenEstimate,
+      safetyTokens: options?.safetyTokens,
+    }
+  );
+  const result = compactMessagesByTokenBudget(messages, {
+    maxTokens,
+    maxMessages: options?.maxMessages,
+  });
+  return { ...result, maxTokens };
+}

--- a/src/shared/aiModels.ts
+++ b/src/shared/aiModels.ts
@@ -10,18 +10,23 @@ export const AI_MODELS = {
   "sonnet-4.6": {
     name: "sonnet-4.6",
     provider: "Anthropic",
+    /** Total model context window (input + output). */
+    contextWindow: 1_000_000,
   },
   "gpt-5.5": {
     name: "gpt-5.5",
     provider: "OpenAI",
+    contextWindow: 1_000_000,
   },
   "gemini-3-flash": {
     name: "gemini-3-flash",
     provider: "Google",
+    contextWindow: 1_048_576,
   },
   "gemini-3.1-pro-preview": {
     name: "gemini-3.1-pro-preview",
     provider: "Google",
+    contextWindow: 1_048_576,
   },
 } as const;
 
@@ -37,6 +42,7 @@ export interface AIModelInfo {
   id: SupportedModel;
   name: string;
   provider: string;
+  contextWindow: number;
 }
 
 export const AI_MODEL_METADATA: AIModelInfo[] = Object.entries(AI_MODELS).map(
@@ -48,3 +54,44 @@ export const AI_MODEL_METADATA: AIModelInfo[] = Object.entries(AI_MODELS).map(
 
 // Default model
 export const DEFAULT_AI_MODEL: SupportedModel = "gpt-5.5";
+
+/**
+ * Reserved output tokens for the main chat agent loop. Keep in sync with
+ * `RYO_AGENT_PRESETS.chat.maxOutputTokens` in `api/_utils/ryo-agent.ts`.
+ */
+export const AI_CHAT_RESERVED_OUTPUT_TOKENS = 48_000;
+
+/** Extra headroom for tool schemas, framing, and estimation error. */
+export const AI_CHAT_COMPACTION_SAFETY_TOKENS = 16_000;
+
+/** Absolute message-count safety net (token budget is the primary limit). */
+export const AI_CHAT_COMPACTION_MESSAGE_SAFETY_MAX = 2_000;
+
+export function getAIModelContextWindow(
+  modelId: SupportedModel | null | undefined
+): number {
+  if (modelId && modelId in AI_MODELS) {
+    return AI_MODELS[modelId].contextWindow;
+  }
+  return AI_MODELS[DEFAULT_AI_MODEL].contextWindow;
+}
+
+/**
+ * Tokens available for conversation history after reserving output, fixed
+ * system overhead, and a safety margin.
+ */
+export function getModelConversationTokenBudget(
+  modelId: SupportedModel | null | undefined,
+  options?: {
+    maxOutputTokens?: number;
+    systemTokenEstimate?: number;
+    safetyTokens?: number;
+  }
+): number {
+  const contextWindow = getAIModelContextWindow(modelId);
+  const maxOutput =
+    options?.maxOutputTokens ?? AI_CHAT_RESERVED_OUTPUT_TOKENS;
+  const systemTokens = Math.max(0, options?.systemTokenEstimate ?? 0);
+  const safety = options?.safetyTokens ?? AI_CHAT_COMPACTION_SAFETY_TOKENS;
+  return Math.max(1_024, contextWindow - maxOutput - systemTokens - safety);
+}

--- a/src/stores/useChatsStore.ts
+++ b/src/stores/useChatsStore.ts
@@ -230,6 +230,7 @@ function forceLogoutOnUnauthorized() {
   clearAIConversationSessionCache();
   useChatsStore.setState({
     aiMessages: [getInitialAiMessage()],
+    aiHistoryCompacted: false,
     username: null,
     isAuthenticated: false,
     currentRoomId: null,
@@ -251,6 +252,8 @@ const ensureUsernameRecovery = (username: string | null) => {
 export interface ChatsStoreState {
   // AI Chat State
   aiMessages: AIChatMessage[];
+  /** True when older AI history was compacted/truncated (server or local). */
+  aiHistoryCompacted: boolean;
   // Room State
   username: string | null;
   isAuthenticated: boolean;
@@ -269,6 +272,7 @@ export interface ChatsStoreState {
 
   // Actions
   setAiMessages: (messages: AIChatMessage[]) => void;
+  setAiHistoryCompacted: (compacted: boolean) => void;
   setUsername: (username: string | null) => void;
   setAuthenticated: (authenticated: boolean) => void;
   setPassword: (
@@ -345,6 +349,7 @@ const getInitialState = (): Omit<
   | "logout"
   | "deleteAccount"
   | "setAiMessages"
+  | "setAiHistoryCompacted"
   | "setUsername"
   | "setAuthenticated"
   | "setPassword"
@@ -376,6 +381,7 @@ const getInitialState = (): Omit<
 
   return {
     aiMessages: [getInitialAiMessage()],
+    aiHistoryCompacted: false,
     username: recoveredUsername,
     isAuthenticated: false,
     rooms: [],
@@ -397,6 +403,7 @@ const STORE_NAME = "ryos:chats";
 type ChatsPersistedState = Pick<
   ChatsStoreState,
   | "aiMessages"
+  | "aiHistoryCompacted"
   | "username"
   | "currentRoomId"
   | "isSidebarVisible"
@@ -484,6 +491,7 @@ const mergeChatsState = (
   return {
     ...metadata,
     aiMessages,
+    aiHistoryCompacted: metadata.aiHistoryCompacted === true,
     roomMessages,
   };
 };
@@ -501,6 +509,8 @@ export const useChatsStore = create<ChatsStoreState>()(
 
         // --- Actions ---
         setAiMessages: (messages) => set({ aiMessages: messages }),
+        setAiHistoryCompacted: (compacted) =>
+          set({ aiHistoryCompacted: compacted }),
         setUsername: (username) => {
           const previousUsername = get().username;
           const clearAIHistory = shouldClearAIHistoryForUsernameChange(
@@ -518,7 +528,10 @@ export const useChatsStore = create<ChatsStoreState>()(
           set({
             username,
             ...(clearAIHistory
-              ? { aiMessages: [getInitialAiMessage()] }
+              ? {
+                  aiMessages: [getInitialAiMessage()],
+                  aiHistoryCompacted: false,
+                }
               : {}),
           });
 
@@ -553,6 +566,7 @@ export const useChatsStore = create<ChatsStoreState>()(
             set({
               isAuthenticated: false,
               aiMessages: [getInitialAiMessage()],
+              aiHistoryCompacted: false,
             });
             return;
           }
@@ -850,6 +864,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           set((state) => ({
             ...state,
             aiMessages: [getInitialAiMessage()],
+            aiHistoryCompacted: false,
             username: null,
             isAuthenticated: false,
             currentRoomId: null,
@@ -903,6 +918,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           set((state) => ({
             ...state,
             aiMessages: [getInitialAiMessage()],
+            aiHistoryCompacted: false,
             username: null,
             isAuthenticated: false,
             currentRoomId: null,
@@ -1287,7 +1303,10 @@ export const useChatsStore = create<ChatsStoreState>()(
                 username: data.user.username,
                 isAuthenticated: true,
                 ...(clearAIHistory
-                  ? { aiMessages: [getInitialAiMessage()] }
+                  ? {
+                      aiMessages: [getInitialAiMessage()],
+                      aiHistoryCompacted: false,
+                    }
                   : {}),
               });
 
@@ -1342,6 +1361,7 @@ export const useChatsStore = create<ChatsStoreState>()(
       }),
       partialize: (state) => ({
         aiMessages: state.aiMessages,
+        aiHistoryCompacted: state.aiHistoryCompacted,
         username: state.username,
         currentRoomId: state.currentRoomId,
         isSidebarVisible: state.isSidebarVisible,

--- a/src/types/aiModels.ts
+++ b/src/types/aiModels.ts
@@ -5,6 +5,11 @@ export {
   SUPPORTED_AI_MODELS,
   AI_MODEL_METADATA,
   DEFAULT_AI_MODEL,
+  AI_CHAT_RESERVED_OUTPUT_TOKENS,
+  AI_CHAT_COMPACTION_SAFETY_TOKENS,
+  AI_CHAT_COMPACTION_MESSAGE_SAFETY_MAX,
+  getAIModelContextWindow,
+  getModelConversationTokenBudget,
 } from "@/shared/aiModels";
 export type {
   AIModel,

--- a/tests/unit/ai/test-ai-conversation-store.test.ts
+++ b/tests/unit/ai/test-ai-conversation-store.test.ts
@@ -1077,7 +1077,11 @@ describe("AI conversation store", () => {
   test("bounds retained history without resetting sequence numbers", async () => {
     const redis = new MemoryConversationRedis();
     let document = await seedTurn(redis, "alice", "chat", "turn-0", "message 0");
-    for (let index = 1; index < 205; index += 1) {
+    // Short messages never approach the ~1M token budget, so use bulky
+    // payloads to force token-based compaction while keeping the loop small.
+    const bulky = "x".repeat(80_000); // ~20k tokens each
+    const overflowCount = 55;
+    for (let index = 1; index < overflowCount; index += 1) {
       document = (
         await beginAIConversationTurn({
           redis,
@@ -1086,16 +1090,18 @@ describe("AI conversation store", () => {
           operationId: `turn-${index}`,
           action: {
             kind: "user-message",
-            message: message(`u${index}`, "user", `message ${index}`),
+            message: message(`u${index}`, "user", `${bulky}-${index}`),
           },
         })
       ).document;
     }
 
-    expect(document.messages).toHaveLength(200);
-    expect(document.messages[0]?.seq).toBe(6);
-    expect(document.messages.at(-1)?.seq).toBe(205);
+    expect(document.messages.length).toBeLessThan(overflowCount);
+    expect(document.messages.length).toBeGreaterThan(0);
+    expect(document.messages.at(-1)?.seq).toBe(overflowCount);
     expect(document.historyTruncated).toBe(true);
+    // Sequence numbers keep advancing; the oldest retained seq is > 1.
+    expect(document.messages[0]?.seq).toBeGreaterThan(1);
   });
 
   test("account deletion tombstones reject in-flight and future writes", async () => {

--- a/tests/unit/chat/test-message-compaction.test.ts
+++ b/tests/unit/chat/test-message-compaction.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AI_MESSAGE_COMPACTION_MAX,
+  COMPACTED_MESSAGES_MARKER,
+  compactAiMessages,
+  isMessagesCompactedMarker,
+  withCompactedMessagesMarker,
+} from "../../../src/apps/chats/utils/messageCompaction";
+import { buildDisplayMessages } from "../../../src/apps/chats/utils/messages";
+import type { AIChatMessage } from "../../../src/types/chat";
+
+function makeAiMessage(
+  id: string,
+  role: "user" | "assistant"
+): AIChatMessage {
+  return {
+    id,
+    role,
+    parts: [{ type: "text", text: `${role}-${id}` }],
+    metadata: { createdAt: new Date(Number(id) * 1000) },
+  };
+}
+
+describe("compactAiMessages", () => {
+  test("returns unchanged when under the cap", () => {
+    const messages = [
+      makeAiMessage("1", "assistant"),
+      makeAiMessage("2", "user"),
+      makeAiMessage("3", "assistant"),
+    ];
+    const result = compactAiMessages(messages, 10);
+    expect(result.compacted).toBe(false);
+    expect(result.messages).toEqual(messages);
+  });
+
+  test("cuts at a user-turn boundary when over the cap", () => {
+    const messages = [
+      makeAiMessage("1", "assistant"),
+      makeAiMessage("2", "user"),
+      makeAiMessage("3", "assistant"),
+      makeAiMessage("4", "user"),
+      makeAiMessage("5", "assistant"),
+      makeAiMessage("6", "user"),
+      makeAiMessage("7", "assistant"),
+    ];
+    const result = compactAiMessages(messages, 4);
+    expect(result.compacted).toBe(true);
+    expect(result.messages.map((message) => message.id)).toEqual([
+      "4",
+      "5",
+      "6",
+      "7",
+    ]);
+  });
+
+  test("defaults to the shared AI compaction max", () => {
+    expect(AI_MESSAGE_COMPACTION_MAX).toBe(200);
+  });
+});
+
+describe("buildDisplayMessages compaction marker", () => {
+  test("prepends compacted marker when AI history exceeds the render limit", () => {
+    const aiMessages = Array.from({ length: 3 }, (_, index) =>
+      makeAiMessage(String(index + 1), index % 2 === 0 ? "assistant" : "user")
+    );
+    const display = buildDisplayMessages({
+      currentRoomId: null,
+      currentRoomMessagesLimited: [],
+      aiMessages,
+      messageRenderLimit: 2,
+      username: "ryo",
+    });
+    expect(display).toHaveLength(3);
+    expect(isMessagesCompactedMarker(display[0]!)).toBe(true);
+    expect(display[1]?.id).toBe("2");
+    expect(display[2]?.id).toBe("3");
+  });
+
+  test("prepends compacted marker when aiHistoryCompacted is set", () => {
+    const aiMessages = [
+      makeAiMessage("1", "assistant"),
+      makeAiMessage("2", "user"),
+    ];
+    const display = buildDisplayMessages({
+      currentRoomId: null,
+      currentRoomMessagesLimited: [],
+      aiMessages,
+      messageRenderLimit: 50,
+      username: "ryo",
+      aiHistoryCompacted: true,
+    });
+    expect(isMessagesCompactedMarker(display[0]!)).toBe(true);
+    expect(display).toHaveLength(3);
+  });
+
+  test("prepends compacted marker for rooms with older messages", () => {
+    const roomMessages = [
+      {
+        id: "m1",
+        roomId: "room-1",
+        username: "alice",
+        content: "hi",
+        timestamp: 1,
+      },
+      {
+        id: "m2",
+        roomId: "room-1",
+        username: "bob",
+        content: "hello",
+        timestamp: 2,
+      },
+    ];
+    const display = buildDisplayMessages({
+      currentRoomId: "room-1",
+      currentRoomMessagesLimited: roomMessages.slice(-1),
+      roomHasOlderMessages: true,
+      aiMessages: [],
+      messageRenderLimit: 1,
+      username: "bob",
+    });
+    expect(isMessagesCompactedMarker(display[0]!)).toBe(true);
+    expect(display).toHaveLength(2);
+    expect(display[1]?.serverId).toBe("m2");
+  });
+
+  test("does not duplicate an existing compacted marker", () => {
+    const result = withCompactedMessagesMarker(
+      [COMPACTED_MESSAGES_MARKER, makeAiMessage("1", "assistant")],
+      true
+    );
+    expect(result.filter(isMessagesCompactedMarker)).toHaveLength(1);
+  });
+});

--- a/tests/unit/chat/test-message-compaction.test.ts
+++ b/tests/unit/chat/test-message-compaction.test.ts
@@ -7,54 +7,113 @@ import {
   withCompactedMessagesMarker,
 } from "../../../src/apps/chats/utils/messageCompaction";
 import { buildDisplayMessages } from "../../../src/apps/chats/utils/messages";
+import {
+  AI_CHAT_COMPACTION_MESSAGE_SAFETY_MAX,
+  AI_MODELS,
+  getModelConversationTokenBudget,
+} from "../../../src/shared/aiModels";
+import {
+  compactMessagesByTokenBudget,
+  estimateTextTokens,
+  estimateUIMessageTokens,
+} from "../../../src/shared/aiConversationCompaction";
 import type { AIChatMessage } from "../../../src/types/chat";
 
 function makeAiMessage(
   id: string,
-  role: "user" | "assistant"
+  role: "user" | "assistant",
+  text = `${role}-${id}`
 ): AIChatMessage {
   return {
     id,
     role,
-    parts: [{ type: "text", text: `${role}-${id}` }],
+    parts: [{ type: "text", text }],
     metadata: { createdAt: new Date(Number(id) * 1000) },
   };
 }
 
-describe("compactAiMessages", () => {
-  test("returns unchanged when under the cap", () => {
+describe("token estimation", () => {
+  test("estimates text tokens conservatively from code points", () => {
+    expect(estimateTextTokens("abcd")).toBe(1);
+    expect(estimateTextTokens("a".repeat(8))).toBe(2);
+  });
+
+  test("counts tool payloads toward message size", () => {
+    const tokens = estimateUIMessageTokens({
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-read",
+          state: "output-available",
+          input: { path: "/Documents/note.md" },
+          output: { content: "x".repeat(400) },
+        },
+      ],
+    });
+    expect(tokens).toBeGreaterThan(80);
+  });
+});
+
+describe("compactMessagesByTokenBudget", () => {
+  test("returns unchanged when under the budget", () => {
     const messages = [
       makeAiMessage("1", "assistant"),
       makeAiMessage("2", "user"),
       makeAiMessage("3", "assistant"),
     ];
-    const result = compactAiMessages(messages, 10);
+    const result = compactMessagesByTokenBudget(messages, { maxTokens: 10_000 });
     expect(result.compacted).toBe(false);
     expect(result.messages).toEqual(messages);
   });
 
-  test("cuts at a user-turn boundary when over the cap", () => {
+  test("keeps newest turns that fit the token budget", () => {
+    const bulky = "y".repeat(400); // ~100 tokens
+    const messages = [
+      makeAiMessage("1", "user", bulky),
+      makeAiMessage("2", "assistant", bulky),
+      makeAiMessage("3", "user", bulky),
+      makeAiMessage("4", "assistant", bulky),
+      makeAiMessage("5", "user", bulky),
+      makeAiMessage("6", "assistant", bulky),
+    ];
+    const result = compactMessagesByTokenBudget(messages, { maxTokens: 250 });
+    expect(result.compacted).toBe(true);
+    expect(result.messages.map((message) => message.id)).toEqual(["5", "6"]);
+    expect(result.estimatedTokens).toBeLessThanOrEqual(250);
+  });
+});
+
+describe("compactAiMessages", () => {
+  test("uses the selected model's conversation token budget", () => {
+    const budget = getModelConversationTokenBudget("gpt-5.5");
+    expect(budget).toBeLessThan(AI_MODELS["gpt-5.5"].contextWindow);
+    expect(budget).toBeGreaterThan(500_000);
+
     const messages = [
       makeAiMessage("1", "assistant"),
       makeAiMessage("2", "user"),
       makeAiMessage("3", "assistant"),
-      makeAiMessage("4", "user"),
-      makeAiMessage("5", "assistant"),
-      makeAiMessage("6", "user"),
-      makeAiMessage("7", "assistant"),
     ];
-    const result = compactAiMessages(messages, 4);
-    expect(result.compacted).toBe(true);
-    expect(result.messages.map((message) => message.id)).toEqual([
-      "4",
-      "5",
-      "6",
-      "7",
-    ]);
+    const result = compactAiMessages(messages, { modelId: "gpt-5.5" });
+    expect(result.compacted).toBe(false);
+    expect(result.messages).toEqual(messages);
   });
 
-  test("defaults to the shared AI compaction max", () => {
-    expect(AI_MESSAGE_COMPACTION_MAX).toBe(200);
+  test("compacts when an explicit token budget is exceeded", () => {
+    const bulky = "z".repeat(400);
+    const messages = [
+      makeAiMessage("1", "user", bulky),
+      makeAiMessage("2", "assistant", bulky),
+      makeAiMessage("3", "user", bulky),
+      makeAiMessage("4", "assistant", bulky),
+    ];
+    const result = compactAiMessages(messages, { maxTokens: 250 });
+    expect(result.compacted).toBe(true);
+    expect(result.messages.map((message) => message.id)).toEqual(["3", "4"]);
+  });
+
+  test("message safety max matches the shared constant", () => {
+    expect(AI_MESSAGE_COMPACTION_MAX).toBe(AI_CHAT_COMPACTION_MESSAGE_SAFETY_MAX);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Auto-compacts chat history to each model's **context-window token budget** (not a fixed message count), reserving output tokens + safety headroom.
- Shared estimator (`chars÷4`, tool/file surcharges) used by anonymous client compaction, `prepareRyoConversationModelInput`, and Redis persistence trim.
- Still shows a center-aligned **Previous messages compacted** system row when history was compacted or older messages fall outside the render window.
- Absolute 2,000-message + 4 MiB parts budgets remain as storage safety nets.

## Demo
![Compacted marker](https://cursor.com/artifacts/c/art-c6ca31eb-3580-4787-ba91-f7c5f6c4bf12)
![Short chat without marker](https://cursor.com/artifacts/c/art-31a041ff-8b57-4910-9179-61aaa92458b1)

## Test plan
- [x] `bun test tests/unit/chat/test-message-compaction.test.ts`
- [x] `bun test tests/unit/ai/test-ai-conversation-store.test.ts`
- [x] `bun run typecheck`
- [x] Manual: compacted flag shows centered marker; short chat does not

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f523f-dc5d-7f4e-82fd-29d4392d0473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f523f-dc5d-7f4e-82fd-29d4392d0473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

