### PR TITLE
fix: resolve kosyncProgressAnchor TypeScript build errors

### DIFF
--- a/src/apps/books/utils/kosyncProgressAnchor.ts
+++ b/src/apps/books/utils/kosyncProgressAnchor.ts
@@ -1,6 +1,5 @@
 import type { Book, Rendition } from "epubjs";
 import {
-  isKoStyleXPath,
   parseKoXPath,
   type ParsedKoXPath,
 } from "@/shared/kosyncProgressLocator";
@@ -169,13 +168,15 @@ export function rangeToKoXPath(
 }
 
 function walkKoXPathSteps(doc: Document, parsed: ParsedKoXPath): Element | null {
-  let element: Element | null = doc.body;
-  if (!element) return null;
+  const root = doc.body;
+  if (!root) return null;
 
+  let current: Element = root;
   for (const step of parsed.steps) {
+    const children: Element[] = Array.from(current.children);
     let match: Element | null = null;
     let count = 0;
-    for (const child of element.children) {
+    for (const child of children) {
       if (localName(child) !== step.tag) continue;
       count += 1;
       if (count === step.index) {
@@ -184,10 +185,10 @@ function walkKoXPathSteps(doc: Document, parsed: ParsedKoXPath): Element | null 
       }
     }
     if (!match) return null;
-    element = match;
+    current = match;
   }
 
-  return element;
+  return current;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Main was red after `feat: sync Books locators with CrossPoint` — Docker/`bun run build` failed typecheck on `kosyncProgressAnchor.ts`.

### Errors
- `TS6133`: `isKoStyleXPath` imported but only re-exported
- `TS7022`: circular `Element` inference in `walkKoXPathSteps` when iterating `element.children` while reassigning `element`

### Fix
- Drop the unused value import; keep the re-export
- Walk children via `Array.from` into an explicit `Element[]`, using a non-null `current: Element`

### Verification
- `bun run build` passes
- `bun test tests/unit/books/test-kosync-progress-anchor.test.ts` — 6/6 pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5ac7-335a-7ee5-9cb1-6175c20b3cb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5ac7-335a-7ee5-9cb1-6175c20b3cb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

