### PR TITLE
Fix karaoke fullscreen menu radio font sizes

### DIFF
--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -350,23 +350,55 @@ const DropdownMenuRadioItem = (
     ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>>;
   }
 ) => {
-  const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
+  const {
+    isWindowsTheme,
+    isMacOSTheme,
+    isSystem7Theme,
+    isAquaMenuChrome,
+  } = useThemeFlags();
 
   return (
     <DropdownMenuPrimitive.RadioItem
       ref={ref}
       className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-        className
+        "relative flex cursor-default select-none items-center py-1.5 pl-8 pr-2 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        // Match CheckboxItem / MenubarRadioItem so karaoke/iPod fullscreen
+        // menus (translations, pronunciations Auto/繁體/簡體, etc.) share one
+        // size under `.karaoke-force-font * { font-size: unset !important }`.
+        isSystem7Theme &&
+          "rounded-none focus:bg-black focus:text-white hover:bg-black hover:text-white mx-0",
+        isMacOSTheme &&
+          "rounded-none focus:bg-[rgba(39,101,202,0.88)] focus:text-white hover:bg-[rgba(39,101,202,0.88)] hover:text-white",
+        !isSystem7Theme &&
+          !isMacOSTheme &&
+          "rounded-sm focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground",
+        className,
+        "data-[state=checked]:text-foreground"
       )}
       style={{
         fontFamily:
           isWindowsTheme || isMacOSTheme ? "var(--os-font-ui)" : undefined,
-        fontSize: isWindowsTheme ? "var(--os-menu-item-font-size)" : undefined,
+        fontSize:
+          isWindowsTheme || isMacOSTheme
+            ? isMacOSTheme
+              ? "var(--os-menu-item-font-size) !important"
+              : "var(--os-menu-item-font-size)"
+            : undefined,
+        ...(!isAquaMenuChrome && {
+          padding: "2px 12px 2px 32px",
+          margin: "0",
+        }),
+        ...(isMacOSTheme && {
+          borderRadius: "0px",
+          padding: "6px 20px 6px 32px",
+          margin: "1px 0",
+          WebkitFontSmoothing: "antialiased",
+          textShadow: "0 2px 3px rgba(0, 0, 0, 0.25)",
+        }),
       }}
       {...props}
     >
-      <span className="absolute left-2 flex size-3.5 items-center justify-center">
+      <span className="absolute left-3 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
           <Circle size={8} weight="fill" />
         </DropdownMenuPrimitive.ItemIndicator>

--- a/tests/unit/theme/test-dropdown-menu-radio-font-size.test.ts
+++ b/tests/unit/theme/test-dropdown-menu-radio-font-size.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const dropdownMenuSource = readFileSync(
+  join(import.meta.dir, "../../../src/components/ui/dropdown-menu.tsx"),
+  "utf8"
+);
+const lyricsControlsSource = readFileSync(
+  join(
+    import.meta.dir,
+    "../../../src/components/shared/fullscreen-player-controls/LyricsControlsIsland.tsx"
+  ),
+  "utf8"
+);
+
+function extractComponentBlock(source: string, constName: string): string {
+  const start = source.indexOf(`const ${constName} = (`);
+  if (start === -1) return "";
+  const displayNameMarker = `${constName}.displayName`;
+  const end = source.indexOf(displayNameMarker, start);
+  if (end === -1) return source.slice(start);
+  return source.slice(start, end);
+}
+
+describe("dropdown menu radio font size", () => {
+  test("DropdownMenuRadioItem matches CheckboxItem macOS menu font-size wiring", () => {
+    const radio = extractComponentBlock(dropdownMenuSource, "DropdownMenuRadioItem");
+    const checkbox = extractComponentBlock(
+      dropdownMenuSource,
+      "DropdownMenuCheckboxItem"
+    );
+
+    expect(radio.length).toBeGreaterThan(0);
+    expect(checkbox.length).toBeGreaterThan(0);
+
+    // Both must re-assert --os-menu-item-font-size with !important on macOS so
+    // `.karaoke-force-font * { font-size: unset !important }` cannot inflate
+    // radio rows (Auto / 繁體 / 簡體) relative to checkbox rows.
+    for (const block of [radio, checkbox]) {
+      expect(block).toContain("isWindowsTheme || isMacOSTheme");
+      expect(block).toContain('"var(--os-menu-item-font-size) !important"');
+      expect(block).toContain('"var(--os-menu-item-font-size)"');
+      expect(block).toContain("isAquaMenuChrome");
+      expect(block).toContain('padding: "6px 20px 6px 32px"');
+    }
+  });
+
+  test("fullscreen lyrics menus use the shared text-md h-6 item classes", () => {
+    expect(lyricsControlsSource).toContain("DropdownMenuRadioItem");
+    expect(lyricsControlsSource).toContain("DropdownMenuCheckboxItem");
+
+    const radioItemClasses = [
+      ...lyricsControlsSource.matchAll(
+        /<DropdownMenuRadioItem[\s\S]*?className="([^"]+)"/g
+      ),
+    ].map((match) => match[1]);
+    const checkboxItemClasses = [
+      ...lyricsControlsSource.matchAll(
+        /<DropdownMenuCheckboxItem[\s\S]*?className="([^"]+)"/g
+      ),
+    ].map((match) => match[1]);
+
+    expect(radioItemClasses.length).toBeGreaterThan(0);
+    expect(checkboxItemClasses.length).toBeGreaterThan(0);
+
+    for (const className of [...radioItemClasses, ...checkboxItemClasses]) {
+      expect(className).toContain("text-md");
+      expect(className).toContain("h-6");
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Karaoke / iPod fullscreen lyrics dropdowns mixed two item sizes: checkbox rows (pronunciation toggles, etc.) used `--os-menu-item-font-size` with `!important`, while radio rows (translations + pronunciations Auto / 繁體 / 簡體) did not.

Under Aqua’s `.karaoke-force-font * { font-size: unset !important }`, radio items fell back to the stage’s `16px` base and looked larger than the surrounding `13px` checkbox items.

## What was inconsistent
| Surface | Before | After |
|---------|--------|-------|
| Fullscreen **pronunciations** radio rows (Auto / 繁體 / 簡體) | Missing macOS menu font-size → inherited 16px under `karaoke-force-font` | Same `--os-menu-item-font-size !important` as checkbox / menubar radios |
| Fullscreen **translations** radio rows | Same gap | Same fix (shared `DropdownMenuRadioItem`) |
| Fullscreen pronunciation **checkbox** rows | Already correct | Unchanged |
| App menubar pronunciation / translation radios (`MenubarRadioItem`) | Already correct | Unchanged |
| Theme overrides (`karaoke-force-font`, Aqua Glass padding for `menuitemradio`, dark Aqua popovers) | Radio rows escaped the menu token under force-font | Force-font no longer inflates radio rows; glass/dark rules already targeted `menuitemradio` |

## Fix
Align `DropdownMenuRadioItem` with `DropdownMenuCheckboxItem` / `MenubarRadioItem`:
- macOS + Windows `--os-menu-item-font-size` (with `!important` on macOS)
- Aqua / System 7 hover + padding chrome
- Indicator gutter `left-3` to match checkbox rows

## Test plan
- [x] `bun test tests/unit/theme/test-dropdown-menu-radio-font-size.test.ts`
- Manual (Aqua / karaoke fullscreen): open pronunciations → Auto / 繁體 / 簡體 match checkbox rows; open translations menu → language radios match; spot-check Aqua Glass + dark Aqua.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-622c31d9-ad94-421a-8af3-671fcf775e7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-622c31d9-ad94-421a-8af3-671fcf775e7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

