### PR TITLE
Fix expired cloud sync blob uploads

### DIFF
--- a/api/_utils/storage.ts
+++ b/api/_utils/storage.ts
@@ -10,6 +10,7 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { signStorageUploadToken } from "./storage-upload-token.js";
 
 export type StorageBackend = "s3";
+export type StorageClientUploadMode = "presigned" | "proxy";
 
 export interface StorageObjectMetadata {
   size: number;
@@ -22,6 +23,7 @@ export interface StorageUploadOptions {
   maximumSizeInBytes: number;
   allowedContentTypes?: string[];
   allowOverwrite?: boolean;
+  clientUploadMode?: StorageClientUploadMode;
 }
 
 interface BaseStorageUploadDescriptor {
@@ -154,8 +156,6 @@ function getS3Config(): S3Config | null {
 export function shouldEnableStorageDebugLogs(): boolean {
   return isTruthy(process.env.STORAGE_DEBUG);
 }
-
-export type StorageClientUploadMode = "presigned" | "proxy";
 
 export function getStorageClientUploadMode(): StorageClientUploadMode {
   const explicit = process.env.STORAGE_CLIENT_UPLOAD?.trim().toLowerCase();
@@ -425,8 +425,10 @@ export async function createStorageUploadDescriptor(
   options: StorageUploadOptions,
 ): Promise<StorageUploadDescriptor> {
   const pathname = normalizePathname(options.pathname);
+  const uploadMode =
+    options.clientUploadMode ?? getStorageClientUploadMode();
 
-  if (getStorageClientUploadMode() === "proxy") {
+  if (uploadMode === "proxy") {
     return createS3ProxyUploadDescriptor(options);
   }
 

--- a/api/sync/v2/blob-upload.ts
+++ b/api/sync/v2/blob-upload.ts
@@ -4,6 +4,7 @@ import {
   RequestBodyTooLargeError,
 } from "../../_utils/request-body.js";
 import {
+  createStorageUploadDescriptor,
   getStorageBackend,
   uploadStoredObject,
 } from "../../_utils/storage.js";
@@ -20,19 +21,78 @@ const RATE_LIMIT_WINDOW = 60;
 /** Allow a full sync blob batch plus a small retry margin. */
 const RATE_LIMIT_MAX = MAX_UPLOAD_ITEMS + 50;
 
-export default apiHandler(
+interface PostBlobUploadBody {
+  sha256?: string;
+  size?: number;
+}
+
+function isValidSha256(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{64}$/.test(value);
+}
+
+function blobPath(username: string, sha256: string): string {
+  return `sync/${username}/blobs/${sha256}.gz`;
+}
+
+export default apiHandler<PostBlobUploadBody>(
   {
-    methods: ["PUT"],
+    methods: ["POST", "PUT"],
     auth: "required",
+    parseJsonBody: true,
     contentType: null,
   },
-  async ({ req, res, redis, user }): Promise<void> => {
+  async ({ req, res, redis, user, body }): Promise<void> => {
     if (getStorageBackend() !== "s3") {
       res.status(400).json({ error: "Blob proxy upload requires S3 storage." });
       return;
     }
 
     const username = user?.username || "";
+    if ((req.method || "").toUpperCase() === "POST") {
+      if (
+        !isValidSha256(body?.sha256) ||
+        typeof body?.size !== "number" ||
+        !Number.isFinite(body.size) ||
+        body.size <= 0 ||
+        body.size > MAX_BLOB_SIZE
+      ) {
+        res.status(400).json({ error: "Invalid blob upload request." });
+        return;
+      }
+
+      const instructionRateLimitKey = makeKey([
+        "rl",
+        "sync2",
+        "blob-upload-instruction",
+        "user",
+        username,
+      ]);
+      const instructionCount = await redis.incr(instructionRateLimitKey);
+      if (instructionCount === 1) {
+        await redis.expire(instructionRateLimitKey, RATE_LIMIT_WINDOW);
+      }
+      if (instructionCount > RATE_LIMIT_MAX) {
+        res.status(429).json({
+          error: "Too many blob upload instructions. Please try again shortly.",
+        });
+        return;
+      }
+
+      const descriptor = await createStorageUploadDescriptor({
+        pathname: blobPath(username, body.sha256),
+        contentType: "application/gzip",
+        allowedContentTypes: [
+          "application/gzip",
+          "application/octet-stream",
+        ],
+        maximumSizeInBytes: body.size,
+        allowOverwrite: true,
+        clientUploadMode: "proxy",
+      });
+      res.status(200).json({ ok: true, upload: descriptor });
+      return;
+    }
+
     const tokenParam = req.query.token;
     const token = typeof tokenParam === "string" ? tokenParam : "";
     const claims = verifyStorageUploadToken(token);

--- a/docs/1.2-api-architecture.md
+++ b/docs/1.2-api-architecture.md
@@ -279,6 +279,7 @@ Routes should default to `apiHandler()`. If an endpoint needs multipart upload, 
 | `/api/sync/v2/changes` | GET | Journal ops after the client cursor (`?since=`) |
 | `/api/sync/v2/snapshot` | GET | Full key-value sync state + current cursor |
 | `/api/sync/v2/blobs` | POST | Batched content-addressed blob prepare/dedupe + download signing |
+| `/api/sync/v2/blob-upload` | POST, PUT | Fresh authenticated proxy instruction + blob upload |
 | `/api/sync/auto-sync-preference` | GET, PUT | Cross-device Auto Sync toggle |
 | `/api/cron/sync-maintenance` | GET | Cron: content-addressed blob GC + user-record healing (`CRON_SECRET`) |
 

--- a/docs/1.3-self-hosting-vps.md
+++ b/docs/1.3-self-hosting-vps.md
@@ -135,9 +135,11 @@ S3_FORCE_PATH_STYLE=true   # required for MinIO and some providers
 STORAGE_CLIENT_UPLOAD=proxy  # optional: route browser uploads through the API (use when bucket CORS is unavailable, e.g. local dev on Hetzner)
 ```
 
-#### Bucket CORS (required for Cloud Sync)
+#### Bucket CORS (required for direct browser transfers)
 
-Cloud Sync uploads and downloads use **presigned URLs** opened directly in the browser. The object storage bucket must allow cross-origin `PUT`, `GET`, and `HEAD` from your app origins. Without this, sync fails with errors like “Upload failed before an HTTP response was received”.
+Cloud Sync normally opens presigned URLs directly in the browser. The object
+storage bucket must allow cross-origin `PUT`, `GET`, and `HEAD` from your app
+origins for that path to work.
 
 Apply the repo helper (reads `.env.local` / env vars):
 
@@ -147,7 +149,11 @@ bun run scripts/configure-s3-cors.ts
 
 It allows local dev origins (`http://localhost:5173`, etc.), `APP_PUBLIC_ORIGIN`, and any explicit entries in `API_ALLOWED_ORIGINS` (wildcard patterns such as `*.example.com` are skipped — list concrete origins in `S3_CORS_EXTRA_ORIGINS` instead).
 
-If presigned browser uploads still fail (some S3-compatible providers do not return CORS headers on presigned `PUT` responses), set `STORAGE_CLIENT_UPLOAD=proxy` so uploads go through `/api/sync/v2/blob-upload` instead of directly to object storage. <!-- pragma: allowlist secret -->
+If a presigned upload expires or fails because of browser CORS/network policy,
+Cloud Sync retries that blob once through an authenticated
+`/api/sync/v2/blob-upload` proxy. Set `STORAGE_CLIENT_UPLOAD=proxy` to use the
+proxy for every initial upload instead of waiting for the automatic fallback.
+<!-- pragma: allowlist secret -->
 
 Example manual CORS rule (Hetzner, MinIO, AWS S3, R2, etc.):
 

--- a/docs/8-api-reference.md
+++ b/docs/8-api-reference.md
@@ -135,6 +135,7 @@ graph LR
 | `/api/sync/v2/changes` | Read journal ops after a cursor |
 | `/api/sync/v2/snapshot` | Read full key-value sync snapshot |
 | `/api/sync/v2/blobs` | Prepare/dedupe content-addressed blob uploads |
+| `/api/sync/v2/blob-upload` | Issue and consume authenticated blob proxy uploads |
 | `/api/cron/sync-maintenance` | Garbage-collect unreferenced sync blobs and heal user records |
 | `/api/analytics/events` | Record lightweight client analytics events |
 | `/api/admin` | Admin operations |

--- a/docs/8.9-utility-apis.md
+++ b/docs/8.9-utility-apis.md
@@ -671,6 +671,7 @@ the winning entry inline (no 409s, no retry loops). See
 | GET | `/api/sync/v2/changes?since={seq}` | Ops after the cursor, or `snapshotRequired` | Required |
 | GET | `/api/sync/v2/snapshot` | Full key-value state + current `seq` | Required |
 | POST | `/api/sync/v2/blobs` | Batch blob upload prepare (sha256 dedupe) + download URL signing | Required |
+| POST/PUT | `/api/sync/v2/blob-upload` | Issue a fresh proxy instruction / receive its blob body | Required |
 | GET | `/api/cron/sync-maintenance` | Maintenance cron: blob GC + user-record healing | `CRON_SECRET` |
 | GET/PUT | `/api/sync/auto-sync-preference` | Cross-device Auto Sync toggle | Required |
 
@@ -739,6 +740,14 @@ download URLs for the user's own objects:
 Response: per-digest `{ exists: true, url }` (skip upload) or
 `{ exists: false, upload: { …storage instruction… } }`, plus signed
 `downloads` aligned with the request array (null for foreign URLs).
+
+The client uploads prepared blobs sequentially. If a storage instruction
+expires or a direct browser PUT fails before a readable response, the client
+posts that blob's `{ sha256, size }` to `/api/sync/v2/blob-upload`. The
+authenticated response contains a fresh, path-bound proxy instruction, which
+the client retries once through the API. This fallback works regardless of
+`STORAGE_CLIENT_UPLOAD`; setting that variable to `proxy` still forces proxy
+instructions for the initial batch.
 
 ### GET /api/cron/sync-maintenance
 

--- a/src/shared/sync2/types.ts
+++ b/src/shared/sync2/types.ts
@@ -97,6 +97,12 @@ export interface PostBlobsResponse {
   downloads?: (string | null)[];
 }
 
+export interface PostBlobUploadInstructionResponse {
+  ok: true;
+  /** Fresh authenticated API-proxy instruction for one sync blob. */
+  upload: unknown;
+}
+
 /** Realtime event payload (Pusher event "sync-ops"). */
 export interface SyncOpsRealtimeEvent {
   seq: number;

--- a/src/sync/blobs.ts
+++ b/src/sync/blobs.ts
@@ -4,10 +4,18 @@
  * (direct for public URLs, signed via the API for s3:// locations).
  */
 
-import { uploadBlobWithStorageInstruction } from "@/utils/storageUpload";
-import type { StorageUploadInstruction } from "@/utils/storageUpload";
+import {
+  isStorageUploadInstruction,
+  uploadBlobWithStorageInstruction,
+  type StorageUploadInstruction,
+  type StorageUploadProgress,
+} from "@/utils/storageUpload";
 import type { SyncBlobRef } from "@/shared/sync2/types";
-import { postSyncBlobs } from "@/sync/transport";
+import {
+  postSyncBlobs,
+  requestSyncBlobProxyUpload,
+} from "@/sync/transport";
+import { cloudSyncLog } from "@/sync/logging";
 
 function assertCompressionSupport(): void {
   if (
@@ -78,6 +86,96 @@ interface BlobDownloadOptions {
   signal?: AbortSignal;
 }
 
+export interface BlobUploadFallbackOptions {
+  blob: Blob;
+  sha256: string;
+  instruction: StorageUploadInstruction;
+  onProgress?: (progress: StorageUploadProgress) => void;
+  signal?: AbortSignal;
+}
+
+export interface BlobUploadFallbackDependencies {
+  uploadBlob: typeof uploadBlobWithStorageInstruction;
+  requestProxyUpload: typeof requestSyncBlobProxyUpload;
+}
+
+const DEFAULT_BLOB_UPLOAD_FALLBACK_DEPENDENCIES: BlobUploadFallbackDependencies = {
+  uploadBlob: uploadBlobWithStorageInstruction,
+  requestProxyUpload: requestSyncBlobProxyUpload,
+};
+
+function isAbortFailure(error: unknown, signal?: AbortSignal): boolean {
+  return (
+    signal?.aborted === true ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
+/**
+ * Retry one failed storage upload through a fresh authenticated API proxy.
+ * The fresh instruction avoids both stale presigned URLs and stale proxy tokens.
+ */
+export async function uploadBlobWithProxyFallback(
+  options: BlobUploadFallbackOptions,
+  dependencies: BlobUploadFallbackDependencies =
+    DEFAULT_BLOB_UPLOAD_FALLBACK_DEPENDENCIES
+): Promise<{ storageUrl: string }> {
+  let maximumReportedBytes = 0;
+  const reportProgress = options.onProgress
+    ? (progress: StorageUploadProgress) => {
+        maximumReportedBytes = Math.max(maximumReportedBytes, progress.loaded);
+        options.onProgress?.({
+          loaded: maximumReportedBytes,
+          total: progress.total,
+          percentage:
+            progress.total > 0
+              ? (maximumReportedBytes / progress.total) * 100
+              : 0,
+        });
+      }
+    : undefined;
+
+  try {
+    return await dependencies.uploadBlob(options.blob, options.instruction, {
+      onProgress: reportProgress,
+      signal: options.signal,
+    });
+  } catch (error) {
+    if (isAbortFailure(error, options.signal)) {
+      throw error;
+    }
+
+    cloudSyncLog.warn(
+      "Blob upload failed; retrying with a fresh authenticated proxy instruction",
+      {
+        sha256Prefix: options.sha256.slice(0, 12),
+        uploadMethod: options.instruction.uploadMethod,
+        errorName: error instanceof Error ? error.name : "unknown",
+      }
+    );
+  }
+
+  const response = await dependencies.requestProxyUpload(
+    {
+      sha256: options.sha256,
+      size: options.blob.size,
+    },
+    options.signal
+  );
+  if (
+    !isStorageUploadInstruction(response.upload) ||
+    response.upload.uploadMethod !== "api-proxy-put" ||
+    response.upload.storageUrl !== options.instruction.storageUrl
+  ) {
+    throw new Error("Sync blob proxy instruction was invalid.");
+  }
+
+  return dependencies.uploadBlob(options.blob, response.upload, {
+    onProgress: reportProgress,
+    signal: options.signal,
+  });
+}
+
 /**
  * Upload a batch of blob items, skipping content the server already has.
  * Returns a map key → SyncBlobRef for inclusion in docs.
@@ -145,15 +243,20 @@ export async function uploadBlobItems(
     if (result.exists && result.url) {
       url = result.url;
     } else if (result.upload) {
-      const uploadResult = await uploadBlobWithStorageInstruction(
-        new Blob([entry.compressed.slice().buffer as ArrayBuffer], {
+      if (!isStorageUploadInstruction(result.upload)) {
+        throw new Error(`Invalid blob upload instruction for ${result.sha256}`);
+      }
+      const uploadResult = await uploadBlobWithProxyFallback({
+        blob: new Blob([entry.compressed.slice().buffer as ArrayBuffer], {
           type: "application/gzip",
         }),
-        result.upload as StorageUploadInstruction,
-        (progress) => {
+        sha256: result.sha256,
+        instruction: result.upload,
+        onProgress: (progress) => {
           emitProgress(completedUploadBytes + progress.loaded);
-        }
-      );
+        },
+        signal: options.signal,
+      });
       url = uploadResult.storageUrl;
       completedUploadBytes += entry.compressed.length;
       completedUploadItems += 1;

--- a/src/sync/transport.ts
+++ b/src/sync/transport.ts
@@ -9,6 +9,7 @@ import type {
   BlobUploadRequestItem,
   GetChangesResponse,
   GetSnapshotResponse,
+  PostBlobUploadInstructionResponse,
   PostBlobsResponse,
   PostOpsResponse,
   SyncOp,
@@ -88,4 +89,26 @@ export async function postSyncBlobs(
     retry: { maxAttempts: 2, initialDelayMs: 500 },
   });
   return parseJsonOrThrow<PostBlobsResponse>(response, "Sync blobs");
+}
+
+export async function requestSyncBlobProxyUpload(
+  body: BlobUploadRequestItem,
+  signal?: AbortSignal
+): Promise<PostBlobUploadInstructionResponse> {
+  const response = await abortableFetch(
+    getApiUrl("/api/sync/v2/blob-upload"),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      timeout: 20000,
+      signal,
+      throwOnHttpError: false,
+      retry: { maxAttempts: 2, initialDelayMs: 500 },
+    }
+  );
+  return parseJsonOrThrow<PostBlobUploadInstructionResponse>(
+    response,
+    "Sync blob proxy instruction"
+  );
 }

--- a/src/utils/storageUpload.ts
+++ b/src/utils/storageUpload.ts
@@ -23,17 +23,61 @@ export interface S3UploadInstruction extends BaseStorageUploadInstruction {
 
 export type StorageUploadInstruction = S3UploadInstruction;
 
+export interface StorageUploadRequestOptions {
+  onProgress?: (progress: StorageUploadProgress) => void;
+  signal?: AbortSignal;
+}
+
+function hasStringHeaders(value: unknown): value is Record<string, string> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Object.values(value).every((header) => typeof header === "string")
+  );
+}
+
+export function isStorageUploadInstruction(
+  value: unknown
+): value is StorageUploadInstruction {
+  if (typeof value !== "object" || value === null) return false;
+  if (!("provider" in value) || value.provider !== "s3") return false;
+  if (
+    !("uploadMethod" in value) ||
+    (value.uploadMethod !== "presigned-put" &&
+      value.uploadMethod !== "api-proxy-put")
+  ) {
+    return false;
+  }
+  if (!("pathname" in value) || typeof value.pathname !== "string") return false;
+  if (!("contentType" in value) || typeof value.contentType !== "string") {
+    return false;
+  }
+  if (
+    !("maximumSizeInBytes" in value) ||
+    typeof value.maximumSizeInBytes !== "number" ||
+    !Number.isFinite(value.maximumSizeInBytes) ||
+    value.maximumSizeInBytes <= 0
+  ) {
+    return false;
+  }
+  if (!("uploadUrl" in value) || typeof value.uploadUrl !== "string") return false;
+  if (!("storageUrl" in value) || typeof value.storageUrl !== "string") return false;
+  if ("headers" in value && value.headers !== undefined) {
+    return hasStringHeaders(value.headers);
+  }
+  return true;
+}
+
 function uploadWithXhr(
   uploadUrl: string,
   body: Blob,
   headers: Record<string, string>,
-  onProgress?: (progress: StorageUploadProgress) => void,
-  options?: { withCredentials?: boolean }
+  options: StorageUploadRequestOptions & { withCredentials?: boolean } = {}
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     xhr.open("PUT", uploadUrl, true);
-    if (options?.withCredentials) {
+    if (options.withCredentials) {
       xhr.withCredentials = true;
     }
 
@@ -41,12 +85,24 @@ function uploadWithXhr(
       xhr.setRequestHeader(key, value);
     }
 
+    let settled = false;
+    const cleanup = () => {
+      options.signal?.removeEventListener("abort", abortUpload);
+    };
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback();
+    };
+    const abortUpload = () => xhr.abort();
+
     xhr.upload.onprogress = (event) => {
-      if (!onProgress || !event.lengthComputable) {
+      if (!options.onProgress || !event.lengthComputable) {
         return;
       }
 
-      onProgress({
+      options.onProgress({
         loaded: event.loaded,
         total: event.total,
         percentage: event.total > 0 ? (event.loaded / event.total) * 100 : 0,
@@ -55,20 +111,31 @@ function uploadWithXhr(
 
     xhr.onload = () => {
       if (xhr.status >= 200 && xhr.status < 300) {
-        resolve();
+        finish(resolve);
         return;
       }
 
-      reject(new Error(`Upload failed with status ${xhr.status}`));
+      finish(() => reject(new Error(`Upload failed with status ${xhr.status}`)));
     };
 
     xhr.onerror = () =>
-      reject(
-        new Error(
-          `Upload failed before an HTTP response was received for ${uploadUrl}. Check bucket CORS, endpoint reachability, and TLS/mixed-content configuration. For S3-compatible providers without working browser CORS, set STORAGE_CLIENT_UPLOAD=proxy.`
+      finish(() =>
+        reject(
+          new Error(
+            "Upload failed before an HTTP response was received. Check endpoint reachability and TLS/mixed-content configuration."
+          )
         )
       );
-    xhr.ontimeout = () => reject(new Error("Upload timed out"));
+    xhr.ontimeout = () =>
+      finish(() => reject(new Error("Upload timed out")));
+    xhr.onabort = () =>
+      finish(() => reject(new DOMException("Aborted", "AbortError")));
+
+    if (options.signal?.aborted) {
+      finish(() => reject(new DOMException("Aborted", "AbortError")));
+      return;
+    }
+    options.signal?.addEventListener("abort", abortUpload, { once: true });
     xhr.send(body);
   });
 }
@@ -76,7 +143,7 @@ function uploadWithXhr(
 export async function uploadBlobWithStorageInstruction(
   blob: Blob,
   instruction: StorageUploadInstruction,
-  onProgress?: (progress: StorageUploadProgress) => void
+  options: StorageUploadRequestOptions = {}
 ): Promise<{ storageUrl: string }> {
   if (instruction.uploadMethod === "api-proxy-put") {
     await uploadWithXhr(
@@ -85,8 +152,7 @@ export async function uploadBlobWithStorageInstruction(
       instruction.headers || {
         "Content-Type": instruction.contentType,
       },
-      onProgress,
-      { withCredentials: true }
+      { ...options, withCredentials: true }
     );
     return { storageUrl: instruction.storageUrl };
   }
@@ -97,7 +163,7 @@ export async function uploadBlobWithStorageInstruction(
     instruction.headers || {
       "Content-Type": instruction.contentType,
     },
-    onProgress
+    options
   );
 
   return { storageUrl: instruction.storageUrl };

--- a/tests/integration/api/test-sync-v2-api.test.ts
+++ b/tests/integration/api/test-sync-v2-api.test.ts
@@ -189,6 +189,52 @@ describe("sync v2 API", () => {
     expect(body.downloads?.[1]).toBeNull();
   });
 
+  test("issues a fresh authenticated proxy instruction for one failed blob", async () => {
+    const sha256 = "ef".repeat(32);
+    const response = await fetchWithAuth(
+      `${BASE_URL}/api/sync/v2/blob-upload`,
+      USERNAME,
+      token,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sha256, size: 1024 }),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      ok: boolean;
+      upload?: {
+        uploadMethod?: string;
+        uploadUrl?: string;
+        pathname?: string;
+        maximumSizeInBytes?: number;
+      };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.upload?.uploadMethod).toBe("api-proxy-put");
+    expect(body.upload?.uploadUrl?.startsWith(
+      "/api/sync/v2/blob-upload?token="
+    )).toBe(true);
+    expect(body.upload?.pathname).toBe(
+      `sync/${USERNAME}/blobs/${sha256}.gz`
+    );
+    expect(body.upload?.maximumSizeInBytes).toBe(1024);
+  });
+
+  test("proxy fallback instruction requires authentication", async () => {
+    const response = await fetchWithOrigin(
+      `${BASE_URL}/api/sync/v2/blob-upload`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sha256: "ef".repeat(32), size: 1024 }),
+      }
+    );
+    expect([401, 403]).toContain(response.status);
+  });
+
   test(
     "blob endpoint prepares a large descriptor batch within its function budget",
     async () => {

--- a/tests/integration/api/test-sync-v2-api.test.ts
+++ b/tests/integration/api/test-sync-v2-api.test.ts
@@ -6,6 +6,7 @@ import {
   fetchWithOrigin,
 } from "../../helpers/test-utils";
 import { formatHlc } from "../../../src/shared/sync2/hlc";
+import { deleteStoredObject } from "../../../api/_utils/storage";
 
 /**
  * Cloud Sync v2 API integration tests (sync-v2 suite).
@@ -191,6 +192,7 @@ describe("sync v2 API", () => {
 
   test("issues a fresh authenticated proxy instruction for one failed blob", async () => {
     const sha256 = "ef".repeat(32);
+    const uploadBytes = new Uint8Array([31, 139, 8, 0]);
     const response = await fetchWithAuth(
       `${BASE_URL}/api/sync/v2/blob-upload`,
       USERNAME,
@@ -198,7 +200,7 @@ describe("sync v2 API", () => {
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sha256, size: 1024 }),
+        body: JSON.stringify({ sha256, size: uploadBytes.byteLength }),
       }
     );
 
@@ -210,6 +212,7 @@ describe("sync v2 API", () => {
         uploadUrl?: string;
         pathname?: string;
         maximumSizeInBytes?: number;
+        storageUrl?: string;
       };
     };
     expect(body.ok).toBe(true);
@@ -220,7 +223,30 @@ describe("sync v2 API", () => {
     expect(body.upload?.pathname).toBe(
       `sync/${USERNAME}/blobs/${sha256}.gz`
     );
-    expect(body.upload?.maximumSizeInBytes).toBe(1024);
+    expect(body.upload?.maximumSizeInBytes).toBe(uploadBytes.byteLength);
+    expect(typeof body.upload?.storageUrl).toBe("string");
+
+    const uploadUrl = body.upload?.uploadUrl;
+    const storageUrl = body.upload?.storageUrl;
+    if (!uploadUrl || !storageUrl) {
+      throw new Error("Expected a complete proxy upload instruction");
+    }
+
+    try {
+      const uploadResponse = await fetchWithAuth(
+        `${BASE_URL}${uploadUrl}`,
+        USERNAME,
+        token,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/gzip" },
+          body: new Blob([uploadBytes], { type: "application/gzip" }),
+        }
+      );
+      expect(uploadResponse.status).toBe(204);
+    } finally {
+      await deleteStoredObject(storageUrl);
+    }
   });
 
   test("proxy fallback instruction requires authentication", async () => {

--- a/tests/unit/sync/test-blob-upload-proxy-fallback.test.ts
+++ b/tests/unit/sync/test-blob-upload-proxy-fallback.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  uploadBlobWithProxyFallback,
+  type BlobUploadFallbackDependencies,
+} from "../../../src/sync/blobs";
+import type {
+  StorageUploadInstruction,
+  StorageUploadProgress,
+} from "../../../src/utils/storageUpload";
+
+const STORAGE_URL = "s3://bucket/sync/alice/blobs/abc.gz";
+
+function instruction(
+  uploadMethod: StorageUploadInstruction["uploadMethod"],
+  uploadUrl: string
+): StorageUploadInstruction {
+  return {
+    provider: "s3",
+    uploadMethod,
+    pathname: "sync/alice/blobs/abc.gz",
+    contentType: "application/gzip",
+    maximumSizeInBytes: 1024,
+    uploadUrl,
+    storageUrl: STORAGE_URL,
+    headers: { "Content-Type": "application/gzip" },
+  };
+}
+
+describe("sync blob authenticated proxy fallback", () => {
+  test("retries a failed direct upload with a fresh per-blob proxy instruction", async () => {
+    const primary = instruction(
+      "presigned-put",
+      "https://bucket.example.com/abc.gz?X-Amz-Expires=60"
+    );
+    const fallback = instruction(
+      "api-proxy-put",
+      "/api/sync/v2/blob-upload?token=fresh"
+    );
+    const uploadMethods: string[] = [];
+    const progress: number[] = [];
+    let uploadAttempt = 0;
+
+    const dependencies: BlobUploadFallbackDependencies = {
+      uploadBlob: mock(async (_blob, current, options = {}) => {
+        uploadAttempt += 1;
+        uploadMethods.push(current.uploadMethod);
+        if (uploadAttempt === 1) {
+          options.onProgress?.({ loaded: 90, total: 100, percentage: 90 });
+          throw new Error(
+            "Upload failed before an HTTP response was received."
+          );
+        }
+        options.onProgress?.({ loaded: 10, total: 100, percentage: 10 });
+        options.onProgress?.({ loaded: 100, total: 100, percentage: 100 });
+        return { storageUrl: current.storageUrl };
+      }),
+      requestProxyUpload: mock(async (body) => {
+        expect(body).toEqual({ sha256: "ab".repeat(32), size: 100 });
+        return { ok: true, upload: fallback };
+      }),
+    };
+
+    const result = await uploadBlobWithProxyFallback(
+      {
+        blob: new Blob([new Uint8Array(100)]),
+        sha256: "ab".repeat(32),
+        instruction: primary,
+        onProgress: (event: StorageUploadProgress) => {
+          progress.push(event.loaded);
+        },
+      },
+      dependencies
+    );
+
+    expect(result.storageUrl).toBe(STORAGE_URL);
+    expect(uploadMethods).toEqual(["presigned-put", "api-proxy-put"]);
+    expect(dependencies.requestProxyUpload).toHaveBeenCalledTimes(1);
+    expect(progress).toEqual([90, 90, 100]);
+  });
+
+  test("refreshes an expired pre-issued proxy token once", async () => {
+    const expired = instruction(
+      "api-proxy-put",
+      "/api/sync/v2/blob-upload?token=expired"
+    );
+    const fresh = instruction(
+      "api-proxy-put",
+      "/api/sync/v2/blob-upload?token=fresh"
+    );
+    let uploadAttempt = 0;
+    const dependencies: BlobUploadFallbackDependencies = {
+      uploadBlob: mock(async (_blob, current) => {
+        uploadAttempt += 1;
+        if (uploadAttempt === 1) {
+          throw new Error("Upload failed with status 403");
+        }
+        return { storageUrl: current.storageUrl };
+      }),
+      requestProxyUpload: mock(async () => ({ ok: true, upload: fresh })),
+    };
+
+    await expect(
+      uploadBlobWithProxyFallback(
+        {
+          blob: new Blob([new Uint8Array(100)]),
+          sha256: "ab".repeat(32),
+          instruction: expired,
+        },
+        dependencies
+      )
+    ).resolves.toEqual({ storageUrl: STORAGE_URL });
+    expect(dependencies.requestProxyUpload).toHaveBeenCalledTimes(1);
+    expect(dependencies.uploadBlob).toHaveBeenCalledTimes(2);
+  });
+
+  test("falls back when an expired presigned PUT returns 403", async () => {
+    const fresh = instruction(
+      "api-proxy-put",
+      "/api/sync/v2/blob-upload?token=fresh"
+    );
+    let uploadAttempt = 0;
+    const dependencies: BlobUploadFallbackDependencies = {
+      uploadBlob: mock(async (_blob, current) => {
+        uploadAttempt += 1;
+        if (uploadAttempt === 1) {
+          throw new Error("Upload failed with status 403");
+        }
+        return { storageUrl: current.storageUrl };
+      }),
+      requestProxyUpload: mock(async () => ({ ok: true, upload: fresh })),
+    };
+
+    await expect(
+      uploadBlobWithProxyFallback(
+        {
+          blob: new Blob([new Uint8Array(100)]),
+          sha256: "ab".repeat(32),
+          instruction: instruction(
+            "presigned-put",
+            "https://bucket.example.com/abc.gz?X-Amz-Expires=60"
+          ),
+        },
+        dependencies
+      )
+    ).resolves.toEqual({ storageUrl: STORAGE_URL });
+    expect(dependencies.requestProxyUpload).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not request a fallback after cancellation", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const dependencies: BlobUploadFallbackDependencies = {
+      uploadBlob: mock(async () => {
+        throw new DOMException("Aborted", "AbortError");
+      }),
+      requestProxyUpload: mock(async () => {
+        throw new Error("fallback should not be requested");
+      }),
+    };
+
+    await expect(
+      uploadBlobWithProxyFallback(
+        {
+          blob: new Blob([new Uint8Array(100)]),
+          sha256: "ab".repeat(32),
+          instruction: instruction(
+            "presigned-put",
+            "https://bucket.example.com/abc.gz"
+          ),
+          signal: controller.signal,
+        },
+        dependencies
+      )
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(dependencies.requestProxyUpload).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/sync/test-self-host-storage-config.test.ts
+++ b/tests/unit/sync/test-self-host-storage-config.test.ts
@@ -212,4 +212,24 @@ describe("self-host storage backend selection", () => {
     expect(upload.uploadUrl.startsWith("/api/sync/v2/blob-upload?token=")).toBe(true);
     expect(upload.storageUrl).toBe("s3://bucket/sync/test-user/blobs/abc123.gz");
   });
+
+  test("allows a fresh proxy instruction regardless of deployment upload mode", async () => {
+    process.env.STORAGE_PROVIDER = "s3"; // pragma: allowlist secret
+    process.env.STORAGE_CLIENT_UPLOAD = "presigned";
+    process.env.S3_BUCKET = "bucket";
+    process.env.S3_REGION = "auto";
+    process.env.S3_ENDPOINT = "https://example-account.r2.cloudflarestorage.com"; // pragma: allowlist secret
+    process.env.S3_ACCESS_KEY_ID = "key";
+    process.env.S3_SECRET_ACCESS_KEY = "secret";
+
+    const upload = await createStorageUploadDescriptor({
+      pathname: "sync/test-user/blobs/abc123.gz",
+      contentType: "application/gzip",
+      maximumSizeInBytes: 1024,
+      clientUploadMode: "proxy",
+    });
+
+    expect(upload.uploadMethod).toBe("api-proxy-put");
+    expect(upload.uploadUrl.startsWith("/api/sync/v2/blob-upload?token=")).toBe(true);
+  });
 });

--- a/tests/unit/sync/test-storage-upload-token.test.ts
+++ b/tests/unit/sync/test-storage-upload-token.test.ts
@@ -61,6 +61,20 @@ describe("storage upload token", () => {
     expect(verifyStorageUploadToken(`${payload}.invalid`)).toBe(null);
   });
 
+  test("rejects expired proxy upload tokens", async () => {
+    process.env.S3_SECRET_ACCESS_KEY = "test-signing-secret";
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const token = await signStorageUploadToken({
+      pathname: "sync/alice/blobs/expired.gz",
+      contentType: "application/gzip",
+      maximumSizeInBytes: 1024,
+      expiresInSeconds: 60,
+    });
+
+    expect(verifyStorageUploadToken(token, nowSeconds + 59)).not.toBeNull();
+    expect(verifyStorageUploadToken(token, nowSeconds + 61)).toBeNull();
+  });
+
   test("restricts proxy uploads to sync blobs and the user's backup object", () => {
     expect(isUploadPathOwnedByUser("sync/alice/blobs/abc.gz", "alice")).toBe(true);
     expect(isUploadPathOwnedByUser("backups/alice/backup.gz", "alice")).toBe(true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Retry a failed or expired blob upload once with a fresh authenticated API-proxy instruction.
- Add abort-aware XHR uploads and validate storage instructions at the client boundary.
- Cover direct-upload failure, stale proxy tokens, authentication, instruction issuance, and a real proxy PUT to object storage.

## Root cause
Sync prepares upload instructions in a batch but uploads blobs sequentially. Instructions expire after 60 seconds, so later Books uploads can start after their presigned URL or proxy token has expired. The reported URL was signed at `05:25:54Z`, expired at `05:26:54Z`, and failed at `05:28:31Z`.

## Testing
- `STORAGE_CLIENT_UPLOAD=presigned bun run test:sync-v2:unit` (142 passed)
- `bun test tests/integration/api/test-sync-v2-api.test.ts` (13 passed, including real proxy PUT and cleanup)
- `bun run typecheck`
- targeted ESLint on changed TypeScript files
- `bun run build`
- `bun run test:registration`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e682abf4-d874-4497-b59c-107d5119e113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e682abf4-d874-4497-b59c-107d5119e113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

