### PR TITLE
Complete AI SDK 7 migration + adopt timeouts, reasoning, toolsContext, uploadFile, cache

### DIFF
--- a/api/_utils/_aiModels.ts
+++ b/api/_utils/_aiModels.ts
@@ -21,11 +21,24 @@ export type { SupportedModel };
 export const DEFAULT_MODEL: SupportedModel = DEFAULT_AI_MODEL;
 export const TELEGRAM_DEFAULT_MODEL: SupportedModel = DEFAULT_MODEL;
 
-type OpenAIReasoningEffort = "none" | "medium";
+/**
+ * AI SDK 7 top-level `reasoning` levels.
+ * Prefer this over provider-specific `providerOptions.openai.reasoningEffort`
+ * — if both are set, provider options win and the top-level value is ignored.
+ */
+export type ModelReasoningLevel =
+  | "provider-default"
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh";
 
-const OPENAI_REASONING_EFFORT_BY_MODEL: Partial<
-  Record<SupportedModel, OpenAIReasoningEffort>
+const MODEL_REASONING_BY_MODEL: Partial<
+  Record<SupportedModel, ModelReasoningLevel>
 > = {
+  // gpt-5.5 defaults to extended reasoning; disable for chat latency/cost.
   "gpt-5.5": "none",
 };
 
@@ -47,29 +60,14 @@ export const getModelInstance = (model: SupportedModel): LanguageModel => {
   }
 };
 
-export function getOpenAIProviderOptions(
+/**
+ * Top-level AI SDK 7 `reasoning` setting for a model, when we override the
+ * provider default. Returns undefined to leave the provider default alone.
+ */
+export function getModelReasoning(
   model: SupportedModel
-): { openai: { reasoningEffort?: OpenAIReasoningEffort } } | undefined {
-  if (AI_MODELS[model].provider !== "OpenAI") {
-    return undefined;
-  }
-
-  const openaiOptions: {
-    reasoningEffort?: OpenAIReasoningEffort;
-  } = {};
-
-  const reasoningEffort = OPENAI_REASONING_EFFORT_BY_MODEL[model];
-  if (reasoningEffort) {
-    openaiOptions.reasoningEffort = reasoningEffort;
-  }
-
-  if (Object.keys(openaiOptions).length === 0) {
-    return undefined;
-  }
-
-  return {
-    openai: openaiOptions,
-  };
+): ModelReasoningLevel | undefined {
+  return MODEL_REASONING_BY_MODEL[model];
 }
 
 export function getTelegramModel(

--- a/api/_utils/ai-prompt-cache.ts
+++ b/api/_utils/ai-prompt-cache.ts
@@ -16,9 +16,18 @@ function isAnthropicModel(model: LanguageModel): boolean {
   );
 }
 
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
 /**
  * Mark the last message with Anthropic ephemeral cache control so each
  * agent step can incrementally reuse the conversation prefix.
+ *
+ * Merges into existing `providerOptions.anthropic` instead of replacing the
+ * whole provider bag (preserves other Anthropic options on that message).
  *
  * See https://ai-sdk.dev/v7/cookbook/node/dynamic-prompt-caching
  */
@@ -36,12 +45,20 @@ export function addCacheControlToMessages({
 
   return messages.map((message, index) => {
     if (index !== messages.length - 1) return message;
+
+    const existing = asRecord(message.providerOptions);
+    const incoming = asRecord(providerOptions);
+
     return {
       ...message,
       providerOptions: {
-        ...message.providerOptions,
-        ...providerOptions,
-      },
+        ...existing,
+        ...incoming,
+        anthropic: {
+          ...asRecord(existing.anthropic),
+          ...asRecord(incoming.anthropic),
+        },
+      } as ProviderOptions,
     };
   });
 }

--- a/api/_utils/ai-prompt-cache.ts
+++ b/api/_utils/ai-prompt-cache.ts
@@ -1,0 +1,47 @@
+import type { LanguageModel, ModelMessage, ProviderOptions } from "ai";
+
+const DEFAULT_ANTHROPIC_CACHE_OPTIONS = {
+  anthropic: { cacheControl: { type: "ephemeral" as const } },
+} satisfies ProviderOptions;
+
+function isAnthropicModel(model: LanguageModel): boolean {
+  if (typeof model === "string") {
+    return model.includes("anthropic") || model.includes("claude");
+  }
+  return (
+    model.provider === "anthropic" ||
+    model.provider.includes("anthropic") ||
+    model.modelId.includes("anthropic") ||
+    model.modelId.includes("claude")
+  );
+}
+
+/**
+ * Mark the last message with Anthropic ephemeral cache control so each
+ * agent step can incrementally reuse the conversation prefix.
+ *
+ * See https://ai-sdk.dev/v7/cookbook/node/dynamic-prompt-caching
+ */
+export function addCacheControlToMessages({
+  messages,
+  model,
+  providerOptions = DEFAULT_ANTHROPIC_CACHE_OPTIONS,
+}: {
+  messages: ModelMessage[];
+  model: LanguageModel;
+  providerOptions?: ProviderOptions;
+}): ModelMessage[] {
+  if (messages.length === 0) return messages;
+  if (!isAnthropicModel(model)) return messages;
+
+  return messages.map((message, index) => {
+    if (index !== messages.length - 1) return message;
+    return {
+      ...message,
+      providerOptions: {
+        ...message.providerOptions,
+        ...providerOptions,
+      },
+    };
+  });
+}

--- a/api/_utils/parse-youtube-title.ts
+++ b/api/_utils/parse-youtube-title.ts
@@ -201,10 +201,7 @@ export async function parseYouTubeTitleWithAI(
         schema: ParsedTitleSchema,
         name: "parsed_youtube_title",
       }),
-      messages: [
-        {
-          role: "system",
-          content: `You are an expert music metadata parser. Given a raw YouTube video title and optionally the channel name, extract the song title and artist. If possible, also extract the album name.
+      instructions: `You are an expert music metadata parser. Given a raw YouTube video title and optionally the channel name, extract the song title and artist. If possible, also extract the album name.
 
 Rules:
 - Return ONLY the clean song title, artist name, and optional album name as simple strings.
@@ -218,7 +215,7 @@ Examples:
 - title="Jay Chou - Sunny Day (周杰倫 - 晴天)", channel="Jay Chou" -> {"title":"晴天","artist":"周杰倫","album":null}
 - title="NewJeans (뉴진스) 'How Sweet' Official MV", channel="HYBE LABELS" -> {"title":"How Sweet","artist":"뉴진스","album":null}
 - title="Lofi Hip Hop Radio - Beats to Relax/Study to", channel="ChillHop Music" -> {"title":"Lofi Hip Hop Radio - Beats to Relax/Study to","artist":null,"album":null}`,
-        },
+      messages: [
         {
           role: "user",
           content: `Title: ${cleanTitle}${cleanChannel ? `\nChannel: ${cleanChannel}` : ""}`,

--- a/api/_utils/ryo-agent.ts
+++ b/api/_utils/ryo-agent.ts
@@ -63,7 +63,15 @@ export const repairRyoToolCall: ToolCallRepairFunction<ToolSet> = async ({
   return null;
 };
 
-const RYO_AGENT_TIMEOUTS = {
+/**
+ * Per-preset timeouts for Ryo ToolLoopAgent runs.
+ *
+ * IMPORTANT: AI SDK 7's `agent.stream()` / `agent.generate()` always forward
+ * the call-time `timeout` argument (even when omitted as `undefined`), which
+ * overwrites the constructor default. Call sites MUST pass
+ * `timeout: RYO_AGENT_TIMEOUTS[preset]` explicitly.
+ */
+export const RYO_AGENT_TIMEOUTS = {
   chat: {
     totalMs: 180_000,
     stepMs: 90_000,
@@ -75,6 +83,11 @@ const RYO_AGENT_TIMEOUTS = {
       searchSongsMs: 25_000,
       mapsSearchPlacesMs: 20_000,
       getWeatherMs: 15_000,
+      memoryWriteMs: 15_000,
+      memoryReadMs: 15_000,
+      memoryDeleteMs: 15_000,
+      generateHtmlMs: 30_000,
+      infiniteMacControlMs: 45_000,
     },
   },
   telegram: {
@@ -88,6 +101,13 @@ const RYO_AGENT_TIMEOUTS = {
       mapsSearchPlacesMs: 20_000,
       getWeatherMs: 15_000,
       songLibraryControlMs: 25_000,
+      memoryWriteMs: 15_000,
+      memoryReadMs: 15_000,
+      memoryDeleteMs: 15_000,
+      documentsControlMs: 20_000,
+      calendarControlMs: 20_000,
+      stickiesControlMs: 15_000,
+      contactsControlMs: 15_000,
     },
   },
   telegramHeartbeat: {
@@ -97,6 +117,8 @@ const RYO_AGENT_TIMEOUTS = {
     tools: {
       webFetchMs: 15_000,
       runJsMs: 10_000,
+      memoryWriteMs: 10_000,
+      memoryReadMs: 10_000,
     },
   },
 } as const satisfies Record<string, TimeoutConfiguration<ToolSet>>;

--- a/api/_utils/ryo-agent.ts
+++ b/api/_utils/ryo-agent.ts
@@ -80,7 +80,11 @@ type RyoToolLoopAgentOptions = {
   preset: RyoAgentPresetName;
   prepared: Pick<
     PreparedRyoConversation,
-    "selectedModel" | "modelId" | "tools" | "instructions"
+    | "selectedModel"
+    | "modelId"
+    | "tools"
+    | "instructions"
+    | "dynamicContextMessages"
   >;
   temperature?: number;
   tools?: ToolSet;
@@ -107,15 +111,29 @@ export function createRyoToolLoopAgent({
     ? { "anthropic-beta": "fine-grained-tool-streaming-2025-05-14" }
     : undefined;
   const resolvedTools = tools ?? prepared.tools;
+  const dynamicContextMessages = prepared.dynamicContextMessages;
 
   return new ToolLoopAgent<never, ToolSet>({
     id: agentPreset.id,
     model: prepared.selectedModel,
     tools: resolvedTools,
+    // Static system prompt only — never mutate this for per-request state.
     instructions: prepared.instructions,
     temperature,
     maxOutputTokens: agentPreset.maxOutputTokens,
     stopWhen: isStepCount(agentPreset.stopAfterSteps),
+    // Inject memory + volatile state once via messages (AI SDK 7 prepareStep).
+    // Returned messages carry forward for later steps, so we only prepend on
+    // step 0. Do not override `instructions` here — that would bust the static
+    // prompt cache.
+    prepareStep: ({ stepNumber, messages }) => {
+      if (stepNumber !== 0 || dynamicContextMessages.length === 0) {
+        return {};
+      }
+      return {
+        messages: [...dynamicContextMessages, ...messages],
+      };
+    },
     // Only attach approval policy when the tool is actually registered for
     // this profile (e.g. telegram omits getPreciseLocation).
     ...(resolvedTools.getPreciseLocation

--- a/api/_utils/ryo-agent.ts
+++ b/api/_utils/ryo-agent.ts
@@ -5,9 +5,16 @@ import {
   type TextStreamPart,
   type ToolCallRepairFunction,
   type ToolSet,
+  type TimeoutConfiguration,
 } from "ai";
-import { getOpenAIProviderOptions } from "./_aiModels.js";
-import type { PreparedRyoConversation } from "./ryo-conversation.js";
+import { getModelReasoning } from "./_aiModels.js";
+import { addCacheControlToMessages } from "./ai-prompt-cache.js";
+import type {
+  PreparedRyoConversation,
+  RyoAgentRuntimeContext,
+} from "./ryo-conversation.js";
+
+export type { RyoAgentRuntimeContext };
 
 /**
  * Deterministic tool-call repair for malformed inputs.
@@ -56,6 +63,44 @@ export const repairRyoToolCall: ToolCallRepairFunction<ToolSet> = async ({
   return null;
 };
 
+const RYO_AGENT_TIMEOUTS = {
+  chat: {
+    totalMs: 180_000,
+    stepMs: 90_000,
+    chunkMs: 45_000,
+    toolMs: 45_000,
+    tools: {
+      webFetchMs: 25_000,
+      runJsMs: 20_000,
+      searchSongsMs: 25_000,
+      mapsSearchPlacesMs: 20_000,
+      getWeatherMs: 15_000,
+    },
+  },
+  telegram: {
+    totalMs: 120_000,
+    stepMs: 60_000,
+    chunkMs: 30_000,
+    toolMs: 30_000,
+    tools: {
+      webFetchMs: 20_000,
+      runJsMs: 15_000,
+      mapsSearchPlacesMs: 20_000,
+      getWeatherMs: 15_000,
+      songLibraryControlMs: 25_000,
+    },
+  },
+  telegramHeartbeat: {
+    totalMs: 90_000,
+    stepMs: 45_000,
+    toolMs: 25_000,
+    tools: {
+      webFetchMs: 15_000,
+      runJsMs: 10_000,
+    },
+  },
+} as const satisfies Record<string, TimeoutConfiguration<ToolSet>>;
+
 export const RYO_AGENT_PRESETS = {
   chat: {
     id: "ryo-chat",
@@ -85,9 +130,13 @@ type RyoToolLoopAgentOptions = {
     | "tools"
     | "instructions"
     | "dynamicContextMessages"
+    | "toolsContext"
+    | "runtimeContext"
   >;
   temperature?: number;
   tools?: ToolSet;
+  toolsContext?: PreparedRyoConversation["toolsContext"];
+  runtimeContext?: RyoAgentRuntimeContext;
 };
 
 /**
@@ -104,16 +153,26 @@ export function createRyoToolLoopAgent({
   prepared,
   temperature = 0.7,
   tools,
-}: RyoToolLoopAgentOptions): ToolLoopAgent<never, ToolSet> {
+  toolsContext,
+  runtimeContext,
+}: RyoToolLoopAgentOptions): ToolLoopAgent<
+  never,
+  ToolSet,
+  RyoAgentRuntimeContext
+> {
   const agentPreset = RYO_AGENT_PRESETS[preset];
-  const providerOptions = getOpenAIProviderOptions(prepared.modelId);
+  const reasoning = getModelReasoning(prepared.modelId);
   const headers = prepared.modelId.startsWith("sonnet")
     ? { "anthropic-beta": "fine-grained-tool-streaming-2025-05-14" }
     : undefined;
   const resolvedTools = tools ?? prepared.tools;
   const dynamicContextMessages = prepared.dynamicContextMessages;
+  const resolvedToolsContext = toolsContext ?? prepared.toolsContext;
+  const resolvedRuntimeContext = runtimeContext ?? prepared.runtimeContext;
+  const hasToolsContext =
+    resolvedToolsContext && Object.keys(resolvedToolsContext).length > 0;
 
-  return new ToolLoopAgent<never, ToolSet>({
+  return new ToolLoopAgent<never, ToolSet, RyoAgentRuntimeContext>({
     id: agentPreset.id,
     model: prepared.selectedModel,
     tools: resolvedTools,
@@ -122,16 +181,30 @@ export function createRyoToolLoopAgent({
     temperature,
     maxOutputTokens: agentPreset.maxOutputTokens,
     stopWhen: isStepCount(agentPreset.stopAfterSteps),
+    timeout: RYO_AGENT_TIMEOUTS[preset],
+    ...(reasoning ? { reasoning } : {}),
+    ...(hasToolsContext ? { toolsContext: resolvedToolsContext } : {}),
+    ...(resolvedRuntimeContext
+      ? { runtimeContext: resolvedRuntimeContext }
+      : {}),
     // Inject memory + volatile state once via messages (AI SDK 7 prepareStep).
     // Returned messages carry forward for later steps, so we only prepend on
     // step 0. Do not override `instructions` here — that would bust the static
     // prompt cache.
-    prepareStep: ({ stepNumber, messages }) => {
-      if (stepNumber !== 0 || dynamicContextMessages.length === 0) {
-        return {};
-      }
+    //
+    // Every step also marks the last message with Anthropic ephemeral
+    // cacheControl so multi-step tool loops can incrementally reuse prefixes.
+    prepareStep: ({ stepNumber, messages, model }) => {
+      const withDynamicContext =
+        stepNumber === 0 && dynamicContextMessages.length > 0
+          ? [...dynamicContextMessages, ...messages]
+          : messages;
+
       return {
-        messages: [...dynamicContextMessages, ...messages],
+        messages: addCacheControlToMessages({
+          messages: withDynamicContext,
+          model,
+        }),
       };
     },
     // Only attach approval policy when the tool is actually registered for
@@ -141,7 +214,6 @@ export function createRyoToolLoopAgent({
       : {}),
     experimental_repairToolCall: repairRyoToolCall,
     ...(headers ? { headers } : {}),
-    ...(providerOptions ? { providerOptions } : {}),
   });
 }
 

--- a/api/_utils/ryo-agent.ts
+++ b/api/_utils/ryo-agent.ts
@@ -78,9 +78,21 @@ type RyoAgentPresetName = keyof typeof RYO_AGENT_PRESETS;
 
 type RyoToolLoopAgentOptions = {
   preset: RyoAgentPresetName;
-  prepared: Pick<PreparedRyoConversation, "selectedModel" | "modelId" | "tools">;
+  prepared: Pick<
+    PreparedRyoConversation,
+    "selectedModel" | "modelId" | "tools" | "instructions"
+  >;
   temperature?: number;
   tools?: ToolSet;
+};
+
+/**
+ * Client-executed tools that require in-chat user approval before running.
+ * Declared on the agent via AI SDK 7 `toolApproval` (replaces tool-level
+ * `needsApproval`).
+ */
+const RYO_TOOL_APPROVAL = {
+  getPreciseLocation: "user-approval" as const,
 };
 
 export function createRyoToolLoopAgent({
@@ -94,15 +106,21 @@ export function createRyoToolLoopAgent({
   const headers = prepared.modelId.startsWith("sonnet")
     ? { "anthropic-beta": "fine-grained-tool-streaming-2025-05-14" }
     : undefined;
+  const resolvedTools = tools ?? prepared.tools;
 
   return new ToolLoopAgent<never, ToolSet>({
     id: agentPreset.id,
     model: prepared.selectedModel,
-    tools: tools ?? prepared.tools,
-    allowSystemInMessages: true,
+    tools: resolvedTools,
+    instructions: prepared.instructions,
     temperature,
     maxOutputTokens: agentPreset.maxOutputTokens,
     stopWhen: isStepCount(agentPreset.stopAfterSteps),
+    // Only attach approval policy when the tool is actually registered for
+    // this profile (e.g. telegram omits getPreciseLocation).
+    ...(resolvedTools.getPreciseLocation
+      ? { toolApproval: RYO_TOOL_APPROVAL }
+      : {}),
     experimental_repairToolCall: repairRyoToolCall,
     ...(headers ? { headers } : {}),
     ...(providerOptions ? { providerOptions } : {}),
@@ -110,10 +128,10 @@ export function createRyoToolLoopAgent({
 }
 
 export async function* textStreamFromFullStream<TOOLS extends ToolSet>(
-  fullStream: AsyncIterable<TextStreamPart<TOOLS>>,
+  stream: AsyncIterable<TextStreamPart<TOOLS>>,
   onPart?: (part: TextStreamPart<TOOLS>) => Promise<void> | void
 ): AsyncIterable<string> {
-  for await (const part of fullStream) {
+  for await (const part of stream) {
     await onPart?.(part);
 
     if (part.type === "text-delta") {

--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -35,8 +35,10 @@ import {
 } from "./_memory.js";
 import {
   createChatTools,
+  buildChatToolsContextMap,
   type ChatToolProfile,
   type ChatToolsContext,
+  type ChatToolsContextMap,
 } from "../chat/tools/index.js";
 import {
   CURSOR_CLOUD_AGENT_DESCRIPTION,
@@ -192,10 +194,27 @@ export interface PrepareRyoConversationOptions {
   cursorRepoAgentNotifyTelegram?: CursorRepoAgentTelegramNotify;
 }
 
+export type RyoAgentRuntimeContext = {
+  username: string | null;
+  channel: string;
+  modelId: string;
+};
+
 export interface PreparedRyoConversation {
   selectedModel: LanguageModel;
   modelId: SupportedModel;
   tools: ToolSet;
+  /**
+   * AI SDK 7 per-tool context map (keyed by tool name). Passed to
+   * ToolLoopAgent as `toolsContext` so server tools receive typed `context`
+   * instead of closing over request state.
+   */
+  toolsContext: ChatToolsContextMap;
+  /**
+   * Shared agent runtime state (username/channel/model) for prepareStep and
+   * lifecycle callbacks — not injected into the model prompt.
+   */
+  runtimeContext: RyoAgentRuntimeContext;
   /**
    * AI SDK 7 top-level instructions: static system prompt only (cacheable).
    * Dynamic per-request context is injected via `prepareStep` messages —
@@ -932,24 +951,25 @@ export async function prepareRyoConversationModelInput(
     username,
   });
 
-  const baseTools: ToolSet = createChatTools(
-    {
-      log,
-      logError,
-      env: {
-        YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
-        YOUTUBE_API_KEY_2: process.env.YOUTUBE_API_KEY_2,
-      },
-      username: username ?? null,
-      redis,
-      timeZone: userTimeZone,
-      ...(effectiveSystemState?.requestGeo
-        ? { requestGeo: effectiveSystemState.requestGeo }
-        : {}),
-      ...toolContextOverrides,
+  const chatToolsContext: ChatToolsContext = {
+    log,
+    logError,
+    env: {
+      YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
+      YOUTUBE_API_KEY_2: process.env.YOUTUBE_API_KEY_2,
     },
-    { profile: toolProfile }
-  );
+    username: username ?? null,
+    redis,
+    timeZone: userTimeZone,
+    ...(effectiveSystemState?.requestGeo
+      ? { requestGeo: effectiveSystemState.requestGeo }
+      : {}),
+    ...toolContextOverrides,
+  };
+
+  const baseTools: ToolSet = createChatTools(chatToolsContext, {
+    profile: toolProfile,
+  });
 
   const cursorRepoTools: ToolSet =
     enableCursorRepoTool &&
@@ -961,20 +981,11 @@ export async function prepareRyoConversationModelInput(
             inputSchema: cursorCloudAgentSchema,
             execute: async (input: CursorCloudAgentInput) =>
               executeCursorCloudAgent(input, {
-                log,
-                logError,
-                env: {
-                  YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
-                  YOUTUBE_API_KEY_2: process.env.YOUTUBE_API_KEY_2,
-                },
-                username: username ?? null,
-                redis,
-                timeZone: userTimeZone,
+                ...chatToolsContext,
                 apiKey: cursorApiKey,
                 ...(cursorRepoAgentNotifyTelegram
                   ? { notifyTelegram: cursorRepoAgentNotifyTelegram }
                   : {}),
-                ...toolContextOverrides,
               }),
           },
           listCursorCloudAgentRuns: {
@@ -982,18 +993,7 @@ export async function prepareRyoConversationModelInput(
               "List recent Cursor Cloud coding-agent runs against ryokun6/ryos (real product repo, not the browser VFS). Returns stable run ids, agentDashboardUrl, status, timestamps, prompt/summary previews, PR URLs when known, and poll URLs for live events. When summarizing for the user, describe status and titles only — do not paste agentDashboardUrl, agent ids, or run ids in text (the UI list card already exposes dashboard links).",
             inputSchema: listCursorCloudAgentRunsSchema,
             execute: async (input) =>
-              executeListCursorCloudAgentRuns(input, {
-                log,
-                logError,
-                env: {
-                  YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
-                  YOUTUBE_API_KEY_2: process.env.YOUTUBE_API_KEY_2,
-                },
-                username: username ?? null,
-                redis,
-                timeZone: userTimeZone,
-                ...toolContextOverrides,
-              }),
+              executeListCursorCloudAgentRuns(input, chatToolsContext),
           },
         }
       : {};
@@ -1064,6 +1064,12 @@ export async function prepareRyoConversationModelInput(
     selectedModel: getModelInstance(model),
     modelId: model,
     tools,
+    toolsContext: buildChatToolsContextMap(tools, chatToolsContext),
+    runtimeContext: {
+      username: username ?? null,
+      channel,
+      modelId: model,
+    },
     instructions,
     dynamicContextMessages,
     enrichedMessages: modelMessages,

--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -4,8 +4,10 @@ import type { Redis } from "./redis.js";
 import {
   convertToModelMessages,
   validateUIMessages,
+  type Instructions,
   type LanguageModel,
   type ModelMessage,
+  type SystemModelMessage,
   type ToolSet,
   type UIMessage,
 } from "ai";
@@ -195,6 +197,16 @@ export interface PreparedRyoConversation {
   selectedModel: LanguageModel;
   modelId: SupportedModel;
   tools: ToolSet;
+  /**
+   * AI SDK 7 top-level instructions (static + memory + volatile system
+   * prompts). Kept separate from conversation `messages` so system content
+   * is not injectable via chat history.
+   */
+  instructions: Instructions;
+  /**
+   * Conversation model messages only (no system roles). Formerly included
+   * prepended system messages; those now live in `instructions`.
+   */
   enrichedMessages: ModelMessage[];
   loadedSections: string[];
   staticSystemPrompt: string;
@@ -1016,13 +1028,13 @@ export async function prepareRyoConversationModelInput(
     ignoreIncompleteToolCalls: true,
   });
 
-  // Three-tier system message structure for optimal prompt caching:
+  // Three-tier instructions structure for optimal prompt caching (AI SDK 7):
   //   1. Static instructions — identical across all users/requests (cacheable)
   //   2. Memory context   — stable per-user, changes ~once per session (cacheable prefix extends)
   //   3. Volatile state    — changes every request (time, apps, media — never cached)
-  const enrichedMessages = [
+  const instructions: SystemModelMessage[] = [
     {
-      role: "system" as const,
+      role: "system",
       content: staticSystemPrompt,
       ...CACHE_CONTROL_OPTIONS,
     },
@@ -1038,14 +1050,14 @@ export async function prepareRyoConversationModelInput(
     ...(volatileStatePrompt
       ? [{ role: "system" as const, content: volatileStatePrompt }]
       : []),
-    ...modelMessages,
   ];
 
   return {
     selectedModel: getModelInstance(model),
     modelId: model,
     tools,
-    enrichedMessages,
+    instructions,
+    enrichedMessages: modelMessages,
     loadedSections,
     staticSystemPrompt,
     memoryContextPrompt,

--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -4,7 +4,6 @@ import type { Redis } from "./redis.js";
 import {
   convertToModelMessages,
   validateUIMessages,
-  type Instructions,
   type LanguageModel,
   type ModelMessage,
   type SystemModelMessage,
@@ -198,14 +197,18 @@ export interface PreparedRyoConversation {
   modelId: SupportedModel;
   tools: ToolSet;
   /**
-   * AI SDK 7 top-level instructions (static + memory + volatile system
-   * prompts). Kept separate from conversation `messages` so system content
-   * is not injectable via chat history.
+   * AI SDK 7 top-level instructions: static system prompt only (cacheable).
+   * Dynamic per-request context is injected via `prepareStep` messages —
+   * do not put memory/volatile state here.
    */
-  instructions: Instructions;
+  instructions: SystemModelMessage;
   /**
-   * Conversation model messages only (no system roles). Formerly included
-   * prepended system messages; those now live in `instructions`.
+   * Per-request dynamic context (memory + volatile system state). Injected
+   * once at step 0 through `prepareStep` and then carried forward.
+   */
+  dynamicContextMessages: ModelMessage[];
+  /**
+   * Conversation model messages only (no system roles).
    */
   enrichedMessages: ModelMessage[];
   loadedSections: string[];
@@ -1028,27 +1031,32 @@ export async function prepareRyoConversationModelInput(
     ignoreIncompleteToolCalls: true,
   });
 
-  // Three-tier instructions structure for optimal prompt caching (AI SDK 7):
-  //   1. Static instructions — identical across all users/requests (cacheable)
-  //   2. Memory context   — stable per-user, changes ~once per session (cacheable prefix extends)
-  //   3. Volatile state    — changes every request (time, apps, media — never cached)
-  const instructions: SystemModelMessage[] = [
-    {
-      role: "system",
-      content: staticSystemPrompt,
-      ...CACHE_CONTROL_OPTIONS,
-    },
+  // Static instructions stay in the top-level `instructions` option so the
+  // provider can cache them across users/requests (AI SDK 7).
+  //
+  // Dynamic context (memory + volatile state) is NOT folded into instructions.
+  // It is returned as `dynamicContextMessages` and prepended once via
+  // `prepareStep` on the ToolLoopAgent (see createRyoToolLoopAgent).
+  const instructions: SystemModelMessage = {
+    role: "system",
+    content: staticSystemPrompt,
+    ...CACHE_CONTROL_OPTIONS,
+  };
+
+  const dynamicContextMessages: ModelMessage[] = [
     ...(memoryContextPrompt
       ? [
           {
-            role: "system" as const,
+            role: "user" as const,
             content: memoryContextPrompt,
+            // Memory is stable per-user for a session — keep a cache breakpoint
+            // so Anthropic can reuse the prefix after the static instructions.
             ...CACHE_CONTROL_OPTIONS,
           },
         ]
       : []),
     ...(volatileStatePrompt
-      ? [{ role: "system" as const, content: volatileStatePrompt }]
+      ? [{ role: "user" as const, content: volatileStatePrompt }]
       : []),
   ];
 
@@ -1057,6 +1065,7 @@ export async function prepareRyoConversationModelInput(
     modelId: model,
     tools,
     instructions,
+    dynamicContextMessages,
     enrichedMessages: modelMessages,
     loadedSections,
     staticSystemPrompt,

--- a/api/_utils/upload-provider-file.ts
+++ b/api/_utils/upload-provider-file.ts
@@ -1,0 +1,63 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { google } from "@ai-sdk/google";
+import { openai } from "@ai-sdk/openai";
+import { uploadFile, type ProviderReference } from "ai";
+import { AI_MODELS, type SupportedModel } from "./_aiModels.js";
+
+function getFilesApiForModel(modelId: SupportedModel) {
+  switch (AI_MODELS[modelId].provider) {
+    case "OpenAI":
+      return openai.files();
+    case "Anthropic":
+      return anthropic.files();
+    case "Google":
+      return google.files();
+    default:
+      return null;
+  }
+}
+
+/**
+ * Upload raw bytes to the active model provider and return a ProviderReference
+ * suitable for `{ type: "file", data: providerReference }` message parts.
+ *
+ * Returns null when the provider has no files API or the upload fails, so
+ * callers can fall back to inline data.
+ */
+export async function uploadProviderFileForModel({
+  modelId,
+  data,
+  mediaType,
+  filename,
+  log,
+}: {
+  modelId: SupportedModel;
+  data: Uint8Array;
+  mediaType: string;
+  filename?: string;
+  log?: (...args: unknown[]) => void;
+}): Promise<ProviderReference | null> {
+  const api = getFilesApiForModel(modelId);
+  if (!api) {
+    log?.(
+      `[uploadProviderFile] No files API for model ${modelId}; using inline data`
+    );
+    return null;
+  }
+
+  try {
+    const result = await uploadFile({
+      api,
+      data,
+      mediaType,
+      ...(filename ? { filename } : {}),
+    });
+    return result.providerReference;
+  } catch (error) {
+    log?.(
+      `[uploadProviderFile] Upload failed for ${modelId}; falling back to inline data`,
+      error instanceof Error ? error.message : error
+    );
+    return null;
+  }
+}

--- a/api/_utils/upload-provider-file.ts
+++ b/api/_utils/upload-provider-file.ts
@@ -4,6 +4,9 @@ import { openai } from "@ai-sdk/openai";
 import { uploadFile, type ProviderReference } from "ai";
 import { AI_MODELS, type SupportedModel } from "./_aiModels.js";
 
+/** Cap Google Files API PROCESSING polls so we fall back to inline data quickly. */
+export const GOOGLE_FILES_POLL_TIMEOUT_MS = 30_000;
+
 function getFilesApiForModel(modelId: SupportedModel) {
   switch (AI_MODELS[modelId].provider) {
     case "OpenAI":
@@ -17,12 +20,21 @@ function getFilesApiForModel(modelId: SupportedModel) {
   }
 }
 
+export type UploadedProviderFile = {
+  providerReference: ProviderReference;
+  mediaType: string;
+};
+
 /**
  * Upload raw bytes to the active model provider and return a ProviderReference
  * suitable for `{ type: "file", data: providerReference }` message parts.
  *
  * Returns null when the provider has no files API or the upload fails, so
  * callers can fall back to inline data.
+ *
+ * Callers must use the returned `mediaType` (full MIME, e.g. `image/jpeg`) on
+ * the file part — top-level types like `"image"` throw in provider converters
+ * when the data is a provider reference rather than inline bytes.
  */
 export async function uploadProviderFileForModel({
   modelId,
@@ -36,7 +48,7 @@ export async function uploadProviderFileForModel({
   mediaType: string;
   filename?: string;
   log?: (...args: unknown[]) => void;
-}): Promise<ProviderReference | null> {
+}): Promise<UploadedProviderFile | null> {
   const api = getFilesApiForModel(modelId);
   if (!api) {
     log?.(
@@ -51,8 +63,16 @@ export async function uploadProviderFileForModel({
       data,
       mediaType,
       ...(filename ? { filename } : {}),
+      // Google polls PROCESSING up to 5m by default; keep chat/telegram snappy.
+      providerOptions: {
+        google: { pollTimeoutMs: GOOGLE_FILES_POLL_TIMEOUT_MS },
+      },
     });
-    return result.providerReference;
+    return {
+      providerReference: result.providerReference,
+      // Prefer the provider's resolved MIME; fall back to the request type.
+      mediaType: result.mediaType || mediaType,
+    };
   } catch (error) {
     log?.(
       `[uploadProviderFile] Upload failed for ${modelId}; falling back to inline data`,

--- a/api/ai/_memory-consolidation.ts
+++ b/api/ai/_memory-consolidation.ts
@@ -61,7 +61,8 @@ export async function consolidateMemoryContent(
     output: Output.object({
       schema: memoryConsolidationSchema,
     }),
-    prompt: `${CONSOLIDATION_PROMPT}\n\nNEW:\nSummary: ${newMemory.summary}\nContent: ${newMemory.content}\n\nEXISTING:\n${existingContentText}\n\nMerge into one clean, deduplicated entry.`,
+    instructions: CONSOLIDATION_PROMPT,
+    prompt: `NEW:\nSummary: ${newMemory.summary}\nContent: ${newMemory.content}\n\nEXISTING:\n${existingContentText}\n\nMerge into one clean, deduplicated entry.`,
     temperature: 0.3,
   });
 

--- a/api/ai/conversations/[channel]/greeting.ts
+++ b/api/ai/conversations/[channel]/greeting.ts
@@ -154,10 +154,11 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
         model: google("gemini-3-flash-preview"),
         temperature: 1,
         maxOutputTokens: 2000,
-        allowSystemInMessages: true,
-        messages: [
+        instructions: [
           { role: "system" as const, content: PROACTIVE_GREETING_INSTRUCTIONS },
           { role: "system" as const, content: greetingDynamicContext },
+        ],
+        messages: [
           { role: "user" as const, content: "Generate a proactive greeting." },
         ],
       });

--- a/api/ai/conversations/[channel]/greeting.ts
+++ b/api/ai/conversations/[channel]/greeting.ts
@@ -154,13 +154,19 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
         model: google("gemini-3-flash-preview"),
         temperature: 1,
         maxOutputTokens: 2000,
-        instructions: [
-          { role: "system" as const, content: PROACTIVE_GREETING_INSTRUCTIONS },
-          { role: "system" as const, content: greetingDynamicContext },
-        ],
+        instructions: PROACTIVE_GREETING_INSTRUCTIONS,
         messages: [
           { role: "user" as const, content: "Generate a proactive greeting." },
         ],
+        prepareStep: ({ stepNumber, messages }) => {
+          if (stepNumber !== 0) return {};
+          return {
+            messages: [
+              { role: "user" as const, content: greetingDynamicContext },
+              ...messages,
+            ],
+          };
+        },
       });
 
       const greeting = text.trim();

--- a/api/ai/extract-memories.ts
+++ b/api/ai/extract-memories.ts
@@ -354,8 +354,9 @@ export async function extractMemoriesFromConversation({
     output: Output.object({
       schema: extractionSchema,
     }),
+    instructions: EXTRACTION_PROMPT,
     prompt:
-      `${EXTRACTION_PROMPT}${existingStateSection}\n\n--- CONVERSATION ---\n${conversationText}\n--- END CONVERSATION ---\n\n` +
+      `${existingStateSection}\n\n--- CONVERSATION ---\n${conversationText}\n--- END CONVERSATION ---\n\n` +
       `Extract up to 8 daily notes and up to ${maxLongTerm} long-term memories. Return empty arrays if nothing qualifies.`,
     temperature: 0.3,
   });

--- a/api/ai/process-daily-notes.ts
+++ b/api/ai/process-daily-notes.ts
@@ -478,7 +478,8 @@ async function _processSingleDayBatch(
     output: Output.object({
       schema: dailyNotesExtractionSchema,
     }),
-    prompt: `${DAILY_NOTES_EXTRACTION_PROMPT}${existingStateSection}\n\n--- DAILY NOTES ---\n${dailyNotesText}\n--- END DAILY NOTES ---\n\nExtract up to ${Math.max(maxExtract, 3)} long-term memories. For existing keys, you may suggest updates via relatedKeys. Return empty array if nothing qualifies.`,
+    instructions: DAILY_NOTES_EXTRACTION_PROMPT,
+    prompt: `${existingStateSection}\n\n--- DAILY NOTES ---\n${dailyNotesText}\n--- END DAILY NOTES ---\n\nExtract up to ${Math.max(maxExtract, 3)} long-term memories. For existing keys, you may suggest updates via relatedKeys. Return empty array if nothing qualifies.`,
     temperature: 0.3,
   });
 

--- a/api/ai/ryo-reply.ts
+++ b/api/ai/ryo-reply.ts
@@ -86,27 +86,25 @@ export default apiHandler<RyoReplyRequest>(
     }
 
     const messages = [
-      { role: "system" as const, content: CHAT_ROOM_REPLY_INSTRUCTIONS },
       systemState?.chatRoomContext
         ? {
-            role: "system" as const,
-            content: `\n<chat_room_context>\nroomId: ${roomId}\nrecentMessages:\n${
+            role: "user" as const,
+            content: `${prompt}\n\n<chat_room_context>\nroomId: ${roomId}\nrecentMessages:\n${
               systemState.chatRoomContext.recentMessages || ""
             }\nmentionedMessage: ${
               systemState.chatRoomContext.mentionedMessage || prompt
             }\n</chat_room_context>`,
           }
-        : null,
-      { role: "user" as const, content: prompt },
-    ].filter((m): m is NonNullable<typeof m> => m !== null);
+        : { role: "user" as const, content: prompt },
+    ];
 
     let replyText = "";
     try {
       logger.info("Generating AI reply", { roomId, promptLength: prompt.length });
       const { text } = await generateText({
         model: google("gemini-3-flash-preview"),
+        instructions: CHAT_ROOM_REPLY_INSTRUCTIONS,
         messages,
-        allowSystemInMessages: true,
         temperature: 0.6,
       });
       replyText = text;

--- a/api/applet-ai.ts
+++ b/api/applet-ai.ts
@@ -1,6 +1,7 @@
 import {
   generateText,
-  type ImagePart,
+  uploadFile,
+  type FilePart,
   type ModelMessage,
   type SystemModelMessage,
   type TextPart,
@@ -15,6 +16,7 @@ import * as RateLimit from "./_utils/_rate-limit.js";
 import { getClientIp } from "./_utils/_rate-limit.js";
 import { apiHandler } from "./_utils/api-handler.js";
 import { isAllowedAppHost } from "./_utils/runtime-config.js";
+import { addCacheControlToMessages } from "./_utils/ai-prompt-cache.js";
 
 // ============================================================================
 // Constants and Schemas
@@ -192,11 +194,11 @@ const decodeBase64Image = (input: string): Uint8Array => {
   return bytes;
 };
 
-const createMessageParts = (
+const createMessageParts = async (
   message: ParsedMessage,
   messageIndex: number
-): Array<TextPart | ImagePart> => {
-  const parts: Array<TextPart | ImagePart> = [];
+): Promise<Array<TextPart | FilePart>> => {
+  const parts: Array<TextPart | FilePart> = [];
   const text = message.content?.trim();
 
   if (text && text.length > 0) {
@@ -204,7 +206,7 @@ const createMessageParts = (
   }
 
   if (message.attachments) {
-    message.attachments.forEach((attachment, attachmentIndex) => {
+    for (const [attachmentIndex, attachment] of message.attachments.entries()) {
       let imageData: Uint8Array;
       try {
         imageData = decodeBase64Image(attachment.data);
@@ -217,13 +219,29 @@ const createMessageParts = (
           }: ${details}`
         );
       }
-      const imagePart: ImagePart = {
-        type: 'file',
-        data: imageData,
-        mediaType: attachment.mediaType,
-      };
-      parts.push(imagePart);
-    });
+
+      let filePart: FilePart;
+      try {
+        const { providerReference } = await uploadFile({
+          api: google.files(),
+          data: imageData,
+          mediaType: attachment.mediaType,
+          filename: `applet-attachment-${messageIndex}-${attachmentIndex}`,
+        });
+        filePart = {
+          type: "file",
+          mediaType: "image",
+          data: providerReference,
+        };
+      } catch {
+        filePart = {
+          type: "file",
+          mediaType: attachment.mediaType,
+          data: { type: "data", data: imageData },
+        };
+      }
+      parts.push(filePart);
+    }
   }
 
   return parts;
@@ -235,14 +253,14 @@ const CACHE_CONTROL_OPTIONS = {
   },
 } as const;
 
-const buildModelMessages = (
+const buildModelMessages = async (
   conversation: ParsedMessage[],
   context?: string
-): {
+): Promise<{
   instructions: SystemModelMessage;
   dynamicContextMessages: ModelMessage[];
   messages: ModelMessage[];
-} => {
+}> => {
   const instructions: SystemModelMessage = {
     role: "system",
     content: APPLET_SYSTEM_PROMPT.trim(),
@@ -260,7 +278,7 @@ const buildModelMessages = (
 
   const messages: ModelMessage[] = [];
 
-  conversation.forEach((message, index) => {
+  for (const [index, message] of conversation.entries()) {
     const trimmedContent = message.content?.trim() ?? "";
 
     if (message.role === "system") {
@@ -272,17 +290,17 @@ const buildModelMessages = (
           content: trimmedContent,
         });
       }
-      return;
+      continue;
     }
 
     if (message.role === "assistant") {
       if (trimmedContent.length > 0) {
         messages.push({ role: "assistant", content: trimmedContent });
       }
-      return;
+      continue;
     }
 
-    const parts = createMessageParts(message, index);
+    const parts = await createMessageParts(message, index);
     if (parts.length === 0) {
       throw new Error(
         `User message ${index + 1} must include text or at least one attachment.`
@@ -298,7 +316,7 @@ const buildModelMessages = (
       role: "user",
       content,
     });
-  });
+  }
 
   return { instructions, dynamicContextMessages, messages };
 };
@@ -477,7 +495,7 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
 
   if (mode === "image") {
     const promptText = prompt?.trim() ?? "";
-    const promptParts: Array<TextPart | ImagePart> = [];
+    const promptParts: Array<TextPart | FilePart> = [];
 
     if (context && context.trim().length > 0) {
       promptParts.push({ type: "text", text: context.trim() });
@@ -489,7 +507,7 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
 
     try {
       if (parsedBody.images) {
-        parsedBody.images.forEach((image, index) => {
+        for (const [index, image] of parsedBody.images.entries()) {
           let imageData: Uint8Array;
           try {
             imageData = decodeBase64Image(image.data);
@@ -501,12 +519,26 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
             );
           }
 
-          promptParts.push({
-            type: 'file',
-            data: imageData,
-            mediaType: image.mediaType,
-          });
-        });
+          try {
+            const { providerReference } = await uploadFile({
+              api: google.files(),
+              data: imageData,
+              mediaType: image.mediaType,
+              filename: `applet-image-${index}`,
+            });
+            promptParts.push({
+              type: "file",
+              mediaType: "image",
+              data: providerReference,
+            });
+          } catch {
+            promptParts.push({
+              type: "file",
+              mediaType: image.mediaType,
+              data: { type: "data", data: imageData },
+            });
+          }
+        }
       }
     } catch (error) {
       logger.error("Image attachment parsing failed:", error);
@@ -588,7 +620,7 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
     messages: ModelMessage[];
   };
   try {
-    prepared = buildModelMessages(conversation, context);
+    prepared = await buildModelMessages(conversation, context);
   } catch (error) {
     logger.error("Message preparation failed:", error);
     logger.response(400, Date.now() - startTime);
@@ -603,23 +635,29 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
       messageCount: prepared.messages.length,
       dynamicContextCount: prepared.dynamicContextMessages.length,
     });
+    const appletModel = google("gemini-3-flash-preview");
     const { text } = await generateText({
-      model: google("gemini-3-flash-preview"),
+      model: appletModel,
       instructions: prepared.instructions,
       messages: prepared.messages,
-      prepareStep: ({ stepNumber, messages }) => {
-        if (
-          stepNumber !== 0 ||
-          prepared.dynamicContextMessages.length === 0
-        ) {
-          return {};
-        }
+      prepareStep: ({ stepNumber, messages, model: stepModel }) => {
+        const withDynamicContext =
+          stepNumber === 0 && prepared.dynamicContextMessages.length > 0
+            ? [...prepared.dynamicContextMessages, ...messages]
+            : messages;
         return {
-          messages: [...prepared.dynamicContextMessages, ...messages],
+          messages: addCacheControlToMessages({
+            messages: withDynamicContext,
+            model: stepModel,
+          }),
         };
       },
       temperature: temperature ?? 0.6,
       maxOutputTokens: 4000,
+      timeout: {
+        totalMs: 60_000,
+        stepMs: 45_000,
+      },
     });
 
     const trimmedReply = text.trim();

--- a/api/applet-ai.ts
+++ b/api/applet-ai.ts
@@ -238,14 +238,22 @@ const CACHE_CONTROL_OPTIONS = {
 const buildModelMessages = (
   conversation: ParsedMessage[],
   context?: string
-): { instructions: SystemModelMessage[]; messages: ModelMessage[] } => {
-  const instructions: SystemModelMessage[] = [
-    { role: "system", content: APPLET_SYSTEM_PROMPT.trim(), ...CACHE_CONTROL_OPTIONS },
-  ];
+): {
+  instructions: SystemModelMessage;
+  dynamicContextMessages: ModelMessage[];
+  messages: ModelMessage[];
+} => {
+  const instructions: SystemModelMessage = {
+    role: "system",
+    content: APPLET_SYSTEM_PROMPT.trim(),
+    ...CACHE_CONTROL_OPTIONS,
+  };
+
+  const dynamicContextMessages: ModelMessage[] = [];
 
   if (context) {
-    instructions.push({
-      role: "system",
+    dynamicContextMessages.push({
+      role: "user",
       content: `<applet_context>${context}</applet_context>`,
     });
   }
@@ -256,10 +264,13 @@ const buildModelMessages = (
     const trimmedContent = message.content?.trim() ?? "";
 
     if (message.role === "system") {
-      // Fold applet-supplied system content into trusted instructions so we
-      // never allow system roles in the messages array (AI SDK 7 default).
+      // Treat applet-supplied system content as dynamic context (not
+      // instructions) so the static applet prompt stays cacheable.
       if (trimmedContent.length > 0) {
-        instructions.push({ role: "system", content: trimmedContent });
+        dynamicContextMessages.push({
+          role: "user",
+          content: trimmedContent,
+        });
       }
       return;
     }
@@ -289,7 +300,7 @@ const buildModelMessages = (
     });
   });
 
-  return { instructions, messages };
+  return { instructions, dynamicContextMessages, messages };
 };
 
 // ============================================================================
@@ -572,7 +583,8 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
       : [{ role: "user", content: prompt!.trim() }];
 
   let prepared: {
-    instructions: SystemModelMessage[];
+    instructions: SystemModelMessage;
+    dynamicContextMessages: ModelMessage[];
     messages: ModelMessage[];
   };
   try {
@@ -589,12 +601,23 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
   try {
     logger.info("Starting text generation", {
       messageCount: prepared.messages.length,
-      instructionCount: prepared.instructions.length,
+      dynamicContextCount: prepared.dynamicContextMessages.length,
     });
     const { text } = await generateText({
       model: google("gemini-3-flash-preview"),
       instructions: prepared.instructions,
       messages: prepared.messages,
+      prepareStep: ({ stepNumber, messages }) => {
+        if (
+          stepNumber !== 0 ||
+          prepared.dynamicContextMessages.length === 0
+        ) {
+          return {};
+        }
+        return {
+          messages: [...prepared.dynamicContextMessages, ...messages],
+        };
+      },
       temperature: temperature ?? 0.6,
       maxOutputTokens: 4000,
     });

--- a/api/applet-ai.ts
+++ b/api/applet-ai.ts
@@ -17,6 +17,7 @@ import { getClientIp } from "./_utils/_rate-limit.js";
 import { apiHandler } from "./_utils/api-handler.js";
 import { isAllowedAppHost } from "./_utils/runtime-config.js";
 import { addCacheControlToMessages } from "./_utils/ai-prompt-cache.js";
+import { GOOGLE_FILES_POLL_TIMEOUT_MS } from "./_utils/upload-provider-file.js";
 
 // ============================================================================
 // Constants and Schemas
@@ -222,16 +223,20 @@ const createMessageParts = async (
 
       let filePart: FilePart;
       try {
-        const { providerReference } = await uploadFile({
+        const uploaded = await uploadFile({
           api: google.files(),
           data: imageData,
           mediaType: attachment.mediaType,
           filename: `applet-attachment-${messageIndex}-${attachmentIndex}`,
+          providerOptions: {
+            google: { pollTimeoutMs: GOOGLE_FILES_POLL_TIMEOUT_MS },
+          },
         });
         filePart = {
           type: "file",
-          mediaType: "image",
-          data: providerReference,
+          // Full MIME required for provider references (not top-level "image").
+          mediaType: uploaded.mediaType || attachment.mediaType,
+          data: uploaded.providerReference,
         };
       } catch {
         filePart = {
@@ -520,16 +525,20 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
           }
 
           try {
-            const { providerReference } = await uploadFile({
+            const uploaded = await uploadFile({
               api: google.files(),
               data: imageData,
               mediaType: image.mediaType,
               filename: `applet-image-${index}`,
+              providerOptions: {
+                google: { pollTimeoutMs: GOOGLE_FILES_POLL_TIMEOUT_MS },
+              },
             });
             promptParts.push({
               type: "file",
-              mediaType: "image",
-              data: providerReference,
+              // Full MIME required for provider references (not top-level "image").
+              mediaType: uploaded.mediaType || image.mediaType,
+              data: uploaded.providerReference,
             });
           } catch {
             promptParts.push({

--- a/api/applet-ai.ts
+++ b/api/applet-ai.ts
@@ -2,6 +2,7 @@ import {
   generateText,
   type ImagePart,
   type ModelMessage,
+  type SystemModelMessage,
   type TextPart,
   type UserContent,
 } from "ai";
@@ -237,24 +238,28 @@ const CACHE_CONTROL_OPTIONS = {
 const buildModelMessages = (
   conversation: ParsedMessage[],
   context?: string
-): ModelMessage[] => {
-  const messages: ModelMessage[] = [
+): { instructions: SystemModelMessage[]; messages: ModelMessage[] } => {
+  const instructions: SystemModelMessage[] = [
     { role: "system", content: APPLET_SYSTEM_PROMPT.trim(), ...CACHE_CONTROL_OPTIONS },
   ];
 
   if (context) {
-    messages.push({
+    instructions.push({
       role: "system",
       content: `<applet_context>${context}</applet_context>`,
     });
   }
 
+  const messages: ModelMessage[] = [];
+
   conversation.forEach((message, index) => {
     const trimmedContent = message.content?.trim() ?? "";
 
     if (message.role === "system") {
+      // Fold applet-supplied system content into trusted instructions so we
+      // never allow system roles in the messages array (AI SDK 7 default).
       if (trimmedContent.length > 0) {
-        messages.push({ role: "system", content: trimmedContent });
+        instructions.push({ role: "system", content: trimmedContent });
       }
       return;
     }
@@ -284,7 +289,7 @@ const buildModelMessages = (
     });
   });
 
-  return messages;
+  return { instructions, messages };
 };
 
 // ============================================================================
@@ -566,9 +571,12 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
       ? messages
       : [{ role: "user", content: prompt!.trim() }];
 
-  let finalMessages: ModelMessage[];
+  let prepared: {
+    instructions: SystemModelMessage[];
+    messages: ModelMessage[];
+  };
   try {
-    finalMessages = buildModelMessages(conversation, context);
+    prepared = buildModelMessages(conversation, context);
   } catch (error) {
     logger.error("Message preparation failed:", error);
     logger.response(400, Date.now() - startTime);
@@ -579,11 +587,14 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
   }
 
   try {
-    logger.info("Starting text generation", { messageCount: finalMessages.length });
+    logger.info("Starting text generation", {
+      messageCount: prepared.messages.length,
+      instructionCount: prepared.instructions.length,
+    });
     const { text } = await generateText({
       model: google("gemini-3-flash-preview"),
-      messages: finalMessages,
-      allowSystemInMessages: true,
+      instructions: prepared.instructions,
+      messages: prepared.messages,
       temperature: temperature ?? 0.6,
       maxOutputTokens: 4000,
     });
@@ -591,7 +602,7 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
     const trimmedReply = text.trim();
     logger.info("Text generation succeeded", {
       replyLength: trimmedReply.length,
-      messageCount: finalMessages.length,
+      messageCount: prepared.messages.length,
       temperature: temperature ?? 0.6,
     });
 

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -552,7 +552,7 @@ export default apiHandler<{
           }
         : {}),
     });
-    const { enrichedMessages, loadedSections, staticSystemPrompt } =
+    const { enrichedMessages, loadedSections, staticSystemPrompt, instructions } =
       preparedConversation;
 
     log(
@@ -564,6 +564,20 @@ export default apiHandler<{
     log(`Approximate prompt tokens: ${Math.round(approxTokens)}`);
 
     // Log message structure without retaining transcript content.
+    const instructionMessages = Array.isArray(instructions)
+      ? instructions
+      : instructions
+        ? [instructions]
+        : [];
+    instructionMessages.forEach((msg, index) => {
+      const contentStr =
+        typeof msg === "string"
+          ? msg
+          : typeof msg.content === "string"
+            ? msg.content
+            : JSON.stringify(msg.content);
+      log(`Instruction ${index}, ${contentStr.length} chars`);
+    });
     enrichedMessages.forEach((msg, index) => {
       const contentStr =
         typeof msg.content === "string"

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -552,8 +552,13 @@ export default apiHandler<{
           }
         : {}),
     });
-    const { enrichedMessages, loadedSections, staticSystemPrompt, instructions } =
-      preparedConversation;
+    const {
+      enrichedMessages,
+      loadedSections,
+      staticSystemPrompt,
+      instructions,
+      dynamicContextMessages,
+    } = preparedConversation;
 
     log(
       `Context-aware prompts (${
@@ -564,19 +569,17 @@ export default apiHandler<{
     log(`Approximate prompt tokens: ${Math.round(approxTokens)}`);
 
     // Log message structure without retaining transcript content.
-    const instructionMessages = Array.isArray(instructions)
-      ? instructions
-      : instructions
-        ? [instructions]
-        : [];
-    instructionMessages.forEach((msg, index) => {
+    const instructionContent =
+      typeof instructions.content === "string"
+        ? instructions.content
+        : JSON.stringify(instructions.content);
+    log(`Static instructions, ${instructionContent.length} chars`);
+    dynamicContextMessages.forEach((msg, index) => {
       const contentStr =
-        typeof msg === "string"
-          ? msg
-          : typeof msg.content === "string"
-            ? msg.content
-            : JSON.stringify(msg.content);
-      log(`Instruction ${index}, ${contentStr.length} chars`);
+        typeof msg.content === "string"
+          ? msg.content
+          : JSON.stringify(msg.content);
+      log(`Dynamic context ${index} [${msg.role}], ${contentStr.length} chars`);
     });
     enrichedMessages.forEach((msg, index) => {
       const contentStr =

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -25,7 +25,10 @@ import {
 import { apiHandler } from "./_utils/api-handler.js";
 import { getHeader } from "./_utils/request-helpers.js";
 import { resolveIpGeolocation } from "./_utils/_geolocation.js";
-import { createRyoToolLoopAgent } from "./_utils/ryo-agent.js";
+import {
+  createRyoToolLoopAgent,
+  RYO_AGENT_TIMEOUTS,
+} from "./_utils/ryo-agent.js";
 import {
   getStoredUserTimeZone,
   updateStoredUserTimeZone,
@@ -596,6 +599,8 @@ export default apiHandler<{
 
     const result = await agent.stream({
       messages: enrichedMessages,
+      // Must pass explicitly — call-time `timeout` overwrites constructor default.
+      timeout: RYO_AGENT_TIMEOUTS.chat,
       abortSignal: generationAbortController.signal,
       experimental_transform: smoothStream({
         chunking: /[\u4E00-\u9FFF]|\S+\s+/,

--- a/api/chat/tools/context.ts
+++ b/api/chat/tools/context.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import type { ToolSet } from "ai";
+import type { MemoryToolContext } from "./executors.js";
+
+/**
+ * AI SDK 7 per-tool context schema for server-executed chat tools.
+ * Validates that the toolsContext entry has the logging/env surface tools need.
+ * Redis/username/geo are optional depending on channel and auth.
+ */
+export const chatToolsContextSchema = z.custom<MemoryToolContext>(
+  (value): value is MemoryToolContext =>
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as MemoryToolContext).log === "function" &&
+    typeof (value as MemoryToolContext).logError === "function" &&
+    typeof (value as MemoryToolContext).env === "object" &&
+    (value as MemoryToolContext).env !== null,
+  { message: "Invalid chat tools context" }
+);
+
+export type ChatToolsContextMap = Record<string, MemoryToolContext>;
+
+/**
+ * Build a per-tool toolsContext map for every tool that declares contextSchema.
+ * AI SDK 7 keys toolsContext by tool name; each tool only receives its entry.
+ */
+export function buildChatToolsContextMap(
+  tools: ToolSet,
+  context: MemoryToolContext
+): ChatToolsContextMap {
+  const map: ChatToolsContextMap = {};
+  for (const [name, toolDef] of Object.entries(tools)) {
+    if (
+      toolDef &&
+      typeof toolDef === "object" &&
+      "contextSchema" in toolDef &&
+      toolDef.contextSchema
+    ) {
+      map[name] = context;
+    }
+  }
+  return map;
+}

--- a/api/chat/tools/index.ts
+++ b/api/chat/tools/index.ts
@@ -454,11 +454,11 @@ export function createChatTools(
     // Precise Location Tool (Client-side execution, approval-gated)
     // The user must approve via the in-chat permission card before the
     // browser geolocation handler runs (see src/apps/chats/tools).
+    // Approval policy is set on ToolLoopAgent via `toolApproval` (AI SDK 7).
     // ============================================================================
     getPreciseLocation: {
       description: TOOL_DESCRIPTIONS.getPreciseLocation,
       inputSchema: schemas.getPreciseLocationSchema,
-      needsApproval: true,
       // No execute - handled client-side after user approval
     },
 
@@ -521,9 +521,9 @@ export function createChatTools(
                   text: result.message || "Screen captured from emulator.",
                 },
                 {
-                  type: "image-data" as const,
-                  data: base64Data,
+                  type: "file" as const,
                   mediaType,
+                  data: { type: "data" as const, data: base64Data },
                 },
               ],
             };

--- a/api/chat/tools/index.ts
+++ b/api/chat/tools/index.ts
@@ -24,32 +24,13 @@
  *   logError: logger.error,
  *   env: process.env,
  * });
- * 
- * streamText({
- *   model: selectedModel,
- *   tools,
- *   // ...
- * });
+ *
+ * // Pass per-tool toolsContext (AI SDK 7) when streaming / creating agents:
+ * // toolsContext: buildChatToolsContextMap(tools, context)
  * ```
  */
 
-import type {
-  MemoryWriteInput,
-  MemoryReadInput,
-  MemoryDeleteInput,
-  WebFetchInput,
-  RunJsInput,
-  MapsSearchPlacesInput,
-  GetWeatherInput,
-} from "./types.js";
 import * as schemas from "./schemas.js";
-import type {
-  CalendarControlInput,
-  DocumentsControlInput,
-  StickiesControlInput,
-  ContactsControlInput,
-  SongLibraryControlInput,
-} from "./types.js";
 import {
   executeGenerateHtml,
   executeSearchSongs,
@@ -69,10 +50,16 @@ import {
 } from "./app-state-executors.js";
 import { executeMapsSearchPlaces } from "./maps-executor.js";
 import { executeGetWeather } from "./weather-executor.js";
+import { chatToolsContextSchema } from "./context.js";
 
 // Re-export types and schemas for external use
 export * from "./types.js";
 export * from "./schemas.js";
+export {
+  chatToolsContextSchema,
+  buildChatToolsContextMap,
+  type ChatToolsContextMap,
+} from "./context.js";
 export {
   executeGenerateHtml,
   executeSearchSongs,
@@ -92,6 +79,21 @@ export {
 } from "./app-state-executors.js";
 export { executeMapsSearchPlaces } from "./maps-executor.js";
 export { executeGetWeather } from "./weather-executor.js";
+
+/**
+ * Bind a server executor to AI SDK 7 tool `context` (from toolsContext).
+ * Falls back to the closed-over request context when execute is invoked
+ * directly in unit tests without a toolsContext options bag.
+ */
+function bindServerExecute<TInput, TOutput>(
+  fallbackContext: MemoryToolContext,
+  executor: (input: TInput, context: MemoryToolContext) => Promise<TOutput>
+) {
+  return async (
+    input: TInput,
+    options?: { context?: MemoryToolContext }
+  ) => executor(input, options?.context ?? fallbackContext);
+}
 
 const MEMORY_TOOL_NAMES = [
   "memoryWrite",
@@ -363,9 +365,8 @@ export function createChatTools(
     generateHtml: {
       description: TOOL_DESCRIPTIONS.generateHtml,
       inputSchema: schemas.generateHtmlSchema,
-      execute: async (input: { html: string; title?: string; icon?: string }) => {
-        return executeGenerateHtml(input, context);
-      },
+      contextSchema: chatToolsContextSchema,
+      execute: bindServerExecute(context, executeGenerateHtml),
     },
 
     // ============================================================================
@@ -413,9 +414,8 @@ export function createChatTools(
     searchSongs: {
       description: TOOL_DESCRIPTIONS.searchSongs,
       inputSchema: schemas.searchSongsSchema,
-      execute: async (input: { query: string; maxResults?: number }) => {
-        return executeSearchSongs(input, context);
-      },
+      contextSchema: chatToolsContextSchema,
+      execute: bindServerExecute(context, executeSearchSongs),
     },
     // ============================================================================
     // Web Fetch Tool (Server-side execution)
@@ -423,9 +423,8 @@ export function createChatTools(
     webFetch: {
       description: TOOL_DESCRIPTIONS.webFetch,
       inputSchema: schemas.webFetchSchema,
-      execute: async (input: WebFetchInput) => {
-        return executeWebFetch(input, context);
-      },
+      contextSchema: chatToolsContextSchema,
+      execute: bindServerExecute(context, executeWebFetch),
     },
 
     // ============================================================================
@@ -434,9 +433,8 @@ export function createChatTools(
     getWeather: {
       description: TOOL_DESCRIPTIONS.getWeather,
       inputSchema: schemas.getWeatherSchema,
-      execute: async (input: GetWeatherInput) => {
-        return executeGetWeather(input, context);
-      },
+      contextSchema: chatToolsContextSchema,
+      execute: bindServerExecute(context, executeGetWeather),
     },
 
     // ============================================================================
@@ -445,9 +443,8 @@ export function createChatTools(
     runJs: {
       description: TOOL_DESCRIPTIONS.runJs,
       inputSchema: schemas.runJsSchema,
-      execute: async (input: RunJsInput) => {
-        return executeRunJs(input, context);
-      },
+      contextSchema: chatToolsContextSchema,
+      execute: bindServerExecute(context, executeRunJs),
     },
 
     // ============================================================================
@@ -468,9 +465,8 @@ export function createChatTools(
     mapsSearchPlaces: {
       description: TOOL_DESCRIPTIONS.mapsSearchPlaces,
       inputSchema: schemas.mapsSearchPlacesSchema,
-      execute: async (input: MapsSearchPlacesInput) => {
-        return executeMapsSearchPlaces(input, context);
-      },
+      contextSchema: chatToolsContextSchema,
+      execute: bindServerExecute(context, executeMapsSearchPlaces),
     },
 
     // ============================================================================
@@ -555,23 +551,20 @@ export function createChatTools(
     memoryWrite: {
       description: TOOL_DESCRIPTIONS.memoryWrite,
       inputSchema: schemas.memoryWriteSchema,
-      execute: async (input: MemoryWriteInput) => {
-        return executeMemoryWrite(input, context);
-      },
+      contextSchema: chatToolsContextSchema,
+      execute: bindServerExecute(context, executeMemoryWrite),
     },
     memoryRead: {
       description: TOOL_DESCRIPTIONS.memoryRead,
       inputSchema: schemas.memoryReadSchema,
-      execute: async (input: MemoryReadInput) => {
-        return executeMemoryRead(input, context);
-      },
+      contextSchema: chatToolsContextSchema,
+      execute: bindServerExecute(context, executeMemoryRead),
     },
     memoryDelete: {
       description: TOOL_DESCRIPTIONS.memoryDelete,
       inputSchema: schemas.memoryDeleteSchema,
-      execute: async (input: MemoryDeleteInput) => {
-        return executeMemoryDelete(input, context);
-      },
+      contextSchema: chatToolsContextSchema,
+      execute: bindServerExecute(context, executeMemoryDelete),
     },
   };
 
@@ -603,37 +596,32 @@ export function createChatTools(
       documentsControl: {
         description: TOOL_DESCRIPTIONS.documentsControl,
         inputSchema: schemas.documentsControlSchema,
-        execute: async (input: DocumentsControlInput) => {
-          return executeDocumentsControl(input, context);
-        },
+        contextSchema: chatToolsContextSchema,
+        execute: bindServerExecute(context, executeDocumentsControl),
       },
       calendarControl: {
         description: TOOL_DESCRIPTIONS.calendarControl,
         inputSchema: schemas.calendarControlSchema,
-        execute: async (input: CalendarControlInput) => {
-          return executeCalendarControl(input, context);
-        },
+        contextSchema: chatToolsContextSchema,
+        execute: bindServerExecute(context, executeCalendarControl),
       },
       stickiesControl: {
         description: TOOL_DESCRIPTIONS.stickiesControl,
         inputSchema: schemas.stickiesControlSchema,
-        execute: async (input: StickiesControlInput) => {
-          return executeStickiesControl(input, context);
-        },
+        contextSchema: chatToolsContextSchema,
+        execute: bindServerExecute(context, executeStickiesControl),
       },
       contactsControl: {
         description: TOOL_DESCRIPTIONS.contactsControl,
         inputSchema: schemas.contactsControlSchema,
-        execute: async (input: ContactsControlInput) => {
-          return executeContactsControl(input, context);
-        },
+        contextSchema: chatToolsContextSchema,
+        execute: bindServerExecute(context, executeContactsControl),
       },
       songLibraryControl: {
         description: TOOL_DESCRIPTIONS.songLibraryControl,
         inputSchema: schemas.songLibraryControlSchema,
-        execute: async (input: SongLibraryControlInput) => {
-          return executeSongLibraryControl(input, context);
-        },
+        contextSchema: chatToolsContextSchema,
+        execute: bindServerExecute(context, executeSongLibraryControl),
       },
       mapsSearchPlaces: {
         ...allTools.mapsSearchPlaces,

--- a/api/cron/telegram-heartbeat.ts
+++ b/api/cron/telegram-heartbeat.ts
@@ -42,7 +42,10 @@ import {
   getTelegramModel,
 } from "../_utils/_aiModels.js";
 import { getHeader } from "../_utils/request-helpers.js";
-import { createRyoToolLoopAgent } from "../_utils/ryo-agent.js";
+import {
+  createRyoToolLoopAgent,
+  RYO_AGENT_TIMEOUTS,
+} from "../_utils/ryo-agent.js";
 import { getStoredUserTimeZone } from "../_utils/auth/_user-record.js";
 
 function setResponseHeaders(res: ApiResponse): void {
@@ -397,6 +400,8 @@ export default async function handler(
 
   const result = await agent.generate({
     messages: enrichedMessages,
+    // Must pass explicitly — call-time `timeout` overwrites constructor default.
+    timeout: RYO_AGENT_TIMEOUTS.telegramHeartbeat,
     onStepEnd: async (stepResult) => {
       if (stepResult.toolResults.length > 0) {
         logger.info("Telegram heartbeat completed tool step", {

--- a/api/ie-generate.ts
+++ b/api/ie-generate.ts
@@ -10,8 +10,9 @@ import {
   SupportedModel,
   DEFAULT_MODEL,
   getModelInstance,
-  getOpenAIProviderOptions,
+  getModelReasoning,
 } from "./_utils/_aiModels.js";
+import { addCacheControlToMessages } from "./_utils/ai-prompt-cache.js";
 import { normalizeUrlForCacheKey } from "./_utils/_url.js";
 import { redisKeys, sha256RedisIdentifier } from "../src/shared/redisKeys.js";
 import {
@@ -302,21 +303,33 @@ export default apiHandler<IEGenerateRequestBody>(
       cacheKey,
     });
 
+    const reasoning = getModelReasoning(model);
     const result = streamText({
       model: selectedModel,
       instructions,
       messages: modelMessages,
-      prepareStep: ({ stepNumber, messages }) => {
-        if (stepNumber !== 0) return {};
+      prepareStep: ({ stepNumber, messages, model: stepModel }) => {
+        const withDynamicContext =
+          stepNumber === 0
+            ? [...dynamicContextMessages, ...messages]
+            : messages;
         return {
-          messages: [...dynamicContextMessages, ...messages],
+          messages: addCacheControlToMessages({
+            messages: withDynamicContext,
+            model: stepModel,
+          }),
         };
       },
       // We assume prompt/messages already include necessary system/user details
       temperature: 0.7,
       maxOutputTokens: 4000,
+      timeout: {
+        totalMs: 90_000,
+        stepMs: 60_000,
+        chunkMs: 30_000,
+      },
       experimental_transform: smoothStream(),
-      providerOptions: getOpenAIProviderOptions(model),
+      ...(reasoning ? { reasoning } : {}),
       onEnd: async ({ text }) => {
         if (!cacheKey) {
           logger.info("No cacheKey available, skipping cache save");

--- a/api/ie-generate.ts
+++ b/api/ie-generate.ts
@@ -276,18 +276,18 @@ export default apiHandler<IEGenerateRequestBody>(
     // Generate dynamic portion of the system prompt, passing the rawUrl
     const systemPrompt = getDynamicSystemPrompt(effectiveYear, rawUrl ?? null);
 
-    // Build instructions — static portion gets cache control so providers
-    // can reuse the prefix across requests with different year/url params
-    const instructions = [
-      {
-        role: "system" as const,
-        content: STATIC_SYSTEM_PROMPT,
-        providerOptions: {
-          anthropic: { cacheControl: { type: "ephemeral" } },
-        },
+    // Static instructions stay cacheable; year/url context is injected via
+    // prepareStep messages so we don't mutate the cached instructions.
+    const instructions = {
+      role: "system" as const,
+      content: STATIC_SYSTEM_PROMPT,
+      providerOptions: {
+        anthropic: { cacheControl: { type: "ephemeral" } },
       },
+    };
+    const dynamicContextMessages = [
       {
-        role: "system" as const,
+        role: "user" as const,
         content: systemPrompt,
       },
     ];
@@ -306,6 +306,12 @@ export default apiHandler<IEGenerateRequestBody>(
       model: selectedModel,
       instructions,
       messages: modelMessages,
+      prepareStep: ({ stepNumber, messages }) => {
+        if (stepNumber !== 0) return {};
+        return {
+          messages: [...dynamicContextMessages, ...messages],
+        };
+      },
       // We assume prompt/messages already include necessary system/user details
       temperature: 0.7,
       maxOutputTokens: 4000,

--- a/api/ie-generate.ts
+++ b/api/ie-generate.ts
@@ -2,7 +2,6 @@ import {
   streamText,
   smoothStream,
   convertToModelMessages,
-  type ModelMessage,
   type UIMessage,
 } from "ai";
 import * as RateLimit from "./_utils/_rate-limit.js";
@@ -277,41 +276,36 @@ export default apiHandler<IEGenerateRequestBody>(
     // Generate dynamic portion of the system prompt, passing the rawUrl
     const systemPrompt = getDynamicSystemPrompt(effectiveYear, rawUrl ?? null);
 
-    // Build system messages — static portion gets cache control so providers
+    // Build instructions — static portion gets cache control so providers
     // can reuse the prefix across requests with different year/url params
-    const staticSystemMessage = {
-      role: "system" as const,
-      content: STATIC_SYSTEM_PROMPT,
-      providerOptions: {
-        anthropic: { cacheControl: { type: "ephemeral" } },
+    const instructions = [
+      {
+        role: "system" as const,
+        content: STATIC_SYSTEM_PROMPT,
+        providerOptions: {
+          anthropic: { cacheControl: { type: "ephemeral" } },
+        },
       },
-    };
+      {
+        role: "system" as const,
+        content: systemPrompt,
+      },
+    ];
 
-    const dynamicSystemMessage = {
-      role: "system" as const,
-      content: systemPrompt,
-    };
-
-    // Convert UIMessages to ModelMessages for the AI model (AI SDK v6)
+    // Convert UIMessages to ModelMessages for the AI model (AI SDK v7)
     const uiMessages = ensureUIMessageFormat(incomingMessages);
     const modelMessages = await convertToModelMessages(uiMessages);
 
-    const enrichedMessages: ModelMessage[] = [
-      staticSystemMessage,
-      dynamicSystemMessage,
-      ...modelMessages,
-    ];
-
     logger.info("Starting generation", {
       model,
-      messageCount: enrichedMessages.length,
+      messageCount: modelMessages.length,
       cacheKey,
     });
 
     const result = streamText({
       model: selectedModel,
-      messages: enrichedMessages,
-      allowSystemInMessages: true,
+      instructions,
+      messages: modelMessages,
       // We assume prompt/messages already include necessary system/user details
       temperature: 0.7,
       maxOutputTokens: 4000,

--- a/api/songs/[id].ts
+++ b/api/songs/[id].ts
@@ -1160,8 +1160,8 @@ export default apiHandler<Record<string, unknown>>(
           // Use streamText with GPT-5.4
           const result = streamText({
             model: openai("gpt-5.4"),
+            instructions: getTranslationSystemPrompt(language),
             messages: [
-              { role: "system", content: getTranslationSystemPrompt(language) },
               { role: "user", content: textsToProcess },
             ],
             temperature: 0.3,
@@ -1385,8 +1385,8 @@ export default apiHandler<Record<string, unknown>>(
 
           const result = streamText({
             model: openai("gpt-5.4"),
+            instructions: FURIGANA_STREAM_SYSTEM_PROMPT,
             messages: [
-              { role: "system", content: FURIGANA_STREAM_SYSTEM_PROMPT },
               { role: "user", content: textsToProcess },
             ],
             temperature: 0.1,
@@ -1668,8 +1668,8 @@ export default apiHandler<Record<string, unknown>>(
           // Use streamText
           const result = streamText({
             model: openai("gpt-5.4"),
+            instructions: systemPrompt,
             messages: [
-              { role: "system", content: systemPrompt },
               { role: "user", content: textsToProcess },
             ],
             temperature: 0.7,

--- a/api/songs/_furigana.ts
+++ b/api/songs/_furigana.ts
@@ -254,8 +254,8 @@ export async function streamFurigana(
   try {
     const result = streamText({
       model: openai("gpt-5.4"),
+      instructions: systemPrompt,
       messages: [
-        { role: "system", content: systemPrompt },
         { role: "user", content: textsToProcess },
       ],
       temperature: 0.1,

--- a/api/songs/_lyrics.ts
+++ b/api/songs/_lyrics.ts
@@ -604,8 +604,8 @@ export async function streamTranslation(
   try {
     const result = streamText({
       model: openai("gpt-5.4"),
+      instructions: systemPrompt,
       messages: [
-        { role: "system", content: systemPrompt },
         { role: "user", content: textsToProcess },
       ],
       temperature: 0.3,

--- a/api/tv/create-channel.ts
+++ b/api/tv/create-channel.ts
@@ -190,13 +190,12 @@ export default apiHandler<CreateChannelRequest>(
     try {
       const { output } = await generateText({
         model: google("gemini-3-flash-preview"),
-        allowSystemInMessages: true,
+        instructions: SYSTEM_PROMPT,
         output: Output.object({
           schema: ChannelPlanSchema,
           name: "channel_plan",
         }),
         messages: [
-          { role: "system", content: SYSTEM_PROMPT },
           {
             role: "user",
             content: `Description: ${description}`,

--- a/api/webhooks/telegram.ts
+++ b/api/webhooks/telegram.ts
@@ -40,6 +40,7 @@ import {
 import { getTelegramModel } from "../_utils/_aiModels.js";
 import {
   createRyoToolLoopAgent,
+  RYO_AGENT_TIMEOUTS,
   textStreamFromFullStream,
 } from "../_utils/ryo-agent.js";
 import {
@@ -197,7 +198,7 @@ async function injectImageIntoLastUserMessage(
         ? msg.content
         : [];
 
-  const providerReference = await uploadProviderFileForModel({
+  const uploaded = await uploadProviderFileForModel({
     modelId: options.modelId,
     data: image.data,
     mediaType: image.mimeType,
@@ -205,11 +206,13 @@ async function injectImageIntoLastUserMessage(
     log: options.log,
   });
 
-  const imagePart = providerReference
+  // Provider references require a full MIME subtype (e.g. image/jpeg).
+  // Top-level "image" throws in resolveFullMediaType for non-inline data.
+  const imagePart = uploaded
     ? {
         type: "file" as const,
-        mediaType: "image",
-        data: providerReference,
+        mediaType: uploaded.mediaType,
+        data: uploaded.providerReference,
       }
     : {
         type: "file" as const,
@@ -737,6 +740,8 @@ export default async function handler(
 
     const result = await agent.stream({
       messages: finalMessages,
+      // Must pass explicitly — call-time `timeout` overwrites constructor default.
+      timeout: RYO_AGENT_TIMEOUTS.telegram,
       onStepEnd: async (stepResult) => {
         if (stepResult.toolResults.length > 0) {
           await statusReporter.markThinking();

--- a/api/webhooks/telegram.ts
+++ b/api/webhooks/telegram.ts
@@ -3,6 +3,8 @@ import { type ModelMessage, type ToolSet } from "ai";
 import { initLogger } from "../_utils/_logging.js";
 import createRedis from "../_utils/redis.js";
 import * as RateLimit from "../_utils/_rate-limit.js";
+import { uploadProviderFileForModel } from "../_utils/upload-provider-file.js";
+import type { SupportedModel } from "../_utils/_aiModels.js";
 import {
   appendTelegramConversationMessage,
   claimTelegramUpdate,
@@ -168,36 +170,57 @@ async function handleTelegramCommandUpdate(args: {
   sendJson(args.res, 200, args.payload);
 }
 
-function injectImageIntoLastUserMessage(
+async function injectImageIntoLastUserMessage(
   messages: ModelMessage[],
-  image: { data: Uint8Array; mimeType: string }
-): ModelMessage[] {
+  image: { data: Uint8Array; mimeType: string },
+  options: {
+    modelId: SupportedModel;
+    log?: (...args: unknown[]) => void;
+  }
+): Promise<ModelMessage[]> {
   let lastUserIdx = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].role === "user") { lastUserIdx = i; break; }
+    if (messages[i].role === "user") {
+      lastUserIdx = i;
+      break;
+    }
   }
   if (lastUserIdx === -1) return messages;
 
   const msg = messages[lastUserIdx];
   if (msg.role !== "user") return messages;
 
-  const existingContent = typeof msg.content === "string"
-    ? [{ type: "text" as const, text: msg.content }]
-    : Array.isArray(msg.content)
-      ? msg.content
-      : [];
+  const existingContent =
+    typeof msg.content === "string"
+      ? [{ type: "text" as const, text: msg.content }]
+      : Array.isArray(msg.content)
+        ? msg.content
+        : [];
+
+  const providerReference = await uploadProviderFileForModel({
+    modelId: options.modelId,
+    data: image.data,
+    mediaType: image.mimeType,
+    filename: "telegram-image",
+    log: options.log,
+  });
+
+  const imagePart = providerReference
+    ? {
+        type: "file" as const,
+        mediaType: "image",
+        data: providerReference,
+      }
+    : {
+        type: "file" as const,
+        mediaType: image.mimeType,
+        data: { type: "data" as const, data: image.data },
+      };
 
   const updated: ModelMessage[] = [...messages];
   updated[lastUserIdx] = {
     ...msg,
-    content: [
-      ...existingContent,
-      {
-        type: "image" as const,
-        image: image.data,
-        mimeType: image.mimeType,
-      },
-    ],
+    content: [...existingContent, imagePart],
   } as ModelMessage;
 
   return updated;
@@ -656,7 +679,7 @@ export default async function handler(
     logError: (...args: unknown[]) =>
       logger.error(`[Telegram:${linkedAccount.username}]`, args),
   });
-  const { tools, enrichedMessages, loadedSections, staticSystemPrompt } =
+  const { tools, enrichedMessages, loadedSections, staticSystemPrompt, modelId } =
     preparedConversation;
 
   logger.info("Telegram prompt sections loaded", {
@@ -666,7 +689,15 @@ export default async function handler(
   });
 
   const finalMessages: ModelMessage[] = imageData
-    ? injectImageIntoLastUserMessage(enrichedMessages as ModelMessage[], imageData)
+    ? await injectImageIntoLastUserMessage(
+        enrichedMessages as ModelMessage[],
+        imageData,
+        {
+          modelId,
+          log: (...args: unknown[]) =>
+            logger.info(`[Telegram:${linkedAccount.username}]`, args),
+        }
+      )
     : (enrichedMessages as ModelMessage[]);
 
   const statusReporter = createTelegramStatusReporter({

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "soundboard",
       "dependencies": {
-        "@ai-sdk/anthropic": "^4.0.8",
-        "@ai-sdk/google": "^4.0.8",
-        "@ai-sdk/openai": "^4.0.8",
-        "@ai-sdk/react": "^4.0.17",
+        "@ai-sdk/anthropic": "^4.0.12",
+        "@ai-sdk/google": "^4.0.12",
+        "@ai-sdk/openai": "^4.0.11",
+        "@ai-sdk/react": "^4.0.23",
         "@aws-sdk/client-s3": "^3.1081.0",
         "@aws-sdk/s3-request-presigner": "^3.1081.0",
         "@cursor/sdk": "1.0.23",
@@ -39,7 +39,7 @@
         "@tiptap/suggestion": "^3.27.3",
         "@types/three": "^0.185.0",
         "@upstash/redis": "^1.38.0",
-        "ai": "^7.0.16",
+        "ai": "^7.0.22",
         "audio-buffer-utils": "^5.1.2",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
@@ -159,21 +159,21 @@
   "packages": {
     "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
 
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.8", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZqT9kLxS2Cbo/4juwtEGbYyP0jNQTnUUKy2nQ8Vn28xqNu50+TukO/oCEWCpm18YbQq7N+hr6ClJs/ATTFpBTg=="],
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.12", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-IquWNkGRSF2ulYJ6YIIUqMsNAIDeZFB3/4W92aSOtCxH1TfuVoq3qw4M4TxTxIw4As9cnkeRLe7b9LDMzPDsnA=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.12", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Y7Fy8xJwPz7ZC0DhSQG3HIVk+drup42hrIj6yqKlib3CxwiR0F7nYyUI8+kPrEtbZEoyKoRstvT4/o0HEyFBHA=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9iYxdOLquoOFk5e+02P9qfBIA+EJU0FNJvyjGxi4iXJabt2+GlbaCg7TX0sTtxOsBVkdabkatqWM6+kvp53tBg=="],
 
-    "@ai-sdk/google": ["@ai-sdk/google@4.0.8", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-GELd0RkltieuODzr6tfnEOIufeooctYpGUNxujeh+zrChbHUkX2K6Li4h2EAfizctkY4k3JvC93dU9eh2QxzoQ=="],
+    "@ai-sdk/google": ["@ai-sdk/google@4.0.12", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-4Rw4viFwH2Wprx6OssZzhV/KgNWaA7qYr5Kg28AlZ7r3sEvyXH0kDZtZok7onPjr0RuFTg2EjCjTIeoCesg0Ww=="],
 
-    "@ai-sdk/mcp": ["@ai-sdk/mcp@2.0.7", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "pkce-challenge": "^5.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-DX1v5M/R4RD2yi1KSH2ERLKcb6h2qJF0DKt0PGTTpNJNK+meXMmouwSRZS8Y+JocbyHk7U9p6PgqVmKU/e5XhQ=="],
+    "@ai-sdk/mcp": ["@ai-sdk/mcp@2.0.10", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7", "pkce-challenge": "^5.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LP47CEk3e6BwCqXamvv4nKbgOWQ5z5T/qS/J2fola5h98KTy7JT7I1yw5LKtB89MZBLviYmEh98Ep4ovHOz/vA=="],
 
-    "@ai-sdk/openai": ["@ai-sdk/openai@4.0.8", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-yW2UuS6jlu2LRYCd+cSpVdu/umf+QjypihYAiGvKk5HnpqQf21ffNjFbke9xo9jhT+TBt2YR30Fs5Sy0md/dfA=="],
+    "@ai-sdk/openai": ["@ai-sdk/openai@4.0.11", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2PLnVPBsdJusgquPVYgPWd3ox4lbUFkp7DVUSmM0lQ4VISQoNxdgo6TvFAHgwQn9wJ/ckVYVRLU7+BvHc7T8ww=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@4.0.2", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@4.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.5", "", { "dependencies": { "@ai-sdk/provider": "4.0.2", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.7", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg=="],
 
-    "@ai-sdk/react": ["@ai-sdk/react@4.0.17", "", { "dependencies": { "@ai-sdk/mcp": "2.0.7", "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5", "ai": "7.0.16", "swr": "^2.4.1", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-pjcYHhSygd99erFH6EaDgYi3YpzEozVFmLBoz6guEDeoeyJV2K0EvHR21oRxV6U7cx/cuCwjfevtwOQD6uUKeA=="],
+    "@ai-sdk/react": ["@ai-sdk/react@4.0.23", "", { "dependencies": { "@ai-sdk/mcp": "2.0.10", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7", "ai": "7.0.22", "swr": "^2.4.1", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-nJ96yQE1013tafK9Pec3uSGTScXg8dc3t4xyydm+a0AfkaSewR58+Eg3l+xqmQAR8tzFAgo/38we5DeXrcgcqw=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
@@ -1179,7 +1179,7 @@
 
     "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
-    "ai": ["ai@7.0.16", "", { "dependencies": { "@ai-sdk/gateway": "4.0.12", "@ai-sdk/provider": "4.0.2", "@ai-sdk/provider-utils": "5.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OuA+uz6ZUVId+SVeB5bThi25Ofee/FmLvffAA368tlgqYCe2qAhqZUpfHL0dd9QC/iPiszdvCQYENJavSo/0gw=="],
+    "ai": ["ai@7.0.22", "", { "dependencies": { "@ai-sdk/gateway": "4.0.16", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg=="],
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 

--- a/package.json
+++ b/package.json
@@ -92,10 +92,10 @@
     "measure:react-render": "bun run scripts/measure-react-render-perf.ts"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^4.0.8",
-    "@ai-sdk/google": "^4.0.8",
-    "@ai-sdk/openai": "^4.0.8",
-    "@ai-sdk/react": "^4.0.17",
+    "@ai-sdk/anthropic": "^4.0.12",
+    "@ai-sdk/google": "^4.0.12",
+    "@ai-sdk/openai": "^4.0.11",
+    "@ai-sdk/react": "^4.0.23",
     "@aws-sdk/client-s3": "^3.1081.0",
     "@aws-sdk/s3-request-presigner": "^3.1081.0",
     "@cursor/sdk": "1.0.23",
@@ -126,7 +126,7 @@
     "@tiptap/suggestion": "^3.27.3",
     "@types/three": "^0.185.0",
     "@upstash/redis": "^1.38.0",
-    "ai": "^7.0.16",
+    "ai": "^7.0.22",
     "audio-buffer-utils": "^5.1.2",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",

--- a/src/apps/chats/tools/toolApprovals.ts
+++ b/src/apps/chats/tools/toolApprovals.ts
@@ -1,7 +1,7 @@
 /**
  * Approval plumbing for approval-gated client tools (AI SDK tool-approval
- * flow: `needsApproval` on the server → `approval-requested` tool part →
- * user decision → `addToolApprovalResponse` / client execution).
+ * flow: agent `toolApproval: { tool: 'user-approval' }` → `approval-requested`
+ * tool part → user decision → `addToolApprovalResponse` / client execution).
  *
  * Multiple chat surfaces (the Chats app's shared chat, the desktop
  * assistant's bubble chat) can host approval-gated tool calls, so each

--- a/src/components/shared/tool-invocation-message/types.ts
+++ b/src/components/shared/tool-invocation-message/types.ts
@@ -7,7 +7,7 @@ export interface ToolInvocationPart {
     | "input-available"
     | "output-available"
     | "output-error"
-    // Tool-approval flow (needsApproval tools, e.g. getPreciseLocation)
+    // Tool-approval flow (toolApproval tools, e.g. getPreciseLocation)
     | "approval-requested"
     | "approval-responded"
     | "output-denied";

--- a/src/shared/tools/approvalGated.ts
+++ b/src/shared/tools/approvalGated.ts
@@ -1,11 +1,11 @@
 /**
  * Client-executed tools that require explicit user approval before running.
  *
- * The server marks these tools with `needsApproval`, so the AI SDK emits a
- * `tool-approval-request` instead of expecting immediate execution. The
- * client-side dispatcher (`dispatchToolCall`) must NOT run them from
- * `onToolCall`; execution happens from the approval UI after the user
- * approves (see `src/apps/chats/tools/toolApprovals.ts`).
+ * The server registers these on `ToolLoopAgent` via AI SDK 7 `toolApproval`
+ * (`user-approval`), so the SDK emits a `tool-approval-request` instead of
+ * expecting immediate execution. The client-side dispatcher (`dispatchToolCall`)
+ * must NOT run them from `onToolCall`; execution happens from the approval UI
+ * after the user approves (see `src/apps/chats/tools/toolApprovals.ts`).
  */
 
 export const APPROVAL_GATED_TOOL_NAMES = ["getPreciseLocation"] as const;

--- a/src/shared/tools/preciseLocation.ts
+++ b/src/shared/tools/preciseLocation.ts
@@ -2,8 +2,9 @@
  * Shared types for the `getPreciseLocation` chat tool.
  *
  * The tool is client-executed (browser geolocation) and approval-gated: the
- * server marks it `needsApproval`, the chat UI renders an Allow / Don't Allow
- * prompt, and the handler only runs after the user approves.
+ * server registers `toolApproval: { getPreciseLocation: 'user-approval' }`,
+ * the chat UI renders an Allow / Don't Allow prompt, and the handler only
+ * runs after the user approves.
  */
 
 export interface GetPreciseLocationInput {

--- a/tests/unit/ai/test-ai-model-provider-options.test.ts
+++ b/tests/unit/ai/test-ai-model-provider-options.test.ts
@@ -1,16 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { getOpenAIProviderOptions } from "../../../api/_utils/_aiModels.js";
+import { getModelReasoning } from "../../../api/_utils/_aiModels.js";
 
-describe("OpenAI provider options", () => {
-  test("preserves explicit reasoning effort for gpt-5.5", () => {
-    expect(getOpenAIProviderOptions("gpt-5.5")).toEqual({
-      openai: {
-        reasoningEffort: "none",
-      },
-    });
+describe("model reasoning options", () => {
+  test("uses top-level reasoning none for gpt-5.5", () => {
+    expect(getModelReasoning("gpt-5.5")).toBe("none");
   });
 
-  test("ignores OpenAI provider options for non-OpenAI models", () => {
-    expect(getOpenAIProviderOptions("sonnet-4.6")).toBeUndefined();
+  test("leaves non-OpenAI models on provider default", () => {
+    expect(getModelReasoning("sonnet-4.6")).toBeUndefined();
+    expect(getModelReasoning("gemini-3-flash")).toBeUndefined();
   });
 });

--- a/tests/unit/ai/test-ai-sdk-7-agent-wiring.test.ts
+++ b/tests/unit/ai/test-ai-sdk-7-agent-wiring.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { addCacheControlToMessages } from "../../../api/_utils/ai-prompt-cache.js";
+import { buildChatToolsContextMap } from "../../../api/chat/tools/context.js";
+import { chatToolsContextSchema } from "../../../api/chat/tools/context.js";
+import type { ModelMessage } from "ai";
 
 const readSource = (relativePath: string) =>
   readFileSync(resolve(process.cwd(), relativePath), "utf-8");
@@ -14,7 +18,13 @@ describe("AI SDK 7 Ryo agent wiring", () => {
     expect(source).toContain("dynamicContextMessages");
     expect(source).toContain('getPreciseLocation: "user-approval"');
     expect(source).toContain("toolApproval: RYO_TOOL_APPROVAL");
+    expect(source).toContain("timeout: RYO_AGENT_TIMEOUTS[preset]");
+    expect(source).toContain("getModelReasoning");
+    expect(source).toContain("toolsContext");
+    expect(source).toContain("runtimeContext");
+    expect(source).toContain("addCacheControlToMessages");
     expect(source).not.toContain("allowSystemInMessages");
+    expect(source).not.toContain("getOpenAIProviderOptions");
     expect(source).not.toMatch(/needsApproval\s*:/);
     // prepareStep must not override instructions (keeps static prompt cache)
     expect(source).not.toMatch(/prepareStep:[\s\S]*?instructions\s*:/);
@@ -25,7 +35,10 @@ describe("AI SDK 7 Ryo agent wiring", () => {
 
     expect(source).toContain("instructions: SystemModelMessage");
     expect(source).toContain("dynamicContextMessages: ModelMessage[]");
+    expect(source).toContain("toolsContext: ChatToolsContextMap");
+    expect(source).toContain("runtimeContext: RyoAgentRuntimeContext");
     expect(source).toContain("enrichedMessages: modelMessages");
+    expect(source).toContain("buildChatToolsContextMap");
     expect(source).toMatch(/Static instructions stay in the top-level/);
   });
 
@@ -42,5 +55,74 @@ describe("AI SDK 7 Ryo agent wiring", () => {
     expect(toolBlock).toContain("getPreciseLocation:");
     expect(toolBlock).toContain("toolApproval");
     expect(toolBlock).not.toMatch(/needsApproval\s*:/);
+  });
+
+  test("server chat tools declare contextSchema for toolsContext", () => {
+    const source = readSource("api/chat/tools/index.ts");
+    expect(source).toContain("contextSchema: chatToolsContextSchema");
+    expect(source).toContain("bindServerExecute");
+    expect(source).toContain("options?.context ?? fallbackContext");
+  });
+});
+
+describe("AI SDK 7 prompt cache helper", () => {
+  test("marks last message for Anthropic models only", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "again" },
+    ];
+
+    const anthropicCached = addCacheControlToMessages({
+      messages,
+      model: {
+        provider: "anthropic.messages",
+        modelId: "claude-sonnet-4-6",
+      } as never,
+    });
+
+    expect(anthropicCached[0].providerOptions).toBeUndefined();
+    expect(anthropicCached[2].providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+
+    const openaiPassthrough = addCacheControlToMessages({
+      messages,
+      model: {
+        provider: "openai.responses",
+        modelId: "gpt-5.5",
+      } as never,
+    });
+    expect(openaiPassthrough).toEqual(messages);
+  });
+});
+
+describe("AI SDK 7 toolsContext map", () => {
+  test("buildChatToolsContextMap only includes tools with contextSchema", () => {
+    const context = {
+      log: () => {},
+      logError: () => {},
+      env: {},
+      username: "ryo",
+    };
+
+    const map = buildChatToolsContextMap(
+      {
+        memoryWrite: {
+          description: "write",
+          inputSchema: chatToolsContextSchema,
+          contextSchema: chatToolsContextSchema,
+          execute: async () => ({ ok: true }),
+        },
+        launchApp: {
+          description: "launch",
+          inputSchema: chatToolsContextSchema,
+        },
+      } as never,
+      context
+    );
+
+    expect(Object.keys(map)).toEqual(["memoryWrite"]);
+    expect(map.memoryWrite).toBe(context);
   });
 });

--- a/tests/unit/ai/test-ai-sdk-7-agent-wiring.test.ts
+++ b/tests/unit/ai/test-ai-sdk-7-agent-wiring.test.ts
@@ -95,6 +95,55 @@ describe("AI SDK 7 prompt cache helper", () => {
     });
     expect(openaiPassthrough).toEqual(messages);
   });
+
+  test("merges into existing anthropic providerOptions instead of replacing them", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "user",
+        content: "cached",
+        providerOptions: {
+          anthropic: {
+            cacheControl: { type: "ephemeral" },
+            // Preserve any other Anthropic bag fields already on the message.
+            somethingElse: true,
+          } as never,
+          otherProvider: { keep: true } as never,
+        },
+      },
+    ];
+
+    const cached = addCacheControlToMessages({
+      messages,
+      model: {
+        provider: "anthropic.messages",
+        modelId: "claude-sonnet-4-6",
+      } as never,
+    });
+
+    expect(cached[0].providerOptions).toEqual({
+      otherProvider: { keep: true },
+      anthropic: {
+        somethingElse: true,
+        cacheControl: { type: "ephemeral" },
+      },
+    });
+  });
+});
+
+describe("AI SDK 7 agent call-site timeouts", () => {
+  test("chat / telegram / heartbeat pass timeout on stream/generate", () => {
+    const chat = readSource("api/chat.ts");
+    expect(chat).toContain("RYO_AGENT_TIMEOUTS");
+    expect(chat).toContain("timeout: RYO_AGENT_TIMEOUTS.chat");
+
+    const telegram = readSource("api/webhooks/telegram.ts");
+    expect(telegram).toContain("timeout: RYO_AGENT_TIMEOUTS.telegram");
+
+    const heartbeat = readSource("api/cron/telegram-heartbeat.ts");
+    expect(heartbeat).toContain(
+      "timeout: RYO_AGENT_TIMEOUTS.telegramHeartbeat"
+    );
+  });
 });
 
 describe("AI SDK 7 toolsContext map", () => {

--- a/tests/unit/ai/test-ai-sdk-7-agent-wiring.test.ts
+++ b/tests/unit/ai/test-ai-sdk-7-agent-wiring.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const readSource = (relativePath: string) =>
+  readFileSync(resolve(process.cwd(), relativePath), "utf-8");
+
+describe("AI SDK 7 Ryo agent wiring", () => {
+  test("ToolLoopAgent uses instructions and toolApproval (not allowSystemInMessages / needsApproval)", () => {
+    const source = readSource("api/_utils/ryo-agent.ts");
+
+    expect(source).toContain("instructions: prepared.instructions");
+    expect(source).toContain('getPreciseLocation: "user-approval"');
+    expect(source).toContain("toolApproval: RYO_TOOL_APPROVAL");
+    expect(source).not.toContain("allowSystemInMessages");
+    expect(source).not.toContain("needsApproval");
+  });
+
+  test("prepareRyoConversationModelInput returns instructions separate from messages", () => {
+    const source = readSource("api/_utils/ryo-conversation.ts");
+
+    expect(source).toContain("instructions: Instructions");
+    expect(source).toContain("instructions,");
+    expect(source).toContain("enrichedMessages: modelMessages");
+    expect(source).toMatch(/Three-tier instructions structure/);
+  });
+
+  test("chat tools no longer set needsApproval on getPreciseLocation", () => {
+    const source = readSource("api/chat/tools/index.ts");
+    const toolBlockStart = source.indexOf(
+      "// Precise Location Tool (Client-side execution, approval-gated)"
+    );
+    const toolBlock = source.slice(
+      toolBlockStart,
+      source.indexOf("mapsSearchPlaces:", toolBlockStart)
+    );
+
+    expect(toolBlock).toContain("getPreciseLocation:");
+    expect(toolBlock).toContain("toolApproval");
+    expect(toolBlock).not.toMatch(/needsApproval\s*:/);
+  });
+});

--- a/tests/unit/ai/test-ai-sdk-7-agent-wiring.test.ts
+++ b/tests/unit/ai/test-ai-sdk-7-agent-wiring.test.ts
@@ -6,23 +6,27 @@ const readSource = (relativePath: string) =>
   readFileSync(resolve(process.cwd(), relativePath), "utf-8");
 
 describe("AI SDK 7 Ryo agent wiring", () => {
-  test("ToolLoopAgent uses instructions and toolApproval (not allowSystemInMessages / needsApproval)", () => {
+  test("ToolLoopAgent uses static instructions and prepareStep for dynamic context", () => {
     const source = readSource("api/_utils/ryo-agent.ts");
 
     expect(source).toContain("instructions: prepared.instructions");
+    expect(source).toContain("prepareStep:");
+    expect(source).toContain("dynamicContextMessages");
     expect(source).toContain('getPreciseLocation: "user-approval"');
     expect(source).toContain("toolApproval: RYO_TOOL_APPROVAL");
     expect(source).not.toContain("allowSystemInMessages");
     expect(source).not.toMatch(/needsApproval\s*:/);
+    // prepareStep must not override instructions (keeps static prompt cache)
+    expect(source).not.toMatch(/prepareStep:[\s\S]*?instructions\s*:/);
   });
 
-  test("prepareRyoConversationModelInput returns instructions separate from messages", () => {
+  test("prepareRyoConversationModelInput returns static instructions + dynamicContextMessages", () => {
     const source = readSource("api/_utils/ryo-conversation.ts");
 
-    expect(source).toContain("instructions: Instructions");
-    expect(source).toContain("instructions,");
+    expect(source).toContain("instructions: SystemModelMessage");
+    expect(source).toContain("dynamicContextMessages: ModelMessage[]");
     expect(source).toContain("enrichedMessages: modelMessages");
-    expect(source).toMatch(/Three-tier instructions structure/);
+    expect(source).toMatch(/Static instructions stay in the top-level/);
   });
 
   test("chat tools no longer set needsApproval on getPreciseLocation", () => {

--- a/tests/unit/ai/test-ai-sdk-7-agent-wiring.test.ts
+++ b/tests/unit/ai/test-ai-sdk-7-agent-wiring.test.ts
@@ -13,7 +13,7 @@ describe("AI SDK 7 Ryo agent wiring", () => {
     expect(source).toContain('getPreciseLocation: "user-approval"');
     expect(source).toContain("toolApproval: RYO_TOOL_APPROVAL");
     expect(source).not.toContain("allowSystemInMessages");
-    expect(source).not.toContain("needsApproval");
+    expect(source).not.toMatch(/needsApproval\s*:/);
   });
 
   test("prepareRyoConversationModelInput returns instructions separate from messages", () => {

--- a/tests/unit/ai/test-ai-sdk-7-upload-file.test.ts
+++ b/tests/unit/ai/test-ai-sdk-7-upload-file.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const readSource = (relativePath: string) =>
+  readFileSync(resolve(process.cwd(), relativePath), "utf-8");
+
+describe("AI SDK 7 uploadFile wiring", () => {
+  test("Telegram injects provider file references for images", () => {
+    const source = readSource("api/webhooks/telegram.ts");
+    expect(source).toContain("uploadProviderFileForModel");
+    expect(source).toContain('type: "file" as const');
+    expect(source).toContain("providerReference");
+    expect(source).not.toMatch(/type:\s*"image"\s+as\s+const/);
+  });
+
+  test("applet-ai uploads attachments via google.files()", () => {
+    const source = readSource("api/applet-ai.ts");
+    expect(source).toContain("uploadFile");
+    expect(source).toContain("google.files()");
+    expect(source).toContain("providerReference");
+  });
+
+  test("upload helper selects files API by model provider", () => {
+    const source = readSource("api/_utils/upload-provider-file.ts");
+    expect(source).toContain("openai.files()");
+    expect(source).toContain("anthropic.files()");
+    expect(source).toContain("google.files()");
+    expect(source).toContain("uploadFile");
+  });
+});

--- a/tests/unit/ai/test-ai-sdk-7-upload-file.test.ts
+++ b/tests/unit/ai/test-ai-sdk-7-upload-file.test.ts
@@ -1,31 +1,41 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { GOOGLE_FILES_POLL_TIMEOUT_MS } from "../../../api/_utils/upload-provider-file.js";
 
 const readSource = (relativePath: string) =>
   readFileSync(resolve(process.cwd(), relativePath), "utf-8");
 
 describe("AI SDK 7 uploadFile wiring", () => {
-  test("Telegram injects provider file references for images", () => {
+  test("Telegram injects provider file references with full MIME mediaType", () => {
     const source = readSource("api/webhooks/telegram.ts");
     expect(source).toContain("uploadProviderFileForModel");
     expect(source).toContain('type: "file" as const');
-    expect(source).toContain("providerReference");
+    expect(source).toContain("uploaded.providerReference");
+    expect(source).toContain("uploaded.mediaType");
+    // Top-level "image" breaks resolveFullMediaType for provider references.
+    expect(source).not.toMatch(/mediaType:\s*"image"/);
     expect(source).not.toMatch(/type:\s*"image"\s+as\s+const/);
   });
 
-  test("applet-ai uploads attachments via google.files()", () => {
+  test("applet-ai uploads attachments via google.files() with full MIME", () => {
     const source = readSource("api/applet-ai.ts");
     expect(source).toContain("uploadFile");
     expect(source).toContain("google.files()");
-    expect(source).toContain("providerReference");
+    expect(source).toContain("uploaded.providerReference");
+    expect(source).toContain("uploaded.mediaType ||");
+    expect(source).toContain("GOOGLE_FILES_POLL_TIMEOUT_MS");
+    expect(source).not.toMatch(/mediaType:\s*"image"/);
   });
 
-  test("upload helper selects files API by model provider", () => {
+  test("upload helper selects files API and caps Google poll timeout", () => {
     const source = readSource("api/_utils/upload-provider-file.ts");
     expect(source).toContain("openai.files()");
     expect(source).toContain("anthropic.files()");
     expect(source).toContain("google.files()");
     expect(source).toContain("uploadFile");
+    expect(source).toContain("pollTimeoutMs: GOOGLE_FILES_POLL_TIMEOUT_MS");
+    expect(source).toContain("mediaType: result.mediaType || mediaType");
+    expect(GOOGLE_FILES_POLL_TIMEOUT_MS).toBe(30_000);
   });
 });

--- a/tests/unit/ai/test-ryo-conversation-prompt-caching.test.ts
+++ b/tests/unit/ai/test-ryo-conversation-prompt-caching.test.ts
@@ -153,7 +153,7 @@ describe("prompt caching structure", () => {
     expect(prompt).not.toContain("MEDIA PLAYBACK");
   });
 
-  test("prepareRyoConversationModelInput emits three instruction messages with cache control", async () => {
+  test("prepareRyoConversationModelInput keeps static instructions and dynamic prepareStep context", async () => {
     const result = await prepareRyoConversationModelInput({
       channel: "chat",
       messages: [{ id: "1", role: "user", content: "hello" }],
@@ -165,39 +165,43 @@ describe("prompt caching structure", () => {
       },
     });
 
-    expect(Array.isArray(result.instructions)).toBe(true);
-    const instructionMessages = result.instructions as Array<{
-      role: string;
-      content: string;
-      providerOptions?: unknown;
-    }>;
+    // Static instructions only (AI SDK 7 top-level instructions)
+    expect(result.instructions.role).toBe("system");
+    expect(result.instructions.content).toContain("core_priority");
+    expect(
+      (result.instructions as { providerOptions?: unknown }).providerOptions
+    ).toBeDefined();
 
-    expect(instructionMessages.length).toBe(3);
+    // Dynamic context is separate for prepareStep injection
+    expect(result.dynamicContextMessages.length).toBe(2);
+    expect(result.dynamicContextMessages[0].role).toBe("user");
+    expect(result.dynamicContextMessages[0].content).toContain("user_context");
+    expect(result.dynamicContextMessages[0].content).toContain(
+      "LONG-TERM MEMORIES"
+    );
+    expect(
+      (result.dynamicContextMessages[0] as { providerOptions?: unknown })
+        .providerOptions
+    ).toBeDefined();
 
-    // First: static instructions (cached)
-    expect(instructionMessages[0].content).toContain("core_priority");
-    expect(instructionMessages[0].providerOptions).toBeDefined();
-
-    // Second: memory context (cached)
-    expect(instructionMessages[1].content).toContain("user_context");
-    expect(instructionMessages[1].content).toContain("LONG-TERM MEMORIES");
-    expect(instructionMessages[1].providerOptions).toBeDefined();
-
-    // Third: volatile state (NOT cached)
-    expect(instructionMessages[2].content).toContain("system_state");
-    expect(instructionMessages[2].content).toContain("Ryo Time:");
-    expect(instructionMessages[2].providerOptions).toBeUndefined();
+    expect(result.dynamicContextMessages[1].role).toBe("user");
+    expect(result.dynamicContextMessages[1].content).toContain("system_state");
+    expect(result.dynamicContextMessages[1].content).toContain("Ryo Time:");
+    expect(
+      (result.dynamicContextMessages[1] as { providerOptions?: unknown })
+        .providerOptions
+    ).toBeUndefined();
 
     // Conversation messages must not carry system roles (AI SDK 7)
     expect(result.enrichedMessages.every((m) => m.role !== "system")).toBe(true);
     expect(result.enrichedMessages.some((m) => m.role === "user")).toBe(true);
 
-    // Verify the new fields are populated
+    // Verify the helper fields are populated
     expect(result.memoryContextPrompt).toContain("user_context");
     expect(result.volatileStatePrompt).toContain("system_state");
   });
 
-  test("prepareRyoConversationModelInput emits three instruction messages without memories", async () => {
+  test("prepareRyoConversationModelInput emits dynamic context without memories", async () => {
     const result = await prepareRyoConversationModelInput({
       channel: "chat",
       messages: [{ id: "1", role: "user", content: "hello" }],
@@ -209,16 +213,11 @@ describe("prompt caching structure", () => {
       },
     });
 
-    const instructionMessages = result.instructions as Array<{
-      role: string;
-      content: string;
-    }>;
-
-    // Still 3 messages: static + minimal memory context (user identity) + volatile
-    expect(instructionMessages.length).toBe(3);
-    expect(instructionMessages[0].content).toContain("core_priority");
-    expect(instructionMessages[1].content).toContain("user_context");
-    expect(instructionMessages[2].content).toContain("system_state");
+    expect(result.instructions.content).toContain("core_priority");
+    // Still 2 dynamic messages: minimal memory context (user identity) + volatile
+    expect(result.dynamicContextMessages.length).toBe(2);
+    expect(result.dynamicContextMessages[0].content).toContain("user_context");
+    expect(result.dynamicContextMessages[1].content).toContain("system_state");
     expect(result.enrichedMessages.every((m) => m.role !== "system")).toBe(true);
   });
 });

--- a/tests/unit/ai/test-ryo-conversation-prompt-caching.test.ts
+++ b/tests/unit/ai/test-ryo-conversation-prompt-caching.test.ts
@@ -153,7 +153,7 @@ describe("prompt caching structure", () => {
     expect(prompt).not.toContain("MEDIA PLAYBACK");
   });
 
-  test("prepareRyoConversationModelInput emits three system messages with cache control", async () => {
+  test("prepareRyoConversationModelInput emits three instruction messages with cache control", async () => {
     const result = await prepareRyoConversationModelInput({
       channel: "chat",
       messages: [{ id: "1", role: "user", content: "hello" }],
@@ -165,32 +165,39 @@ describe("prompt caching structure", () => {
       },
     });
 
-    const systemMessages = result.enrichedMessages.filter(
-      (m) => m.role === "system"
-    );
+    expect(Array.isArray(result.instructions)).toBe(true);
+    const instructionMessages = result.instructions as Array<{
+      role: string;
+      content: string;
+      providerOptions?: unknown;
+    }>;
 
-    expect(systemMessages.length).toBe(3);
+    expect(instructionMessages.length).toBe(3);
 
     // First: static instructions (cached)
-    expect(systemMessages[0].content).toContain("core_priority");
-    expect((systemMessages[0] as Record<string, unknown>).providerOptions).toBeDefined();
+    expect(instructionMessages[0].content).toContain("core_priority");
+    expect(instructionMessages[0].providerOptions).toBeDefined();
 
     // Second: memory context (cached)
-    expect(systemMessages[1].content).toContain("user_context");
-    expect(systemMessages[1].content).toContain("LONG-TERM MEMORIES");
-    expect((systemMessages[1] as Record<string, unknown>).providerOptions).toBeDefined();
+    expect(instructionMessages[1].content).toContain("user_context");
+    expect(instructionMessages[1].content).toContain("LONG-TERM MEMORIES");
+    expect(instructionMessages[1].providerOptions).toBeDefined();
 
     // Third: volatile state (NOT cached)
-    expect(systemMessages[2].content).toContain("system_state");
-    expect(systemMessages[2].content).toContain("Ryo Time:");
-    expect((systemMessages[2] as Record<string, unknown>).providerOptions).toBeUndefined();
+    expect(instructionMessages[2].content).toContain("system_state");
+    expect(instructionMessages[2].content).toContain("Ryo Time:");
+    expect(instructionMessages[2].providerOptions).toBeUndefined();
+
+    // Conversation messages must not carry system roles (AI SDK 7)
+    expect(result.enrichedMessages.every((m) => m.role !== "system")).toBe(true);
+    expect(result.enrichedMessages.some((m) => m.role === "user")).toBe(true);
 
     // Verify the new fields are populated
     expect(result.memoryContextPrompt).toContain("user_context");
     expect(result.volatileStatePrompt).toContain("system_state");
   });
 
-  test("prepareRyoConversationModelInput emits three system messages without memories", async () => {
+  test("prepareRyoConversationModelInput emits three instruction messages without memories", async () => {
     const result = await prepareRyoConversationModelInput({
       channel: "chat",
       messages: [{ id: "1", role: "user", content: "hello" }],
@@ -202,14 +209,16 @@ describe("prompt caching structure", () => {
       },
     });
 
-    const systemMessages = result.enrichedMessages.filter(
-      (m) => m.role === "system"
-    );
+    const instructionMessages = result.instructions as Array<{
+      role: string;
+      content: string;
+    }>;
 
     // Still 3 messages: static + minimal memory context (user identity) + volatile
-    expect(systemMessages.length).toBe(3);
-    expect(systemMessages[0].content).toContain("core_priority");
-    expect(systemMessages[1].content).toContain("user_context");
-    expect(systemMessages[2].content).toContain("system_state");
+    expect(instructionMessages.length).toBe(3);
+    expect(instructionMessages[0].content).toContain("core_priority");
+    expect(instructionMessages[1].content).toContain("user_context");
+    expect(instructionMessages[2].content).toContain("system_state");
+    expect(result.enrichedMessages.every((m) => m.role !== "system")).toBe(true);
   });
 });

--- a/tests/unit/ai/test-ryo-conversation-prompt-caching.test.ts
+++ b/tests/unit/ai/test-ryo-conversation-prompt-caching.test.ts
@@ -196,6 +196,18 @@ describe("prompt caching structure", () => {
     expect(result.enrichedMessages.every((m) => m.role !== "system")).toBe(true);
     expect(result.enrichedMessages.some((m) => m.role === "user")).toBe(true);
 
+    // AI SDK 7 toolsContext / runtimeContext wiring
+    expect(result.runtimeContext).toEqual({
+      username: "testuser",
+      channel: "chat",
+      modelId: result.modelId,
+    });
+    expect(Object.keys(result.toolsContext).length).toBeGreaterThan(0);
+    expect(result.toolsContext.memoryWrite?.username).toBe("testuser");
+    expect(
+      (result.tools.memoryWrite as { contextSchema?: unknown }).contextSchema
+    ).toBeDefined();
+
     // Verify the helper fields are populated
     expect(result.memoryContextPrompt).toContain("user_context");
     expect(result.volatileStatePrompt).toContain("system_state");

--- a/tests/unit/ai/test-shared-ai-chat-wiring.test.ts
+++ b/tests/unit/ai/test-shared-ai-chat-wiring.test.ts
@@ -145,8 +145,12 @@ describe("server AI chat lifecycle wiring", () => {
     expect(source).toContain('req.off("aborted", abortGeneration)');
     expect(source).toContain('res.off("close", handleResponseClose)');
     expect(source).toContain('requestSocket?.off("close", abortGeneration)');
-    expect(source).toMatch(
-      /agent\.stream\(\{\s*messages: enrichedMessages,\s*abortSignal: generationAbortController\.signal/
+    expect(source).toContain("messages: enrichedMessages");
+    // Call-time timeout is required — ToolLoopAgent overwrites constructor
+    // timeout with undefined when the stream() arg is omitted.
+    expect(source).toContain("timeout: RYO_AGENT_TIMEOUTS.chat");
+    expect(source).toContain(
+      "abortSignal: generationAbortController.signal"
     );
     expect(source).toContain("consumeSseStream: consumeStream");
     // An aborted or failed turn simply skips persistence: the begun user

--- a/tests/unit/maps/test-weather-location-tools.test.ts
+++ b/tests/unit/maps/test-weather-location-tools.test.ts
@@ -139,7 +139,7 @@ describe("createChatTools weather/location registration", () => {
     timeZone: "America/Los_Angeles",
   };
 
-  test("all profile registers getWeather (server execute) and getPreciseLocation (needsApproval, client)", () => {
+  test("all profile registers getWeather (server execute) and getPreciseLocation (client, approval via toolApproval)", () => {
     const tools = createChatTools(context, { profile: "all" }) as Record<
       string,
       { description?: string; execute?: unknown; needsApproval?: boolean }
@@ -149,7 +149,9 @@ describe("createChatTools weather/location registration", () => {
     expect(tools.getWeather.description).toBe(TOOL_DESCRIPTIONS.getWeather);
 
     expect(tools.getPreciseLocation).toBeDefined();
-    expect(tools.getPreciseLocation.needsApproval).toBe(true);
+    // AI SDK 7: approval is configured on ToolLoopAgent via toolApproval, not
+    // on the tool definition itself.
+    expect(tools.getPreciseLocation.needsApproval).toBeUndefined();
     // Client-executed after user approval — the server must not execute it.
     expect(tools.getPreciseLocation.execute).toBeUndefined();
   });

--- a/tests/unit/telegram/test-telegram-status.test.ts
+++ b/tests/unit/telegram/test-telegram-status.test.ts
@@ -13,7 +13,7 @@ import {
 import {
   getTelegramProviderStatusToolCall,
 } from "../../../api/webhooks/telegram";
-import { getOpenAIProviderOptions } from "../../../api/_utils/_aiModels.js";
+import { getModelReasoning } from "../../../api/_utils/_aiModels.js";
 
 describe("telegram status helpers", () => {
   test("maps tool names to concise status text", () => {
@@ -138,12 +138,8 @@ describe("telegram status helpers", () => {
     ).toBeNull();
   });
 
-  test("uses shared OpenAI provider options for Telegram replies", () => {
-    expect(getOpenAIProviderOptions("gpt-5.5")).toEqual({
-      openai: {
-        reasoningEffort: "none",
-      },
-    });
+  test("uses shared OpenAI reasoning setting for Telegram replies", () => {
+    expect(getModelReasoning("gpt-5.5")).toBe("none");
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Finishes the AI SDK 7 migration and adopts the next set of v7 features for Ryo agents.

### Prompt structure (AI SDK 7)
- **`instructions`**: static `SystemModelMessage` only (Anthropic cache control)
- **`prepareStep`**: injects memory + volatile dynamic context as messages on step 0 (carries forward; does **not** override `instructions`)
- Same pattern for IE generate, applet AI, and proactive greetings

### Other migration
- Removed **`allowSystemInMessages`** workarounds
- **`needsApproval` → `toolApproval: { getPreciseLocation: 'user-approval' }`** on `ToolLoopAgent`
- Infinite Mac `toModelOutput`: `image-data` → canonical `file`
- Memory extract/consolidate/daily-notes prompts → `instructions`
- Packages: `ai@7.0.22`, `@ai-sdk/{openai,anthropic,google,react}` latest

### New AI SDK 7 features in this PR
1. **`timeout`** on `ToolLoopAgent` / `streamText` / `generateText` (total/step/chunk/per-tool) — also passed explicitly at `stream`/`generate` call sites (SDK overwrites constructor defaults)
2. **Top-level `reasoning`** via `getModelReasoning()` (replaces `providerOptions.openai.reasoningEffort`)
5. **`toolsContext` / `runtimeContext`** — server tools declare `contextSchema`; per-tool context map + shared runtime metadata
6. **`uploadFile`** — Telegram images and applet attachments upload to provider files APIs (inline fallback); full MIME on provider references; Google poll capped at 30s
7. **Incremental Anthropic cache** — `addCacheControlToMessages` marks the last message each `prepareStep` (deep-merges `anthropic` providerOptions)

Skipped for now: otel (#3), HMAC tool approvals (#4). Memory/volatile context stays as `user` messages via `prepareStep` (review finding #3 deferred).

## Test plan
- [x] Prompt-caching + agent wiring unit tests
- [x] Agent smoke: static instructions + `dynamicContextMessages` for prepareStep
- [x] toolsContext map + uploadFile wiring tests
- [x] Call-site timeout + full MIME + cache merge regression tests
- [x] Song library / Telegram status / model reasoning unit tests

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f52d7-9c07-718e-ac85-6c2ba0d791d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f52d7-9c07-718e-ac85-6c2ba0d791d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

