### PR TITLE
Re-fetch cover & color on karaoke/iPod clear cache and lyrics search

### DIFF
--- a/api/_utils/_song-service.ts
+++ b/api/_utils/_song-service.ts
@@ -137,6 +137,8 @@ export interface SaveSongOptions {
   preserveFurigana?: boolean;
   /** Preserve existing soramimi if not provided */
   preserveSoramimi?: boolean;
+  /** Drop cached cover glow color so clients re-extract it */
+  clearCoverColor?: boolean;
 }
 
 // =============================================================================
@@ -340,7 +342,8 @@ export async function saveSong(
     preserveLyrics = false, 
     preserveTranslations = false, 
     preserveFurigana = false, 
-    preserveSoramimi = false, 
+    preserveSoramimi = false,
+    clearCoverColor = false,
   } = options;
   const now = Date.now();
 
@@ -366,7 +369,9 @@ export async function saveSong(
     artist: song.artist ?? existing?.artist,
     album: song.album ?? existing?.album,
     cover: song.cover ?? existing?.cover,
-    coverColor: song.coverColor ?? (coverChanged ? undefined : existing?.coverColor),
+    coverColor: clearCoverColor
+      ? undefined
+      : (song.coverColor ?? (coverChanged ? undefined : existing?.coverColor)),
     lyricOffset: song.lyricOffset ?? existing?.lyricOffset,
     lyricsSource: song.lyricsSource ?? existing?.lyricsSource,
     createdBy: createdByValue,
@@ -695,13 +700,16 @@ export async function saveLyrics(
 
   // Build/update metadata
   const coverChanged = cover !== undefined && cover !== existingMeta?.cover;
+  // Force refresh / lyrics-source change should drop the cached glow color
+  // even when the cover URL is unchanged, so clients re-extract it.
+  const shouldClearCoverColor = coverChanged || shouldClearAnnotations;
   const meta: SongMetadata = {
     id,
     title: existingMeta?.title || lyricsSource?.title || id,
     artist: existingMeta?.artist || lyricsSource?.artist,
     album: existingMeta?.album || lyricsSource?.album,
     cover: cover ?? existingMeta?.cover,
-    coverColor: coverChanged ? undefined : existingMeta?.coverColor,
+    coverColor: shouldClearCoverColor ? undefined : existingMeta?.coverColor,
     lyricOffset: existingMeta?.lyricOffset,
     lyricsSource: lyricsSource ?? existingMeta?.lyricsSource,
     createdBy: existingMeta?.createdBy,

--- a/api/songs/[id].ts
+++ b/api/songs/[id].ts
@@ -1728,7 +1728,12 @@ export default apiHandler<Record<string, unknown>>(
           return errorResponse("Invalid request body");
         }
 
-        const { clearTranslations: shouldClearTranslations, clearFurigana: shouldClearFurigana, clearSoramimi: shouldClearSoramimi } = parsed.data;
+        const {
+          clearTranslations: shouldClearTranslations,
+          clearFurigana: shouldClearFurigana,
+          clearSoramimi: shouldClearSoramimi,
+          clearCoverColor: shouldClearCoverColor,
+        } = parsed.data;
 
         // Get song to check what needs clearing
         const song = await getSong(redis, songId, {
@@ -1769,6 +1774,14 @@ export default apiHandler<Record<string, unknown>>(
             await saveSong(redis, { id: songId, soramimi: [], soramimiByLang: {} }, { preserveSoramimi: false });
           }
           cleared.push("soramimi");
+        }
+
+        // Clear cached cover glow color so clients re-extract after cover refresh
+        if (shouldClearCoverColor) {
+          if (song.coverColor) {
+            await saveSong(redis, { id: songId }, { clearCoverColor: true });
+          }
+          cleared.push("coverColor");
         }
 
         logger.info(`Cleared cached data: ${cleared.length > 0 ? cleared.join(", ") : "nothing to clear"}`);
@@ -1837,7 +1850,16 @@ export default apiHandler<Record<string, unknown>>(
 
       // Update song
       const isUpdate = !!existingSong;
-      const { lyricsSource, clearTranslations, clearFurigana, clearSoramimi, clearLyrics, isShare, ...restData } = parsed.data;
+      const {
+        lyricsSource,
+        clearTranslations,
+        clearFurigana,
+        clearSoramimi,
+        clearLyrics,
+        clearCoverColor,
+        isShare,
+        ...restData
+      } = parsed.data;
       
       // Determine what to preserve vs clear
       const preserveOptions = {
@@ -1845,6 +1867,7 @@ export default apiHandler<Record<string, unknown>>(
         preserveTranslations: !clearTranslations,
         preserveFurigana: !clearFurigana,
         preserveSoramimi: !clearSoramimi,
+        clearCoverColor: Boolean(clearCoverColor),
       };
 
       // Determine createdBy

--- a/api/songs/_constants.ts
+++ b/api/songs/_constants.ts
@@ -74,6 +74,7 @@ export const UpdateSongSchema = z.object({
   clearFurigana: z.boolean().optional(),
   clearSoramimi: z.boolean().optional(),
   clearLyrics: z.boolean().optional(),
+  clearCoverColor: z.boolean().optional(),
   // Flag to indicate this is a share action (sets createdBy)
   isShare: z.boolean().optional(),
 });
@@ -134,12 +135,13 @@ export const SoramimiStreamSchema = z.object({
   }))).optional(),
 });
 
-// Schema for clearing cached translations, furigana, and soramimi
+// Schema for clearing cached translations, furigana, soramimi, and cover color
 export const ClearCachedDataSchema = z.object({
   action: z.literal("clear-cached-data"),
   clearTranslations: z.boolean().optional(),
   clearFurigana: z.boolean().optional(),
   clearSoramimi: z.boolean().optional(),
+  clearCoverColor: z.boolean().optional(),
 });
 
 // Schema for unsharing a song (clearing createdBy)

--- a/src/api/songs.ts
+++ b/src/api/songs.ts
@@ -57,6 +57,7 @@ export interface SongMetadataPatch {
   clearFurigana?: boolean;
   clearSoramimi?: boolean;
   clearLyrics?: boolean;
+  clearCoverColor?: boolean;
   isShare?: boolean;
 }
 
@@ -354,6 +355,7 @@ export async function clearSongCachedData(
     clearTranslations?: boolean;
     clearFurigana?: boolean;
     clearSoramimi?: boolean;
+    clearCoverColor?: boolean;
   } = {}
 ): Promise<Record<string, unknown>> {
   invalidateLyricsCacheForSong(songId);
@@ -365,6 +367,7 @@ export async function clearSongCachedData(
       clearTranslations: options.clearTranslations ?? true,
       clearFurigana: options.clearFurigana ?? true,
       clearSoramimi: options.clearSoramimi ?? true,
+      clearCoverColor: options.clearCoverColor ?? true,
     },
   });
 }

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -198,7 +198,6 @@ export function useIpodLogic({
     youtubePreviousTrack,
     appleMusicNextTrack,
     appleMusicPreviousTrack,
-    refreshLyrics,
     setTrackLyricsSource,
     clearTrackLyricsSource,
     setLyricOffset,
@@ -236,7 +235,6 @@ export function useIpodLogic({
     youtubePreviousTrack: s.previousTrack,
     appleMusicNextTrack: s.appleMusicNextTrack,
     appleMusicPreviousTrack: s.appleMusicPreviousTrack,
-    refreshLyrics: s.refreshLyrics,
     setTrackLyricsSource: s.setTrackLyricsSource,
     clearTrackLyricsSource: s.clearTrackLyricsSource,
     setDisplayMode: s.setDisplayMode,
@@ -4788,23 +4786,31 @@ export function useIpodLogic({
   );
 
   const handleLyricsSearchSelect = useCallback(
-    (result: { hash: string; albumId: string | number; title: string; artist: string; album?: string }) => {
+    (result: {
+      hash: string;
+      albumId: string | number;
+      title: string;
+      artist: string;
+      album?: string;
+      cover?: string;
+    }) => {
       const targetId = resolveLyricsOverrideTargetId();
       if (targetId) {
-        setTrackLyricsSource(targetId, result);
-        refreshLyrics();
+        // Updates local+AM cover, clears coverColor, hard-refetches lyrics
+        // (returnMetadata applies the refreshed cover into local/cloud caches).
+        setTrackLyricsSource(targetId, result, { cover: result.cover });
       }
     },
-    [resolveLyricsOverrideTargetId, setTrackLyricsSource, refreshLyrics]
+    [resolveLyricsOverrideTargetId, setTrackLyricsSource]
   );
 
   const handleLyricsSearchReset = useCallback(() => {
     const targetId = resolveLyricsOverrideTargetId();
     if (targetId) {
+      // clearTrackLyricsSource already hard-refetches lyrics
       clearTrackLyricsSource(targetId);
-      refreshLyrics();
     }
-  }, [resolveLyricsOverrideTargetId, clearTrackLyricsSource, refreshLyrics]);
+  }, [resolveLyricsOverrideTargetId, clearTrackLyricsSource]);
 
   const ipodGenerateShareUrl = useCallback(
     (songId: string): string => {

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -94,7 +94,6 @@ export function useKaraokeLogic({
     setLyricsTranslationLanguage,
     toggleLyrics,
     clearLibrary,
-    refreshLyrics,
     setTrackLyricsSource,
     clearTrackLyricsSource,
     addTrackFromVideoId,
@@ -105,7 +104,6 @@ export function useKaraokeLogic({
     setLyricsTranslationLanguage: s.setLyricsTranslationLanguage,
     toggleLyrics: s.toggleLyrics,
     clearLibrary: s.clearLibrary,
-    refreshLyrics: s.refreshLyrics,
     setTrackLyricsSource: s.setTrackLyricsSource,
     clearTrackLyricsSource: s.clearTrackLyricsSource,
     addTrackFromVideoId: s.addTrackFromVideoId,
@@ -1412,23 +1410,31 @@ export function useKaraokeLogic({
   }, [tracks, currentIndex]);
 
   const handleLyricsSearchSelect = useCallback(
-    (result: { hash: string; albumId: string | number; title: string; artist: string; album?: string }) => {
+    (result: {
+      hash: string;
+      albumId: string | number;
+      title: string;
+      artist: string;
+      album?: string;
+      cover?: string;
+    }) => {
       const track = tracks[currentIndex];
       if (track) {
-        setTrackLyricsSource(track.id, result);
-        refreshLyrics();
+        // Updates local cover, clears coverColor, hard-refetches lyrics
+        // (returnMetadata applies the refreshed cover into local/cloud caches).
+        setTrackLyricsSource(track.id, result, { cover: result.cover });
       }
     },
-    [tracks, currentIndex, setTrackLyricsSource, refreshLyrics]
+    [tracks, currentIndex, setTrackLyricsSource]
   );
 
   const handleLyricsSearchReset = useCallback(() => {
     const track = tracks[currentIndex];
     if (track) {
+      // clearTrackLyricsSource already hard-refetches lyrics
       clearTrackLyricsSource(track.id);
-      refreshLyrics();
     }
-  }, [tracks, currentIndex, clearTrackLyricsSource, refreshLyrics]);
+  }, [tracks, currentIndex, clearTrackLyricsSource]);
 
   // Song search/add handlers
   const handleAddSong = useCallback(() => {

--- a/src/hooks/useLyrics.ts
+++ b/src/hooks/useLyrics.ts
@@ -110,6 +110,20 @@ interface UnifiedLyricsResponse {
   translation?: TranslationStreamInfo;
   furigana?: FuriganaStreamInfo;
   soramimi?: SoramimiStreamInfo;
+  metadata?: {
+    title?: string;
+    artist?: string;
+    album?: string;
+    cover?: string;
+    coverColor?: string;
+    lyricsSource?: {
+      hash: string;
+      albumId: string | number;
+      title: string;
+      artist: string;
+      album?: string;
+    };
+  };
 }
 
 interface LyricsLogContext {
@@ -450,7 +464,10 @@ export function useLyrics(
       isAuthenticated: Boolean(authCredentials),
     });
 
-    // Build request - include translateTo, includeFurigana, includeSoramimi to reduce round-trips
+    // Build request - include translateTo, includeFurigana, includeSoramimi to reduce round-trips.
+    // Clear-cache and lyrics-search bump lyricsCacheBustTrigger; ask for metadata then
+    // so we can refresh local cover + color caches (and Cloud Sync via the store).
+    const shouldReturnMetadata = isCacheBustRequest;
     const requestBody: Record<string, unknown> = {
       action: "fetch-lyrics",
       force: forceServerFetch,
@@ -461,6 +478,7 @@ export function useLyrics(
       includeFurigana: includeFurigana || undefined,
       includeSoramimi: includeSoramimi || undefined,
       soramimiTargetLanguage: includeSoramimi ? soramimiTargetLanguage : undefined,
+      returnMetadata: shouldReturnMetadata || undefined,
     };
 
     if (selectedMatch) {
@@ -478,6 +496,7 @@ export function useLyrics(
       force: Boolean(requestBody.force),
       isRefetchRequest,
       isCacheBustRequest,
+      returnMetadata: shouldReturnMetadata,
       hasAuthenticatedUser: Boolean(authCredentials),
     });
     fetchLyrics(effectSongId, {
@@ -496,6 +515,7 @@ export function useLyrics(
       lyricsSource: requestBody.lyricsSource as
         | NonNullable<Parameters<typeof fetchSongLyrics>[1]>["lyricsSource"]
         | undefined,
+      returnMetadata: shouldReturnMetadata,
       signal: controller.signal,
     })
       .then(async (json) => {
@@ -533,6 +553,33 @@ export function useLyrics(
         });
         cachedKeyRef.current = cacheKey;
         useIpodStore.setState({ currentLyrics: { lines: parsed } });
+
+        // Refresh local + cloud-synced cover metadata after clear-cache / search.
+        // Server clears coverColor on force/source-change; apply cover and clear
+        // local color so glow extraction re-runs and re-saves.
+        if (shouldReturnMetadata && json.metadata) {
+          const meta = json.metadata;
+          const coverUpdate: {
+            cover?: string;
+            coverColor?: string | null;
+          } = {};
+          if (typeof meta.cover === "string" && meta.cover.length > 0) {
+            coverUpdate.cover = meta.cover;
+          }
+          if (typeof meta.coverColor === "string" && meta.coverColor.length > 0) {
+            coverUpdate.coverColor = meta.coverColor;
+          } else {
+            coverUpdate.coverColor = null;
+          }
+          if (coverUpdate.cover !== undefined || coverUpdate.coverColor !== undefined) {
+            useIpodStore.getState().applyTrackCoverMetadata(effectSongId, coverUpdate);
+            lyricsLog.debug("Applied cover metadata from lyrics fetch", {
+              ...logContext,
+              cover: coverUpdate.cover,
+              coverColor: coverUpdate.coverColor,
+            });
+          }
+        }
 
         // Store translation info for the translation effect to use (with language to ensure correct matching)
         if (json.translation && translateTo) {

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -123,6 +123,202 @@ function updateTrackCoverColorList(
   return { tracks: changed ? updatedTracks : tracks, changed };
 }
 
+/** Patch applied to every local copy of a track (YouTube + Apple Music caches). */
+export interface TrackCoverMetadataUpdate {
+  cover?: string;
+  /** Set a new color, or `null` to clear a cached glow color. */
+  coverColor?: string | null;
+}
+
+function updateTrackCoverMetadataList(
+  tracks: Track[],
+  trackId: string,
+  update: TrackCoverMetadataUpdate
+): { tracks: Track[]; changed: boolean } {
+  let changed = false;
+  const updatedTracks = tracks.map((track) => {
+    if (track.id !== trackId) return track;
+
+    let next: Track = track;
+    if (update.cover !== undefined && track.cover !== update.cover) {
+      next = { ...next, cover: update.cover };
+    }
+    if (update.coverColor !== undefined) {
+      const nextColor =
+        update.coverColor === null ? undefined : update.coverColor;
+      if (track.coverColor !== nextColor) {
+        next = { ...next, coverColor: nextColor };
+      }
+    }
+    // Cover art change always invalidates a stale glow color unless a
+    // replacement color was explicitly provided in the same update.
+    if (
+      update.cover !== undefined &&
+      track.cover !== update.cover &&
+      update.coverColor === undefined &&
+      next.coverColor !== undefined
+    ) {
+      next = { ...next, coverColor: undefined };
+    }
+
+    if (next !== track) changed = true;
+    return next;
+  });
+  return { tracks: changed ? updatedTracks : tracks, changed };
+}
+
+type IpodAppleMusicCollectionState = Pick<
+  IpodState,
+  | "tracks"
+  | "appleMusicTracks"
+  | "appleMusicRecentlyAddedTracks"
+  | "appleMusicFavoriteTracks"
+  | "appleMusicPlaylistTracks"
+  | "appleMusicLibraryLoadedAt"
+  | "appleMusicStorefrontId"
+  | "appleMusicRecentlyAddedLoadedAt"
+  | "appleMusicFavoriteTracksLoadedAt"
+  | "appleMusicPlaylistTracksLoadedAt"
+>;
+
+function applyTrackListUpdateAcrossLibraries(
+  state: IpodAppleMusicCollectionState,
+  trackId: string,
+  updateList: (
+    tracks: Track[],
+    trackId: string
+  ) => { tracks: Track[]; changed: boolean }
+): {
+  nextState: Partial<IpodAppleMusicCollectionState>;
+  changed: boolean;
+  appleMusicTracksToSave: Track[] | null;
+  appleMusicLoadedAt: number;
+  appleMusicStorefrontId: string | null;
+  recentlyAddedTracksToSave: { tracks: Track[]; loadedAt: number } | null;
+  favoriteTracksToSave: { tracks: Track[]; loadedAt: number } | null;
+  playlistTracksToSave: {
+    playlistId: string;
+    tracks: Track[];
+    loadedAt: number;
+  }[];
+} {
+  const youtubeUpdate = updateList(state.tracks, trackId);
+  const appleMusicUpdate = updateList(state.appleMusicTracks, trackId);
+  const recentlyAddedUpdate = updateList(
+    state.appleMusicRecentlyAddedTracks,
+    trackId
+  );
+  const favoritesUpdate = updateList(
+    state.appleMusicFavoriteTracks,
+    trackId
+  );
+
+  let playlistTracksChanged = false;
+  const nextPlaylistTracks: Record<string, Track[]> = {};
+  for (const [playlistId, tracks] of Object.entries(
+    state.appleMusicPlaylistTracks
+  )) {
+    const playlistUpdate = updateList(tracks, trackId);
+    nextPlaylistTracks[playlistId] = playlistUpdate.tracks;
+    playlistTracksChanged ||= playlistUpdate.changed;
+  }
+
+  const changed =
+    youtubeUpdate.changed ||
+    appleMusicUpdate.changed ||
+    recentlyAddedUpdate.changed ||
+    favoritesUpdate.changed ||
+    playlistTracksChanged;
+
+  return {
+    changed,
+    nextState: changed
+      ? {
+          tracks: youtubeUpdate.tracks,
+          appleMusicTracks: appleMusicUpdate.tracks,
+          appleMusicRecentlyAddedTracks: recentlyAddedUpdate.tracks,
+          appleMusicFavoriteTracks: favoritesUpdate.tracks,
+          ...(playlistTracksChanged && {
+            appleMusicPlaylistTracks: nextPlaylistTracks,
+          }),
+        }
+      : {},
+    appleMusicTracksToSave: appleMusicUpdate.changed
+      ? appleMusicUpdate.tracks.filter(
+          (track) => !isAppleMusicCollectionTrack(track)
+        )
+      : null,
+    appleMusicLoadedAt: state.appleMusicLibraryLoadedAt ?? Date.now(),
+    appleMusicStorefrontId: state.appleMusicStorefrontId,
+    recentlyAddedTracksToSave: recentlyAddedUpdate.changed
+      ? {
+          tracks: recentlyAddedUpdate.tracks,
+          loadedAt: state.appleMusicRecentlyAddedLoadedAt ?? Date.now(),
+        }
+      : null,
+    favoriteTracksToSave: favoritesUpdate.changed
+      ? {
+          tracks: favoritesUpdate.tracks,
+          loadedAt: state.appleMusicFavoriteTracksLoadedAt ?? Date.now(),
+        }
+      : null,
+    playlistTracksToSave: playlistTracksChanged
+      ? Object.entries(nextPlaylistTracks).flatMap(([playlistId, tracks]) => {
+          const originalTracks = state.appleMusicPlaylistTracks[playlistId];
+          if (tracks === originalTracks) return [];
+          return [
+            {
+              playlistId,
+              tracks,
+              loadedAt:
+                state.appleMusicPlaylistTracksLoadedAt[playlistId] ??
+                Date.now(),
+            },
+          ];
+        })
+      : [],
+  };
+}
+
+function persistAppleMusicTrackCollectionUpdates(result: {
+  appleMusicTracksToSave: Track[] | null;
+  appleMusicLoadedAt: number;
+  appleMusicStorefrontId: string | null;
+  recentlyAddedTracksToSave: { tracks: Track[]; loadedAt: number } | null;
+  favoriteTracksToSave: { tracks: Track[]; loadedAt: number } | null;
+  playlistTracksToSave: {
+    playlistId: string;
+    tracks: Track[];
+    loadedAt: number;
+  }[];
+}): void {
+  if (result.appleMusicTracksToSave) {
+    void saveAppleMusicLibrary({
+      tracks: result.appleMusicTracksToSave,
+      loadedAt: result.appleMusicLoadedAt,
+      storefrontId: result.appleMusicStorefrontId,
+    });
+  }
+  if (result.recentlyAddedTracksToSave) {
+    void saveAppleMusicTrackCollection(
+      "recently-added",
+      result.recentlyAddedTracksToSave
+    );
+  }
+  if (result.favoriteTracksToSave) {
+    void saveAppleMusicTrackCollection(
+      "favorite-songs",
+      result.favoriteTracksToSave
+    );
+  }
+  for (const playlistTracks of result.playlistTracksToSave) {
+    void saveAppleMusicPlaylistTracks(playlistTracks.playlistId, {
+      tracks: playlistTracks.tracks,
+      loadedAt: playlistTracks.loadedAt,
+    });
+  }
+}
+
 /**
  * Live now-playing row from MusicKit (`mediaItemDidChange`) while a station or
  * catalog playlist queue is active. Drives LCD metadata, title bar rotation,
@@ -450,6 +646,16 @@ export interface IpodState extends IpodData {
   addTrack: (track: Track) => void;
   /** Cache a resolved cover glow color on any local copy of a track. */
   setTrackCoverColor: (trackId: string, coverColor: string) => void;
+  /**
+   * Apply cover URL / glow-color updates to every local copy of a track
+   * (YouTube library + Apple Music caches). Persists into IndexedDB /
+   * Cloud Sync via the songs store. Pass `coverColor: null` to clear a
+   * stale cached color so extraction re-runs.
+   */
+  applyTrackCoverMetadata: (
+    trackId: string,
+    update: TrackCoverMetadataUpdate
+  ) => void;
   /** Remove one track from the library by id (e.g. TV playlist trash). */
   removeTrackById: (trackId: string) => void;
   clearLibrary: () => void;
@@ -504,7 +710,8 @@ export interface IpodState extends IpodData {
   /** Set lyrics source override for a specific track */
   setTrackLyricsSource: (
     trackId: string,
-    lyricsSource: LyricsSource | null
+    lyricsSource: LyricsSource | null,
+    options?: { cover?: string }
   ) => void;
   /** Clear lyrics source override for a specific track */
   clearTrackLyricsSource: (trackId: string) => void;
@@ -1011,7 +1218,8 @@ export async function flushPendingLyricOffsetSave(trackId: string): Promise<void
  */
 async function saveLyricsSourceToServer(
   trackId: string,
-  lyricsSource: LyricsSource | null
+  lyricsSource: LyricsSource | null,
+  options?: { cover?: string }
 ): Promise<void> {
   // Get auth state from chats store
   const { username, isAuthenticated } = useChatsStore.getState();
@@ -1033,15 +1241,17 @@ async function saveLyricsSourceToServer(
           artist: lyricsSource.artist,
           album: lyricsSource.album,
         }),
-        // Clear translations, furigana, and soramimi since lyrics changed
+        ...(options?.cover ? { cover: options.cover } : {}),
+        // Clear translations, furigana, soramimi, and cover color since lyrics/cover changed
         clearTranslations: true,
         clearFurigana: true,
         clearSoramimi: true,
         clearLyrics: true,
+        clearCoverColor: true,
       },
       { username, isAuthenticated }
     );
-    debug(`[iPod Store] Saved lyrics source for ${trackId}, cleared translations/furigana (by ${data.createdBy || username})`);
+    debug(`[iPod Store] Saved lyrics source for ${trackId}, cleared translations/furigana/coverColor (by ${data.createdBy || username})`);
   } catch (error) {
     if (error instanceof ApiRequestError) {
       if (error.status === 401) {
@@ -1422,21 +1632,46 @@ export const useIpodStore = create<IpodState>()(
       clearLyricsCache: () => {
         const state = get();
         const currentTrack = getActiveIpodCurrentTrack(state);
+        const trackId = currentTrack?.id;
         
-        // Clear server-side cache for translations, furigana, and soramimi
-        if (currentTrack?.id) {
-          clearSongCachedData(currentTrack.id).catch((err) => {
+        // Clear server-side cache for translations, furigana, soramimi, and cover color
+        if (trackId) {
+          clearSongCachedData(trackId, { clearCoverColor: true }).catch((err) => {
             console.error("[iPod Store] Failed to clear server cache:", err);
           });
         }
         
-        // Clear local state and trigger refetch
-        set((s) => ({
-          lyricsRefetchTrigger: s.lyricsRefetchTrigger + 1,
-          lyricsCacheBustTrigger: s.lyricsCacheBustTrigger + 1,
-          currentLyrics: null,
-          currentFuriganaMap: null,
-        }));
+        // Clear local cover glow color so extraction re-runs after cover refresh,
+        // then bust lyrics caches and force a refetch (with returnMetadata).
+        set((s) => {
+          const coverClear = trackId
+            ? applyTrackListUpdateAcrossLibraries(s, trackId, (tracks, id) =>
+                updateTrackCoverMetadataList(tracks, id, { coverColor: null })
+              )
+            : null;
+          if (coverClear) {
+            persistAppleMusicTrackCollectionUpdates(coverClear);
+          }
+          return {
+            ...(coverClear?.nextState ?? {}),
+            lyricsRefetchTrigger: s.lyricsRefetchTrigger + 1,
+            lyricsCacheBustTrigger: s.lyricsCacheBustTrigger + 1,
+            currentLyrics: null,
+            currentFuriganaMap: null,
+          };
+        });
+      },
+      applyTrackCoverMetadata: (trackId, update) => {
+        set((state) => {
+          const result = applyTrackListUpdateAcrossLibraries(
+            state,
+            trackId,
+            (tracks, id) => updateTrackCoverMetadataList(tracks, id, update)
+          );
+          if (!result.changed) return {};
+          persistAppleMusicTrackCollectionUpdates(result);
+          return result.nextState;
+        });
       },
       setCurrentFuriganaMap: (map) => set({ currentFuriganaMap: map }),
       adjustLyricOffset: (trackIndex, deltaMs, library = "active") => {
@@ -1960,39 +2195,95 @@ export const useIpodStore = create<IpodState>()(
           throw error;
         }
       },
-      setTrackLyricsSource: (trackId, lyricsSource) => {
+      setTrackLyricsSource: (trackId, lyricsSource, options) => {
         set((state) => {
-          const tracks = state.tracks.map((track) =>
-            track.id === trackId
-              ? {
+          const result = applyTrackListUpdateAcrossLibraries(
+            state,
+            trackId,
+            (tracks, id) => {
+              let changed = false;
+              const updatedTracks = tracks.map((track) => {
+                if (track.id !== id) return track;
+                const nextCover =
+                  options?.cover !== undefined ? options.cover : track.cover;
+                const coverChanged =
+                  options?.cover !== undefined && track.cover !== options.cover;
+                const next: Track = {
                   ...track,
                   lyricsSource: lyricsSource || undefined,
-                  // Update track metadata from lyricsSource (KuGou has more accurate metadata)
                   ...(lyricsSource && {
                     title: lyricsSource.title,
                     artist: lyricsSource.artist,
                     album: lyricsSource.album || track.album,
                   }),
+                  ...(options?.cover !== undefined && { cover: nextCover }),
+                  // Always drop cached glow color on lyrics-source change so
+                  // the new (or same) cover is re-sampled.
+                  coverColor: undefined,
+                };
+                const unchanged =
+                  track.lyricsSource === next.lyricsSource &&
+                  track.title === next.title &&
+                  track.artist === next.artist &&
+                  track.album === next.album &&
+                  track.cover === next.cover &&
+                  track.coverColor === next.coverColor &&
+                  !coverChanged;
+                if (unchanged && track.coverColor === undefined) {
+                  return track;
                 }
-              : track
+                changed = true;
+                return next;
+              });
+              return { tracks: changed ? updatedTracks : tracks, changed };
+            }
           );
-          return { tracks };
+          if (result.changed) {
+            persistAppleMusicTrackCollectionUpdates(result);
+          }
+          return {
+            ...result.nextState,
+            // Hard-refresh lyrics so fetch-lyrics re-pulls cover metadata
+            lyricsRefetchTrigger: state.lyricsRefetchTrigger + 1,
+            lyricsCacheBustTrigger: state.lyricsCacheBustTrigger + 1,
+            currentLyrics: null,
+            currentFuriganaMap: null,
+          };
         });
         
-        // Save to server and clear translations/furigana
-        saveLyricsSourceToServer(trackId, lyricsSource);
+        // Save to server and clear translations/furigana/coverColor
+        saveLyricsSourceToServer(trackId, lyricsSource, options);
       },
       clearTrackLyricsSource: (trackId) => {
         set((state) => {
-          const tracks = state.tracks.map((track) =>
-            track.id === trackId
-              ? {
+          const result = applyTrackListUpdateAcrossLibraries(
+            state,
+            trackId,
+            (tracks, id) => {
+              let changed = false;
+              const updatedTracks = tracks.map((track) => {
+                if (track.id !== id || track.lyricsSource === undefined) {
+                  return track;
+                }
+                changed = true;
+                return {
                   ...track,
                   lyricsSource: undefined,
-                }
-              : track
+                };
+              });
+              return { tracks: changed ? updatedTracks : tracks, changed };
+            }
           );
-          return { tracks };
+          if (result.changed) {
+            persistAppleMusicTrackCollectionUpdates(result);
+          }
+          return {
+            ...result.nextState,
+            lyricsRefetchTrigger: state.lyricsRefetchTrigger + 1,
+            lyricsCacheBustTrigger: state.lyricsCacheBustTrigger + 1,
+            currentLyrics: null,
+            currentFuriganaMap: null,
+          };
         });
         
         // Save to server (clearing the source) and clear translations/furigana

--- a/tests/unit/chat/test-chat-tools-songs.test.ts
+++ b/tests/unit/chat/test-chat-tools-songs.test.ts
@@ -142,6 +142,55 @@ describe("song library chat tools", () => {
     expect(updated.coverColor).toBeUndefined();
   });
 
+  test("saveLyrics clears coverColor on force refresh even when cover URL is unchanged", async () => {
+    const redis = new FakeRedis();
+    const cover = "https://example.com/cover-same.png";
+
+    await saveLyrics(
+      redis as unknown as Redis,
+      "song_color_force",
+      { lrc: "[00:00.00]hello" },
+      undefined,
+      cover
+    );
+    await saveSong(redis as unknown as Redis, {
+      id: "song_color_force",
+      coverColor: "#fedcba",
+    });
+
+    const updated = await saveLyrics(
+      redis as unknown as Redis,
+      "song_color_force",
+      { lrc: "[00:00.00]hello again" },
+      undefined,
+      cover,
+      true // clearAnnotations / force refresh
+    );
+
+    expect(updated.cover).toBe(cover);
+    expect(updated.coverColor).toBeUndefined();
+  });
+
+  test("saveSong clearCoverColor drops cached glow color without changing cover", async () => {
+    const redis = new FakeRedis();
+
+    await saveSong(redis as unknown as Redis, {
+      id: "song_clear_color",
+      title: "Clear Color",
+      cover: "https://example.com/cover.png",
+      coverColor: "#112233",
+    });
+
+    const cleared = await saveSong(
+      redis as unknown as Redis,
+      { id: "song_clear_color" },
+      { clearCoverColor: true }
+    );
+
+    expect(cleared.cover).toBe("https://example.com/cover.png");
+    expect(cleared.coverColor).toBeUndefined();
+  });
+
   test("all profile does not expose songLibraryControl", () => {
     const tools = createChatTools(createContext(new FakeRedis()), { profile: "all" });
     expect("songLibraryControl" in tools).toBe(false);

--- a/tests/unit/ipod/test-ipod-lyrics-track-metadata.test.ts
+++ b/tests/unit/ipod/test-ipod-lyrics-track-metadata.test.ts
@@ -274,6 +274,148 @@ describe("setTrackCoverColor", () => {
   });
 });
 
+describe("applyTrackCoverMetadata / setTrackLyricsSource / clearLyricsCache", () => {
+  test("applyTrackCoverMetadata updates cover and clears color across libraries", async () => {
+    useIpodStore.setState({
+      tracks: [
+        {
+          id: "dQw4w9WgXcQ",
+          url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          title: "Never Gonna Give You Up",
+          cover: "https://example.com/old.png",
+          coverColor: "#111111",
+        },
+      ],
+      appleMusicTracks: [
+        {
+          id: "am:1616228595",
+          url: "applemusic:1616228595",
+          title: "Bohemian Rhapsody",
+          source: "appleMusic",
+          cover: "https://example.com/am-old.png",
+          coverColor: "#222222",
+        },
+      ],
+      appleMusicRecentlyAddedTracks: [],
+      appleMusicFavoriteTracks: [],
+      appleMusicPlaylistTracks: {},
+    });
+
+    useIpodStore.getState().applyTrackCoverMetadata("dQw4w9WgXcQ", {
+      cover: "https://example.com/new.png",
+      coverColor: null,
+    });
+    useIpodStore.getState().applyTrackCoverMetadata("am:1616228595", {
+      cover: "https://example.com/am-new.png",
+    });
+
+    const updated = useIpodStore.getState();
+    expect(updated.tracks[0]?.cover).toBe("https://example.com/new.png");
+    expect(updated.tracks[0]?.coverColor).toBeUndefined();
+    expect(updated.appleMusicTracks[0]?.cover).toBe(
+      "https://example.com/am-new.png"
+    );
+    // Cover URL change without an explicit color clears the stale glow color.
+    expect(updated.appleMusicTracks[0]?.coverColor).toBeUndefined();
+
+    await settlePersistWrites();
+    const persisted = (await readPersistedIpodState()) as {
+      state?: { tracks?: Track[] };
+    };
+    expect(persisted.state?.tracks?.[0]?.cover).toBe(
+      "https://example.com/new.png"
+    );
+    expect(persisted.state?.tracks?.[0]?.coverColor).toBeUndefined();
+  });
+
+  test("setTrackLyricsSource applies cover, clears color, and hard-refetches", () => {
+    useIpodStore.setState({
+      tracks: [
+        {
+          id: "dQw4w9WgXcQ",
+          url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          title: "Old Title",
+          artist: "Old Artist",
+          cover: "https://example.com/old.png",
+          coverColor: "#abcdef",
+        },
+      ],
+      appleMusicTracks: [],
+      lyricsRefetchTrigger: 0,
+      lyricsCacheBustTrigger: 0,
+      currentLyrics: { lines: [{ startTimeMs: "0", words: "hi" }] },
+      currentFuriganaMap: { "0": [{ text: "hi" }] },
+    });
+
+    useIpodStore.getState().setTrackLyricsSource(
+      "dQw4w9WgXcQ",
+      {
+        hash: "abc",
+        albumId: "1",
+        title: "New Title",
+        artist: "New Artist",
+        album: "New Album",
+      },
+      { cover: "https://example.com/kugou/{size}.jpg" }
+    );
+
+    const updated = useIpodStore.getState();
+    expect(updated.tracks[0]?.lyricsSource?.hash).toBe("abc");
+    expect(updated.tracks[0]?.title).toBe("New Title");
+    expect(updated.tracks[0]?.artist).toBe("New Artist");
+    expect(updated.tracks[0]?.cover).toBe(
+      "https://example.com/kugou/{size}.jpg"
+    );
+    expect(updated.tracks[0]?.coverColor).toBeUndefined();
+    expect(updated.lyricsRefetchTrigger).toBe(1);
+    expect(updated.lyricsCacheBustTrigger).toBe(1);
+    expect(updated.currentLyrics).toBeNull();
+    expect(updated.currentFuriganaMap).toBeNull();
+  });
+
+  test("clearLyricsCache clears local coverColor and busts lyrics caches", () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ success: true, cleared: ["coverColor"] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as typeof fetch;
+
+    try {
+      useIpodStore.setState({
+        tracks: [
+          {
+            id: "dQw4w9WgXcQ",
+            url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            title: "Never Gonna Give You Up",
+            cover: "https://example.com/cover.png",
+            coverColor: "#123456",
+          },
+        ],
+        currentSongId: "dQw4w9WgXcQ",
+        librarySource: "youtube",
+        appleMusicTracks: [],
+        lyricsRefetchTrigger: 3,
+        lyricsCacheBustTrigger: 5,
+        currentLyrics: { lines: [{ startTimeMs: "0", words: "hi" }] },
+        currentFuriganaMap: { "0": [{ text: "hi" }] },
+      });
+
+      useIpodStore.getState().clearLyricsCache();
+
+      const updated = useIpodStore.getState();
+      expect(updated.tracks[0]?.cover).toBe("https://example.com/cover.png");
+      expect(updated.tracks[0]?.coverColor).toBeUndefined();
+      expect(updated.lyricsRefetchTrigger).toBe(4);
+      expect(updated.lyricsCacheBustTrigger).toBe(6);
+      expect(updated.currentLyrics).toBeNull();
+      expect(updated.currentFuriganaMap).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
 describe("resolveLyricsOverrideTargetId", () => {
   test("returns the YouTube track id directly", () => {
     expect(resolveLyricsOverrideTargetId(youtubeTrack, null)).toBe(

--- a/tests/unit/songs/test-song-chinese-lyrics.test.ts
+++ b/tests/unit/songs/test-song-chinese-lyrics.test.ts
@@ -12,7 +12,11 @@ import {
   saveLyrics,
   saveTranslations,
 } from "../../../api/_utils/_song-service";
-import { FetchLyricsSchema } from "../../../api/songs/_constants";
+import {
+  ClearCachedDataSchema,
+  FetchLyricsSchema,
+  UpdateSongSchema,
+} from "../../../api/songs/_constants";
 import { FakeRedis } from "../../helpers/fake-redis";
 
 const simplifiedKrc =
@@ -119,5 +123,25 @@ describe("Chinese lyric persistence", () => {
     );
     expect(stored?.translations?.["zh-CN"]).toContain("头发里面");
     expect(stored?.translations?.["zh-TW"]).toContain("頭髮裡面");
+  });
+});
+
+describe("clearCoverColor schemas", () => {
+  test("ClearCachedDataSchema accepts clearCoverColor", () => {
+    expect(
+      ClearCachedDataSchema.safeParse({
+        action: "clear-cached-data",
+        clearCoverColor: true,
+      }).success
+    ).toBe(true);
+  });
+
+  test("UpdateSongSchema accepts clearCoverColor with cover updates", () => {
+    expect(
+      UpdateSongSchema.safeParse({
+        cover: "https://example.com/cover.jpg",
+        clearCoverColor: true,
+      }).success
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clear Cache and Search Lyrics in Karaoke / iPod now re-fetch cover art and glow color, and update both the local track store (IndexedDB → Cloud Sync) and Redis song metadata.

### Behavior

| Action | Local track | Redis meta | Cloud Sync |
|--------|-------------|------------|------------|
| **Clear cache** | Clears `coverColor`, hard-refetches lyrics with `returnMetadata`, applies new `cover` | Clears `coverColor`; force fetch refreshes `cover` via `saveLyrics` | Via updated `songs/track:<id>` |
| **Search lyrics** | Sets `cover` from result, clears `coverColor`, hard-refetches | Patches source/cover + `clearCoverColor`; fetch refreshes cover | Via updated track |
| **After paint** | `useCoverGlowColor` re-extracts → `setTrackCoverColor` + `updateSongById` | New `coverColor` | Syncs with track |

### Key changes

- **Server**: `clear-cached-data` / song updates support `clearCoverColor`; `saveLyrics` clears color on force/source-change even when the cover URL is unchanged
- **Store**: `applyTrackCoverMetadata`, `clearLyricsCache` clears local color, `setTrackLyricsSource` applies cover + clears color across YouTube/AM caches and hard-refetches
- **`useLyrics`**: On cache bust, requests `returnMetadata` and writes cover/color back into the store
- **Search handlers** (iPod + Karaoke): Pass `result.cover`; rely on store hard-refresh instead of soft `refreshLyrics()`

### Tests

- Unit coverage for `saveSong`/`saveLyrics` color clearing, store cover metadata paths, and schema acceptance of `clearCoverColor`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcee1-1fe7-7e9a-89b6-7149c2f68980?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcee1-1fe7-7e9a-89b6-7149c2f68980&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

