### PR TITLE
fix: Finder sidebar empty after reload + Desktop last

### DIFF
--- a/src/apps/finder/hooks/useFinderLogic.ts
+++ b/src/apps/finder/hooks/useFinderLogic.ts
@@ -61,7 +61,10 @@ import {
   validateNewRootFolderName,
 } from "@/services/vfs/pathPolicy";
 import { getStoreForFile } from "@/utils/indexedDBOperations";
-import { orderSidebarRootFolders } from "../utils/sidebarPlaces";
+import {
+  orderFinderRootFolders,
+  orderSidebarRootFolders,
+} from "../utils/sidebarPlaces";
 
 const log = createClientLogger("Finder");
 
@@ -1142,9 +1145,10 @@ export function useFinderLogic({
   const rootItems = useFileMetadataInPath("/");
 
   // Get all root folders for the Go menu using fileStore
-  // This will always show root folders regardless of current path
+  // This will always show root folders regardless of current path.
+  // Same place order as the sidebar: Applications, Applets, A–Z, Desktop.
   const rootFolders = useMemo(() => {
-    return rootItems.reduce<
+    const folders = rootItems.reduce<
       { name: string; isDirectory: true; path: string; icon: string }[]
     >((acc, item) => {
       if (!item.isDirectory || item.path === "/Trash") {
@@ -1158,6 +1162,7 @@ export function useFinderLogic({
       });
       return acc;
     }, []);
+    return orderFinderRootFolders(folders);
   }, [rootItems]);
 
   // Add a new handler for rename requests

--- a/src/apps/finder/hooks/useFinderLogic.ts
+++ b/src/apps/finder/hooks/useFinderLogic.ts
@@ -45,6 +45,7 @@ import {
 } from "@/utils/finderDisplay";
 import { helpItems } from "../index";
 import { useFilesStoreShallow } from "@/stores/useFilesStore";
+import { useFileMetadataInPath } from "@/services/vfs/FileMetadataService";
 import { useDockStore } from "@/stores/useDockStore";
 import {
   emitFileRenamed,
@@ -60,26 +61,13 @@ import {
   validateNewRootFolderName,
 } from "@/services/vfs/pathPolicy";
 import { getStoreForFile } from "@/utils/indexedDBOperations";
+import { orderSidebarRootFolders } from "../utils/sidebarPlaces";
 
 const log = createClientLogger("Finder");
 
 type FinderUndoAction =
   | { type: "moveToTrash"; fileName: string; originalPath: string }
   | { type: "rename"; basePath: string; oldName: string; newName: string };
-
-const SIDEBAR_HIDDEN_FOLDERS = new Set(["/Trash", "/Sites"]);
-
-// Explicit sidebar folder order; any visible folders not listed here keep their
-// natural order, appended after these.
-const SIDEBAR_FOLDER_ORDER = [
-  "/Applications",
-  "/Applets",
-  "/Documents",
-  "/Images",
-  "/Music",
-  "/Videos",
-  "/Books",
-];
 
 // Type for Finder initial data
 export interface FinderInitialData {
@@ -1149,10 +1137,14 @@ export function useFinderLogic({
   // the writable system subtrees, and any user root folder subtree.
   const canCreateFolder = isWritablePath(currentPath);
 
+  // Subscribe to root children so sidebar/Go menu refresh after IndexedDB
+  // rehydrate (stable getItemsInPath refs alone would keep an empty snapshot).
+  const rootItems = useFileMetadataInPath("/");
+
   // Get all root folders for the Go menu using fileStore
   // This will always show root folders regardless of current path
   const rootFolders = useMemo(() => {
-    return getItemsInPath("/").reduce<
+    return rootItems.reduce<
       { name: string; isDirectory: true; path: string; icon: string }[]
     >((acc, item) => {
       if (!item.isDirectory || item.path === "/Trash") {
@@ -1166,7 +1158,7 @@ export function useFinderLogic({
       });
       return acc;
     }, []);
-  }, [getItemsInPath]);
+  }, [rootItems]);
 
   // Add a new handler for rename requests
   const handleRenameRequest = (file: FileItem) => {
@@ -1571,26 +1563,13 @@ export function useFinderLogic({
   );
 
   const sidebarItems = useMemo(() => {
-    const visibleRootFolders = rootFolders.filter(
-      (f) => !SIDEBAR_HIDDEN_FOLDERS.has(f.path)
-    );
-
-    // Order by the explicit list; unlisted folders keep their natural order
-    // after the listed ones (stable sort).
-    const orderRank = (path: string) => {
-      const i = SIDEBAR_FOLDER_ORDER.indexOf(path);
-      return i === -1 ? Number.MAX_SAFE_INTEGER : i;
-    };
-    visibleRootFolders.sort((a, b) => orderRank(a.path) - orderRank(b.path));
-
-    const places = visibleRootFolders
-      .map((f) => ({
-        name: getTranslatedFolderNameFromName(f.name) || f.name,
-        path: f.path,
-        icon: f.icon,
-        divider: false,
-        isAirDrop: false,
-      }));
+    const places = orderSidebarRootFolders(rootFolders).map((f) => ({
+      name: getTranslatedFolderNameFromName(f.name) || f.name,
+      path: f.path,
+      icon: f.icon,
+      divider: false,
+      isAirDrop: false,
+    }));
     return [
       { name: t("apps.finder.window.macintoshHd"), path: "/", icon: "/icons/default/disk.png", divider: false, isAirDrop: false },
       {

--- a/src/apps/finder/utils/sidebarPlaces.ts
+++ b/src/apps/finder/utils/sidebarPlaces.ts
@@ -1,0 +1,45 @@
+export const SIDEBAR_HIDDEN_FOLDERS = new Set(["/Trash", "/Sites"]);
+
+// Explicit sidebar folder order; any visible folders not listed here keep their
+// natural order after these, and Desktop is always last.
+export const SIDEBAR_FOLDER_ORDER = [
+  "/Applications",
+  "/Applets",
+  "/Documents",
+  "/Images",
+  "/Music",
+  "/Videos",
+  "/Books",
+];
+
+export const SIDEBAR_LAST_FOLDER = "/Desktop";
+
+export interface SidebarPlaceFolder {
+  name: string;
+  path: string;
+  icon: string;
+}
+
+/**
+ * Sort visible root folders for the Finder sidebar.
+ * Known folders follow SIDEBAR_FOLDER_ORDER; other folders keep relative
+ * order after them; Desktop is always last.
+ */
+export function orderSidebarRootFolders<T extends { path: string }>(
+  folders: T[]
+): T[] {
+  const visible = folders.filter((f) => !SIDEBAR_HIDDEN_FOLDERS.has(f.path));
+
+  const orderRank = (path: string) => {
+    if (path === SIDEBAR_LAST_FOLDER) {
+      return Number.MAX_SAFE_INTEGER;
+    }
+    const i = SIDEBAR_FOLDER_ORDER.indexOf(path);
+    // Unlisted folders (except Desktop) sit just before Desktop.
+    return i === -1 ? Number.MAX_SAFE_INTEGER - 1 : i;
+  };
+
+  return visible.toSorted(
+    (a, b) => orderRank(a.path) - orderRank(b.path)
+  );
+}

--- a/src/apps/finder/utils/sidebarPlaces.ts
+++ b/src/apps/finder/utils/sidebarPlaces.ts
@@ -1,16 +1,10 @@
+import { compareFinderSortText } from "@/utils/finderDisplay";
+import { getTranslatedFolderNameFromName } from "@/utils/i18n";
+
 export const SIDEBAR_HIDDEN_FOLDERS = new Set(["/Trash", "/Sites"]);
 
-// Explicit sidebar folder order; any visible folders not listed here keep their
-// natural order after these, and Desktop is always last.
-export const SIDEBAR_FOLDER_ORDER = [
-  "/Applications",
-  "/Applets",
-  "/Documents",
-  "/Images",
-  "/Music",
-  "/Videos",
-  "/Books",
-];
+/** Pinned at the top of Finder places (sidebar + Go menu), in this order. */
+export const SIDEBAR_PINNED_FOLDERS = ["/Applications", "/Applets"];
 
 export const SIDEBAR_LAST_FOLDER = "/Desktop";
 
@@ -20,26 +14,44 @@ export interface SidebarPlaceFolder {
   icon: string;
 }
 
+function placeSortName(folder: { name: string }): string {
+  return getTranslatedFolderNameFromName(folder.name) || folder.name;
+}
+
 /**
- * Sort visible root folders for the Finder sidebar.
- * Known folders follow SIDEBAR_FOLDER_ORDER; other folders keep relative
- * order after them; Desktop is always last.
+ * Order root folders for Finder places (sidebar + Go menu):
+ * Applications and Applets pinned first, then alphabetical, Desktop last.
  */
-export function orderSidebarRootFolders<T extends { path: string }>(
+export function orderFinderRootFolders<T extends { path: string; name: string }>(
   folders: T[]
 ): T[] {
-  const visible = folders.filter((f) => !SIDEBAR_HIDDEN_FOLDERS.has(f.path));
-
-  const orderRank = (path: string) => {
-    if (path === SIDEBAR_LAST_FOLDER) {
-      return Number.MAX_SAFE_INTEGER;
-    }
-    const i = SIDEBAR_FOLDER_ORDER.indexOf(path);
-    // Unlisted folders (except Desktop) sit just before Desktop.
-    return i === -1 ? Number.MAX_SAFE_INTEGER - 1 : i;
+  const pinnedRank = (path: string): number | null => {
+    const i = SIDEBAR_PINNED_FOLDERS.indexOf(path);
+    return i === -1 ? null : i;
   };
 
-  return visible.toSorted(
-    (a, b) => orderRank(a.path) - orderRank(b.path)
+  return folders.toSorted((a, b) => {
+    const aPinned = pinnedRank(a.path);
+    const bPinned = pinnedRank(b.path);
+    if (aPinned !== null || bPinned !== null) {
+      if (aPinned !== null && bPinned !== null) {
+        return aPinned - bPinned;
+      }
+      return aPinned !== null ? -1 : 1;
+    }
+
+    if (a.path === SIDEBAR_LAST_FOLDER) return 1;
+    if (b.path === SIDEBAR_LAST_FOLDER) return -1;
+
+    return compareFinderSortText(placeSortName(a), placeSortName(b));
+  });
+}
+
+/** Visible sidebar places: hide Trash/Sites, then apply Finder places order. */
+export function orderSidebarRootFolders<T extends { path: string; name: string }>(
+  folders: T[]
+): T[] {
+  return orderFinderRootFolders(
+    folders.filter((f) => !SIDEBAR_HIDDEN_FOLDERS.has(f.path))
   );
 }

--- a/tests/unit/finder/test-finder-sidebar-places.test.ts
+++ b/tests/unit/finder/test-finder-sidebar-places.test.ts
@@ -1,62 +1,121 @@
 #!/usr/bin/env bun
 
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { applyLanguage, initializeI18n } from "../../../src/lib/i18n";
 import {
+  orderFinderRootFolders,
   orderSidebarRootFolders,
-  SIDEBAR_FOLDER_ORDER,
   SIDEBAR_HIDDEN_FOLDERS,
   SIDEBAR_LAST_FOLDER,
+  SIDEBAR_PINNED_FOLDERS,
 } from "../../../src/apps/finder/utils/sidebarPlaces";
 
-describe("Finder sidebar places ordering", () => {
-  test("orders known folders, then unlisted, with Desktop last", () => {
+describe("Finder places ordering", () => {
+  const originalNavigator = globalThis.navigator;
+
+  beforeAll(async () => {
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        language: "en",
+        languages: ["en"],
+      },
+    });
+    await initializeI18n();
+    await applyLanguage("en");
+  });
+
+  afterAll(async () => {
+    await applyLanguage("en");
+    if (originalNavigator) {
+      Object.defineProperty(globalThis, "navigator", {
+        configurable: true,
+        value: originalNavigator,
+      });
+      return;
+    }
+    Reflect.deleteProperty(globalThis, "navigator");
+  });
+
+  test("pins Applications and Applets, then alphabetical, Desktop last", () => {
     const folders = [
       { path: "/Desktop", name: "Desktop" },
+      { path: "/Videos", name: "Videos" },
+      { path: "/Applets", name: "Applets" },
       { path: "/Downloads", name: "Downloads" },
       { path: "/Applications", name: "Applications" },
       { path: "/Books", name: "Books" },
       { path: "/MyStuff", name: "MyStuff" },
       { path: "/Documents", name: "Documents" },
+      { path: "/Images", name: "Images" },
+      { path: "/Music", name: "Music" },
+    ];
+
+    expect(orderFinderRootFolders(folders).map((f) => f.path)).toEqual([
+      "/Applications",
+      "/Applets",
+      "/Books",
+      "/Documents",
+      "/Downloads",
+      "/Images",
+      "/Music",
+      "/MyStuff",
+      "/Videos",
+      "/Desktop",
+    ]);
+  });
+
+  test("hides Trash and Sites from sidebar places only", () => {
+    const folders = [
+      { path: "/Applications", name: "Applications" },
+      { path: "/Trash", name: "Trash" },
+      { path: "/Sites", name: "Sites" },
+      { path: "/Documents", name: "Documents" },
+      { path: "/Desktop", name: "Desktop" },
     ];
 
     expect(orderSidebarRootFolders(folders).map((f) => f.path)).toEqual([
       "/Applications",
       "/Documents",
-      "/Books",
-      "/Downloads",
-      "/MyStuff",
       "/Desktop",
     ]);
-  });
 
-  test("hides Trash and Sites from sidebar places", () => {
-    const folders = [
-      { path: "/Applications", name: "Applications" },
-      { path: "/Trash", name: "Trash" },
-      { path: "/Sites", name: "Sites" },
-      { path: "/Desktop", name: "Desktop" },
-    ];
-
-    const ordered = orderSidebarRootFolders(folders);
-    expect(ordered.map((f) => f.path)).toEqual([
+    // Go menu keeps Sites (Trash is excluded upstream); order still applies.
+    expect(orderFinderRootFolders(folders).map((f) => f.path)).toEqual([
       "/Applications",
+      "/Documents",
+      "/Sites",
+      "/Trash",
       "/Desktop",
     ]);
+
     for (const hidden of SIDEBAR_HIDDEN_FOLDERS) {
-      expect(ordered.some((f) => f.path === hidden)).toBe(false);
+      expect(
+        orderSidebarRootFolders(folders).some((f) => f.path === hidden)
+      ).toBe(false);
     }
   });
 
-  test("keeps Desktop last even when it is the only unlisted folder", () => {
-    const folders = SIDEBAR_FOLDER_ORDER.map((path) => ({
-      path,
-      name: path.slice(1),
-    })).concat([{ path: SIDEBAR_LAST_FOLDER, name: "Desktop" }]);
+  test("keeps pinned folders first and Desktop last", () => {
+    const folders = [
+      { path: SIDEBAR_LAST_FOLDER, name: "Desktop" },
+      { path: "/Zebra", name: "Zebra" },
+      { path: "/Applets", name: "Applets" },
+      { path: "/Applications", name: "Applications" },
+      { path: "/Alpha", name: "Alpha" },
+    ];
 
-    const ordered = orderSidebarRootFolders(folders);
+    const ordered = orderFinderRootFolders(folders);
+    expect(ordered.slice(0, 2).map((f) => f.path)).toEqual([
+      ...SIDEBAR_PINNED_FOLDERS,
+    ]);
     expect(ordered.at(-1)?.path).toBe("/Desktop");
-    expect(ordered.map((f) => f.path).slice(0, -1)).toEqual([
-      ...SIDEBAR_FOLDER_ORDER,
+    expect(ordered.map((f) => f.path)).toEqual([
+      "/Applications",
+      "/Applets",
+      "/Alpha",
+      "/Zebra",
+      "/Desktop",
     ]);
   });
 });

--- a/tests/unit/finder/test-finder-sidebar-places.test.ts
+++ b/tests/unit/finder/test-finder-sidebar-places.test.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env bun
+
+import { describe, expect, test } from "bun:test";
+import {
+  orderSidebarRootFolders,
+  SIDEBAR_FOLDER_ORDER,
+  SIDEBAR_HIDDEN_FOLDERS,
+  SIDEBAR_LAST_FOLDER,
+} from "../../../src/apps/finder/utils/sidebarPlaces";
+
+describe("Finder sidebar places ordering", () => {
+  test("orders known folders, then unlisted, with Desktop last", () => {
+    const folders = [
+      { path: "/Desktop", name: "Desktop" },
+      { path: "/Downloads", name: "Downloads" },
+      { path: "/Applications", name: "Applications" },
+      { path: "/Books", name: "Books" },
+      { path: "/MyStuff", name: "MyStuff" },
+      { path: "/Documents", name: "Documents" },
+    ];
+
+    expect(orderSidebarRootFolders(folders).map((f) => f.path)).toEqual([
+      "/Applications",
+      "/Documents",
+      "/Books",
+      "/Downloads",
+      "/MyStuff",
+      "/Desktop",
+    ]);
+  });
+
+  test("hides Trash and Sites from sidebar places", () => {
+    const folders = [
+      { path: "/Applications", name: "Applications" },
+      { path: "/Trash", name: "Trash" },
+      { path: "/Sites", name: "Sites" },
+      { path: "/Desktop", name: "Desktop" },
+    ];
+
+    const ordered = orderSidebarRootFolders(folders);
+    expect(ordered.map((f) => f.path)).toEqual([
+      "/Applications",
+      "/Desktop",
+    ]);
+    for (const hidden of SIDEBAR_HIDDEN_FOLDERS) {
+      expect(ordered.some((f) => f.path === hidden)).toBe(false);
+    }
+  });
+
+  test("keeps Desktop last even when it is the only unlisted folder", () => {
+    const folders = SIDEBAR_FOLDER_ORDER.map((path) => ({
+      path,
+      name: path.slice(1),
+    })).concat([{ path: SIDEBAR_LAST_FOLDER, name: "Desktop" }]);
+
+    const ordered = orderSidebarRootFolders(folders);
+    expect(ordered.at(-1)?.path).toBe("/Desktop");
+    expect(ordered.map((f) => f.path).slice(0, -1)).toEqual([
+      ...SIDEBAR_FOLDER_ORDER,
+    ]);
+  });
+});

--- a/tests/unit/finder/test-vfs-service-wiring.test.ts
+++ b/tests/unit/finder/test-vfs-service-wiring.test.ts
@@ -78,6 +78,7 @@ describe("VFS service wiring", () => {
   test("Finder sidebar root folders subscribe to VFS items (not stable action refs)", () => {
     expect(finderLogicSource).toContain("@/services/vfs/FileMetadataService");
     expect(finderLogicSource).toContain("useFileMetadataInPath(\"/\")");
+    expect(finderLogicSource).toContain("orderFinderRootFolders");
     expect(finderLogicSource).toContain("orderSidebarRootFolders");
     // Regression: memoizing rootFolders on getItemsInPath alone left sidebar
     // empty after reload until remount, because action refs never change.

--- a/tests/unit/finder/test-vfs-service-wiring.test.ts
+++ b/tests/unit/finder/test-vfs-service-wiring.test.ts
@@ -25,6 +25,10 @@ const vfsFileOperationsSource = readFileSync(
   "src/services/vfs/useVfsFileOperations.ts",
   "utf8"
 );
+const finderLogicSource = readFileSync(
+  "src/apps/finder/hooks/useFinderLogic.ts",
+  "utf8"
+);
 
 describe("VFS service wiring", () => {
   test("TextEdit uses VFS services for save/load", () => {
@@ -69,5 +73,14 @@ describe("VFS service wiring", () => {
     expect(vfsFileOperationsSource).toContain(
       "useFileSystem(basePath, { skipLoad: true })"
     );
+  });
+
+  test("Finder sidebar root folders subscribe to VFS items (not stable action refs)", () => {
+    expect(finderLogicSource).toContain("@/services/vfs/FileMetadataService");
+    expect(finderLogicSource).toContain("useFileMetadataInPath(\"/\")");
+    expect(finderLogicSource).toContain("orderSidebarRootFolders");
+    // Regression: memoizing rootFolders on getItemsInPath alone left sidebar
+    // empty after reload until remount, because action refs never change.
+    expect(finderLogicSource).not.toContain("}, [getItemsInPath]);");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Finder sidebar places stayed empty after reload because `rootFolders` memoized on the stable `getItemsInPath` action ref and never recomputed when IndexedDB rehydrated the VFS.
- Sidebar/Go menu now subscribe via `useFileMetadataInPath("/")` so places refresh when items arrive.
- Shared places order for sidebar + Go menu: **Applications**, **Applets**, then alphabetical (localized name), then **Desktop** last.

## Test plan
- [x] `bun test tests/unit/finder/test-finder-sidebar-places.test.ts tests/unit/finder/test-vfs-service-wiring.test.ts`
- [ ] Reload with Finder open (macOS theme) and confirm places appear without remounting
- [ ] Confirm sidebar order: Applications, Applets, A–Z, Desktop
- [ ] Confirm Go menu uses the same folder order (Trash still last)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7144-f1cb-771b-b493-78f73277e7f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7144-f1cb-771b-b493-78f73277e7f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

