### PR TITLE
Fix books load-error screen with Back to Shelf button

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -164,6 +164,8 @@ interface BooksReaderPaneProps {
   onBookmarkStateChange?: (isBookmarked: boolean) => void;
   /** Continue the Ask Ryo conversation in Chats with the passage quoted. */
   onAskRyo: (passage: string) => void;
+  /** Leave the reader and return to the bookshelf (error-screen CTA). */
+  onBackToShelf: () => void;
 }
 
 const clamp01 = (value: number): number =>
@@ -505,6 +507,7 @@ export const BooksReaderPane = forwardRef<
     onRemoveBookmark,
     onBookmarkStateChange,
     onAskRyo,
+    onBackToShelf,
   },
   ref
 ) {
@@ -3148,10 +3151,12 @@ export const BooksReaderPane = forwardRef<
         </div>
       )}
 
-      {/* Error message shown when the EPUB can't be opened. */}
+      {/* Error message shown when the EPUB can't be opened. Cover zoom
+          intros are dismissed on error, so include an explicit shelf CTA —
+          the auto-hiding titlebar control is easy to miss. */}
       {loadError && (
         <div
-          className="absolute inset-0 z-50 flex items-center justify-center px-6 text-center"
+          className="absolute inset-0 z-50 flex flex-col items-center justify-center gap-4 px-6 text-center"
           style={{ backgroundColor: overlayBackground }}
         >
           <span
@@ -3162,6 +3167,18 @@ export const BooksReaderPane = forwardRef<
           >
             {loadError}
           </span>
+          <button
+            type="button"
+            onClick={onBackToShelf}
+            className={cn(
+              "font-os-ui text-sm px-4 py-1.5 rounded-full transition-colors",
+              palette.isDark
+                ? "bg-white/15 text-white/85 hover:bg-white/25"
+                : "bg-black/10 text-black/70 hover:bg-black/15"
+            )}
+          >
+            {t("apps.books.menu.backToShelf")}
+          </button>
         </div>
       )}
 

--- a/src/apps/books/components/books-app/BooksAppComponent.tsx
+++ b/src/apps/books/components/books-app/BooksAppComponent.tsx
@@ -338,6 +338,7 @@ export function BooksAppComponent({
             onRemoveBookmark={removeBookmark}
             onBookmarkStateChange={handleBookmarkStateChange}
             onAskRyo={handleAskRyo}
+            onBackToShelf={closeBook}
           />
         ) : (
           <BooksShelfView

--- a/tests/unit/books/test-books-reader-error-shelf-cta.test.ts
+++ b/tests/unit/books/test-books-reader-error-shelf-cta.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dir, "..", "..", "..");
+
+describe("Books reader load-error shelf CTA", () => {
+  test("BooksReaderPane renders a Back to Shelf button on loadError", () => {
+    const source = readFileSync(
+      path.join(ROOT, "src/apps/books/components/BooksReaderPane.tsx"),
+      "utf8"
+    );
+    expect(source).toContain("onBackToShelf: () => void");
+    expect(source).toContain("onClick={onBackToShelf}");
+    expect(source).toContain('t("apps.books.menu.backToShelf")');
+    expect(source).toContain("loadError &&");
+  });
+
+  test("BooksAppComponent wires closeBook into the reader error CTA", () => {
+    const source = readFileSync(
+      path.join(
+        ROOT,
+        "src/apps/books/components/books-app/BooksAppComponent.tsx"
+      ),
+      "utf8"
+    );
+    expect(source).toContain("onBackToShelf={closeBook}");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -279,6 +279,14 @@ export default defineConfig({
       // Motion (motion/react) is used on initial load for animations
       "motion/react",
       "motion",
+      // Force cjs-interop pre-bundling for tone's transitive CJS deps.
+      // "tone" itself is excluded (see below) so it's served unbundled in
+      // dev, but its nested deps are UMD/CJS builds with no static ESM
+      // exports. Vite must esbuild-transform them or the browser fails to
+      // resolve named exports (e.g. "AutomationEventList"), crashing the
+      // whole desktop boot the first time any Tone-using hook mounts.
+      "automation-events",
+      "standardized-audio-context",
     ],
     // Exclude heavy deps from initial pre-bundling to reduce memory
     // These will be bundled on-demand when their apps are opened


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When an EPUB fails to open, the cover zoom intro is dismissed and the reader titlebar auto-hides, so the only way back to the shelf was easy to miss.

### Changes
- Show an explicit **Back to Shelf** button on the books reader load-error overlay
- Wire the button to `closeBook` from `BooksAppComponent`
- Add a source wiring unit test for the CTA
- Also fix Vite `optimizeDeps` prebundling for `tone`'s nested CJS deps (`automation-events`, `standardized-audio-context`) so named imports resolve in dev

### Demo
<a href="https://cursor.com/agents/bc-019f7153-f96c-7b59-ac87-72dc814b78d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbooks_error_back_to_shelf_cta.mp4"><img src="https://cursor.com/artifacts/c/art-4aa77ece-8a9b-4354-84af-55a250407b46" alt="books_error_back_to_shelf_cta.mp4" /></a>

![Load error screen with Back to Shelf button](https://cursor.com/artifacts/c/art-78e6dc0f-6185-4ef1-9ffd-18ab2fc5eea0)
![Shelf after clicking Back to Shelf](https://cursor.com/artifacts/c/art-1b71e6c9-004e-4e95-92d9-0c5657623227)

### Testing
- `bun test tests/unit/books/test-books-reader-error-shelf-cta.test.ts`
- Manual: imported a corrupt EPUB, opened it, confirmed error overlay CTA returns to shelf
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7153-f96c-7b59-ac87-72dc814b78d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7153-f96c-7b59-ac87-72dc814b78d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

