### PR TITLE
fix(sync): recover missing book blobs and stop false tombstones

### DIFF
--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -406,7 +406,8 @@ function scheduleDefaultBookWarmup(): void {
  */
 async function ensureCloudBlobContentLoaded(
   storeName: string,
-  uuid: string
+  uuid: string,
+  options: { forceReload?: boolean } = {}
 ): Promise<boolean> {
   if (typeof navigator !== "undefined" && navigator.onLine === false) {
     return false;
@@ -424,7 +425,9 @@ async function ensureCloudBlobContentLoaded(
     }
     const engine = getActiveCloudSyncEngine();
     if (!engine) return false;
-    return engine.ensureBlobItemLocal(namespace, uuid);
+    return engine.ensureBlobItemLocal(namespace, uuid, {
+      forceReload: options.forceReload,
+    });
   } catch (error) {
     console.warn(
       `[FilesStore] Cloud blob hydrate failed for ${storeName}/${uuid}:`,
@@ -524,11 +527,14 @@ export async function ensureFileContentLoaded(
     }
     if (!pendingFile?.assetPath) {
       // User-imported / synced binaries have no bundled assetPath. When the
-      // VFS metadata still points at a UUID whose IndexedDB payload is gone,
-      // ask cloud sync to re-hydrate that single blob.
+      // VFS metadata still points at a UUID whose IndexedDB payload is gone
+      // (or forceReload needs to replace an unreadable Blob), ask cloud sync
+      // to re-hydrate that single blob.
       loadingAssets.add(uuid);
       try {
-        return await ensureCloudBlobContentLoaded(storeName, uuid);
+        return await ensureCloudBlobContentLoaded(storeName, uuid, {
+          forceReload: options.forceReload,
+        });
       } finally {
         loadingAssets.delete(uuid);
       }

--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -400,6 +400,41 @@ function scheduleDefaultBookWarmup(): void {
 }
 
 /**
+ * Re-hydrate a missing IndexedDB blob from cloud sync (user-imported books,
+ * images, applets, etc.). Uses a dynamic import so this module does not form
+ * a static cycle with the sync engine (which imports useFilesStore).
+ */
+async function ensureCloudBlobContentLoaded(
+  storeName: string,
+  uuid: string
+): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.onLine === false) {
+    return false;
+  }
+  try {
+    const [{ getActiveCloudSyncEngine }, { getCloudSyncDomainForContentStore }, { isSyncBlobNamespace }] =
+      await Promise.all([
+        import("@/sync/engine"),
+        import("@/apps/finder/utils/fileSystemHelpers"),
+        import("@/shared/sync2/namespaces"),
+      ]);
+    const namespace = getCloudSyncDomainForContentStore(storeName);
+    if (!namespace || !isSyncBlobNamespace(namespace)) {
+      return false;
+    }
+    const engine = getActiveCloudSyncEngine();
+    if (!engine) return false;
+    return engine.ensureBlobItemLocal(namespace, uuid);
+  } catch (error) {
+    console.warn(
+      `[FilesStore] Cloud blob hydrate failed for ${storeName}/${uuid}:`,
+      error
+    );
+    return false;
+  }
+}
+
+/**
  * Load content for a specific file on-demand (lazy loading).
  * Call this when a file is opened to ensure its content is in IndexedDB.
  * Returns true if content was loaded (or already exists), false on error.
@@ -488,7 +523,15 @@ export async function ensureFileContentLoaded(
       }
     }
     if (!pendingFile?.assetPath) {
-      return false;
+      // User-imported / synced binaries have no bundled assetPath. When the
+      // VFS metadata still points at a UUID whose IndexedDB payload is gone,
+      // ask cloud sync to re-hydrate that single blob.
+      loadingAssets.add(uuid);
+      try {
+        return await ensureCloudBlobContentLoaded(storeName, uuid);
+      } finally {
+        loadingAssets.delete(uuid);
+      }
     }
 
     // Offline: the asset fetch below cannot succeed — fail fast instead of

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -914,10 +914,15 @@ export class CloudSyncEngine {
    * Ensure a single blob-namespace item is present in IndexedDB, re-fetching
    * from cloud when the VFS metadata/shadow says it should exist but the
    * local bytes are gone (Safari IDB loss, quota eviction, partial restore).
+   *
+   * With `forceReload`, an existing local record is discarded first so a
+   * corrupt/unreadable blob can be replaced from cloud (used by the Books
+   * Safari Blob recovery path).
    */
   async ensureBlobItemLocal(
     namespace: SyncBlobNamespace,
-    storeKey: string
+    storeKey: string,
+    options: { forceReload?: boolean } = {}
   ): Promise<boolean> {
     if (!storeKey || this.stopped) return false;
     if (!this.isNamespaceEnabled(namespace)) {
@@ -932,16 +937,29 @@ export class CloudSyncEngine {
 
     const syncKey = `${namespace}/item:${storeKey}`;
     const db = await ensureIndexedDBInitialized();
+    const ctx: CodecContext = { db };
     try {
       const existing = await readStoreItemsByKeys(db, codec.storeName, [
         storeKey,
       ]);
-      if (existing.length > 0) return true;
+      if (existing.length > 0 && !options.forceReload) return true;
 
-      cloudSyncLog.debug("Local blob missing; fetching from cloud", {
-        namespace,
-        storeKey,
-      });
+      if (existing.length > 0 && options.forceReload) {
+        // Drop the unreadable local record and its shadow so applyBlobOps
+        // cannot treat the stale hash as "already local".
+        cloudSyncLog.debug("Force-reloading local blob from cloud", {
+          namespace,
+          storeKey,
+        });
+        await codec.deleteItems([storeKey], ctx);
+        this.state.deleteShadow(syncKey);
+      } else {
+        cloudSyncLog.debug("Local blob missing; fetching from cloud", {
+          namespace,
+          storeKey,
+        });
+      }
+
       const snapshot = await getSyncSnapshot({
         signal: this.abortController.signal,
         prefix: syncKey,

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -21,6 +21,7 @@ import {
   getSyncNamespaceCategory,
   isSyncBlobNamespace,
   SYNC_NAMESPACES,
+  type SyncBlobNamespace,
   type SyncNamespace,
 } from "@/shared/sync2/namespaces";
 import {
@@ -63,7 +64,10 @@ import {
 } from "@/sync/codecs";
 import { getPersistedSyncShadowKeys } from "@/sync/stateStorage";
 import { useFilesStore } from "@/stores/useFilesStore";
-import type { IndexedDBStoreItemWithKey as StoreItemWithKey } from "@/utils/indexedDBBackup";
+import {
+  readStoreItemsByKeys,
+  type IndexedDBStoreItemWithKey as StoreItemWithKey,
+} from "@/utils/indexedDBBackup";
 
 const FLUSH_DEBOUNCE_MS = 1000;
 const FLUSH_MAX_DEBOUNCE_MS = 3000;
@@ -875,7 +879,9 @@ export class CloudSyncEngine {
    * timestamp matches the shadow are skipped.
    */
   async applySnapshot(force: boolean): Promise<void> {
-    const snapshot = await getSyncSnapshot(this.abortController.signal);
+    const snapshot = await getSyncSnapshot({
+      signal: this.abortController.signal,
+    });
     if (this.stopped) return;
     const ops: SyncOp[] = [];
 
@@ -893,7 +899,7 @@ export class CloudSyncEngine {
         entryCount: Object.keys(snapshot.entries).length,
         ops: summarizeSyncOps(ops),
       });
-      await this.applyRemoteOps(ops);
+      await this.applyRemoteOps(ops, { force });
     } else {
       cloudSyncLog.debug("Snapshot already current", {
         force,
@@ -902,6 +908,74 @@ export class CloudSyncEngine {
       });
     }
     this.state.setCursor(snapshot.seq);
+  }
+
+  /**
+   * Ensure a single blob-namespace item is present in IndexedDB, re-fetching
+   * from cloud when the VFS metadata/shadow says it should exist but the
+   * local bytes are gone (Safari IDB loss, quota eviction, partial restore).
+   */
+  async ensureBlobItemLocal(
+    namespace: SyncBlobNamespace,
+    storeKey: string
+  ): Promise<boolean> {
+    if (!storeKey || this.stopped) return false;
+    if (!this.isNamespaceEnabled(namespace)) {
+      cloudSyncLog.debug("ensureBlobItemLocal skipped; category disabled", {
+        namespace,
+        storeKey,
+      });
+      return false;
+    }
+    const codec = SYNC_CODECS[namespace];
+    if (!isBlobCodec(codec)) return false;
+
+    const syncKey = `${namespace}/item:${storeKey}`;
+    const db = await ensureIndexedDBInitialized();
+    try {
+      const existing = await readStoreItemsByKeys(db, codec.storeName, [
+        storeKey,
+      ]);
+      if (existing.length > 0) return true;
+
+      cloudSyncLog.debug("Local blob missing; fetching from cloud", {
+        namespace,
+        storeKey,
+      });
+      const snapshot = await getSyncSnapshot({
+        signal: this.abortController.signal,
+        prefix: syncKey,
+      });
+      if (this.stopped) return false;
+
+      const entry = snapshot.entries[syncKey];
+      if (!entry || entry.del) {
+        cloudSyncLog.warn("Cloud blob entry missing for local file", {
+          namespace,
+          storeKey,
+        });
+        return false;
+      }
+
+      await this.applyRemoteOps([this.entryToOp(syncKey, entry)], {
+        force: true,
+      });
+
+      const restored = await readStoreItemsByKeys(db, codec.storeName, [
+        storeKey,
+      ]);
+      return restored.length > 0;
+    } catch (error) {
+      if (this.stopped || isAbortError(error)) return false;
+      cloudSyncLog.error("ensureBlobItemLocal failed", {
+        namespace,
+        storeKey,
+        error,
+      });
+      return false;
+    } finally {
+      db.close();
+    }
   }
 
   private entryToOp(key: string, entry: SyncKvEntry): SyncOp {
@@ -973,7 +1047,10 @@ export class CloudSyncEngine {
   // Remote op application
   // -------------------------------------------------------------------------
 
-  async applyRemoteOps(ops: SyncOp[]): Promise<void> {
+  async applyRemoteOps(
+    ops: SyncOp[],
+    options: { force?: boolean } = {}
+  ): Promise<void> {
     const clientId = getSyncClientId();
     const byNamespace = new Map<SyncNamespace, AppliedSyncOp[]>();
     let skippedOwnCount = 0;
@@ -990,7 +1067,10 @@ export class CloudSyncEngine {
       }
 
       const shadow = this.state.getShadow(op.k);
-      if (shadow && shadow.t === op.t) {
+      // Force downloads must re-enter appliers even when the shadow timestamp
+      // already matches — blob namespaces verify IndexedDB presence and may
+      // need to re-hydrate missing local bytes.
+      if (!options.force && shadow && shadow.t === op.t) {
         skippedAlreadyAppliedCount += 1;
         continue; // already applied
       }
@@ -1120,6 +1200,13 @@ export class CloudSyncEngine {
       url: string;
       size: number;
     }> = [];
+    const maybeLocal: Array<{
+      op: AppliedSyncOp;
+      contentHash: string;
+      url: string;
+      size: number;
+      storeKey: string;
+    }> = [];
 
     for (const op of ops) {
       if (!op.k.startsWith(prefix)) continue;
@@ -1133,11 +1220,47 @@ export class CloudSyncEngine {
       const contentHash = ref.sha256 || ref.sig || "";
       const shadow = this.state.getShadow(op.k);
       if (contentHash && shadow?.h === contentHash) {
-        // Content already local; record the new timestamp.
-        this.state.setShadow(op.k, { t: op.t, h: contentHash });
+        // Shadow says we already have these bytes — but IndexedDB can lose
+        // them (Safari, quota, partial wipe) while the shadow survives.
+        // Verify presence before skipping the download.
+        maybeLocal.push({
+          op,
+          contentHash,
+          url: ref.url,
+          size: ref.size,
+          storeKey: op.k.slice(prefix.length),
+        });
         continue;
       }
       downloads.push({ op, contentHash, url: ref.url, size: ref.size });
+    }
+
+    if (maybeLocal.length > 0) {
+      const db = ctx.db;
+      if (!db) {
+        downloads.push(...maybeLocal);
+      } else {
+        const present = await readStoreItemsByKeys(
+          db,
+          codec.storeName,
+          maybeLocal.map((item) => item.storeKey)
+        );
+        const presentKeys = new Set(present.map((item) => item.key));
+        for (const item of maybeLocal) {
+          if (presentKeys.has(item.storeKey)) {
+            this.state.setShadow(item.op.k, {
+              t: item.op.t,
+              h: item.contentHash,
+            });
+          } else {
+            cloudSyncLog.warn(
+              "Blob shadow matched but local content missing; re-downloading",
+              { namespace, key: item.op.k }
+            );
+            downloads.push(item);
+          }
+        }
+      }
     }
 
     if (deletes.length > 0) {
@@ -1300,7 +1423,9 @@ export class CloudSyncEngine {
 
     try {
       cloudSyncLog.debug("Manual restore promotion started", { namespaces });
-      const snapshot = await getSyncSnapshot(this.abortController.signal);
+      const snapshot = await getSyncSnapshot({
+        signal: this.abortController.signal,
+      });
       if (this.stopped) {
         throw new DOMException("Cloud sync stopped", "AbortError");
       }

--- a/src/sync/transport.ts
+++ b/src/sync/transport.ts
@@ -60,12 +60,19 @@ export async function getSyncChanges(
 }
 
 export async function getSyncSnapshot(
-  signal?: AbortSignal
+  options: { signal?: AbortSignal; prefix?: string } = {}
 ): Promise<GetSnapshotResponse> {
-  const response = await abortableFetch(getApiUrl("/api/sync/v2/snapshot"), {
+  const prefix =
+    typeof options.prefix === "string" && options.prefix.length > 0
+      ? options.prefix
+      : undefined;
+  const url = prefix
+    ? `/api/sync/v2/snapshot?prefix=${encodeURIComponent(prefix)}`
+    : "/api/sync/v2/snapshot";
+  const response = await abortableFetch(getApiUrl(url), {
     method: "GET",
     timeout: 30000,
-    signal,
+    signal: options.signal,
     throwOnHttpError: false,
     retry: { maxAttempts: 2, initialDelayMs: 500 },
   });

--- a/tests/unit/sync/test-blob-missing-local-repair.test.ts
+++ b/tests/unit/sync/test-blob-missing-local-repair.test.ts
@@ -1,0 +1,296 @@
+import "../../helpers/local-storage-stub";
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { CloudSyncEngine } from "../../../src/sync/engine";
+import { gzipJson, sha256Json } from "../../../src/sync/blobs";
+import { SyncClientState } from "../../../src/sync/state";
+import { useCloudSyncStore } from "../../../src/stores/useCloudSyncStore";
+import {
+  dbOperations,
+  ensureIndexedDBInitialized,
+  STORES,
+} from "../../../src/utils/indexedDB";
+import { serializeStoreItem } from "../../../src/utils/indexedDBBackup";
+
+const t = "01718180000000-0000-test";
+const BOOK_UUID = "a66df7db-ef19-4b22-a23c-587dbd2ac620";
+const SYNC_KEY = `books/item:${BOOK_UUID}`;
+const BOOK_NAME = "Steve Jobs in Exile.epub";
+
+async function deleteRyOsDatabase(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase("ryOS");
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => resolve();
+  });
+}
+
+async function bookStoreItem(content = "epub-bytes") {
+  // Match the on-wire shape used by blob upload (Blob → base64 envelope).
+  return serializeStoreItem({
+    key: BOOK_UUID,
+    value: {
+      name: BOOK_NAME,
+      content: new Blob([new TextEncoder().encode(content)], {
+        type: "application/epub+zip",
+      }),
+    },
+  });
+}
+
+describe("cloud sync blob missing-local repair", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(async () => {
+    await deleteRyOsDatabase();
+    useCloudSyncStore.setState({
+      autoSyncEnabled: true,
+      syncFiles: true,
+      syncBooks: true,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("applyBlobOps re-downloads when shadow hash matches but IndexedDB is empty", async () => {
+    const item = await bookStoreItem();
+    const digest = await sha256Json(item);
+    const compressed = await gzipJson(item);
+    let downloadCount = 0;
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("example.test/book.gz")) {
+        downloadCount += 1;
+        return new Response(new Blob([compressed]), {
+          status: 200,
+          headers: { "content-length": String(compressed.byteLength) },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const engine = await CloudSyncEngine.create(
+      `blob-repair-${crypto.randomUUID()}`
+    );
+    try {
+      const state = (engine as unknown as { state: SyncClientState }).state;
+      // Simulate a device that previously synced this blob (shadow present)
+      // but later lost the IndexedDB payload.
+      state.setShadow(SYNC_KEY, { t, h: digest });
+
+      const before = await dbOperations.get(STORES.BOOKS, BOOK_UUID);
+      expect(before).toBeUndefined();
+
+      // Newer timestamp so applyRemoteOps admits the op; same content hash so
+      // the old code path would skip the download based on shadow alone.
+      await engine.applyRemoteOps([
+        {
+          k: SYNC_KEY,
+          v: {
+            blob: {
+              url: "https://example.test/book.gz",
+              size: compressed.byteLength,
+              sha256: digest,
+            },
+          },
+          t: `${t}-newer`,
+        },
+      ]);
+
+      expect(downloadCount).toBe(1);
+      const restored = await dbOperations.get<{
+        name: string;
+        content: ArrayBuffer;
+      }>(STORES.BOOKS, BOOK_UUID);
+      expect(restored?.name).toBe(BOOK_NAME);
+      expect(restored?.content).toBeInstanceOf(ArrayBuffer);
+      expect(new TextDecoder().decode(restored!.content)).toBe("epub-bytes");
+    } finally {
+      await engine.stop();
+    }
+  });
+
+  test("force apply re-enters blob applier even when shadow timestamp matches", async () => {
+    const item = await bookStoreItem("forced");
+    const digest = await sha256Json(item);
+    const compressed = await gzipJson(item);
+    let downloadCount = 0;
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("example.test/book.gz")) {
+        downloadCount += 1;
+        return new Response(new Blob([compressed]), {
+          status: 200,
+          headers: { "content-length": String(compressed.byteLength) },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const engine = await CloudSyncEngine.create(
+      `blob-force-${crypto.randomUUID()}`
+    );
+    try {
+      const state = (engine as unknown as { state: SyncClientState }).state;
+      state.setShadow(SYNC_KEY, { t, h: digest });
+
+      // Without force, matching timestamp would skip before applyBlobOps.
+      await engine.applyRemoteOps(
+        [
+          {
+            k: SYNC_KEY,
+            v: {
+              blob: {
+                url: "https://example.test/book.gz",
+                size: compressed.byteLength,
+                sha256: digest,
+              },
+            },
+            t,
+          },
+        ],
+        { force: true }
+      );
+
+      expect(downloadCount).toBe(1);
+      const restored = await dbOperations.get<{ content: ArrayBuffer }>(
+        STORES.BOOKS,
+        BOOK_UUID
+      );
+      expect(new TextDecoder().decode(restored!.content)).toBe("forced");
+    } finally {
+      await engine.stop();
+    }
+  });
+
+  test("ensureBlobItemLocal restores a missing book blob from a prefixed snapshot", async () => {
+    const item = await bookStoreItem("from-cloud");
+    const digest = await sha256Json(item);
+    const compressed = await gzipJson(item);
+    let snapshotCalls = 0;
+    let downloadCount = 0;
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/sync/v2/snapshot")) {
+        snapshotCalls += 1;
+        expect(url).toContain(`prefix=${encodeURIComponent(SYNC_KEY)}`);
+        return Response.json({
+          ok: true,
+          seq: 42,
+          entries: {
+            [SYNC_KEY]: {
+              v: {
+                blob: {
+                  url: "https://example.test/book.gz",
+                  size: compressed.byteLength,
+                  sha256: digest,
+                },
+              },
+              t,
+              seq: 42,
+            },
+          },
+        });
+      }
+      if (url.includes("example.test/book.gz")) {
+        downloadCount += 1;
+        return new Response(new Blob([compressed]), {
+          status: 200,
+          headers: { "content-length": String(compressed.byteLength) },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const engine = await CloudSyncEngine.create(
+      `blob-ensure-${crypto.randomUUID()}`
+    );
+    try {
+      const state = (engine as unknown as { state: SyncClientState }).state;
+      state.setShadow(SYNC_KEY, { t, h: digest });
+
+      const ok = await engine.ensureBlobItemLocal("books", BOOK_UUID);
+      expect(ok).toBe(true);
+      expect(snapshotCalls).toBe(1);
+      expect(downloadCount).toBe(1);
+
+      const restored = await dbOperations.get<{ content: ArrayBuffer }>(
+        STORES.BOOKS,
+        BOOK_UUID
+      );
+      expect(new TextDecoder().decode(restored!.content)).toBe("from-cloud");
+
+      // Second call is a no-op once bytes are local.
+      const again = await engine.ensureBlobItemLocal("books", BOOK_UUID);
+      expect(again).toBe(true);
+      expect(snapshotCalls).toBe(1);
+      expect(downloadCount).toBe(1);
+    } finally {
+      await engine.stop();
+    }
+  });
+
+  test("matching shadow with local content still skips download", async () => {
+    const item = await bookStoreItem("already-local");
+    const digest = await sha256Json(item);
+    let downloadCount = 0;
+
+    globalThis.fetch = (async () => {
+      downloadCount += 1;
+      throw new Error("should not download");
+    }) as typeof fetch;
+
+    const db = await ensureIndexedDBInitialized();
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(STORES.BOOKS, "readwrite");
+        // Local presence check only needs a record under the UUID key.
+        tx.objectStore(STORES.BOOKS).put(
+          {
+            name: BOOK_NAME,
+            content: new TextEncoder().encode("already-local").buffer,
+          },
+          BOOK_UUID
+        );
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+      });
+    } finally {
+      db.close();
+    }
+
+    const engine = await CloudSyncEngine.create(
+      `blob-skip-${crypto.randomUUID()}`
+    );
+    try {
+      const state = (engine as unknown as { state: SyncClientState }).state;
+      state.setShadow(SYNC_KEY, { t, h: digest });
+
+      await engine.applyRemoteOps([
+        {
+          k: SYNC_KEY,
+          v: {
+            blob: {
+              url: "https://example.test/book.gz",
+              size: 10,
+              sha256: digest,
+            },
+          },
+          t: `${t}-newer`,
+        },
+      ]);
+
+      expect(downloadCount).toBe(0);
+      expect(state.getShadow(SYNC_KEY)?.t).toBe(`${t}-newer`);
+      expect(state.getShadow(SYNC_KEY)?.h).toBe(digest);
+    } finally {
+      await engine.stop();
+    }
+  });
+});

--- a/tests/unit/sync/test-blob-missing-local-repair.test.ts
+++ b/tests/unit/sync/test-blob-missing-local-repair.test.ts
@@ -236,6 +236,77 @@ describe("cloud sync blob missing-local repair", () => {
     }
   });
 
+  test("ensureBlobItemLocal forceReload replaces an existing corrupt local blob", async () => {
+    const item = await bookStoreItem("good-bytes");
+    const digest = await sha256Json(item);
+    const compressed = await gzipJson(item);
+    let downloadCount = 0;
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/sync/v2/snapshot")) {
+        return Response.json({
+          ok: true,
+          seq: 7,
+          entries: {
+            [SYNC_KEY]: {
+              v: {
+                blob: {
+                  url: "https://example.test/book.gz",
+                  size: compressed.byteLength,
+                  sha256: digest,
+                },
+              },
+              t,
+              seq: 7,
+            },
+          },
+        });
+      }
+      if (url.includes("example.test/book.gz")) {
+        downloadCount += 1;
+        return new Response(new Blob([compressed]), {
+          status: 200,
+          headers: { "content-length": String(compressed.byteLength) },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    await dbOperations.put(
+      STORES.BOOKS,
+      { name: BOOK_NAME, content: new Blob(["bad"]) },
+      BOOK_UUID
+    );
+
+    const engine = await CloudSyncEngine.create(
+      `blob-force-reload-${crypto.randomUUID()}`
+    );
+    try {
+      const state = (engine as unknown as { state: SyncClientState }).state;
+      state.setShadow(SYNC_KEY, { t, h: digest });
+
+      // Without forceReload, presence short-circuits.
+      const skipped = await engine.ensureBlobItemLocal("books", BOOK_UUID);
+      expect(skipped).toBe(true);
+      expect(downloadCount).toBe(0);
+
+      const ok = await engine.ensureBlobItemLocal("books", BOOK_UUID, {
+        forceReload: true,
+      });
+      expect(ok).toBe(true);
+      expect(downloadCount).toBe(1);
+
+      const restored = await dbOperations.get<{ content: ArrayBuffer }>(
+        STORES.BOOKS,
+        BOOK_UUID
+      );
+      expect(new TextDecoder().decode(restored!.content)).toBe("good-bytes");
+    } finally {
+      await engine.stop();
+    }
+  });
+
   test("matching shadow with local content still skips download", async () => {
     const item = await bookStoreItem("already-local");
     const digest = await sha256Json(item);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Books can appear in the VFS/shelf (metadata present) but fail to open with `content:vfs:missing` / IndexedDB `undefined` for the UUID — matching the “Steve Jobs in Exile.epub” logs (`a66df7db-…`).

### Root causes (layered)

1. **Shadow skip without IndexedDB check** — Sync treated a matching blob shadow hash as “already local” and skipped download even when IndexedDB was empty. Force-download also short-circuited on matching shadow timestamps.
2. **False blob tombstones** — Flush inferred cloud deletes when a shadow key was missing from local collect. A single Safari/quota IDB eviction (metadata still pointing at the UUID) could permanently tombstone `books/item:{uuid}` on the server.
3. **Orphan UUID after replace** — Re-import/`saveFile` preserved the old UUID. If that key was already tombstoned in cloud, new bytes never revived it. Devices holding the old UUID also couldn’t adopt a newer remote files UUID for the same path.

Newer production logs showed hydrate running correctly but cloud returning no blob entry — so (2)/(3) explain why the first repair alone was insufficient.

## Changes

- Verify IndexedDB presence before skipping blob downloads on shadow hash match; re-download when bytes are missing
- Pass `force` through `applyRemoteOps`; `ensureBlobItemLocal()` does prefixed snapshot fetch + forced apply (incl. `forceReload` for corrupt local Blobs)
- Call cloud hydrate from `ensureFileContentLoaded` for synced binaries with no bundled `assetPath`, passing the VFS `path`
- **Never infer blob-namespace deletes without an explicit deletion marker** (`fileBookKeys`, etc.)
- When cloud blob for the local UUID is missing, fetch `files/item:{path}` and adopt a different remote content UUID, then hydrate that blob
- On `saveFile` replace over an orphan UUID (IDB miss), mint a new content UUID; `addItem` honors explicit UUID rotation
- Richer debug-mode logs in Books reader + CloudSync hydrate/repair path

## Test plan

- [x] `bun test tests/unit/sync/test-blob-missing-local-repair.test.ts` (9/9)
- [x] `bun test tests/unit/sync/` (151/151)
- [ ] Manual: open a synced user EPUB after clearing only the `books` IndexedDB store (metadata + shadow intact) → rehydrates
- [ ] Manual: with cloud blob tombstoned for old UUID but newer `files/item` UUID + blob present → open adopts remote UUID
- [ ] Manual: re-import over orphan local UUID → new content id + opens

## Note for the stuck book on iPhone

If cloud has neither `books/item:a66df7db-…` nor a newer files UUID with a live blob, recovery is **re-import the EPUB** (this build mints a fresh UUID when local bytes are gone). A device that still has the bytes can sync them up first.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9112-4904-770d-aaed-91be00bcd5fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9112-4904-770d-aaed-91be00bcd5fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

