### PR TITLE
feat(dashboard): enlarge Widget Bar icons and tray height

### DIFF
--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -341,7 +341,7 @@ function WidgetStrip({
         )}
         <div
           ref={scrollRef}
-          className="widget-strip-scroll flex items-start gap-6 overflow-x-auto px-8 py-3"
+          className="widget-strip-scroll flex items-start gap-6 overflow-x-auto px-8 py-2"
           style={{
             justifyContent: "center",
             position: "relative",
@@ -353,7 +353,7 @@ function WidgetStrip({
               key={w.type}
               type="button"
               onClick={() => onAdd(w.type)}
-              className="flex flex-col items-center gap-2 shrink-0 group"
+              className="flex flex-col items-center gap-1.5 shrink-0 group"
               style={{ minWidth: WIDGET_TRAY_ITEM_MIN_WIDTH }}
             >
               <motion.div

--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -341,7 +341,7 @@ function WidgetStrip({
         )}
         <div
           ref={scrollRef}
-          className="widget-strip-scroll flex items-start gap-6 overflow-x-auto px-8 py-7"
+          className="widget-strip-scroll flex items-start gap-6 overflow-x-auto px-8 py-3"
           style={{
             justifyContent: "center",
             position: "relative",

--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -22,7 +22,11 @@ import { useTranslation } from "react-i18next";
 import { Plus } from "@phosphor-icons/react";
 import { useDashboardStore, type WidgetType } from "@/stores/useDashboardStore";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
-import { WIDGET_ICONS } from "@/components/layout/dashboard/dashboardWidgetConstants";
+import {
+  WIDGET_ICONS,
+  WIDGET_TRAY_ICON_SIZE,
+  WIDGET_TRAY_ITEM_MIN_WIDTH,
+} from "@/components/layout/dashboard/dashboardWidgetConstants";
 import { WidgetBarIcon } from "@/components/layout/dashboard/WidgetBarIcon";
 
 type WidgetFrontProps = {
@@ -337,7 +341,7 @@ function WidgetStrip({
         )}
         <div
           ref={scrollRef}
-          className="widget-strip-scroll flex items-start gap-5 overflow-x-auto px-6 py-4"
+          className="widget-strip-scroll flex items-start gap-6 overflow-x-auto px-8 py-7"
           style={{
             justifyContent: "center",
             position: "relative",
@@ -349,8 +353,8 @@ function WidgetStrip({
               key={w.type}
               type="button"
               onClick={() => onAdd(w.type)}
-              className="flex flex-col items-center gap-1.5 shrink-0 group"
-              style={{ minWidth: 72 }}
+              className="flex flex-col items-center gap-2 shrink-0 group"
+              style={{ minWidth: WIDGET_TRAY_ITEM_MIN_WIDTH }}
             >
               <motion.div
                 whileTap={{ scale: 0.95 }}
@@ -358,17 +362,20 @@ function WidgetStrip({
                 className="flex items-center justify-center"
                 style={{
                   filter: "drop-shadow(0 4px 12px rgba(0,0,0,0.4))",
+                  width: WIDGET_TRAY_ICON_SIZE,
+                  height: WIDGET_TRAY_ICON_SIZE,
                 }}
               >
                 <WidgetBarIcon
                   icon={WIDGET_ICONS[w.type]}
-                  size={36}
+                  size={WIDGET_TRAY_ICON_SIZE}
                   alt={w.label}
                 />
               </motion.div>
               <span
-                className="text-[10px] font-bold text-center leading-tight max-w-[72px] truncate"
+                className="text-[11px] font-bold text-center leading-tight truncate"
                 style={{
+                  maxWidth: WIDGET_TRAY_ITEM_MIN_WIDTH,
                   color: isWindowsTheme ? "rgba(0,0,0,0.75)" : "rgba(255,255,255,0.7)",
                   textShadow: isWindowsTheme ? "none" : "0 1px 3px rgba(0,0,0,0.5)",
                 }}

--- a/src/components/layout/dashboard/dashboardWidgetConstants.ts
+++ b/src/components/layout/dashboard/dashboardWidgetConstants.ts
@@ -27,3 +27,9 @@ export const WIDGET_ICONS: Record<WidgetType, string> = {
 export function isWidgetImageIcon(icon: string): boolean {
   return icon.startsWith("/") || icon.startsWith("http");
 }
+
+/** Pixel size for Tiger Widget Bar icons in the Dashboard add-widget tray. */
+export const WIDGET_TRAY_ICON_SIZE = 64;
+
+/** Minimum column width for each tray item (icon + label). */
+export const WIDGET_TRAY_ITEM_MIN_WIDTH = 96;

--- a/tests/unit/dashboard/test-dashboard-widget-icons.test.ts
+++ b/tests/unit/dashboard/test-dashboard-widget-icons.test.ts
@@ -3,6 +3,8 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   WIDGET_ICONS,
+  WIDGET_TRAY_ICON_SIZE,
+  WIDGET_TRAY_ITEM_MIN_WIDTH,
   isWidgetImageIcon,
 } from "@/components/layout/dashboard/dashboardWidgetConstants";
 import type { WidgetType } from "@/stores/useDashboardStore";
@@ -43,6 +45,13 @@ describe("dashboard widget icons", () => {
       const diskPath = resolve(process.cwd(), "public" + icon);
       expect(existsSync(diskPath)).toBe(true);
     }
+  });
+
+  test("sizes the Dashboard widget tray for larger Tiger icons", () => {
+    expect(WIDGET_TRAY_ICON_SIZE).toBeGreaterThanOrEqual(64);
+    expect(WIDGET_TRAY_ITEM_MIN_WIDTH).toBeGreaterThanOrEqual(
+      WIDGET_TRAY_ICON_SIZE
+    );
   });
 
   test("catalogs the full Tiger Widget Bar set including unused stock icons", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Makes the Dashboard add-widget tray closer to Tiger Widget Bar scale.

## Changes

- Tray icons: `36px` → `64px` (`WIDGET_TRAY_ICON_SIZE`)
- Tray item columns widened to `96px`
- Horizontal padding/gaps increased; vertical padding kept tight (`py-2`, icon/label `gap-1.5`) so the strip isn’t overly tall
- Label size nudged up slightly

Mobile still pushes content up via the measured strip height (`ResizeObserver` → `stripHeight`), including when the picker is open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8aae-0104-7f34-a682-371a85655e49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8aae-0104-7f34-a682-371a85655e49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

