### PR TITLE
fix(sync): stop false book blob tombstones and recover orphan UUIDs

### DIFF
--- a/src/apps/books/components/BooksReaderPane.tsx
+++ b/src/apps/books/components/BooksReaderPane.tsx
@@ -629,9 +629,29 @@ export const BooksReaderPane = forwardRef<
   const readActiveBookBlob = useCallback(async (): Promise<Blob | null> => {
     const fallbackAssetUrl = DEFAULT_BOOK_ASSET_BY_PATH[entry.path];
     try {
+      appendDebugEvent("content:vfs:read", {
+        path: entry.path,
+        modifiedAt: entry.modifiedAt,
+      });
       const storedBlob = await readBookBlobContent(entry.path);
-      if (storedBlob) return storedBlob;
-      appendDebugEvent("content:vfs:missing", { fallbackAssetUrl }, "warn");
+      if (storedBlob) {
+        appendDebugEvent("content:vfs:hit", {
+          path: entry.path,
+          size: storedBlob.size,
+          type: storedBlob.type,
+        });
+        return storedBlob;
+      }
+      appendDebugEvent(
+        "content:vfs:missing",
+        {
+          path: entry.path,
+          fallbackAssetUrl,
+          // Help diagnose orphan-UUID / cloud-tombstone cases in debug mode.
+          note: "IndexedDB miss after cloud hydrate attempt; see [CloudSync] logs",
+        },
+        "warn"
+      );
     } catch (error) {
       appendDebugEvent("content:vfs:failed", error, "error");
     }
@@ -660,7 +680,7 @@ export const BooksReaderPane = forwardRef<
     const blob = await response.blob();
     appendDebugEvent("content:fallbackFetch:success", { blob });
     return blob;
-  }, [appendDebugEvent, entry.path]);
+  }, [appendDebugEvent, entry.modifiedAt, entry.path]);
 
   const accentBaseHex = useThemeStore((state) => resolveOsAccentBaseHex(state));
   const palette = resolveReadingPalette(settings, osIsDark, accentBaseHex);

--- a/src/apps/finder/hooks/useFileSystem.ts
+++ b/src/apps/finder/hooks/useFileSystem.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { v4 as uuidv4 } from "uuid";
 import { ensureIndexedDBInitialized, STORES, dbOperations } from "@/utils/indexedDB";
 import { getNonFinderApps, AppId, getAppIconPath } from "@/config/appRegistry";
 import { useIsRyoAdmin } from "@/hooks/useIsRyoAdmin";
@@ -1199,9 +1200,38 @@ export function useFileSystem(
       const isDirectory = false;
       const fileType = fileData.type || getFileTypeFromExtension(name);
 
-      // Check if file already exists to preserve UUID
+      // Check if file already exists to preserve UUID — unless the existing
+      // UUID is an orphan (metadata present, IndexedDB bytes gone). Replacing
+      // over an orphan UUID can never revive a cloud-tombstoned blob; mint a
+      // fresh content id so the new bytes sync as a new key.
       const existingItem = getFileItem(path);
-      const uuid = existingItem?.uuid;
+      let uuid = existingItem?.uuid;
+      const storeName = getStoreForFile(path, { name, type: fileType });
+      let replacedOrphanUuid: string | null = null;
+      if (uuid && storeName) {
+        try {
+          const existingContent = await dbOperations.get<DocumentContent>(
+            storeName,
+            uuid
+          );
+          if (!existingContent) {
+            replacedOrphanUuid = uuid;
+            uuid = uuidv4();
+            log.warn("Replacing file with orphan content UUID; minting new id", {
+              path,
+              orphanUuid: replacedOrphanUuid,
+              newUuid: uuid,
+              storeName,
+            });
+          }
+        } catch (err) {
+          log.warn("Could not probe existing content before save", {
+            path,
+            uuid,
+            error: err,
+          });
+        }
+      }
 
       // 1. Create the full metadata object first
       const now = Date.now();
@@ -1223,7 +1253,7 @@ export function useFileSystem(
         isDirectory: isDirectory,
         type: fileType,
         status: "active", // Explicitly set status
-        uuid: uuid, // Preserve existing UUID if updating
+        uuid: uuid, // Preserve existing UUID if updating (unless orphaned)
         // Set timestamps
         createdAt: existingItem?.createdAt || now,
         modifiedAt: now,
@@ -1246,8 +1276,14 @@ export function useFileSystem(
 
       // 2. Add/Update Metadata in FileStore (will generate UUID if new)
       try {
-        log.debug("Updating metadata store", { path });
-        // Pass the complete metadata object to addItem
+        log.debug("Updating metadata store", {
+          path,
+          uuid: metadata.uuid ?? null,
+          replacedOrphanUuid,
+        });
+        // Pass the complete metadata object to addItem. When rotating off an
+        // orphan UUID, metadata.uuid differs from the existing id and addItem
+        // keeps the caller's new content id.
         addFileItem(metadata);
         track(FINDER_ANALYTICS.FILE_SAVE, {
           appId: "finder",
@@ -1265,11 +1301,10 @@ export function useFileSystem(
         log.debug("Metadata store updated", {
           path,
           uuid: savedItem.uuid,
+          replacedOrphanUuid,
         });
 
         // 3. Save Content to IndexedDB using UUID
-        log.debug("Determining content store", { path });
-        const storeName = getStoreForFile(path, { name, type: fileType });
         log.debug("Selected content store", { path, storeName });
         if (storeName) {
           try {
@@ -1286,12 +1321,25 @@ export function useFileSystem(
               contentLength:
                 typeof content === "string" ? content.length : undefined,
               contentType: content instanceof Blob ? "blob" : typeof content,
+              contentSize:
+                contentToStore.content instanceof ArrayBuffer
+                  ? contentToStore.content.byteLength
+                  : content instanceof Blob
+                    ? content.size
+                    : undefined,
             });
             await dbOperations.put<DocumentContent>(
               storeName,
               contentToStore,
               savedItem.uuid
             );
+            const deletionBucket =
+              getCloudSyncDeletionBucketForContentStore(storeName);
+            if (deletionBucket) {
+              useCloudSyncStore
+                .getState()
+                .clearDeletedKeys(deletionBucket, [savedItem.uuid]);
+            }
             const syncDomain = getCloudSyncDomainForContentStore(storeName);
             if (syncDomain) {
               emitCloudSyncContentChange(syncDomain, savedItem.uuid);

--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -407,9 +407,12 @@ function scheduleDefaultBookWarmup(): void {
 async function ensureCloudBlobContentLoaded(
   storeName: string,
   uuid: string,
-  options: { forceReload?: boolean } = {}
+  options: { forceReload?: boolean; path?: string } = {}
 ): Promise<boolean> {
   if (typeof navigator !== "undefined" && navigator.onLine === false) {
+    debug(
+      `[FilesStore] Offline — cannot hydrate cloud blob for ${options.path ?? uuid}`
+    );
     return false;
   }
   try {
@@ -421,12 +424,28 @@ async function ensureCloudBlobContentLoaded(
       ]);
     const namespace = getCloudSyncDomainForContentStore(storeName);
     if (!namespace || !isSyncBlobNamespace(namespace)) {
+      debug(
+        `[FilesStore] No blob namespace for store ${storeName} (${options.path ?? uuid})`
+      );
       return false;
     }
     const engine = getActiveCloudSyncEngine();
-    if (!engine) return false;
+    if (!engine) {
+      debug(
+        `[FilesStore] No active cloud sync engine for hydrate (${options.path ?? uuid})`
+      );
+      return false;
+    }
+    debug(`[FilesStore] Hydrating cloud blob`, {
+      storeName,
+      namespace,
+      uuid,
+      path: options.path ?? null,
+      forceReload: Boolean(options.forceReload),
+    });
     return engine.ensureBlobItemLocal(namespace, uuid, {
       forceReload: options.forceReload,
+      path: options.path,
     });
   } catch (error) {
     console.warn(
@@ -534,6 +553,7 @@ export async function ensureFileContentLoaded(
       try {
         return await ensureCloudBlobContentLoaded(storeName, uuid, {
           forceReload: options.forceReload,
+          path: filePath,
         });
       } finally {
         loadingAssets.delete(uuid);
@@ -957,14 +977,22 @@ export const useFilesStore = create<FilesStoreState>()(
           // Check if item already exists
           const existingItem = state.items[newItem.path];
           if (existingItem) {
-            // Update existing item, preserving UUID and createdAt
+            // Update existing item, preserving UUID and createdAt — unless the
+            // caller explicitly supplies a different uuid (orphan content-id
+            // rotation after a missing IndexedDB blob / cloud tombstone).
             debug(
               `[FilesStore] Updating existing item at path "${newItem.path}"`
             );
+            const uuidRotated =
+              Boolean(newItem.uuid) &&
+              Boolean(existingItem.uuid) &&
+              newItem.uuid !== existingItem.uuid;
             const updatedItem: FileSystemItem = {
               ...existingItem,
               ...newItem,
-              uuid: existingItem.uuid || newItem.uuid, // Preserve existing UUID
+              uuid: uuidRotated
+                ? newItem.uuid
+                : existingItem.uuid || newItem.uuid,
               createdAt: existingItem.createdAt || newItem.createdAt, // Preserve original creation time
               modifiedAt: newItem.modifiedAt || now, // Always update modification time
               // Preserve shareId and createdBy - use nullish coalescing to only fall back if undefined/null

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -620,19 +620,29 @@ export class CloudSyncEngine {
             const corroborated = missing.filter((key) =>
               Boolean(getDeletionMarkerForKey(key))
             );
-            const suspicious =
-              missing.length > SUSPICIOUS_DELETE_COUNT &&
-              missing.length >= shadowKeys.length * SUSPICIOUS_DELETE_RATIO &&
-              corroborated.length < missing.length;
+            // Blob namespaces (books/images/…) routinely lose IndexedDB rows
+            // without user intent (Safari, quota). Inferring a cloud tombstone
+            // from a missing local blob permanently destroys the only copy.
+            // Require an explicit deletion marker for every blob delete.
+            const blobNamespace = isSyncBlobNamespace(namespace);
+            const suspicious = blobNamespace
+              ? corroborated.length < missing.length
+              : missing.length > SUSPICIOUS_DELETE_COUNT &&
+                missing.length >= shadowKeys.length * SUSPICIOUS_DELETE_RATIO &&
+                corroborated.length < missing.length;
             const deletions = suspicious ? corroborated : missing;
             deletionCount = deletions.length;
             suppressedDeletionCount = missing.length - deletions.length;
             if (suspicious && corroborated.length < missing.length) {
               cloudSyncLog.warn("Suppressed uncorroborated deletions", {
                 namespace,
+                blobNamespace,
                 suppressedDeletionCount,
                 missingCount: missing.length,
                 shadowKeyCount: shadowKeys.length,
+                suppressedKeys: missing.filter(
+                  (key) => !getDeletionMarkerForKey(key)
+                ),
               });
             }
             for (const key of deletions) {
@@ -918,17 +928,27 @@ export class CloudSyncEngine {
    * With `forceReload`, an existing local record is discarded first so a
    * corrupt/unreadable blob can be replaced from cloud (used by the Books
    * Safari Blob recovery path).
+   *
+   * When `path` is provided and the cloud blob for `storeKey` is missing,
+   * re-check `files/item:{path}` — a replace on another device may have
+   * minted a new UUID while this device still holds the orphan id.
    */
   async ensureBlobItemLocal(
     namespace: SyncBlobNamespace,
     storeKey: string,
-    options: { forceReload?: boolean } = {}
+    options: {
+      forceReload?: boolean;
+      path?: string;
+      /** Internal: avoid infinite files-metadata repair loops. */
+      _retriedPath?: boolean;
+    } = {}
   ): Promise<boolean> {
     if (!storeKey || this.stopped) return false;
     if (!this.isNamespaceEnabled(namespace)) {
       cloudSyncLog.debug("ensureBlobItemLocal skipped; category disabled", {
         namespace,
         storeKey,
+        path: options.path ?? null,
       });
       return false;
     }
@@ -936,6 +956,9 @@ export class CloudSyncEngine {
     if (!isBlobCodec(codec)) return false;
 
     const syncKey = `${namespace}/item:${storeKey}`;
+    const localFile = options.path
+      ? useFilesStore.getState().items[options.path]
+      : undefined;
     const db = await ensureIndexedDBInitialized();
     const ctx: CodecContext = { db };
     try {
@@ -950,6 +973,7 @@ export class CloudSyncEngine {
         cloudSyncLog.debug("Force-reloading local blob from cloud", {
           namespace,
           storeKey,
+          path: options.path ?? null,
         });
         await codec.deleteItems([storeKey], ctx);
         this.state.deleteShadow(syncKey);
@@ -957,6 +981,12 @@ export class CloudSyncEngine {
         cloudSyncLog.debug("Local blob missing; fetching from cloud", {
           namespace,
           storeKey,
+          path: options.path ?? null,
+          localFileUuid: localFile?.uuid ?? null,
+          localFileStatus: localFile?.status ?? null,
+          localFileModifiedAt: localFile?.modifiedAt ?? null,
+          shadow: this.state.getShadow(syncKey),
+          deletionMarker: getDeletionMarkerForKey(syncKey),
         });
       }
 
@@ -971,7 +1001,22 @@ export class CloudSyncEngine {
         cloudSyncLog.warn("Cloud blob entry missing for local file", {
           namespace,
           storeKey,
+          path: options.path ?? null,
+          tombstoned: Boolean(entry?.del),
+          snapshotEntryCount: Object.keys(snapshot.entries).length,
+          shadow: this.state.getShadow(syncKey),
+          deletionMarker: getDeletionMarkerForKey(syncKey),
+          localFileUuid: localFile?.uuid ?? null,
         });
+
+        if (options.path && !options._retriedPath) {
+          const repaired = await this.repairBlobViaRemoteFileMetadata(
+            namespace,
+            options.path,
+            storeKey
+          );
+          if (repaired) return true;
+        }
         return false;
       }
 
@@ -982,18 +1027,87 @@ export class CloudSyncEngine {
       const restored = await readStoreItemsByKeys(db, codec.storeName, [
         storeKey,
       ]);
+      cloudSyncLog.debug("Cloud blob hydrate result", {
+        namespace,
+        storeKey,
+        path: options.path ?? null,
+        restored: restored.length > 0,
+      });
       return restored.length > 0;
     } catch (error) {
       if (this.stopped || isAbortError(error)) return false;
       cloudSyncLog.error("ensureBlobItemLocal failed", {
         namespace,
         storeKey,
+        path: options.path ?? null,
         error,
       });
       return false;
     } finally {
       db.close();
     }
+  }
+
+  /**
+   * If remote files metadata for `path` points at a different content UUID
+   * than the orphan local id, adopt that metadata and hydrate the new blob.
+   */
+  private async repairBlobViaRemoteFileMetadata(
+    namespace: SyncBlobNamespace,
+    path: string,
+    localUuid: string
+  ): Promise<boolean> {
+    const filesKey = `files/item:${path}`;
+    cloudSyncLog.debug("Attempting blob repair via remote files metadata", {
+      namespace,
+      path,
+      localUuid,
+      filesKey,
+    });
+    const snapshot = await getSyncSnapshot({
+      signal: this.abortController.signal,
+      prefix: filesKey,
+    });
+    if (this.stopped) return false;
+
+    const entry = snapshot.entries[filesKey];
+    const remoteValue =
+      entry && !entry.del && entry.v && typeof entry.v === "object"
+        ? (entry.v as Record<string, unknown>)
+        : null;
+    const remoteUuid =
+      typeof remoteValue?.uuid === "string" ? remoteValue.uuid : null;
+
+    cloudSyncLog.debug("Remote files metadata for orphan blob", {
+      path,
+      localUuid,
+      remoteUuid,
+      remoteStatus:
+        typeof remoteValue?.status === "string" ? remoteValue.status : null,
+      remoteModifiedAt:
+        typeof remoteValue?.modifiedAt === "number"
+          ? remoteValue.modifiedAt
+          : null,
+      hasRemoteEntry: Boolean(entry),
+      remoteDeleted: Boolean(entry?.del),
+    });
+
+    if (!entry || !remoteUuid || remoteUuid === localUuid) {
+      return false;
+    }
+
+    cloudSyncLog.warn("Adopting remote file content UUID for orphan blob", {
+      path,
+      localUuid,
+      remoteUuid,
+    });
+    await this.applyRemoteOps([this.entryToOp(filesKey, entry)], {
+      force: true,
+    });
+    return this.ensureBlobItemLocal(namespace, remoteUuid, {
+      path,
+      _retriedPath: true,
+    });
   }
 
   private entryToOp(key: string, entry: SyncKvEntry): SyncOp {

--- a/tests/unit/sync/test-blob-missing-local-repair.test.ts
+++ b/tests/unit/sync/test-blob-missing-local-repair.test.ts
@@ -5,16 +5,20 @@ import { CloudSyncEngine } from "../../../src/sync/engine";
 import { gzipJson, sha256Json } from "../../../src/sync/blobs";
 import { SyncClientState } from "../../../src/sync/state";
 import { useCloudSyncStore } from "../../../src/stores/useCloudSyncStore";
+import { useFilesStore } from "../../../src/stores/useFilesStore";
 import {
   dbOperations,
   ensureIndexedDBInitialized,
   STORES,
 } from "../../../src/utils/indexedDB";
 import { serializeStoreItem } from "../../../src/utils/indexedDBBackup";
+import type { SyncOp } from "../../../src/shared/sync2/types";
 
 const t = "01718180000000-0000-test";
 const BOOK_UUID = "a66df7db-ef19-4b22-a23c-587dbd2ac620";
+const BOOK_UUID_REMOTE = "b77ef8ec-f020-5c33-b34d-698ece3bd731";
 const SYNC_KEY = `books/item:${BOOK_UUID}`;
+const BOOK_PATH = "/Books/Steve Jobs in Exile.epub";
 const BOOK_NAME = "Steve Jobs in Exile.epub";
 
 async function deleteRyOsDatabase(): Promise<void> {
@@ -48,7 +52,15 @@ describe("cloud sync blob missing-local repair", () => {
       autoSyncEnabled: true,
       syncFiles: true,
       syncBooks: true,
+      deletionMarkers: {
+        ...useCloudSyncStore.getState().deletionMarkers,
+        fileBookKeys: {},
+      },
     });
+    useFilesStore.setState({
+      items: {},
+      libraryState: "loaded",
+    } as never);
   });
 
   afterEach(() => {
@@ -363,5 +375,250 @@ describe("cloud sync blob missing-local repair", () => {
     } finally {
       await engine.stop();
     }
+  });
+
+  test("does not tombstone a missing local book blob without a deletion marker", async () => {
+    const uploadedOps: SyncOp[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/sync/v2/ops")) {
+        const body = JSON.parse(String(init?.body)) as { ops: SyncOp[] };
+        uploadedOps.push(...body.ops);
+        return Response.json({
+          ok: true,
+          seq: body.ops.length,
+          results: body.ops.map((op) => ({
+            k: op.k,
+            accepted: true,
+            seq: 1,
+          })),
+        });
+      }
+      if (url.includes("/api/sync/v2/snapshot")) {
+        return Response.json({ ok: true, seq: 0, entries: {} });
+      }
+      if (url.includes("/api/sync/v2/changes")) {
+        return Response.json({ ok: true, seq: 0, ops: [] });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const engine = await CloudSyncEngine.create(
+      `blob-no-tombstone-${crypto.randomUUID()}`
+    );
+    try {
+      const state = (engine as unknown as { state: SyncClientState }).state;
+      // Shadow says the book was synced, but IndexedDB no longer has bytes.
+      state.setShadow(SYNC_KEY, { t, h: "a".repeat(64) });
+      engine.markDirty("books", [SYNC_KEY]);
+      await engine.flush({ throwOnError: true });
+
+      expect(uploadedOps.some((op) => op.k === SYNC_KEY && op.del)).toBe(false);
+      // Shadow kept — we did not locally record a tombstone either.
+      expect(state.getShadow(SYNC_KEY)?.h).toBe("a".repeat(64));
+    } finally {
+      await engine.stop();
+    }
+  });
+
+  test("tombstones a missing local book blob when explicitly marked deleted", async () => {
+    const uploadedOps: SyncOp[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/api/sync/v2/ops")) {
+        const body = JSON.parse(String(init?.body)) as { ops: SyncOp[] };
+        uploadedOps.push(...body.ops);
+        return Response.json({
+          ok: true,
+          seq: body.ops.length,
+          results: body.ops.map((op) => ({
+            k: op.k,
+            accepted: true,
+            seq: 1,
+          })),
+        });
+      }
+      if (url.includes("/api/sync/v2/snapshot")) {
+        return Response.json({ ok: true, seq: 0, entries: {} });
+      }
+      if (url.includes("/api/sync/v2/changes")) {
+        return Response.json({ ok: true, seq: 0, ops: [] });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    useCloudSyncStore
+      .getState()
+      .markDeletedKeys("fileBookKeys", [BOOK_UUID]);
+
+    const engine = await CloudSyncEngine.create(
+      `blob-tombstone-${crypto.randomUUID()}`
+    );
+    try {
+      const state = (engine as unknown as { state: SyncClientState }).state;
+      state.setShadow(SYNC_KEY, { t, h: "a".repeat(64) });
+      engine.markDirty("books", [SYNC_KEY]);
+      await engine.flush({ throwOnError: true });
+
+      expect(uploadedOps.some((op) => op.k === SYNC_KEY && op.del)).toBe(true);
+      // Accepted deletes clear the local shadow (see sendOps) rather than
+      // leaving an "__del__" placeholder.
+      expect(state.getShadow(SYNC_KEY)).toBeNull();
+    } finally {
+      await engine.stop();
+    }
+  });
+
+  test("ensureBlobItemLocal adopts a newer remote files UUID when local blob is gone", async () => {
+    const remoteItem = await serializeStoreItem({
+      key: BOOK_UUID_REMOTE,
+      value: {
+        name: BOOK_NAME,
+        content: new Blob([new TextEncoder().encode("replacement")], {
+          type: "application/epub+zip",
+        }),
+      },
+    });
+    const digest = await sha256Json(remoteItem);
+    const compressed = await gzipJson(remoteItem);
+    const remoteFilesKey = `files/item:${BOOK_PATH}`;
+    const remoteBlobKey = `books/item:${BOOK_UUID_REMOTE}`;
+
+    useFilesStore.setState({
+      items: {
+        [BOOK_PATH]: {
+          path: BOOK_PATH,
+          name: BOOK_NAME,
+          isDirectory: false,
+          type: "epub",
+          status: "active",
+          uuid: BOOK_UUID,
+          modifiedAt: 1,
+        },
+      },
+      libraryState: "loaded",
+    } as never);
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/sync/v2/snapshot")) {
+        if (url.includes(encodeURIComponent(SYNC_KEY))) {
+          // Local orphan UUID has no cloud blob (tombstoned / never uploaded).
+          return Response.json({ ok: true, seq: 9, entries: {} });
+        }
+        if (url.includes(encodeURIComponent(remoteFilesKey))) {
+          return Response.json({
+            ok: true,
+            seq: 9,
+            entries: {
+              [remoteFilesKey]: {
+                v: {
+                  path: BOOK_PATH,
+                  name: BOOK_NAME,
+                  isDirectory: false,
+                  type: "epub",
+                  status: "active",
+                  uuid: BOOK_UUID_REMOTE,
+                  modifiedAt: 2,
+                },
+                t: `${t}-remote-files`,
+                seq: 8,
+              },
+            },
+          });
+        }
+        if (url.includes(encodeURIComponent(remoteBlobKey))) {
+          return Response.json({
+            ok: true,
+            seq: 9,
+            entries: {
+              [remoteBlobKey]: {
+                v: {
+                  blob: {
+                    url: "https://example.test/book.gz",
+                    size: compressed.byteLength,
+                    sha256: digest,
+                  },
+                },
+                t: `${t}-remote-blob`,
+                seq: 9,
+              },
+            },
+          });
+        }
+        return Response.json({ ok: true, seq: 9, entries: {} });
+      }
+      if (url.includes("example.test/book.gz")) {
+        return new Response(new Blob([compressed]), {
+          status: 200,
+          headers: { "content-length": String(compressed.byteLength) },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const engine = await CloudSyncEngine.create(
+      `blob-repair-path-${crypto.randomUUID()}`
+    );
+    try {
+      const ok = await engine.ensureBlobItemLocal("books", BOOK_UUID, {
+        path: BOOK_PATH,
+      });
+      expect(ok).toBe(true);
+      expect(useFilesStore.getState().items[BOOK_PATH]?.uuid).toBe(
+        BOOK_UUID_REMOTE
+      );
+      const restored = await dbOperations.get<{ content: ArrayBuffer }>(
+        STORES.BOOKS,
+        BOOK_UUID_REMOTE
+      );
+      expect(new TextDecoder().decode(restored!.content)).toBe("replacement");
+    } finally {
+      await engine.stop();
+    }
+  });
+});
+
+describe("files store orphan UUID rotation", () => {
+  test("addItem keeps an explicitly rotated content UUID on update", () => {
+    useFilesStore.setState({
+      items: {
+        "/Books": {
+          path: "/Books",
+          name: "Books",
+          isDirectory: true,
+          type: "directory",
+          status: "active",
+          createdAt: 1,
+          modifiedAt: 1,
+        },
+        [BOOK_PATH]: {
+          path: BOOK_PATH,
+          name: BOOK_NAME,
+          isDirectory: false,
+          type: "epub",
+          status: "active",
+          uuid: BOOK_UUID,
+          createdAt: 1,
+          modifiedAt: 1,
+        },
+      },
+      libraryState: "loaded",
+    } as never);
+
+    useFilesStore.getState().addItem({
+      path: BOOK_PATH,
+      name: BOOK_NAME,
+      isDirectory: false,
+      type: "epub",
+      status: "active",
+      uuid: BOOK_UUID_REMOTE,
+      modifiedAt: 2,
+    });
+
+    expect(useFilesStore.getState().items[BOOK_PATH]?.uuid).toBe(
+      BOOK_UUID_REMOTE
+    );
+    expect(useFilesStore.getState().items[BOOK_PATH]?.createdAt).toBe(1);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #1881 (merged the IndexedDB hydrate / force-reload path). Production logs still showed:

```
Local blob missing; fetching from cloud
Cloud blob entry missing for local file
content:vfs:missing
```

So hydrate worked, but the cloud blob for the VFS UUID was already gone.

### Remaining root causes

1. **False blob tombstones** — Flush inferred cloud deletes when a shadow key was missing from local collect. A single Safari/quota IDB eviction (metadata still pointing at the UUID) could permanently tombstone `books/item:{uuid}` on the server.
2. **Orphan UUID after replace** — Re-import/`saveFile` preserved the old UUID. If that key was already tombstoned in cloud, new bytes never revived it. Devices holding the old UUID also couldn’t adopt a newer remote files UUID for the same path.

## Changes

- Never infer blob-namespace deletes without an explicit deletion marker (`fileBookKeys`, etc.)
- When cloud blob for the local UUID is missing, fetch `files/item:{path}` and adopt a different remote content UUID, then hydrate that blob
- On `saveFile` replace over an orphan UUID (IDB miss), mint a new content UUID; `addItem` honors explicit UUID rotation
- Richer debug-mode logs in Books reader + CloudSync hydrate/repair path

## Test plan

- [x] `bun test tests/unit/sync/test-blob-missing-local-repair.test.ts` (9/9)
- [ ] Manual: with cloud blob tombstoned for old UUID but newer `files/item` UUID + blob present → open adopts remote UUID
- [ ] Manual: re-import over orphan local UUID → new content id + opens

## Note for the stuck book on iPhone

If cloud has neither `books/item:a66df7db-…` nor a newer files UUID with a live blob, recovery is **re-import the EPUB** (this build mints a fresh UUID when local bytes are gone). A device that still has the bytes can sync them up first.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9112-4904-770d-aaed-91be00bcd5fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9112-4904-770d-aaed-91be00bcd5fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

